### PR TITLE
fix: Handle ConnectionError when loading datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Fixed
+- Now handles`ConnectionError`s when loading datasets, rather than aborting evaluations.
 
 
 ## [v15.3.0] - 2025-03-12


### PR DESCRIPTION
### Fixed
- Now handles`ConnectionError`s when loading datasets, rather than aborting evaluations.