### PR TITLE
fix: Upper bound on numpy version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Fixed
+- Require `numpy` to be of version `1.x.x`, as the new `2.0.0` clashes with `outlines`.
+
+
 ## [v12.10.6] - 2024-06-19
 ### Fixed
 - Updated `optimum` to `>=1.20.0` as `1.19.x` is incompatible with newer `transformers`

--- a/poetry.lock
+++ b/poetry.lock
@@ -6194,4 +6194,4 @@ quantization = ["auto-gptq", "autoawq", "optimum"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "0bb7389d84f9aeb7c7399a266be88a55c005f2d6ca09b2b4ca92622bf2f15f12"
+content-hash = "f9e149144015514689f029776dd18c4fff19af6a135ebe73ec571767cf45dae8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ python = ">=3.10,<3.12"
 # Core packages
 torch = ">=2.3.0"
 pandas = ">=2.2.0"
-numpy = ">=1.23.0"
+numpy = ">=1.23.0,<2.0.0"
 transformers = ">=4.41.0"
 accelerate = ">=0.26.0"
 evaluate = ">=0.4.1"


### PR DESCRIPTION
### Fixed
- Require `numpy` to be of version `1.x.x`, as the new `2.0.0` clashes with `outlines`.