### PR TITLE
feat: Add inline script metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ $ uv run src/scripts/<name-of-script>.py
 Replace <name-of-script> with the specific script you wish to execute, e.g.,
 
 ```shell
-uv run src/scripts/create_allocine.py
+$ uv run src/scripts/create_allocine.py
 ```
 
 ## Special Thanks :pray:

--- a/README.md
+++ b/README.md
@@ -129,6 +129,19 @@ argument. This could for instance be `--model <model-id> --task
 sentiment-classification`.
 
 
+### Reproducing the datasets
+All datasets used in this project are generated using the scripts located in the [src/scripts](src/scripts) folder. To reproduce a dataset, run the corresponding script with the following command
+
+```shell
+$ uv run src/scripts/<name-of-script>.py
+```
+
+Replace <name-of-script> with the specific script you wish to execute, e.g.,
+
+```shell
+uv run src/scripts/create_allocine.py
+```
+
 ## Special Thanks :pray:
 - Thanks [@Mikeriess](https://github.com/Mikeriess) for evaluating many of the larger
   models on the leaderboards.

--- a/src/scripts/create_allocine.py
+++ b/src/scripts/create_allocine.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10,<4.0"
+# requires-python = ">=3.10"
 # dependencies = [
 #     "datasets",
 #     "huggingface-hub",

--- a/src/scripts/create_allocine.py
+++ b/src/scripts/create_allocine.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the Allocine-mini sentiment dataset and upload it to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_allocine.py
+++ b/src/scripts/create_allocine.py
@@ -1,10 +1,10 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_arc.py
+++ b/src/scripts/create_arc.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the ARC-mini datasets and upload them to the HF Hub."""
 
 from collections import Counter

--- a/src/scripts/create_arc.py
+++ b/src/scripts/create_arc.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_arc_is.py
+++ b/src/scripts/create_arc_is.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the ARC-mini datasets and upload them to the HF Hub."""
 
 from collections import Counter

--- a/src/scripts/create_arc_is.py
+++ b/src/scripts/create_arc_is.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_belebele.py
+++ b/src/scripts/create_belebele.py
@@ -1,11 +1,11 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
-#     "scikit-learn",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
+#     "scikit-learn<1.6.0",
 # ]
 # ///
 

--- a/src/scripts/create_belebele.py
+++ b/src/scripts/create_belebele.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+#     "scikit-learn",
+# ]
+# ///
+
 """Create the Belebele-mini datasets and upload them to the HF Hub."""
 
 import re

--- a/src/scripts/create_cnn_dailymail.py
+++ b/src/scripts/create_cnn_dailymail.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the CNN-DailyMail-mini summarisation dataset."""
 
 import pandas as pd

--- a/src/scripts/create_cnn_dailymail.py
+++ b/src/scripts/create_cnn_dailymail.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_conll_en.py
+++ b/src/scripts/create_conll_en.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_conll_en.py
+++ b/src/scripts/create_conll_en.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the CoNLL-EN-mini NER dataset and upload it to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_conll_es.py
+++ b/src/scripts/create_conll_es.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
+# ]
+# ///
+
 """Create the CoNLL-ES-mini NER dataset and upload it to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_conll_nl.py
+++ b/src/scripts/create_conll_nl.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the CoNLL-NL-mini NER dataset and upload it to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_conll_nl.py
+++ b/src/scripts/create_conll_nl.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_dane.py
+++ b/src/scripts/create_dane.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the DaNE-mini NER dataset and upload it to the HF Hub."""
 
 import re

--- a/src/scripts/create_dane.py
+++ b/src/scripts/create_dane.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_danish_citizen_tests.py
+++ b/src/scripts/create_danish_citizen_tests.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+#     "python-dotenv",
+# ]
+# ///
+
 """Create the Danish Citizen Tests dataset and upload it to the HF Hub."""
 
 import os

--- a/src/scripts/create_danish_citizen_tests.py
+++ b/src/scripts/create_danish_citizen_tests.py
@@ -1,11 +1,11 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
-#     "python-dotenv",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
+#     "python-dotenv==1.0.1",
 # ]
 # ///
 

--- a/src/scripts/create_dansk.py
+++ b/src/scripts/create_dansk.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the DANSK-mini NER dataset and upload it to the HF Hub."""
 
 from dataclasses import dataclass

--- a/src/scripts/create_dansk.py
+++ b/src/scripts/create_dansk.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_danske_talemaader.py
+++ b/src/scripts/create_danske_talemaader.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+#     "scikit-learn",
+# ]
+# ///
+
 """Create the the Danske Talemåder dataset and upload it to the HF Hub."""
 
 import io

--- a/src/scripts/create_danske_talemaader.py
+++ b/src/scripts/create_danske_talemaader.py
@@ -1,11 +1,11 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
-#     "scikit-learn",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
+#     "scikit-learn<1.6.0",
 # ]
 # ///
 

--- a/src/scripts/create_danske_talemaader_old.py
+++ b/src/scripts/create_danske_talemaader_old.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+#     "scikit-learn",
+# ]
+# ///
+
 """Create the old version of the DanskeTalemåder dataset and upload it to the HF Hub."""
 
 from collections import Counter

--- a/src/scripts/create_danske_talemaader_old.py
+++ b/src/scripts/create_danske_talemaader_old.py
@@ -1,11 +1,11 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
-#     "scikit-learn",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
+#     "scikit-learn<1.6.0",
 # ]
 # ///
 

--- a/src/scripts/create_dbrd.py
+++ b/src/scripts/create_dbrd.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the SST5-mini sentiment dataset and upload it to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_dbrd.py
+++ b/src/scripts/create_dbrd.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_dutch_cola.py
+++ b/src/scripts/create_dutch_cola.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the Dutch CoLA dataset and upload it to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_dutch_cola.py
+++ b/src/scripts/create_dutch_cola.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_dutch_social.py
+++ b/src/scripts/create_dutch_social.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the DutchSocial-mini sentiment dataset and upload it to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_dutch_social.py
+++ b/src/scripts/create_dutch_social.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_eltec.py
+++ b/src/scripts/create_eltec.py
@@ -33,7 +33,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("create_eltec")
 
 
-nltk.download("punkt")
+nltk.download("punkt_tab")
 
 
 def main() -> None:

--- a/src/scripts/create_eltec.py
+++ b/src/scripts/create_eltec.py
@@ -1,3 +1,16 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "nltk",
+#     "pandas",
+#     "requests",
+#     "tqdm",
+#     "urllib3",
+# ]
+# ///
+
 """Create the ELTEC-mini NER dataset and upload it to the HF Hub."""
 
 import io

--- a/src/scripts/create_eltec.py
+++ b/src/scripts/create_eltec.py
@@ -1,13 +1,13 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "nltk",
-#     "pandas",
-#     "requests",
-#     "tqdm",
-#     "urllib3",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "nltk==3.9.1",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
+#     "tqdm==4.67.1",
+#     "urllib3==2.3.0",
 # ]
 # ///
 

--- a/src/scripts/create_fone.py
+++ b/src/scripts/create_fone.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the FoNE-mini NER dataset and upload it to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_fone.py
+++ b/src/scripts/create_fone.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_foqa.py
+++ b/src/scripts/create_foqa.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the FoQA dataset and upload them to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_foqa.py
+++ b/src/scripts/create_foqa.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_fosent.py
+++ b/src/scripts/create_fosent.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the FoSent sentiment dataset and upload it to the HF Hub."""
 
 import hashlib

--- a/src/scripts/create_fosent.py
+++ b/src/scripts/create_fosent.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_fquad.py
+++ b/src/scripts/create_fquad.py
@@ -1,11 +1,11 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "click",
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "click==8.1.3",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_fquad.py
+++ b/src/scripts/create_fquad.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "click",
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the FQuAD-mini NER dataset and upload it to the HF Hub."""
 
 from collections import defaultdict

--- a/src/scripts/create_germanquad.py
+++ b/src/scripts/create_germanquad.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the GermanQuAD-mini dataset and upload them to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_germanquad.py
+++ b/src/scripts/create_germanquad.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_germeval.py
+++ b/src/scripts/create_germeval.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the GermEval-mini NER dataset and upload it to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_germeval.py
+++ b/src/scripts/create_germeval.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_hellaswag.py
+++ b/src/scripts/create_hellaswag.py
@@ -1,11 +1,11 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
-#     "scikit-learn",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
+#     "scikit-learn<1.6.0",
 # ]
 # ///
 

--- a/src/scripts/create_hellaswag.py
+++ b/src/scripts/create_hellaswag.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+#     "scikit-learn",
+# ]
+# ///
+
 """Create the HellaSwag-mini datasets and upload them to the HF Hub."""
 
 from collections import Counter

--- a/src/scripts/create_hotter_and_colder_sentiment.py
+++ b/src/scripts/create_hotter_and_colder_sentiment.py
@@ -2,12 +2,12 @@
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
 #     "beautifulsoup4",
-#     "datasets",
-#     "huggingface-hub",
-#     "joblib",
-#     "pandas",
-#     "requests",
-#     "tqdm",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "joblib==1.4.2",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
+#     "tqdm==4.67.1",
 # ]
 # ///
 

--- a/src/scripts/create_hotter_and_colder_sentiment.py
+++ b/src/scripts/create_hotter_and_colder_sentiment.py
@@ -1,3 +1,16 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "beautifulsoup4",
+#     "datasets",
+#     "huggingface-hub",
+#     "joblib",
+#     "pandas",
+#     "requests",
+#     "tqdm",
+# ]
+# ///
+
 """Create the HotterAndColderSentiment dataset and upload it to the HF Hub."""
 
 import datetime as dt

--- a/src/scripts/create_ice_linguistic.py
+++ b/src/scripts/create_ice_linguistic.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create a dataset from the Icelandic Linguistic Benchmarks."""
 
 from ast import literal_eval

--- a/src/scripts/create_ice_linguistic.py
+++ b/src/scripts/create_ice_linguistic.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_icelandic_error_corpus.py
+++ b/src/scripts/create_icelandic_error_corpus.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the Icelandic Error Corpus dataset  and upload it to the HF Hub."""
 
 import re

--- a/src/scripts/create_icelandic_error_corpus.py
+++ b/src/scripts/create_icelandic_error_corpus.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_icelandic_knowledge.py
+++ b/src/scripts/create_icelandic_knowledge.py
@@ -1,14 +1,14 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "openai",
-#     "pandas",
-#     "pydantic",
-#     "python-dotenv",
-#     "requests",
-#     "tqdm",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "openai==1.66.5",
+#     "pandas==2.2.0",
+#     "pydantic==2.6.0",
+#     "python-dotenv==1.0.1",
+#     "requests==2.32.3",
+#     "tqdm==4.67.1",
 # ]
 # ///
 

--- a/src/scripts/create_icelandic_knowledge.py
+++ b/src/scripts/create_icelandic_knowledge.py
@@ -1,3 +1,17 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "openai",
+#     "pandas",
+#     "pydantic",
+#     "python-dotenv",
+#     "requests",
+#     "tqdm",
+# ]
+# ///
+
 """Create mideind/icelandic_qa_scandeval as a knowledge task dataset."""
 
 import json

--- a/src/scripts/create_icelandic_qa.py
+++ b/src/scripts/create_icelandic_qa.py
@@ -1,12 +1,12 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "openai",
-#     "pandas",
-#     "python-dotenv",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "openai==1.66.5",
+#     "pandas==2.2.0",
+#     "python-dotenv==1.0.1",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_icelandic_qa.py
+++ b/src/scripts/create_icelandic_qa.py
@@ -1,3 +1,15 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "openai",
+#     "pandas",
+#     "python-dotenv",
+#     "requests",
+# ]
+# ///
+
 """Create the Icelandic QA dataset and upload it to the HF Hub."""
 
 import os

--- a/src/scripts/create_icesum.py
+++ b/src/scripts/create_icesum.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the icesum summarisation dataset."""
 
 import io

--- a/src/scripts/create_icesum.py
+++ b/src/scripts/create_icesum.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_ilpost_sum.py
+++ b/src/scripts/create_ilpost_sum.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the ilpost summarisation dataset."""
 
 import pandas as pd

--- a/src/scripts/create_ilpost_sum.py
+++ b/src/scripts/create_ilpost_sum.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_jentoft.py
+++ b/src/scripts/create_jentoft.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the Jentoft linguistic acceptability dataset."""
 
 from logging import getLogger

--- a/src/scripts/create_jentoft.py
+++ b/src/scripts/create_jentoft.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_mlqa_es.py
+++ b/src/scripts/create_mlqa_es.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
+# ]
+# ///
+
 """Create the MLQA dataset and upload them to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_mlsum.py
+++ b/src/scripts/create_mlsum.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the MLSum-mini summarisation dataset."""
 
 import pandas as pd

--- a/src/scripts/create_mlsum_de.py
+++ b/src/scripts/create_mlsum_de.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_mlsum_es.py
+++ b/src/scripts/create_mlsum_es.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
+# ]
+# ///
+
 """Create the Spanish MLSum-mini summarisation dataset."""
 
 import pandas as pd

--- a/src/scripts/create_mmlu.py
+++ b/src/scripts/create_mmlu.py
@@ -1,11 +1,11 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
-#     "scikit-learn",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
+#     "scikit-learn<1.6.0",
 # ]
 # ///
 

--- a/src/scripts/create_mmlu.py
+++ b/src/scripts/create_mmlu.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+#     "scikit-learn",
+# ]
+# ///
+
 """Create the MMLU-mini datasets and upload them to the HF Hub."""
 
 from collections import Counter

--- a/src/scripts/create_multinerd-it.py
+++ b/src/scripts/create_multinerd-it.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the multinerd-mini-it NER dataset and upload it to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_multinerd-it.py
+++ b/src/scripts/create_multinerd-it.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_no_cola.py
+++ b/src/scripts/create_no_cola.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+#     "scikit-learn",
+# ]
+# ///
+
 """Create the NoCoLA linguistic acceptability dataset."""
 
 from logging import getLogger

--- a/src/scripts/create_no_cola.py
+++ b/src/scripts/create_no_cola.py
@@ -1,11 +1,11 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
-#     "scikit-learn",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
+#     "scikit-learn<1.6.0",
 # ]
 # ///
 

--- a/src/scripts/create_no_sammendrag.py
+++ b/src/scripts/create_no_sammendrag.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the NoSammendrag-mini summarisation dataset."""
 
 import pandas as pd

--- a/src/scripts/create_no_sammendrag.py
+++ b/src/scripts/create_no_sammendrag.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_nor_common_sense_qa.py
+++ b/src/scripts/create_nor_common_sense_qa.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the NorCommonSenseQA dataset and upload them to the HF Hub."""
 
 import warnings

--- a/src/scripts/create_nor_common_sense_qa.py
+++ b/src/scripts/create_nor_common_sense_qa.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_nordjylland_news.py
+++ b/src/scripts/create_nordjylland_news.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the NordjyllandNews-mini summarisation dataset."""
 
 import pandas as pd

--- a/src/scripts/create_nordjylland_news.py
+++ b/src/scripts/create_nordjylland_news.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_norglm_multiqa.py
+++ b/src/scripts/create_norglm_multiqa.py
@@ -1,12 +1,12 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "openai",
-#     "pandas",
-#     "python-dotenv",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "openai==1.66.5",
+#     "pandas==2.2.0",
+#     "python-dotenv==1.0.1",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_norglm_multiqa.py
+++ b/src/scripts/create_norglm_multiqa.py
@@ -1,3 +1,15 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "openai",
+#     "pandas",
+#     "python-dotenv",
+#     "requests",
+# ]
+# ///
+
 """Create the NorGLM NO-multi question answering dataset."""
 
 import ast

--- a/src/scripts/create_norglm_multisum.py
+++ b/src/scripts/create_norglm_multisum.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the NorGLM NO-multi summarisation dataset."""
 
 import pandas as pd

--- a/src/scripts/create_norglm_multisum.py
+++ b/src/scripts/create_norglm_multisum.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_norne.py
+++ b/src/scripts/create_norne.py
@@ -1,11 +1,11 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
-#     "tqdm",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
+#     "tqdm==4.67.1",
 # ]
 # ///
 

--- a/src/scripts/create_norne.py
+++ b/src/scripts/create_norne.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+#     "tqdm",
+# ]
+# ///
+
 """Create the NorNE-mini NER datasets and upload them to the HF Hub."""
 
 import re

--- a/src/scripts/create_norquad.py
+++ b/src/scripts/create_norquad.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the NorQuAD-mini dataset and upload them to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_norquad.py
+++ b/src/scripts/create_norquad.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_nqii.py
+++ b/src/scripts/create_nqii.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the NQiI-mini dataset and upload them to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_nqii.py
+++ b/src/scripts/create_nqii.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_nrk_quiz_qa.py
+++ b/src/scripts/create_nrk_quiz_qa.py
@@ -1,11 +1,11 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
-#     "scikit-learn",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
+#     "scikit-learn<1.6.0",
 # ]
 # ///
 

--- a/src/scripts/create_nrk_quiz_qa.py
+++ b/src/scripts/create_nrk_quiz_qa.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+#     "scikit-learn",
+# ]
+# ///
+
 """Create the NRK-Quiz-QA-mini dataset and upload them to the HF Hub."""
 
 import warnings

--- a/src/scripts/create_orange_sum.py
+++ b/src/scripts/create_orange_sum.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the OrangeSum-mini summarisation dataset."""
 
 import pandas as pd

--- a/src/scripts/create_orange_sum.py
+++ b/src/scripts/create_orange_sum.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_personal_sum.py
+++ b/src/scripts/create_personal_sum.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the Personal Sum summarisation dataset."""
 
 from logging import getLogger

--- a/src/scripts/create_personal_sum.py
+++ b/src/scripts/create_personal_sum.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_rrn.py
+++ b/src/scripts/create_rrn.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the RRN-mini summarisation dataset."""
 
 import pandas as pd

--- a/src/scripts/create_rrn.py
+++ b/src/scripts/create_rrn.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_sb10k.py
+++ b/src/scripts/create_sb10k.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the SB10k-mini sentiment dataset and upload it to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_sb10k.py
+++ b/src/scripts/create_sb10k.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_scala.py
+++ b/src/scripts/create_scala.py
@@ -1,12 +1,12 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
+#     "datasets==2.15.0",
 #     "euroeval",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
-#     "tqdm",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
+#     "tqdm==4.67.1",
 # ]
 # ///
 

--- a/src/scripts/create_scala.py
+++ b/src/scripts/create_scala.py
@@ -1,3 +1,15 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "euroeval",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+#     "tqdm",
+# ]
+# ///
+
 """Create the ScaLA datasets and upload them to the HF Hub."""
 
 import random

--- a/src/scripts/create_scandiqa.py
+++ b/src/scripts/create_scandiqa.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the ScandiQA-mini datasets and upload them to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_scandiqa.py
+++ b/src/scripts/create_scandiqa.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_schibsted.py
+++ b/src/scripts/create_schibsted.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the Schibsted summarisation dataset."""
 
 import pandas as pd

--- a/src/scripts/create_schibsted.py
+++ b/src/scripts/create_schibsted.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_sentiment_headlines_es.py
+++ b/src/scripts/create_sentiment_headlines_es.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
+# ]
+# ///
+
 """Create the SentimentHeadlines-es dataset and upload to HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_sentipolc16.py
+++ b/src/scripts/create_sentipolc16.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the sentipolc16-mini sentiment dataset and upload it to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_sentipolc16.py
+++ b/src/scripts/create_sentipolc16.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_squad.py
+++ b/src/scripts/create_squad.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_squad.py
+++ b/src/scripts/create_squad.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the SQuAD-mini datasets and upload them to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_squad_it.py
+++ b/src/scripts/create_squad_it.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the SQuAD-it-mini dataset and upload it to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_squad_it.py
+++ b/src/scripts/create_squad_it.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_squad_nl.py
+++ b/src/scripts/create_squad_nl.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the SQuAD-nl-mini dataset and upload them to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_squad_nl.py
+++ b/src/scripts/create_squad_nl.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_squad_nl_old.py
+++ b/src/scripts/create_squad_nl_old.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the old SQuAD-nl-mini dataset and upload them to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_squad_nl_old.py
+++ b/src/scripts/create_squad_nl_old.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_sst5.py
+++ b/src/scripts/create_sst5.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the SST5-mini sentiment dataset and upload it to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_sst5.py
+++ b/src/scripts/create_sst5.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_suc3.py
+++ b/src/scripts/create_suc3.py
@@ -1,11 +1,11 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "lxml",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "lxml==5.3.1",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_suc3.py
+++ b/src/scripts/create_suc3.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "lxml",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the SUC3-mini NER dataset and upload it to the HF Hub."""
 
 import bz2

--- a/src/scripts/create_swedn.py
+++ b/src/scripts/create_swedn.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the SweDN-mini summarisation dataset."""
 
 import pandas as pd

--- a/src/scripts/create_swedn.py
+++ b/src/scripts/create_swedn.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_swerec.py
+++ b/src/scripts/create_swerec.py
@@ -1,11 +1,11 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
-#     "scikit-learn",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
+#     "scikit-learn<1.6.0",
 # ]
 # ///
 

--- a/src/scripts/create_swerec.py
+++ b/src/scripts/create_swerec.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+#     "scikit-learn",
+# ]
+# ///
+
 """Create the SweReC-mini sentiment dataset and upload it to the HF Hub."""
 
 import io

--- a/src/scripts/create_wiki_lingua_nl.py
+++ b/src/scripts/create_wiki_lingua_nl.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the WikiLingua-NL-mini summarisation dataset."""
 
 import pandas as pd

--- a/src/scripts/create_wiki_lingua_nl.py
+++ b/src/scripts/create_wiki_lingua_nl.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_wikineural-it.py
+++ b/src/scripts/create_wikineural-it.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/create_wikineural-it.py
+++ b/src/scripts/create_wikineural-it.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Create the wikineural-mini-it NER dataset and upload it to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/create_winogrande_is.py
+++ b/src/scripts/create_winogrande_is.py
@@ -1,11 +1,11 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "datasets",
-#     "huggingface-hub",
-#     "pandas",
-#     "requests",
-#     "scikit-learn",
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
+#     "scikit-learn<1.6.0",
 # ]
 # ///
 

--- a/src/scripts/create_winogrande_is.py
+++ b/src/scripts/create_winogrande_is.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pandas",
+#     "requests",
+#     "scikit-learn",
+# ]
+# ///
+
 """Create the Winogrande-is dataset and upload it to the HF Hub."""
 
 from collections import Counter

--- a/src/scripts/create_xquad_es.py
+++ b/src/scripts/create_xquad_es.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets==2.15.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
+# ]
+# ///
+
 """Create the XQuAD-es dataset and upload it to the HF Hub."""
 
 import pandas as pd

--- a/src/scripts/fix_dot_env_file.py
+++ b/src/scripts/fix_dot_env_file.py
@@ -1,3 +1,8 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = []
+# ///
+
 """Checks related to the .env file in the repository."""
 
 from pathlib import Path

--- a/src/scripts/load_ud_pos.py
+++ b/src/scripts/load_ud_pos.py
@@ -1,3 +1,11 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "pandas",
+#     "requests",
+# ]
+# ///
+
 """Load the part-of-speech part of a Universal Dependencies treebank."""
 
 import re

--- a/src/scripts/load_ud_pos.py
+++ b/src/scripts/load_ud_pos.py
@@ -1,8 +1,8 @@
 # /// script
 # requires-python = ">=3.10,<4.0"
 # dependencies = [
-#     "pandas",
-#     "requests",
+#     "pandas==2.2.0",
+#     "requests==2.32.3",
 # ]
 # ///
 

--- a/src/scripts/versioning.py
+++ b/src/scripts/versioning.py
@@ -1,3 +1,8 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = []
+# ///
+
 """Scripts related to updating of version."""
 
 import datetime as dt


### PR DESCRIPTION
This PR closes https://github.com/EuroEval/EuroEval/issues/814 by adding inline script metadata to the scripts in [src/scripts](https://github.com/EuroEval/EuroEval/tree/main/src/scripts), e.g., 

```python
# /// script
# requires-python = ">=3.10,<4.0"
# dependencies = [
#     "datasets",
#     "huggingface-hub",
#     "pandas",
#     "requests",
# ]
# ///
```

Install uv by `curl -LsSf https://astral.sh/uv/install.sh | sh`.

To add inline script metadata do

```shell
uv init --script path/to/script.py
uv add --script path/to/script.py pandas datasets huggingface_hub requests
```

Then the script can be runned with `uv run path/to/script.py`.