### PR TITLE
fix: Use `benchmark_config` argument in `_benchmark_single`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   do not support structured generation, and their output are always {"input": actual
   dictionary}. This has been fixed now.
 - Now handles `ReadTimeout`s when loading datasets, rather than aborting evaluations.
+- Benchmark configurations specified when calling `Benchmarker.benchmark` did not
+  properly override the default configurations set during initialisation when
+  benchmarking generative models. This has been fixed now.
 
 ### Changed
 - Moved the `demjson3` dependency from the `generative` extra to the main dependencies,

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -709,7 +709,7 @@ class Benchmarker:
 
                 if dataset_config.task == SPEED:
                     scores = benchmark_speed(
-                        model=model, benchmark_config=self.benchmark_config
+                        model=model, benchmark_config=benchmark_config
                     )
 
                 else:
@@ -727,7 +727,7 @@ class Benchmarker:
                             datasets=prepared_datasets,
                             model_config=model_config,
                             dataset_config=dataset_config,
-                            benchmark_config=self.benchmark_config,
+                            benchmark_config=benchmark_config,
                         )
                     else:
                         scores = finetune(


### PR DESCRIPTION
### Fixed
- Benchmark configurations specified when calling `Benchmarker.benchmark` did not
  properly override the default configurations set during initialisation when
  benchmarking generative models. This has been fixed now.

Fixes #842 