### PR TITLE
fix: Handle ReadTimeout errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   we use the inner-most dictionary. This caused issues with Anthropic models, since they
   do not support structured generation, and their output are always {"input": actual
   dictionary}. This has been fixed now.
+- Now handles `ReadTimeout`s when loading datasets, rather than aborting evaluations.
 
 ### Changed
 - Moved the `demjson3` dependency from the `generative` extra to the main dependencies,
@@ -23,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [v15.3.1] - 2025-03-13
 ### Fixed
-- Now handles`ConnectionError`s when loading datasets, rather than aborting evaluations.
+- Now handles `ConnectionError`s when loading datasets, rather than aborting evaluations.
 
 
 ## [v15.3.0] - 2025-03-12

--- a/src/euroeval/data_loading.py
+++ b/src/euroeval/data_loading.py
@@ -8,6 +8,7 @@ from datasets import Dataset, DatasetDict, load_dataset
 from datasets.exceptions import DatasetsError
 from huggingface_hub.errors import HfHubHTTPError
 from numpy.random import Generator
+from requests import ReadTimeout
 
 from .data_models import BenchmarkConfig, DatasetConfig
 from .exceptions import HuggingFaceHubDown, InvalidBenchmark
@@ -47,7 +48,7 @@ def load_data(
                 token=unscramble("HjccJFhIozVymqXDVqTUTXKvYhZMTbfIjMxG_"),
             )
             break
-        except (FileNotFoundError, DatasetsError, ConnectionError):
+        except (FileNotFoundError, DatasetsError, ConnectionError, ReadTimeout):
             logger.warning(
                 f"Failed to load dataset {dataset_config.huggingface_id!r}. Retrying..."
             )

--- a/tests/test_benchmark_config_factory.py
+++ b/tests/test_benchmark_config_factory.py
@@ -22,7 +22,11 @@ from euroeval.tasks import LA, NER, SENT, SPEED, get_all_tasks
 @pytest.fixture(scope="module")
 def all_official_dataset_names() -> Generator[list[str], None, None]:
     """Fixture for all linguistic acceptability dataset configurations."""
-    yield [cfg.name for cfg in get_all_dataset_configs().values() if not cfg.unofficial]
+    yield [
+        cfg.name
+        for cfg in get_all_dataset_configs().values()
+        if not cfg.unofficial and cfg.task != SPEED
+    ]
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
### Fixed
- Now handles `ReadTimeout`s when loading datasets, rather than aborting evaluations.

Fixes #832 