### PR TITLE
fix: Do not use sliding window size as max_model_len

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Now does not include the speed benchmark by default, as it is not used in the official
   leaderboards. It can still be used by including `--task speed` when benchmarking a
   model, or by using the `task` argument if using the `Benchmarker` API.
+- Do not use sliding window sizes as candidates for maximum context length anymore, as
+  this is no longer needed.
 
 
 ## [v15.3.1] - 2025-03-13

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -881,8 +881,6 @@ def load_model_and_tokenizer(
         "max_position_embeddings",
         "max_sequence_length",
         "model_max_length",
-        "sliding_window",
-        "sliding_window_size",
         "n_positions",
     ]
     true_max_model_len_candidates: list[int] = list()


### PR DESCRIPTION
### Changed
- Do not use sliding window sizes as candidates for maximum context length anymore, as
  this is no longer needed.