### PR TITLE
feat: Do not include speed by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Changed
+- Now does not include the speed benchmark by default, as it is not used in the official
+  leaderboards. It can still be used by including `--task speed` when benchmarking a
+  model, or by using the `task` argument if using the `Benchmarker` API.
 
 
 ## [v15.3.1] - 2025-03-13

--- a/src/euroeval/benchmark_config_factory.py
+++ b/src/euroeval/benchmark_config_factory.py
@@ -12,7 +12,7 @@ from .dataset_configs import get_all_dataset_configs
 from .enums import Device
 from .exceptions import InvalidBenchmark
 from .languages import get_all_languages
-from .tasks import get_all_tasks
+from .tasks import SPEED, get_all_tasks
 from .utils import log_once
 
 if t.TYPE_CHECKING:
@@ -294,7 +294,7 @@ def prepare_tasks_and_datasets(
     # Create the list of dataset tasks
     try:
         if task is None:
-            tasks = list(task_mapping.values())
+            tasks = [t for t in task_mapping.values() if t != SPEED]
         elif isinstance(task, str):
             tasks = [task_mapping[task]]
         else:


### PR DESCRIPTION
### Changed
- Now does not include the speed benchmark by default, as it is not used in the official
  leaderboards. It can still be used by including `--task speed` when benchmarking a
  model, or by using the `task` argument if using the `Benchmarker` API.