### PR TITLE
Encoder bug fixes, missing dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: debug-statements
+      # - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.9
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      # - id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.9
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Some encoder models were not able to be evaluated on reading comprehensions, if their
   tokenizers were not subclassing `PreTrainedTokenizer`. This has been relaxed to
   `PreTrainedTokenizerBase` instead.
+- Newer versions of the `transformers` package changed the model output format, causing
+  errors when evaluating encoder models on some tasks. This has been fixed now.
 
 
 ## [v15.2.0] - 2025-02-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `PreTrainedTokenizerBase` instead.
 - Newer versions of the `transformers` package changed the model output format, causing
   errors when evaluating encoder models on some tasks. This has been fixed now.
+- Added `setuptools` to the dependencies, as it is required for the package to be
+  installed correctly.
 
 
 ## [v15.2.0] - 2025-02-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   machine translated ARC-is dataset. It has also been improved, as some of the generated
   alternative answers were formatted incorrectly.
 
+### Fixed
+- A bug caused fresh encoder models to not be benchmarkable on the speed benchmark -
+  this has been fixed now.
+
 
 ## [v15.2.0] - 2025-02-28
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - A bug caused fresh encoder models to not be benchmarkable on the speed benchmark -
   this has been fixed now.
+- Some encoder models were not able to be evaluated on reading comprehensions, if their
+  tokenizers were not subclassing `PreTrainedTokenizer`. This has been relaxed to
+  `PreTrainedTokenizerBase` instead.
 
 
 ## [v15.2.0] - 2025-02-28

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "bert-score>=0.3.13",
     "levenshtein>=0.24.0",
     "scikit-learn<1.6.0",
+    "setuptools>=75.8.2",
 ]
 
 [project.optional-dependencies]

--- a/src/euroeval/benchmark_modules/fresh.py
+++ b/src/euroeval/benchmark_modules/fresh.py
@@ -221,7 +221,9 @@ def load_model_and_tokenizer(
 
     match dataset_config.task.task_group:
         case (
-            TaskGroup.SEQUENCE_CLASSIFICATION | TaskGroup.MULTIPLE_CHOICE_CLASSIFICATION
+            TaskGroup.SEQUENCE_CLASSIFICATION
+            | TaskGroup.MULTIPLE_CHOICE_CLASSIFICATION
+            | TaskGroup.SPEED
         ):
             model_cls_mapping = dict(
                 fresh_xlm_roberta_base=XLMRobertaForSequenceClassification,

--- a/src/euroeval/task_utils/question_answering.py
+++ b/src/euroeval/task_utils/question_answering.py
@@ -143,7 +143,7 @@ class QuestionAnsweringTrainer(Trainer):
 
 
 def compute_metrics(
-    model_outputs_and_labels: tuple["Predictions", "Labels"] | EvalPrediction,
+    model_outputs_and_labels: tuple["Predictions", "Labels"] | "EvalPrediction",
     dataset_config: "DatasetConfig",
     benchmark_config: "BenchmarkConfig",
 ) -> dict[str, float]:

--- a/src/euroeval/task_utils/question_answering.py
+++ b/src/euroeval/task_utils/question_answering.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 import evaluate
 import numpy as np
 from evaluate import EvaluationModule
-from transformers import PreTrainedTokenizer
+from transformers import PreTrainedTokenizer, PreTrainedTokenizerBase
 from transformers.trainer import Trainer
 
 from ..data_models import BenchmarkConfig, DatasetConfig, GenerativeModelOutput
@@ -23,7 +23,6 @@ if t.TYPE_CHECKING:
     from transformers import (
         EvalPrediction,
         PreTrainedModel,
-        PreTrainedTokenizerBase,
         TrainerCallback,
         TrainingArguments,
     )
@@ -62,8 +61,7 @@ class QuestionAnsweringTrainer(Trainer):
 
         # Get the CLS token id for the tokenizer
         if self.tokenizer is not None:
-            breakpoint()
-            assert isinstance(self.tokenizer, PreTrainedTokenizer)
+            assert isinstance(self.tokenizer, PreTrainedTokenizerBase)
             special_token_metadata = get_special_token_metadata(self.tokenizer)
             self.cls_token_id = special_token_metadata["cls_token_id"]
 

--- a/src/euroeval/task_utils/question_answering.py
+++ b/src/euroeval/task_utils/question_answering.py
@@ -143,7 +143,7 @@ class QuestionAnsweringTrainer(Trainer):
 
 
 def compute_metrics(
-    model_outputs_and_labels: tuple["Predictions", "Labels"],
+    model_outputs_and_labels: tuple["Predictions", "Labels"] | EvalPrediction,
     dataset_config: "DatasetConfig",
     benchmark_config: "BenchmarkConfig",
 ) -> dict[str, float]:
@@ -163,6 +163,13 @@ def compute_metrics(
         values.
     """
     model_outputs, labels = model_outputs_and_labels
+
+    # If the model outputs is a pair, then the first element corresponds to the model
+    # predictions
+    if isinstance(model_outputs, tuple) and len(model_outputs) == 2:
+        model_outputs = model_outputs[0]
+
+    assert not isinstance(model_outputs, tuple)
     raise_if_model_output_contains_nan_values(model_output=model_outputs)
 
     metrics = {

--- a/src/euroeval/task_utils/question_answering.py
+++ b/src/euroeval/task_utils/question_answering.py
@@ -143,7 +143,7 @@ class QuestionAnsweringTrainer(Trainer):
 
 
 def compute_metrics(
-    model_outputs_and_labels: tuple["Predictions", "Labels"] | "EvalPrediction",
+    model_outputs_and_labels: "tuple[Predictions, Labels] | EvalPrediction",
     dataset_config: "DatasetConfig",
     benchmark_config: "BenchmarkConfig",
 ) -> dict[str, float]:

--- a/src/euroeval/task_utils/question_answering.py
+++ b/src/euroeval/task_utils/question_answering.py
@@ -62,6 +62,7 @@ class QuestionAnsweringTrainer(Trainer):
 
         # Get the CLS token id for the tokenizer
         if self.tokenizer is not None:
+            breakpoint()
             assert isinstance(self.tokenizer, PreTrainedTokenizer)
             special_token_metadata = get_special_token_metadata(self.tokenizer)
             self.cls_token_id = special_token_metadata["cls_token_id"]

--- a/src/euroeval/task_utils/sequence_classification.py
+++ b/src/euroeval/task_utils/sequence_classification.py
@@ -42,7 +42,6 @@ def compute_metrics(
     """
     model_outputs, labels = model_outputs_and_labels
     label2id = {label: idx for idx, label in dataset_config.id2label.items()}
-    raise_if_model_output_contains_nan_values(model_output=model_outputs)
 
     metrics = {
         metric_cfg.name: (
@@ -60,6 +59,8 @@ def compute_metrics(
         predictions = np.asarray(model_outputs).argmax(axis=-1)
     else:
         predictions = model_outputs
+
+    raise_if_model_output_contains_nan_values(model_output=model_outputs)
 
     prompt_label_to_label_mapping = {
         prompt_label: label

--- a/src/euroeval/task_utils/sequence_classification.py
+++ b/src/euroeval/task_utils/sequence_classification.py
@@ -8,6 +8,7 @@ import evaluate
 import Levenshtein
 import numpy as np
 from evaluate import EvaluationModule
+from transformers import EvalPrediction
 
 from ..data_models import BenchmarkConfig, GenerativeModelOutput
 from ..utils import log_once, raise_if_model_output_contains_nan_values
@@ -21,7 +22,7 @@ logger = logging.getLogger("euroeval")
 
 
 def compute_metrics(
-    model_outputs_and_labels: tuple["Predictions", "Labels"],
+    model_outputs_and_labels: tuple["Predictions", "Labels"] | EvalPrediction,
     dataset_config: "DatasetConfig",
     benchmark_config: "BenchmarkConfig",
 ) -> dict[str, float]:
@@ -42,6 +43,11 @@ def compute_metrics(
     """
     model_outputs, labels = model_outputs_and_labels
     label2id = {label: idx for idx, label in dataset_config.id2label.items()}
+
+    # If the model outputs is a pair, then the first element corresponds to the model
+    # predictions
+    if isinstance(model_outputs, tuple) and len(model_outputs) == 2:
+        model_outputs = model_outputs[0]
 
     metrics = {
         metric_cfg.name: (

--- a/src/euroeval/task_utils/sequence_classification.py
+++ b/src/euroeval/task_utils/sequence_classification.py
@@ -66,6 +66,7 @@ def compute_metrics(
     else:
         predictions = model_outputs
 
+    assert not isinstance(model_outputs, tuple)
     raise_if_model_output_contains_nan_values(model_output=model_outputs)
 
     prompt_label_to_label_mapping = {

--- a/src/euroeval/task_utils/sequence_classification.py
+++ b/src/euroeval/task_utils/sequence_classification.py
@@ -23,7 +23,7 @@ logger = logging.getLogger("euroeval")
 
 
 def compute_metrics(
-    model_outputs_and_labels: tuple["Predictions", "Labels"] | EvalPrediction,
+    model_outputs_and_labels: "tuple[Predictions, Labels] | EvalPrediction",
     dataset_config: "DatasetConfig",
     benchmark_config: "BenchmarkConfig",
 ) -> dict[str, float]:

--- a/src/euroeval/task_utils/sequence_classification.py
+++ b/src/euroeval/task_utils/sequence_classification.py
@@ -8,12 +8,13 @@ import evaluate
 import Levenshtein
 import numpy as np
 from evaluate import EvaluationModule
-from transformers import EvalPrediction
 
 from ..data_models import BenchmarkConfig, GenerativeModelOutput
 from ..utils import log_once, raise_if_model_output_contains_nan_values
 
 if t.TYPE_CHECKING:
+    from transformers import EvalPrediction
+
     from ..data_models import DatasetConfig
     from ..types import Labels, Predictions
 

--- a/src/euroeval/task_utils/sequence_classification.py
+++ b/src/euroeval/task_utils/sequence_classification.py
@@ -41,6 +41,7 @@ def compute_metrics(
         values.
     """
     model_outputs, labels = model_outputs_and_labels
+    breakpoint()
     label2id = {label: idx for idx, label in dataset_config.id2label.items()}
     raise_if_model_output_contains_nan_values(model_output=model_outputs)
 

--- a/src/euroeval/task_utils/sequence_classification.py
+++ b/src/euroeval/task_utils/sequence_classification.py
@@ -41,7 +41,6 @@ def compute_metrics(
         values.
     """
     model_outputs, labels = model_outputs_and_labels
-    breakpoint()
     label2id = {label: idx for idx, label in dataset_config.id2label.items()}
     raise_if_model_output_contains_nan_values(model_output=model_outputs)
 

--- a/src/euroeval/task_utils/text_to_text.py
+++ b/src/euroeval/task_utils/text_to_text.py
@@ -6,7 +6,6 @@ import typing as t
 import evaluate
 import numpy as np
 from evaluate import EvaluationModule
-from transformers import EvalPrediction
 
 from ..constants import METRIC_ATTRIBUTES_TAKING_UP_MEMORY
 from ..data_models import BenchmarkConfig, DatasetConfig, GenerativeModelOutput
@@ -18,6 +17,8 @@ from ..utils import (
 )
 
 if t.TYPE_CHECKING:
+    from transformers import EvalPrediction
+
     from ..types import Labels, Predictions
 
 
@@ -25,7 +26,7 @@ logger = logging.getLogger("euroeval")
 
 
 def compute_metrics(
-    model_outputs_and_labels: tuple["Predictions", "Labels"] | EvalPrediction,
+    model_outputs_and_labels: tuple["Predictions", "Labels"] | "EvalPrediction",
     dataset_config: "DatasetConfig",
     benchmark_config: "BenchmarkConfig",
 ) -> dict[str, float]:

--- a/src/euroeval/task_utils/text_to_text.py
+++ b/src/euroeval/task_utils/text_to_text.py
@@ -26,7 +26,7 @@ logger = logging.getLogger("euroeval")
 
 
 def compute_metrics(
-    model_outputs_and_labels: tuple["Predictions", "Labels"] | "EvalPrediction",
+    model_outputs_and_labels: "tuple[Predictions, Labels] | EvalPrediction",
     dataset_config: "DatasetConfig",
     benchmark_config: "BenchmarkConfig",
 ) -> dict[str, float]:

--- a/src/euroeval/task_utils/text_to_text.py
+++ b/src/euroeval/task_utils/text_to_text.py
@@ -6,6 +6,7 @@ import typing as t
 import evaluate
 import numpy as np
 from evaluate import EvaluationModule
+from transformers import EvalPrediction
 
 from ..constants import METRIC_ATTRIBUTES_TAKING_UP_MEMORY
 from ..data_models import BenchmarkConfig, DatasetConfig, GenerativeModelOutput
@@ -24,7 +25,7 @@ logger = logging.getLogger("euroeval")
 
 
 def compute_metrics(
-    model_outputs_and_labels: tuple["Predictions", "Labels"],
+    model_outputs_and_labels: tuple["Predictions", "Labels"] | EvalPrediction,
     dataset_config: "DatasetConfig",
     benchmark_config: "BenchmarkConfig",
 ) -> dict[str, float]:
@@ -44,6 +45,13 @@ def compute_metrics(
         values.
     """
     model_outputs, labels = model_outputs_and_labels
+
+    # If the model outputs is a pair, then the first element corresponds to the model
+    # predictions
+    if isinstance(model_outputs, tuple) and len(model_outputs) == 2:
+        model_outputs = model_outputs[0]
+
+    assert not isinstance(model_outputs, tuple)
     raise_if_model_output_contains_nan_values(model_output=model_outputs)
 
     metrics = {

--- a/src/euroeval/task_utils/token_classification.py
+++ b/src/euroeval/task_utils/token_classification.py
@@ -50,7 +50,6 @@ def compute_metrics(
         A dictionary with the names of the metrics as keys and the metric values as
         values.
     """
-    breakpoint()
     model_outputs, labels = model_outputs_and_labels
     raise_if_model_output_contains_nan_values(model_output=model_outputs)
 

--- a/src/euroeval/task_utils/token_classification.py
+++ b/src/euroeval/task_utils/token_classification.py
@@ -9,14 +9,14 @@ from copy import deepcopy
 import evaluate
 import numpy as np
 from evaluate import EvaluationModule
-from transformers import EvalPrediction, PreTrainedTokenizer
+from transformers import PreTrainedTokenizer
 
 from ..data_models import BenchmarkConfig, DatasetConfig, GenerativeModelOutput
 from ..exceptions import InvalidBenchmark, NeedsExtraInstalled
 from ..utils import raise_if_model_output_contains_nan_values
 
 if t.TYPE_CHECKING:
-    from transformers import BatchEncoding
+    from transformers import BatchEncoding, EvalPrediction
 
     from ..types import Labels, Predictions
 
@@ -28,7 +28,7 @@ logger = logging.getLogger("euroeval")
 
 
 def compute_metrics(
-    model_outputs_and_labels: tuple["Predictions", "Labels"] | EvalPrediction,
+    model_outputs_and_labels: tuple["Predictions", "Labels"] | "EvalPrediction",
     has_misc_tags: bool,
     dataset_config: "DatasetConfig",
     benchmark_config: "BenchmarkConfig",

--- a/src/euroeval/task_utils/token_classification.py
+++ b/src/euroeval/task_utils/token_classification.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 import evaluate
 import numpy as np
 from evaluate import EvaluationModule
-from transformers import PreTrainedTokenizer
+from transformers import EvalPrediction, PreTrainedTokenizer
 
 from ..data_models import BenchmarkConfig, DatasetConfig, GenerativeModelOutput
 from ..exceptions import InvalidBenchmark, NeedsExtraInstalled
@@ -28,7 +28,7 @@ logger = logging.getLogger("euroeval")
 
 
 def compute_metrics(
-    model_outputs_and_labels: tuple["Predictions", "Labels"],
+    model_outputs_and_labels: tuple["Predictions", "Labels"] | EvalPrediction,
     has_misc_tags: bool,
     dataset_config: "DatasetConfig",
     benchmark_config: "BenchmarkConfig",
@@ -51,7 +51,6 @@ def compute_metrics(
         values.
     """
     model_outputs, labels = model_outputs_and_labels
-    raise_if_model_output_contains_nan_values(model_output=model_outputs)
 
     metrics = {
         metric_cfg.name: (
@@ -92,6 +91,8 @@ def compute_metrics(
 
     else:
         predictions = model_outputs  # type: ignore[assignment]
+
+    raise_if_model_output_contains_nan_values(model_output=predictions)
 
     # Replace predicted tag with either MISC or O tags if they are not part of the
     # dataset

--- a/src/euroeval/task_utils/token_classification.py
+++ b/src/euroeval/task_utils/token_classification.py
@@ -52,6 +52,11 @@ def compute_metrics(
     """
     model_outputs, labels = model_outputs_and_labels
 
+    # If the model outputs is a pair, then the first element corresponds to the model
+    # predictions
+    if isinstance(model_outputs, tuple) and len(model_outputs) == 2:
+        model_outputs = model_outputs[0]
+
     metrics = {
         metric_cfg.name: (
             evaluate.load(

--- a/src/euroeval/task_utils/token_classification.py
+++ b/src/euroeval/task_utils/token_classification.py
@@ -28,7 +28,7 @@ logger = logging.getLogger("euroeval")
 
 
 def compute_metrics(
-    model_outputs_and_labels: tuple["Predictions", "Labels"] | "EvalPrediction",
+    model_outputs_and_labels: "tuple[Predictions, Labels] | EvalPrediction",
     has_misc_tags: bool,
     dataset_config: "DatasetConfig",
     benchmark_config: "BenchmarkConfig",

--- a/src/euroeval/task_utils/token_classification.py
+++ b/src/euroeval/task_utils/token_classification.py
@@ -50,6 +50,7 @@ def compute_metrics(
         A dictionary with the names of the metrics as keys and the metric values as
         values.
     """
+    breakpoint()
     model_outputs, labels = model_outputs_and_labels
     raise_if_model_output_contains_nan_values(model_output=model_outputs)
 

--- a/src/euroeval/utils.py
+++ b/src/euroeval/utils.py
@@ -21,7 +21,7 @@ import requests
 import torch
 from datasets.utils import disable_progress_bar
 from requests.exceptions import RequestException
-from transformers import PreTrainedTokenizer
+from transformers import PreTrainedTokenizer, PreTrainedTokenizerBase
 from transformers import logging as tf_logging
 
 from .exceptions import InvalidModel, NaNValueInModelOutput
@@ -231,7 +231,7 @@ def internet_connection_available() -> bool:
         return False
 
 
-def get_special_token_metadata(tokenizer: "PreTrainedTokenizer") -> dict:
+def get_special_token_metadata(tokenizer: "PreTrainedTokenizerBase") -> dict:
     """Get the special token metadata for a tokenizer.
 
     Args:

--- a/src/euroeval/utils.py
+++ b/src/euroeval/utils.py
@@ -324,7 +324,6 @@ def raise_if_model_output_contains_nan_values(model_output: "Predictions") -> No
             if any(x != x for x in model_output):
                 raise NaNValueInModelOutput()
         elif len(model_output[0]) > 0:
-            breakpoint()
             if any(x != x for sublist in model_output for x in sublist):
                 raise NaNValueInModelOutput()
 

--- a/src/euroeval/utils.py
+++ b/src/euroeval/utils.py
@@ -324,6 +324,7 @@ def raise_if_model_output_contains_nan_values(model_output: "Predictions") -> No
             if any(x != x for x in model_output):
                 raise NaNValueInModelOutput()
         elif len(model_output[0]) > 0:
+            breakpoint()
             if any(x != x for sublist in model_output for x in sublist):
                 raise NaNValueInModelOutput()
 

--- a/tests/test_benchmarker.py
+++ b/tests/test_benchmarker.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 import torch
+from requests.exceptions import RequestException
 
 from euroeval.benchmarker import (
     Benchmarker,
@@ -43,7 +44,7 @@ def test_benchmark_encoder(
                 model=encoder_model_id, task=task.name, language=language.code
             )
             break
-        except HuggingFaceHubDown:
+        except (HuggingFaceHubDown, RequestException):
             time.sleep(5)
     else:
         pytest.skip(reason="Hugging Face Hub is down, so we skip this test.")
@@ -67,7 +68,7 @@ def test_benchmark_generative(
                 model=generative_model_id, task=task.name, language=language.code
             )
             break
-        except HuggingFaceHubDown:
+        except (HuggingFaceHubDown, RequestException):
             time.sleep(5)
     else:
         pytest.skip(reason="Hugging Face Hub is down, so we skip this test.")
@@ -96,7 +97,7 @@ def test_benchmark_generative_adapter(
                 language=language.code,
             )
             break
-        except HuggingFaceHubDown:
+        except (HuggingFaceHubDown, RequestException):
             time.sleep(5)
     else:
         pytest.skip(reason="Hugging Face Hub is down, so we skip this test.")

--- a/tests/test_benchmarker.py
+++ b/tests/test_benchmarker.py
@@ -44,7 +44,7 @@ def test_benchmark_encoder(
                 model=encoder_model_id, task=task.name, language=language.code
             )
             break
-        except (HuggingFaceHubDown, RequestException):
+        except (HuggingFaceHubDown, RequestException, ConnectionError):
             time.sleep(5)
     else:
         pytest.skip(reason="Hugging Face Hub is down, so we skip this test.")
@@ -68,7 +68,7 @@ def test_benchmark_generative(
                 model=generative_model_id, task=task.name, language=language.code
             )
             break
-        except (HuggingFaceHubDown, RequestException):
+        except (HuggingFaceHubDown, RequestException, ConnectionError):
             time.sleep(5)
     else:
         pytest.skip(reason="Hugging Face Hub is down, so we skip this test.")
@@ -97,7 +97,7 @@ def test_benchmark_generative_adapter(
                 language=language.code,
             )
             break
-        except (HuggingFaceHubDown, RequestException):
+        except (HuggingFaceHubDown, RequestException, ConnectionError):
             time.sleep(5)
     else:
         pytest.skip(reason="Hugging Face Hub is down, so we skip this test.")

--- a/uv.lock
+++ b/uv.lock
@@ -295,8 +295,8 @@ name = "bitsandbytes"
 version = "0.45.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "torch" },
+    { name = "numpy", marker = "sys_platform != 'darwin'" },
+    { name = "torch", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/0f/3a5f062c0ed2252ed128ff028b36d2a46a763a2919b00f12ca5274493ff3/bitsandbytes-0.45.3-py3-none-manylinux_2_24_x86_64.whl", hash = "sha256:720d67ffa8a5c61c958fb62517e8abbb2ab0ac1b33b66506ae911cb34c836c70", size = 76058963 },
@@ -482,9 +482,9 @@ name = "compressed-tensors"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
-    { name = "torch" },
-    { name = "transformers" },
+    { name = "pydantic", marker = "sys_platform != 'darwin'" },
+    { name = "torch", marker = "sys_platform != 'darwin'" },
+    { name = "transformers", marker = "sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/24/12/04c22851e064fa05eb8b5f311f24867297624a76088a614937d86117776f/compressed-tensors-0.8.0.tar.gz", hash = "sha256:48f3ff5d123cc7536d157fc60e4c5a36fd80b620e60e5d89386fa5ce5b327c4c", size = 56138 }
 wheels = [
@@ -775,6 +775,7 @@ dependencies = [
     { name = "scikit-learn" },
     { name = "sentencepiece" },
     { name = "seqeval" },
+    { name = "setuptools" },
     { name = "tenacity" },
     { name = "termcolor" },
     { name = "torch" },
@@ -867,6 +868,7 @@ requires-dist = [
     { name = "scikit-learn", specifier = "<1.6.0" },
     { name = "sentencepiece", specifier = ">=0.1.96" },
     { name = "seqeval", specifier = ">=1.2.2" },
+    { name = "setuptools", specifier = ">=75.8.2" },
     { name = "tenacity", specifier = ">=9.0.0" },
     { name = "termcolor", specifier = ">=2.0.0" },
     { name = "torch", specifier = ">=2.3.0" },
@@ -969,7 +971,7 @@ name = "fbgemm-gpu"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/9c/a0820c23afe153d13e5b0b8e3218550cca794398fc0f4e42eb34eeae54a3/fbgemm_gpu-1.1.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:97b88a8f6895b0369782f84e31352b9b0dd548cdd10cbb14da6892bc3f792a51", size = 417175644 },
@@ -1125,9 +1127,9 @@ name = "gguf"
 version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "pyyaml" },
-    { name = "tqdm" },
+    { name = "numpy", marker = "sys_platform != 'darwin'" },
+    { name = "pyyaml", marker = "sys_platform != 'darwin'" },
+    { name = "tqdm", marker = "sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/c4/a159e9f842b0e8b8495b2689af6cf3426f002cf01207ca8134db82fc4088/gguf-0.10.0.tar.gz", hash = "sha256:52a30ef26328b419ffc47d9269fc580c238edf1c8a19b5ea143c323e04a038c1", size = 65704 }
 wheels = [
@@ -1681,10 +1683,10 @@ name = "lm-format-enforcer"
 version = "0.10.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "interegular" },
-    { name = "packaging" },
-    { name = "pydantic" },
-    { name = "pyyaml" },
+    { name = "interegular", marker = "sys_platform != 'darwin'" },
+    { name = "packaging", marker = "sys_platform != 'darwin'" },
+    { name = "pydantic", marker = "sys_platform != 'darwin'" },
+    { name = "pyyaml", marker = "sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/cc/8a5bf6706385c89474161081d2eeec4dd9cef12dc29cca6acc872685ceb6/lm_format_enforcer-0.10.11.tar.gz", hash = "sha256:8ab371924e166a1df68f243aca73a8a647bea5909f37edd6a53a694e7e7c3274", size = 39390 }
 wheels = [
@@ -1907,14 +1909,14 @@ name = "mistral-common"
 version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonschema" },
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "sentencepiece" },
-    { name = "tiktoken" },
-    { name = "typing-extensions" },
+    { name = "jsonschema", marker = "sys_platform != 'darwin'" },
+    { name = "numpy", marker = "sys_platform != 'darwin'" },
+    { name = "pillow", marker = "sys_platform != 'darwin'" },
+    { name = "pydantic", marker = "sys_platform != 'darwin'" },
+    { name = "requests", marker = "sys_platform != 'darwin'" },
+    { name = "sentencepiece", marker = "sys_platform != 'darwin'" },
+    { name = "tiktoken", marker = "sys_platform != 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/43/09/21752753352fe9cdb15d3f9179086c23da75670c4031ce61e54fcef12ab7/mistral_common-1.5.3.tar.gz", hash = "sha256:1e9cc740197a55f9bc20d44160ce9230d9fff399da2e781d91c2677011765eff", size = 6269649 }
 wheels = [
@@ -1923,7 +1925,7 @@ wheels = [
 
 [package.optional-dependencies]
 opencv = [
-    { name = "opencv-python-headless" },
+    { name = "opencv-python-headless", marker = "sys_platform != 'darwin'" },
 ]
 
 [[package]]
@@ -2322,8 +2324,8 @@ name = "numba"
 version = "0.61.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "llvmlite" },
-    { name = "numpy" },
+    { name = "llvmlite", marker = "sys_platform != 'darwin'" },
+    { name = "numpy", marker = "sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3c/88/c13a935f200fda51384411e49840a8e7f70c9cb1ee8d809dd0f2477cf7ef/numba-0.61.0.tar.gz", hash = "sha256:888d2e89b8160899e19591467e8fdd4970e07606e1fbc248f239c89818d5f925", size = 2816484 }
 wheels = [
@@ -2406,7 +2408,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.1.0.70"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/fd/713452cd72343f682b1c7b9321e23829f00b842ceaedcda96e742ea0b0b3/nvidia_cudnn_cu12-9.1.0.70-py3-none-manylinux2014_x86_64.whl", hash = "sha256:165764f44ef8c61fcdfdfdbe769d687e06374059fbb388b6c89ecb0e28793a6f", size = 664752741 },
@@ -2417,7 +2419,7 @@ name = "nvidia-cufft-cu12"
 version = "11.2.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/94/3266821f65b92b3138631e9c8e7fe1fb513804ac934485a8d05776e1dd43/nvidia_cufft_cu12-11.2.1.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f083fc24912aa410be21fa16d157fed2055dab1cc4b6934a0e03cba69eb242b9", size = 211459117 },
@@ -2436,9 +2438,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.6.1.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "nvidia-cusparse-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/e1/5b9089a4b2a4790dfdea8b3a006052cfecff58139d5a4e34cb1a51df8d6f/nvidia_cusolver_cu12-11.6.1.9-py3-none-manylinux2014_x86_64.whl", hash = "sha256:19e33fa442bcfd085b3086c4ebf7e8debc07cfe01e11513cc6d332fd918ac260", size = 127936057 },
@@ -2449,7 +2451,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.3.1.170"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/f7/97a9ea26ed4bbbfc2d470994b8b4f338ef663be97b8f677519ac195e113d/nvidia_cusparse_cu12-12.3.1.170-py3-none-manylinux2014_x86_64.whl", hash = "sha256:ea4f11a2904e2a8dc4b1833cc1b5181cde564edd0d5cd33e3c168eff2d1863f1", size = 207454763 },
@@ -2512,7 +2514,7 @@ name = "opencv-python-headless"
 version = "4.11.0.86"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/2f/5b2b3ba52c864848885ba988f24b7f105052f68da9ab0e693cc7c25b0b30/opencv-python-headless-4.11.0.86.tar.gz", hash = "sha256:996eb282ca4b43ec6a3972414de0e2331f5d9cda2b41091a49739c19fb843798", size = 95177929 }
 wheels = [
@@ -2585,23 +2587,23 @@ name = "outlines"
 version = "0.0.46"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cloudpickle" },
-    { name = "datasets" },
-    { name = "diskcache" },
-    { name = "interegular" },
-    { name = "jinja2" },
-    { name = "jsonschema" },
-    { name = "lark" },
-    { name = "nest-asyncio" },
-    { name = "numba" },
-    { name = "numpy" },
-    { name = "pyairports" },
-    { name = "pycountry" },
-    { name = "pydantic" },
-    { name = "referencing" },
-    { name = "requests" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
+    { name = "cloudpickle", marker = "sys_platform != 'darwin'" },
+    { name = "datasets", marker = "sys_platform != 'darwin'" },
+    { name = "diskcache", marker = "sys_platform != 'darwin'" },
+    { name = "interegular", marker = "sys_platform != 'darwin'" },
+    { name = "jinja2", marker = "sys_platform != 'darwin'" },
+    { name = "jsonschema", marker = "sys_platform != 'darwin'" },
+    { name = "lark", marker = "sys_platform != 'darwin'" },
+    { name = "nest-asyncio", marker = "sys_platform != 'darwin'" },
+    { name = "numba", marker = "sys_platform != 'darwin'" },
+    { name = "numpy", marker = "sys_platform != 'darwin'" },
+    { name = "pyairports", marker = "sys_platform != 'darwin'" },
+    { name = "pycountry", marker = "sys_platform != 'darwin'" },
+    { name = "pydantic", marker = "sys_platform != 'darwin'" },
+    { name = "referencing", marker = "sys_platform != 'darwin'" },
+    { name = "requests", marker = "sys_platform != 'darwin'" },
+    { name = "tqdm", marker = "sys_platform != 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8d/90/4c63b1b99960905ee2dd0c1b6d8bf059bf000619ccdb2ad89b41bb30efeb/outlines-0.0.46.tar.gz", hash = "sha256:cd272418a268e0a25b7189180dfdcf9fe1b99f50ac1dfb9ffd83c896c5b3fa3c", size = 2062878 }
 wheels = [
@@ -2837,8 +2839,8 @@ name = "prometheus-fastapi-instrumentator"
 version = "7.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "prometheus-client" },
-    { name = "starlette" },
+    { name = "prometheus-client", marker = "sys_platform != 'darwin'" },
+    { name = "starlette", marker = "sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/01/e3ccb464ba9bf6c001ad85652e6fc7e63098c2685275a682cabc8e7871b8/prometheus_fastapi_instrumentator-7.0.2.tar.gz", hash = "sha256:8a4d8fb13dbe19d2882ac6af9ce236e4e1f98dc48e3fa44fe88d8e23ac3c953f", size = 19844 }
 wheels = [
@@ -3328,7 +3330,7 @@ name = "pyzmq"
 version = "26.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "implementation_name == 'pypy'" },
+    { name = "cffi", marker = "implementation_name == 'pypy' and sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/e3/8d0382cb59feb111c252b54e8728257416a38ffcb2243c4e4775a3c990fe/pyzmq-26.2.1.tar.gz", hash = "sha256:17d72a74e5e9ff3829deb72897a175333d3ef5b5413948cae3cf7ebf0b02ecca", size = 278433 }
 wheels = [
@@ -3457,16 +3459,16 @@ name = "ray"
 version = "2.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiosignal" },
-    { name = "click" },
-    { name = "filelock" },
-    { name = "frozenlist" },
-    { name = "jsonschema" },
-    { name = "msgpack" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "pyyaml" },
-    { name = "requests" },
+    { name = "aiosignal", marker = "sys_platform != 'darwin'" },
+    { name = "click", marker = "sys_platform != 'darwin'" },
+    { name = "filelock", marker = "sys_platform != 'darwin'" },
+    { name = "frozenlist", marker = "sys_platform != 'darwin'" },
+    { name = "jsonschema", marker = "sys_platform != 'darwin'" },
+    { name = "msgpack", marker = "sys_platform != 'darwin'" },
+    { name = "packaging", marker = "sys_platform != 'darwin'" },
+    { name = "protobuf", marker = "sys_platform != 'darwin'" },
+    { name = "pyyaml", marker = "sys_platform != 'darwin'" },
+    { name = "requests", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/73/5c72af1a2bcd791d50f8c2ec58b148cefdbdcd37155b887b89365131c4af/ray-2.43.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:57381c54f200e6c0203d5f70ac6f882b13cc1a80faf336518787a39a6d6f65d0", size = 66703785 },
@@ -4166,9 +4168,9 @@ name = "torchvision"
 version = "0.20.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "torch" },
+    { name = "numpy", marker = "sys_platform != 'darwin'" },
+    { name = "pillow", marker = "sys_platform != 'darwin'" },
+    { name = "torch", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/f6/7ff89a9f8703f623f5664afd66c8600e3f09fe188e1e0b7e6f9a8617f865/torchvision-0.20.1-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:8ffbdf8bf5b30eade22d459f5a313329eeadb20dc75efa142987b53c007098c3", size = 7238975 },
@@ -4226,7 +4228,7 @@ name = "triton"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock", marker = "python_full_version < '3.13'" },
+    { name = "filelock", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/29/69aa56dc0b2eb2602b553881e34243475ea2afd9699be042316842788ff5/triton-3.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b0dd10a925263abbe9fa37dcde67a5e9b2383fc269fdf59f5657cac38c5d1d8", size = 209460013 },
@@ -4400,12 +4402,12 @@ wheels = [
 [package.optional-dependencies]
 standard = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "httptools" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
-    { name = "watchfiles" },
-    { name = "websockets" },
+    { name = "httptools", marker = "sys_platform != 'darwin'" },
+    { name = "python-dotenv", marker = "sys_platform != 'darwin'" },
+    { name = "pyyaml", marker = "sys_platform != 'darwin'" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "watchfiles", marker = "sys_platform != 'darwin'" },
+    { name = "websockets", marker = "sys_platform != 'darwin'" },
 ]
 
 [[package]]
@@ -4451,43 +4453,43 @@ name = "vllm"
 version = "0.6.4.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "compressed-tensors" },
-    { name = "einops" },
-    { name = "fastapi" },
-    { name = "filelock" },
-    { name = "gguf" },
-    { name = "importlib-metadata" },
-    { name = "lm-format-enforcer" },
-    { name = "mistral-common", extra = ["opencv"] },
-    { name = "msgspec" },
-    { name = "numpy" },
-    { name = "nvidia-ml-py" },
-    { name = "openai" },
-    { name = "outlines" },
-    { name = "partial-json-parser" },
-    { name = "pillow" },
-    { name = "prometheus-client" },
-    { name = "prometheus-fastapi-instrumentator" },
-    { name = "protobuf" },
-    { name = "psutil" },
-    { name = "py-cpuinfo" },
-    { name = "pydantic" },
-    { name = "pyyaml" },
-    { name = "pyzmq" },
-    { name = "ray" },
-    { name = "requests" },
-    { name = "sentencepiece" },
-    { name = "setuptools", marker = "python_full_version >= '3.12'" },
-    { name = "six", marker = "python_full_version >= '3.12'" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
-    { name = "torch" },
-    { name = "torchvision" },
-    { name = "tqdm" },
-    { name = "transformers" },
-    { name = "typing-extensions" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "aiohttp", marker = "sys_platform != 'darwin'" },
+    { name = "compressed-tensors", marker = "sys_platform != 'darwin'" },
+    { name = "einops", marker = "sys_platform != 'darwin'" },
+    { name = "fastapi", marker = "sys_platform != 'darwin'" },
+    { name = "filelock", marker = "sys_platform != 'darwin'" },
+    { name = "gguf", marker = "sys_platform != 'darwin'" },
+    { name = "importlib-metadata", marker = "sys_platform != 'darwin'" },
+    { name = "lm-format-enforcer", marker = "sys_platform != 'darwin'" },
+    { name = "mistral-common", extra = ["opencv"], marker = "sys_platform != 'darwin'" },
+    { name = "msgspec", marker = "sys_platform != 'darwin'" },
+    { name = "numpy", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-ml-py", marker = "sys_platform != 'darwin'" },
+    { name = "openai", marker = "sys_platform != 'darwin'" },
+    { name = "outlines", marker = "sys_platform != 'darwin'" },
+    { name = "partial-json-parser", marker = "sys_platform != 'darwin'" },
+    { name = "pillow", marker = "sys_platform != 'darwin'" },
+    { name = "prometheus-client", marker = "sys_platform != 'darwin'" },
+    { name = "prometheus-fastapi-instrumentator", marker = "sys_platform != 'darwin'" },
+    { name = "protobuf", marker = "sys_platform != 'darwin'" },
+    { name = "psutil", marker = "sys_platform != 'darwin'" },
+    { name = "py-cpuinfo", marker = "sys_platform != 'darwin'" },
+    { name = "pydantic", marker = "sys_platform != 'darwin'" },
+    { name = "pyyaml", marker = "sys_platform != 'darwin'" },
+    { name = "pyzmq", marker = "sys_platform != 'darwin'" },
+    { name = "ray", marker = "sys_platform != 'darwin'" },
+    { name = "requests", marker = "sys_platform != 'darwin'" },
+    { name = "sentencepiece", marker = "sys_platform != 'darwin'" },
+    { name = "setuptools", marker = "python_full_version >= '3.12' and sys_platform != 'darwin'" },
+    { name = "six", marker = "python_full_version >= '3.12' and sys_platform != 'darwin'" },
+    { name = "tiktoken", marker = "sys_platform != 'darwin'" },
+    { name = "tokenizers", marker = "sys_platform != 'darwin'" },
+    { name = "torch", marker = "sys_platform != 'darwin'" },
+    { name = "torchvision", marker = "sys_platform != 'darwin'" },
+    { name = "tqdm", marker = "sys_platform != 'darwin'" },
+    { name = "transformers", marker = "sys_platform != 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
+    { name = "uvicorn", extra = ["standard"], marker = "sys_platform != 'darwin'" },
     { name = "xformers", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/52/c0/b32d3fb5e863ab95e57afb5271e262b3ed93d6103fc39c9bfeee055b43c5/vllm-0.6.4.post1.tar.gz", hash = "sha256:3cf6fdb46f50fa66cbeec87738e4b91bf2cb086979b4fc74a782cd30f75d1af1", size = 3112461 }
@@ -4532,7 +4534,7 @@ name = "watchfiles"
 version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", marker = "sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/26/c705fc77d0a9ecdb9b66f1e2976d95b81df3cae518967431e7dbf9b5e219/watchfiles-1.0.4.tar.gz", hash = "sha256:6ba473efd11062d73e4f00c2b730255f9c1bdd73cd5f9fe5b5da8dbd4a717205", size = 94625 }
 wheels = [
@@ -4648,8 +4650,8 @@ name = "xformers"
 version = "0.0.28.post3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "torch" },
+    { name = "numpy", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "torch", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/00/d8/7301b2044e29b384b6ec009ed37002f4df48906a2a772654e8386fa3b730/xformers-0.0.28.post3.tar.gz", hash = "sha256:c7a2392c874dfd8f38b73e14492baf048a4f50f77ddf522bfcf6ebf5ee84d567", size = 7758532 }
 wheels = [


### PR DESCRIPTION
### Fixed
- A bug caused fresh encoder models to not be benchmarkable on the speed benchmark -
  this has been fixed now.
- Some encoder models were not able to be evaluated on reading comprehensions, if their
  tokenizers were not subclassing `PreTrainedTokenizer`. This has been relaxed to
  `PreTrainedTokenizerBase` instead.
- Newer versions of the `transformers` package changed the model output format, causing
  errors when evaluating encoder models on some tasks. This has been fixed now.
- Added `setuptools` to the dependencies, as it is required for the package to be
  installed correctly.

Fixes #824.