### PR TITLE
Feat/add nrk quiz qa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Added
+- Added the new Norwegian knowledge dataset NRK-Quiz-QA, consisting of 500 quizzes on
+  the Norwegian language and culture. TODO
+
 ### Changed
 - Updated the Danish Citizen Tests dataset to include the newer 2024 tests, Further,
   rather than splitting the dataset randomly, we include all the citizenship tests in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Added the new Norwegian knowledge dataset NRK-Quiz-QA, consisting of 500 quizzes on
-  the Norwegian language and culture. TODO
+- Added the new Norwegian knowledge dataset NRK-Quiz-QA, consisting of quizzes on the
+  Norwegian language and culture. The dataset has been split into 635 / 256 / 2,048
+  samples for train, val, and test, respectively. This replaces the old MMLU-no as the
+  official Norwegian knowledge dataset.
 
 ### Changed
 - Updated the Danish Citizen Tests dataset to include the newer 2024 tests, Further,

--- a/docs/datasets/norwegian.md
+++ b/docs/datasets/norwegian.md
@@ -576,7 +576,74 @@ $ euroeval --model <model-id> --dataset norglm-multi-qa
 
 ## Knowledge
 
-### MMLU-no
+### NRK Quiz QA
+
+This dataset is a multiple-choice question answering (QA) dataset designed for
+evaluation of the Norwegian language and culture, including both Bokmål and Nynorsk. The
+dataset consists of quizzes from NRK, the national public broadcaster in Norway.
+
+The original dataset contains 4,930 samples, spread across 549 quizzes. We keep the
+top-256 quizzes, allowing us to create splits stratified across all the remaining
+quizzes. We 635 / 256 / 2048 samples for training, validation and test, respectively.
+
+Here are a few examples from the training split:
+
+```json
+{
+  "text": "Gunnar har hatt plutselige og sterke smerteanfall siden han var liten gutt. Det var vondt å tisse og det gjorde vondt i ryggen og magen. Det hjalp litt å drikke vann. Reseptbelagte medisiner kan være nødvendig under anfall.\nSvaralternativer:\na. Nyrestein, kronisk\nb. Irritabel tarmsyndrom\nc. Angst\nd. Urinveisinfeksjon",
+  "label": "a"
+}```
+```json
+{
+  "text": "80 år gamle Harrison Ford er nok ein gong aktuell i rolla som Indiana Jones. Kva heiter filmen?\nSvaralternativer:\na. Indiana Jones and the Nasty Nazis\nb. Indiana Jones and the Dial of Destiny\nc. Indiana Jones and the Hunt for Power\nd. Indiana Jones Forever",
+  "label": "b"
+}```
+```json
+{
+  "text": "I 1980 måtte denne bassisten overnatte ni netter i fengsel i Japan fordi han prøvde å få med seg ca. 200 gram marihuana inn i landet. Hvem var det?\nSvaralternativer:\na. Sting\nb. Lemmy Kilmister\nc. Paul McCartney\nd. Bootsy Collins",
+  "label": "c"
+}```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+  ```
+  Følgende er flervalgsspørsmål (med svar).
+  ```
+- Base prompt template:
+  ```
+  Spørsmål: {text}
+  Svaralternativer:
+  a. {option_a}
+  b. {option_b}
+  c. {option_c}
+  d. {option_d}
+  e. {option_e}
+  Svar: {label}
+  ```
+- Instruction-tuned prompt template:
+  ```
+  Spørsmål: {text}
+  Svaralternativer:
+  a. {option_a}
+  b. {option_b}
+  c. {option_c}
+  d. {option_d}
+  e. {option_e}
+
+  Besvar følgende spørsmål med 'a', 'b', 'c', 'd' eller 'e', og engu öðru.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+$ euroeval --model <model-id> --dataset nrk-quiz-qa
+```
+
+
+### Unofficial: MMLU-no
 
 This dataset is a machine translated version of the English [MMLU
 dataset](https://openreview.net/forum?id=d7KBjmI3GmQ) and features questions within 57

--- a/src/euroeval/dataset_configs.py
+++ b/src/euroeval/dataset_configs.py
@@ -1390,6 +1390,22 @@ DANISH_CITIZEN_TESTS_CONFIG = DatasetConfig(
     max_generated_tokens=5,
 )
 
+NRK_QUIZ_QA_CONFIG = DatasetConfig(
+    name="nrk-quiz-qa",
+    pretty_name="the truncated version of the Norwegian knowledge dataset NRK Quiz QA",
+    huggingface_id="EuroEval/nrk-quiz-qa-mini",
+    task=KNOW,
+    languages=[NB, NN, NO],
+    labels=["a", "b", "c", "d", "e"],
+    prompt_prefix="Følgende er flervalgsspørsmål (med svar).",
+    prompt_template="Spørsmål: {text}\nSvar: {label}",
+    prompt_label_mapping=dict(a="a", b="b", c="c", d="d", e="e"),
+    instruction_prompt="Spørsmål: {text}\n\nBesvar følgende spørsmål med 'a', 'b', "
+    "'c', 'd' eller 'e', og ikke noe annet.",
+    num_few_shot_examples=5,
+    max_generated_tokens=5,
+)
+
 MMLU_NO_CONFIG = DatasetConfig(
     name="mmlu-no",
     pretty_name="the truncated version of the Norwegian knowledge dataset MMLU-no, "
@@ -1405,6 +1421,7 @@ MMLU_NO_CONFIG = DatasetConfig(
     "'c' eller 'd', og ikke noe annet.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
+    unofficial=True,
 )
 
 MMLU_SV_CONFIG = DatasetConfig(

--- a/src/scripts/create_nrk_quiz_qa.py
+++ b/src/scripts/create_nrk_quiz_qa.py
@@ -1,0 +1,150 @@
+"""Create the NRK-Quiz-QA-mini dataset and upload them to the HF Hub."""
+
+import warnings
+from collections import Counter
+
+import pandas as pd
+from constants import (
+    MAX_NUM_CHARS_IN_INSTRUCTION,
+    MAX_REPETITIONS,
+    MIN_NUM_CHARS_IN_INSTRUCTION,
+)
+from datasets import Dataset, DatasetDict, Split, load_dataset
+from huggingface_hub import HfApi
+from pandas.errors import SettingWithCopyWarning
+from requests import HTTPError
+from sklearn.model_selection import train_test_split
+
+warnings.simplefilter(action="ignore", category=SettingWithCopyWarning)
+
+
+def main() -> None:
+    """Create the MMLU-mini datasets and upload them to the HF Hub."""
+    # Define the base download URL
+    repo_id = "ltg/nrk_quiz_qa"
+
+    # Download the dataset
+    nb_dataset = load_dataset(path=repo_id, name="nb", token=True, split="test")
+    nn_dataset = load_dataset(path=repo_id, name="nn", token=True, split="test")
+    assert isinstance(nb_dataset, Dataset) and isinstance(nn_dataset, Dataset)
+
+    # Convert the dataset to a dataframe
+    nb_df = nb_dataset.to_pandas()
+    nn_df = nn_dataset.to_pandas()
+    assert isinstance(nb_df, pd.DataFrame) and isinstance(nn_df, pd.DataFrame)
+
+    # Merge the datasets
+    nb_df["language"] = "nb"
+    nn_df["language"] = "nn"
+    df = pd.concat([nb_df, nn_df], ignore_index=True)
+
+    # Rename the columns
+    df.rename(columns=dict(question="instruction", answer="label"), inplace=True)
+
+    # Remove the samples with overly short or long texts
+    df = df[
+        (df.instruction.str.len() >= MIN_NUM_CHARS_IN_INSTRUCTION)
+        & (df.instruction.str.len() <= MAX_NUM_CHARS_IN_INSTRUCTION)
+    ]
+
+    def is_repetitive(text: str) -> bool:
+        """Return True if the text is repetitive."""
+        max_repetitions = max(Counter(text.split()).values())
+        return max_repetitions > MAX_REPETITIONS
+
+    # Remove overly repetitive samples
+    df = df[~df.instruction.apply(is_repetitive)]
+    assert isinstance(df, pd.DataFrame)
+
+    # We can have at most 256 quizzes, as this is the size of the validation split and
+    # we are stratifying by quiz, so we keep only the top-256 quizzes by count
+    quiz_counts = df.quiz.value_counts()
+    top_quizzes = quiz_counts.head(256).index
+    df = df[df.quiz.isin(top_quizzes)]
+
+    # Make a `text` column with all the options in it
+    df["text"] = [
+        row.instruction.replace("\n", " ").strip() + "\n"
+        "Svaralternativer:\n"
+        + "\n".join(
+            [
+                f"{char}. {clean_text(text=option)}"
+                for char, option in zip("abcd", row.choices["text"])
+            ]
+        )
+        for _, row in df.iterrows()
+    ]
+
+    # Make the `label` column case-consistent with the `text` column
+    df.label = df.label.str.lower()
+
+    # Only keep the `text`, `label` and `quiz` columns
+    df = df[["text", "label", "quiz"]]
+    assert isinstance(df, pd.DataFrame)
+
+    # Remove duplicates
+    df.drop_duplicates(inplace=True)
+    df.reset_index(drop=True, inplace=True)
+
+    # Create validation split
+    val_size = 256
+    traintest_arr, val_arr = train_test_split(
+        df, test_size=val_size, random_state=4242, stratify=df.quiz
+    )
+    traintest_df = pd.DataFrame(traintest_arr, columns=df.columns)
+    val_df = pd.DataFrame(val_arr, columns=df.columns)
+
+    # Create test split
+    test_size = 2048
+    train_arr, test_arr = train_test_split(
+        traintest_df, test_size=test_size, random_state=4242, stratify=traintest_df.quiz
+    )
+    train_df = pd.DataFrame(train_arr, columns=df.columns)
+    test_df = pd.DataFrame(test_arr, columns=df.columns)
+
+    # Create train split
+    max_train_size = 1024
+    if len(train_df) > max_train_size:
+        train_df = train_df.sample(max_train_size, random_state=4242)
+
+    # Reset the index
+    train_df = train_df.reset_index(drop=True)
+    val_df = val_df.reset_index(drop=True)
+    test_df = test_df.reset_index(drop=True)
+
+    # Collect datasets in a dataset dictionary
+    dataset = DatasetDict(
+        train=Dataset.from_pandas(train_df, split=Split.TRAIN),
+        val=Dataset.from_pandas(val_df, split=Split.VALIDATION),
+        test=Dataset.from_pandas(test_df, split=Split.TEST),
+    )
+
+    # Create dataset ID
+    dataset_id = "EuroEval/nrk-quiz-qa-mini"
+
+    # Remove the dataset from Hugging Face Hub if it already exists
+    try:
+        api = HfApi()
+        api.delete_repo(dataset_id, repo_type="dataset")
+    except HTTPError:
+        pass
+
+    # Push the dataset to the Hugging Face Hub
+    dataset.push_to_hub(dataset_id, private=True)
+
+
+def clean_text(text: str) -> str:
+    """Clean the text.
+
+    Args:
+        text:
+            The text to be cleaned.
+
+    Returns:
+        The cleaned text.
+    """
+    return text.replace("\n", " ").strip()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Added
- Added the new Norwegian knowledge dataset NRK-Quiz-QA, consisting of quizzes on the
  Norwegian language and culture. The dataset has been split into 635 / 256 / 2,048
  samples for train, val, and test, respectively. This replaces the old MMLU-no as the
  official Norwegian knowledge dataset.

Closes #802 