### PR TITLE
fix: Truncate prompts for vLLM models with `truncate_prompt_tokens`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
       - id: ruff
         args:
           - --fix
+          - --unsafe-fixes
           - --exit-non-zero-on-fix
         types_or:
           - python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: debug-statements
+      # - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      # - id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   a `RuntimeError` when using newer versions of vLLM with multiple GPUs.
 - Now also detects reasoning tokens specified in the prompt rather than in the
   completion, which is for instance the case for the QwQ reasoning model.
+- Now sets the `truncate_prompt_tokens` argument for vLLM models, to ensure that prompts
+  that exceed the maximal sequence length are truncated correctly.
 
 ### Changed
 - Moved the `demjson3` dependency from the `generative` extra to the main dependencies,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Added support for Spanish! 🇪🇸This includes two reading comprehension datasets: [XQuAD](https://huggingface.co/datasets/google/xquad/viewer/xquad.es) and [MLQA-es](https://huggingface.co/datasets/facebook/mlqa/viewer/mlqa.es.es), the [sentiment-headlines dataset](https://huggingface.co/datasets/pysentimiento/spanish-targeted-sentiment-headlines), the linguistic acceptability dataset ScaLA with the [Spanish Universal Dependencies](https://github.com/UniversalDependencies/UD_Spanish-AnCora), the Spanish part of [mlsum](https://huggingface.co/datasets/reciTAL/mlsum), the knowledge dataset [MMLU-es](https://hf.co/datasets/alexandrainst/m_mmlu), the common-sense reasoning dataset [HellaSwag-es](https://hf.co/datasets/alexandrainst/m_hellaswag), and the named entity recognition dataset [CoNLL-es](https://aclanthology.org/W02-2024/).
+- Added support for Spanish! 🇪🇸This includes two reading comprehension datasets:
+  [XQuAD](https://huggingface.co/datasets/google/xquad/viewer/xquad.es) and
+  [MLQA-es](https://huggingface.co/datasets/facebook/mlqa/viewer/mlqa.es.es), the
+  [sentiment-headlines
+  dataset](https://huggingface.co/datasets/pysentimiento/spanish-targeted-sentiment-headlines),
+  the linguistic acceptability dataset ScaLA with the [Spanish Universal
+  Dependencies](https://github.com/UniversalDependencies/UD_Spanish-AnCora), the Spanish
+  part of [mlsum](https://huggingface.co/datasets/reciTAL/mlsum), the knowledge dataset
+  [MMLU-es](https://hf.co/datasets/alexandrainst/m_mmlu), the common-sense reasoning
+  dataset [HellaSwag-es](https://hf.co/datasets/alexandrainst/m_hellaswag), and the
+  named entity recognition dataset [CoNLL-es](https://aclanthology.org/W02-2024/). This
+  was contributed by [@oliverkinch](https://github.com/oliverkinch) ✨
 - Now extracts number of parameters and context length for Ollama models, using the
   `ollama` package. Vocabulary size is currently not available available in the `ollama`
   package, so this is not extracted for Ollama models. For this reason, the `ollama`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   a `RuntimeError` when using newer versions of vLLM with multiple GPUs.
 - Now also detects reasoning tokens specified in the prompt rather than in the
   completion, which is for instance the case for the QwQ reasoning model.
-- Now sets the `truncate_prompt_tokens` argument for vLLM models, to ensure that prompts
-  that exceed the maximal sequence length are truncated correctly.
 
 ### Changed
 - Update `vllm` to `>=0.8.0`, `transformers` to `>=4.49.0` and `torch` to `>=2.6.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   a `RuntimeError` when using newer versions of vLLM with multiple GPUs.
 - Now also detects reasoning tokens specified in the prompt rather than in the
   completion, which is for instance the case for the QwQ reasoning model.
+- Now recognises models with the pipeline tags `image-text-to-text`,
+  `audio-text-to-text` and `video-text-to-text` as generative models, which mistakenly
+  were detected as encoder models before.
 
 ### Changed
 - Update `vllm` to `>=0.8.0`, `transformers` to `>=4.49.0` and `torch` to `>=2.6.0`.

--- a/docs/datasets/dutch.md
+++ b/docs/datasets/dutch.md
@@ -75,7 +75,7 @@ and features Dutch book reviews from [Hebban.nl](https://www.hebban.nl), annotat
 sentiment labels, written by the users of the website.
 
 The original full dataset consists of 20,000 / 2,200 samples for training and testing,
-respectively. We use a 1,024 / 256 / 2,048 split for training, validation and testing,
+respectively. We use a 1,014 / 253 / 2,014 split for training, validation and testing,
 respectively (so 3,328 samples used in total). The training and testing splits are
 subsets of the original splits, and the validation split is a disjoint subset of the
 original training split.

--- a/docs/datasets/faroese.md
+++ b/docs/datasets/faroese.md
@@ -17,8 +17,8 @@ labels were manually annotated by two native speakers.
 The original full dataset consists of 245 samples, which consisted of both a news
 article, a chosen sentence from the article, and the sentiment label. We use both the
 news article and the chosen sentence as two separate samples, to increase the size of
-the dataset (keeping them within the same dataset split). In total, we use a 74 / 35 /
-283 split for training, validation and testing, respectively.
+the dataset (keeping them within the same dataset split). In total, we use a 72 / 40 /
+279 split for training, validation and testing, respectively.
 
 Here are a few examples from the training split:
 

--- a/docs/datasets/icelandic.md
+++ b/docs/datasets/icelandic.md
@@ -13,7 +13,7 @@ This dataset is being published in an upcoming paper, and consists of texts from
 Icelandic blog post, annotated with sentiment labels (and many others) via a
 crowdsourcing platform.
 
-The original full dataset consists of 2,901 samples, and we use a 1,024 / 256 / 1,621
+The original full dataset consists of 2,901 samples, and we use a 1,021 / 255 / 1,607
 split for training, validation and testing, respectively (so all samples are used in
 total).
 

--- a/src/euroeval/__init__.py
+++ b/src/euroeval/__init__.py
@@ -14,6 +14,7 @@ warnings.filterwarnings("ignore", category=UserWarning)
 logging.getLogger("httpx").setLevel(logging.CRITICAL)
 logging.getLogger("datasets").setLevel(logging.CRITICAL)
 logging.getLogger("vllm").setLevel(logging.CRITICAL)
+logging.getLogger("vllm.platforms").setLevel(logging.CRITICAL)
 
 # Set up logging
 fmt = colored("%(asctime)s", "light_blue") + " ⋅ " + colored("%(message)s", "green")

--- a/src/euroeval/__init__.py
+++ b/src/euroeval/__init__.py
@@ -71,6 +71,11 @@ os.environ["RAY_DISABLE_DOCKER_CPU_WARNING"] = "1"
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
 
+# Use older version v0 of vLLM, as the newer one requires XGrammar as decoding backend,
+# but XGrammar does not support having a maximal amount of elements in lists
+os.environ["VLLM_USE_V1"] = "0"
+
+
 # Set the HF_TOKEN env var to copy the HUGGINGFACE_API_KEY env var, as vLLM uses the
 # former and LiteLLM uses the latter
 if os.getenv("HUGGINGFACE_API_KEY"):

--- a/src/euroeval/benchmark_modules/hf.py
+++ b/src/euroeval/benchmark_modules/hf.py
@@ -224,8 +224,6 @@ class HuggingFaceEncoderModel(BenchmarkModule):
             "max_position_embeddings",
             "max_sequence_length",
             "model_max_length",
-            "sliding_window",
-            "sliding_window_size",
             "n_positions",
         ]
         for candidate_config_max_length in candidate_config_max_lengths:

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -338,6 +338,9 @@ class VLLMModel(HuggingFaceEncoderModel):
             temperature=0.0,
             stop=[stop_token for stop_token in stop_tokens if stop_token],
             guided_decoding=guided_decoding,
+            truncate_prompt_tokens=(
+                self._model.llm_engine.scheduler_config.max_model_len
+            ),
         )
 
         # If any of the prompts are empty then we need to replace them with a BOS token

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -332,7 +332,6 @@ class VLLMModel(HuggingFaceEncoderModel):
             if self.generative_type == GenerativeType.REASONING
             else self.dataset_config.max_generated_tokens
         )
-        breakpoint()
         sampling_params = SamplingParams(
             max_tokens=max_tokens,
             logprobs=MAX_LOGPROBS if self.buffer["output_scores"] else None,
@@ -340,7 +339,7 @@ class VLLMModel(HuggingFaceEncoderModel):
             stop=[stop_token for stop_token in stop_tokens if stop_token],
             guided_decoding=guided_decoding,
             truncate_prompt_tokens=(
-                self._model.llm_engine.scheduler_config.max_model_len
+                self._model.llm_engine.vllm_config.scheduler_config.max_model_len
             ),
         )
 

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -364,7 +364,6 @@ class VLLMModel(HuggingFaceEncoderModel):
 
         # Generate sequences using vLLM
         input_is_a_test = len(prompts) == 1 and len(set(prompts[0])) == 1
-        breakpoint()
         raw_outputs = self._model.generate(
             prompts=prompts,
             sampling_params=sampling_params,

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -898,6 +898,7 @@ def load_model_and_tokenizer(
     clear_vllm()
 
     executor_backend = "ray" if torch.cuda.device_count() > 1 else "mp"
+    breakpoint()
 
     try:
         model = LLM(

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -364,6 +364,7 @@ class VLLMModel(HuggingFaceEncoderModel):
 
         # Generate sequences using vLLM
         input_is_a_test = len(prompts) == 1 and len(set(prompts[0])) == 1
+        breakpoint()
         raw_outputs = self._model.generate(
             prompts=prompts,
             sampling_params=sampling_params,

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -342,6 +342,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                 self._model.llm_engine.vllm_config.scheduler_config.max_model_len
             ),
         )
+        breakpoint()
 
         # If any of the prompts are empty then we need to replace them with a BOS token
         # so that the vLLM model can generate from them

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -321,7 +321,7 @@ class VLLMModel(HuggingFaceEncoderModel):
             pydantic_class = create_model("AnswerFormat", **keys_and_their_types)
             schema = pydantic_class.model_json_schema()
             guided_decoding = GuidedDecodingParams(
-                json=schema, backend="outlines", whitespace_pattern=r" ?"
+                json=schema, backend="xgrammar", whitespace_pattern=r" ?"
             )
         else:
             guided_decoding = None

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -332,6 +332,7 @@ class VLLMModel(HuggingFaceEncoderModel):
             if self.generative_type == GenerativeType.REASONING
             else self.dataset_config.max_generated_tokens
         )
+        breakpoint()
         sampling_params = SamplingParams(
             max_tokens=max_tokens,
             logprobs=MAX_LOGPROBS if self.buffer["output_scores"] else None,

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -898,7 +898,6 @@ def load_model_and_tokenizer(
     clear_vllm()
 
     executor_backend = "ray" if torch.cuda.device_count() > 1 else "mp"
-    breakpoint()
 
     try:
         model = LLM(

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -321,7 +321,7 @@ class VLLMModel(HuggingFaceEncoderModel):
             pydantic_class = create_model("AnswerFormat", **keys_and_their_types)
             schema = pydantic_class.model_json_schema()
             guided_decoding = GuidedDecodingParams(
-                json=schema, backend="xgrammar", whitespace_pattern=r" ?"
+                json=schema, backend="outlines", whitespace_pattern=r" ?"
             )
         else:
             guided_decoding = None

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -338,11 +338,7 @@ class VLLMModel(HuggingFaceEncoderModel):
             temperature=0.0,
             stop=[stop_token for stop_token in stop_tokens if stop_token],
             guided_decoding=guided_decoding,
-            truncate_prompt_tokens=(
-                self._model.llm_engine.vllm_config.scheduler_config.max_model_len
-            ),
         )
-        breakpoint()
 
         # If any of the prompts are empty then we need to replace them with a BOS token
         # so that the vLLM model can generate from them

--- a/src/euroeval/constants.py
+++ b/src/euroeval/constants.py
@@ -13,7 +13,13 @@ REASONING_MAX_TOKENS = 8_192
 
 
 # The Hugging Face Hub pipeline tags used to classify models as generative
-GENERATIVE_PIPELINE_TAGS = ["text-generation", "text2text-generation"]
+GENERATIVE_PIPELINE_TAGS = [
+    "text-generation",
+    "text2text-generation",
+    "image-text-to-text",
+    "audio-text-to-text",
+    "video-text-to-text",
+]
 
 
 # Used to disallow non-generative models to be evaluated on these task groups

--- a/src/scripts/create_allocine.py
+++ b/src/scripts/create_allocine.py
@@ -1,6 +1,7 @@
 """Create the Allocine-mini sentiment dataset and upload it to the HF Hub."""
 
 import pandas as pd
+from constants import MAX_NUM_CHARS_IN_DOCUMENT, MIN_NUM_CHARS_IN_DOCUMENT  # noqa
 from datasets import Dataset, DatasetDict, Split, load_dataset
 from huggingface_hub import HfApi
 from requests import HTTPError
@@ -51,11 +52,30 @@ def main() -> None:
     val_df = val_df.reset_index(drop=True)
     test_df = test_df.reset_index(drop=True)
 
+    # Only work with samples where the document is not very large or small
+    # We do it after we have made the splits to ensure that the dataset is minimally
+    # affected.
+    new_train_df = train_df.copy()
+    new_train_df["text_len"] = new_train_df.text.str.len()
+    new_train_df = new_train_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+    new_val_df = val_df.copy()
+    new_val_df["text_len"] = new_val_df.text.str.len()
+    new_val_df = new_val_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+    new_test_df = test_df.copy()
+    new_test_df["text_len"] = new_test_df.text.str.len()
+    new_test_df = new_test_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+
     # Collect datasets in a dataset dictionary
     dataset = DatasetDict(
-        train=Dataset.from_pandas(train_df, split=Split.TRAIN),
-        val=Dataset.from_pandas(val_df, split=Split.VALIDATION),
-        test=Dataset.from_pandas(test_df, split=Split.TEST),
+        train=Dataset.from_pandas(new_train_df, split=Split.TRAIN),
+        val=Dataset.from_pandas(new_val_df, split=Split.VALIDATION),
+        test=Dataset.from_pandas(new_test_df, split=Split.TEST),
     )
 
     # Create dataset ID

--- a/src/scripts/create_dbrd.py
+++ b/src/scripts/create_dbrd.py
@@ -1,6 +1,7 @@
 """Create the SST5-mini sentiment dataset and upload it to the HF Hub."""
 
 import pandas as pd
+from constants import MAX_NUM_CHARS_IN_DOCUMENT, MIN_NUM_CHARS_IN_DOCUMENT  # noqa
 from datasets import Dataset, DatasetDict, Split, load_dataset
 from huggingface_hub import HfApi
 from requests import HTTPError
@@ -46,11 +47,30 @@ def main() -> None:
     val_df = val_df.reset_index(drop=True)
     test_df = test_df.reset_index(drop=True)
 
+    # Only work with samples where the document is not very large or small
+    # We do it after we have made the splits to ensure that the dataset is minimally
+    # affected.
+    new_train_df = train_df.copy()
+    new_train_df["text_len"] = new_train_df.text.str.len()
+    new_train_df = new_train_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+    new_val_df = val_df.copy()
+    new_val_df["text_len"] = new_val_df.text.str.len()
+    new_val_df = new_val_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+    new_test_df = test_df.copy()
+    new_test_df["text_len"] = new_test_df.text.str.len()
+    new_test_df = new_test_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+
     # Collect datasets in a dataset dictionary
     dataset = DatasetDict(
-        train=Dataset.from_pandas(train_df, split=Split.TRAIN),
-        val=Dataset.from_pandas(val_df, split=Split.VALIDATION),
-        test=Dataset.from_pandas(test_df, split=Split.TEST),
+        train=Dataset.from_pandas(new_train_df, split=Split.TRAIN),
+        val=Dataset.from_pandas(new_val_df, split=Split.VALIDATION),
+        test=Dataset.from_pandas(new_test_df, split=Split.TEST),
     )
 
     # Create dataset ID

--- a/src/scripts/create_dutch_cola.py
+++ b/src/scripts/create_dutch_cola.py
@@ -1,6 +1,7 @@
 """Create the Dutch CoLA dataset and upload it to the HF Hub."""
 
 import pandas as pd
+from constants import MAX_NUM_CHARS_IN_DOCUMENT, MIN_NUM_CHARS_IN_DOCUMENT  # noqa
 from datasets import Dataset, DatasetDict, Split, load_dataset
 from huggingface_hub import HfApi
 from requests import HTTPError
@@ -93,11 +94,30 @@ def main() -> None:
     val_df = val_df.reset_index(drop=True)
     test_df = test_df.reset_index(drop=True)
 
+    # Only work with samples where the document is not very large or small
+    # We do it after we have made the splits to ensure that the dataset is minimally
+    # affected.
+    new_train_df = train_df.copy()
+    new_train_df["text_len"] = new_train_df.text.str.len()
+    new_train_df = new_train_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+    new_val_df = val_df.copy()
+    new_val_df["text_len"] = new_val_df.text.str.len()
+    new_val_df = new_val_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+    new_test_df = test_df.copy()
+    new_test_df["text_len"] = new_test_df.text.str.len()
+    new_test_df = new_test_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+
     # Collect datasets in a dataset dictionary
     dataset = DatasetDict(
-        train=Dataset.from_pandas(train_df, split=Split.TRAIN),
-        val=Dataset.from_pandas(val_df, split=Split.VALIDATION),
-        test=Dataset.from_pandas(test_df, split=Split.TEST),
+        train=Dataset.from_pandas(new_train_df, split=Split.TRAIN),
+        val=Dataset.from_pandas(new_val_df, split=Split.VALIDATION),
+        test=Dataset.from_pandas(new_test_df, split=Split.TEST),
     )
 
     dataset.push_to_hub(dataset_id, private=True)

--- a/src/scripts/create_fosent.py
+++ b/src/scripts/create_fosent.py
@@ -5,6 +5,7 @@ import logging
 from typing import Literal
 
 import pandas as pd
+from constants import MAX_NUM_CHARS_IN_DOCUMENT, MIN_NUM_CHARS_IN_DOCUMENT  # noqa
 from datasets import Dataset, DatasetDict, Split, load_dataset
 from huggingface_hub import HfApi
 from requests import HTTPError
@@ -144,11 +145,29 @@ def main() -> None:
     val_df = val_df.reset_index(drop=True)
     test_df = test_df.reset_index(drop=True)
 
-    # Collect datasets in a dataset dictionary
+    # Only work with samples where the document is not very large or small
+    # We do it after we have made the splits to ensure that the dataset is minimally
+    # affected.
+    new_train_df = train_df.copy()
+    new_train_df["text_len"] = new_train_df.text.str.len()
+    new_train_df = new_train_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+    new_val_df = val_df.copy()
+    new_val_df["text_len"] = new_val_df.text.str.len()
+    new_val_df = new_val_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+    new_test_df = test_df.copy()
+    new_test_df["text_len"] = new_test_df.text.str.len()
+    new_test_df = new_test_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+
     dataset = DatasetDict(
-        train=Dataset.from_pandas(train_df, split=Split.TRAIN),
-        val=Dataset.from_pandas(val_df, split=Split.VALIDATION),
-        test=Dataset.from_pandas(test_df, split=Split.TEST),
+        train=Dataset.from_pandas(new_train_df, split=Split.TRAIN),
+        val=Dataset.from_pandas(new_val_df, split=Split.VALIDATION),
+        test=Dataset.from_pandas(new_test_df, split=Split.TEST),
     )
 
     dataset_id = "EuroEval/fosent"

--- a/src/scripts/create_ice_linguistic.py
+++ b/src/scripts/create_ice_linguistic.py
@@ -4,6 +4,7 @@ from ast import literal_eval
 
 import pandas as pd
 import requests
+from constants import MAX_NUM_CHARS_IN_DOCUMENT, MIN_NUM_CHARS_IN_DOCUMENT  # noqa
 from datasets import Dataset, DatasetDict, Split
 from huggingface_hub import HfApi
 from requests.exceptions import HTTPError
@@ -33,10 +34,33 @@ def main() -> None:
     test_df = train_df.sample(n=test_size, random_state=4242)
     train_df = train_df.drop(test_df.index.tolist())
 
+    # Only work with samples where the document is not very large or small
+    # We do it after we have made the splits to ensure that the dataset is minimally
+    # affected.
+    new_train_df = train_df.copy()
+    new_train_df["text_len"] = new_train_df.text.str.len()
+    new_train_df = new_train_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+    new_val_df = val_df.copy()
+    new_val_df["text_len"] = new_val_df.text.str.len()
+    new_val_df = new_val_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+    new_test_df = test_df.copy()
+    new_test_df["text_len"] = new_test_df.text.str.len()
+    new_test_df = new_test_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+
     dataset = DatasetDict(
-        train=Dataset.from_pandas(train_df, split=Split.TRAIN, preserve_index=False),
-        val=Dataset.from_pandas(val_df, split=Split.VALIDATION, preserve_index=False),
-        test=Dataset.from_pandas(test_df, split=Split.TEST, preserve_index=False),
+        train=Dataset.from_pandas(
+            new_train_df, split=Split.TRAIN, preserve_index=False
+        ),
+        val=Dataset.from_pandas(
+            new_val_df, split=Split.VALIDATION, preserve_index=False
+        ),
+        test=Dataset.from_pandas(new_test_df, split=Split.TEST, preserve_index=False),
     )
 
     # Create dataset ID

--- a/src/scripts/create_icelandic_error_corpus.py
+++ b/src/scripts/create_icelandic_error_corpus.py
@@ -57,13 +57,13 @@ def main() -> None:
     # dataframes have already been shuffled.
     dataset_subset = DatasetDict(
         train=Dataset.from_pandas(
-            train_df.head(1024), split=Split.TRAIN, preserve_index=False
+            new_train_df.head(1024), split=Split.TRAIN, preserve_index=False
         ),
         val=Dataset.from_pandas(
-            val_df.head(256), split=Split.VALIDATION, preserve_index=False
+            new_val_df.head(256), split=Split.VALIDATION, preserve_index=False
         ),
         test=Dataset.from_pandas(
-            test_df.head(2048), split=Split.TEST, preserve_index=False
+            new_test_df.head(2048), split=Split.TEST, preserve_index=False
         ),
     )
 

--- a/src/scripts/create_icelandic_error_corpus.py
+++ b/src/scripts/create_icelandic_error_corpus.py
@@ -4,6 +4,7 @@ import re
 from typing import List
 
 import pandas as pd
+from constants import MAX_NUM_CHARS_IN_DOCUMENT, MIN_NUM_CHARS_IN_DOCUMENT  # noqa
 from datasets import Dataset, DatasetDict, Split, load_dataset
 from huggingface_hub import HfApi
 from requests.exceptions import HTTPError
@@ -23,10 +24,33 @@ def main() -> None:
     val_df = train_df.sample(n=val_size, random_state=4242)
     train_df = train_df.drop(val_df.index)
 
+    # Only work with samples where the document is not very large or small
+    # We do it after we have made the splits to ensure that the dataset is minimally
+    # affected.
+    new_train_df = train_df.copy()
+    new_train_df["text_len"] = new_train_df.text.str.len()
+    new_train_df = new_train_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+    new_val_df = val_df.copy()
+    new_val_df["text_len"] = new_val_df.text.str.len()
+    new_val_df = new_val_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+    new_test_df = test_df.copy()
+    new_test_df["text_len"] = new_test_df.text.str.len()
+    new_test_df = new_test_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+
     dataset = DatasetDict(
-        train=Dataset.from_pandas(train_df, split=Split.TRAIN, preserve_index=False),
-        val=Dataset.from_pandas(val_df, split=Split.VALIDATION, preserve_index=False),
-        test=Dataset.from_pandas(test_df, split=Split.TEST),
+        train=Dataset.from_pandas(
+            new_train_df, split=Split.TRAIN, preserve_index=False
+        ),
+        val=Dataset.from_pandas(
+            new_val_df, split=Split.VALIDATION, preserve_index=False
+        ),
+        test=Dataset.from_pandas(new_test_df, split=Split.TEST),
     )
 
     # Make subset of the dataset. We use `head` instead of `sample` here as the

--- a/src/scripts/create_jentoft.py
+++ b/src/scripts/create_jentoft.py
@@ -114,7 +114,7 @@ def prepare_dataset(dataset_url: str) -> pd.DataFrame:
     df = df.rename(columns={"SOURCE": "text"})
 
     # Only keep relevant columns
-    df = df.loc[["text", "label"]]
+    df = df[["text", "label"]]
 
     # Remove text duplicates
     df = df.drop_duplicates(subset=["text"])

--- a/src/scripts/create_jentoft.py
+++ b/src/scripts/create_jentoft.py
@@ -3,6 +3,7 @@
 from logging import getLogger
 
 import pandas as pd
+from constants import MAX_NUM_CHARS_IN_DOCUMENT, MIN_NUM_CHARS_IN_DOCUMENT  # noqa
 from datasets import Dataset, DatasetDict, Split
 from huggingface_hub import HfApi
 from requests import HTTPError
@@ -48,11 +49,34 @@ def main() -> None:
     test_df = sample_dataset(full_df=full_test_df, size=test_size)
     train_df = sample_dataset(full_df=full_train_df, size=train_size)
 
+    # Only work with samples where the document is not very large or small
+    # We do it after we have made the splits to ensure that the dataset is minimally
+    # affected.
+    new_train_df = train_df.copy()
+    new_train_df["text_len"] = new_train_df.text.str.len()
+    new_train_df = new_train_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+    new_val_df = val_df.copy()
+    new_val_df["text_len"] = new_val_df.text.str.len()
+    new_val_df = new_val_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+    new_test_df = test_df.copy()
+    new_test_df["text_len"] = new_test_df.text.str.len()
+    new_test_df = new_test_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+
     # Collect datasets in a dataset dictionary
     dataset = DatasetDict(
-        train=Dataset.from_pandas(train_df, split=Split.TRAIN, preserve_index=False),
-        val=Dataset.from_pandas(val_df, split=Split.VALIDATION, preserve_index=False),
-        test=Dataset.from_pandas(test_df, split=Split.TEST, preserve_index=False),
+        train=Dataset.from_pandas(
+            new_train_df, split=Split.TRAIN, preserve_index=False
+        ),
+        val=Dataset.from_pandas(
+            new_val_df, split=Split.VALIDATION, preserve_index=False
+        ),
+        test=Dataset.from_pandas(new_test_df, split=Split.TEST, preserve_index=False),
     )
 
     # Create dataset ID

--- a/src/scripts/create_mlsum_es.py
+++ b/src/scripts/create_mlsum_es.py
@@ -7,7 +7,7 @@ from huggingface_hub import HfApi
 from requests import HTTPError
 
 
-def main():
+def main() -> None:
     """Create the Spanish MLSum-mini summarisation dataset and upload to HF Hub."""
     dataset_id = "reciTAL/mlsum"
 

--- a/src/scripts/create_no_cola.py
+++ b/src/scripts/create_no_cola.py
@@ -4,6 +4,7 @@ from logging import getLogger
 
 import pandas as pd
 import requests
+from constants import MAX_NUM_CHARS_IN_DOCUMENT, MIN_NUM_CHARS_IN_DOCUMENT  # noqa
 from datasets import Dataset, DatasetDict, Split
 from huggingface_hub import HfApi
 from requests import HTTPError
@@ -69,11 +70,34 @@ def main() -> None:
     val_df = val_df.reset_index(drop=True)
     test_df = test_df.reset_index(drop=True)
 
+    # Only work with samples where the document is not very large or small
+    # We do it after we have made the splits to ensure that the dataset is minimally
+    # affected.
+    new_train_df = train_df.copy()
+    new_train_df["text_len"] = new_train_df.text.str.len()
+    new_train_df = new_train_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+    new_val_df = val_df.copy()
+    new_val_df["text_len"] = new_val_df.text.str.len()
+    new_val_df = new_val_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+    new_test_df = test_df.copy()
+    new_test_df["text_len"] = new_test_df.text.str.len()
+    new_test_df = new_test_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+
     # Collect datasets in a dataset dictionary
     dataset = DatasetDict(
-        train=Dataset.from_pandas(train_df, split=Split.TRAIN, preserve_index=False),
-        val=Dataset.from_pandas(val_df, split=Split.VALIDATION, preserve_index=False),
-        test=Dataset.from_pandas(test_df, split=Split.TEST, preserve_index=False),
+        train=Dataset.from_pandas(
+            new_train_df, split=Split.TRAIN, preserve_index=False
+        ),
+        val=Dataset.from_pandas(
+            new_val_df, split=Split.VALIDATION, preserve_index=False
+        ),
+        test=Dataset.from_pandas(new_test_df, split=Split.TEST, preserve_index=False),
     )
 
     # Create dataset ID

--- a/src/scripts/create_sb10k.py
+++ b/src/scripts/create_sb10k.py
@@ -1,6 +1,7 @@
 """Create the SB10k-mini sentiment dataset and upload it to the HF Hub."""
 
 import pandas as pd
+from constants import MAX_NUM_CHARS_IN_DOCUMENT, MIN_NUM_CHARS_IN_DOCUMENT  # noqa
 from datasets import Dataset, DatasetDict, Split, load_dataset
 from huggingface_hub import HfApi
 from requests import HTTPError
@@ -51,11 +52,30 @@ def main() -> None:
     val_df = val_df.reset_index(drop=True)
     test_df = test_df.reset_index(drop=True)
 
+    # Only work with samples where the document is not very large or small
+    # We do it after we have made the splits to ensure that the dataset is minimally
+    # affected.
+    new_train_df = train_df.copy()
+    new_train_df["text_len"] = new_train_df.text.str.len()
+    new_train_df = new_train_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+    new_val_df = val_df.copy()
+    new_val_df["text_len"] = new_val_df.text.str.len()
+    new_val_df = new_val_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+    new_test_df = test_df.copy()
+    new_test_df["text_len"] = new_test_df.text.str.len()
+    new_test_df = new_test_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+
     # Collect datasets in a dataset dictionary
     dataset = DatasetDict(
-        train=Dataset.from_pandas(train_df, split=Split.TRAIN),
-        val=Dataset.from_pandas(val_df, split=Split.VALIDATION),
-        test=Dataset.from_pandas(test_df, split=Split.TEST),
+        train=Dataset.from_pandas(new_train_df, split=Split.TRAIN),
+        val=Dataset.from_pandas(new_val_df, split=Split.VALIDATION),
+        test=Dataset.from_pandas(new_test_df, split=Split.TEST),
     )
 
     # Create dataset ID

--- a/src/scripts/create_scala.py
+++ b/src/scripts/create_scala.py
@@ -6,6 +6,7 @@ import warnings
 from typing import List, Tuple, Union
 
 import pandas as pd
+from constants import MAX_NUM_CHARS_IN_DOCUMENT, MIN_NUM_CHARS_IN_DOCUMENT  # noqa
 from datasets.arrow_dataset import Dataset
 from datasets.dataset_dict import DatasetDict
 from huggingface_hub.hf_api import HfApi
@@ -106,12 +107,36 @@ def main() -> None:
                     f"samples, but need at least 768."
                 )
 
+            # Only work with samples where the document is not very large or small We do
+            # it after we have made the splits to ensure that the dataset is minimally
+            # affected.
+            new_train_df = train_df.copy()
+            new_train_df["text_len"] = new_train_df.text.str.len()
+            new_train_df = new_train_df.query(
+                "text_len >= @MIN_NUM_CHARS_IN_DOCUMENT"
+            ).query("text_len <= @MAX_NUM_CHARS_IN_DOCUMENT")
+            new_val_df = val_df.copy()
+            new_val_df["text_len"] = new_val_df.text.str.len()
+            new_val_df = new_val_df.query(
+                "text_len >= @MIN_NUM_CHARS_IN_DOCUMENT"
+            ).query("text_len <= @MAX_NUM_CHARS_IN_DOCUMENT")
+            new_test_df = test_df.copy()
+            new_test_df["text_len"] = new_test_df.text.str.len()
+            new_test_df = new_test_df.query(
+                "text_len >= @MIN_NUM_CHARS_IN_DOCUMENT"
+            ).query("text_len <= @MAX_NUM_CHARS_IN_DOCUMENT")
+            new_full_train_df = full_train_df.copy()
+            new_full_train_df["text_len"] = new_full_train_df.text.str.len()
+            new_full_train_df = new_full_train_df.query(
+                "text_len >= @MIN_NUM_CHARS_IN_DOCUMENT"
+            ).query("text_len <= @MAX_NUM_CHARS_IN_DOCUMENT")
+
             # Add the corrupted data and turn the dataframes into Hugging Face Dataset
             # objects
-            train = prepare_df(train_df, split="train")
-            val = prepare_df(val_df, split="val")
-            test = prepare_df(test_df, split="test")
-            full_train = prepare_df(full_train_df, split="train")
+            train = prepare_df(new_train_df, split="train")
+            val = prepare_df(new_val_df, split="val")
+            test = prepare_df(new_test_df, split="test")
+            full_train = prepare_df(new_full_train_df, split="train")
 
             # Collect datasets in a dataset dictionary
             dataset = DatasetDict(

--- a/src/scripts/create_sentipolc16.py
+++ b/src/scripts/create_sentipolc16.py
@@ -1,6 +1,7 @@
 """Create the sentipolc16-mini sentiment dataset and upload it to the HF Hub."""
 
 import pandas as pd
+from constants import MAX_NUM_CHARS_IN_DOCUMENT, MIN_NUM_CHARS_IN_DOCUMENT  # noqa
 from datasets import Dataset, DatasetDict, Split, load_dataset
 from huggingface_hub import HfApi
 from requests import HTTPError
@@ -50,6 +51,25 @@ def main() -> None:
     train_df = train_df.reset_index(drop=True)
     val_df = val_df.reset_index(drop=True)
     test_df = test_df.reset_index(drop=True)
+
+    # Only work with samples where the document is not very large or small
+    # We do it after we have made the splits to ensure that the dataset is minimally
+    # affected.
+    new_train_df = train_df.copy()
+    new_train_df["text_len"] = new_train_df.text.str.len()
+    new_train_df = new_train_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+    new_val_df = val_df.copy()
+    new_val_df["text_len"] = new_val_df.text.str.len()
+    new_val_df = new_val_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+    new_test_df = test_df.copy()
+    new_test_df["text_len"] = new_test_df.text.str.len()
+    new_test_df = new_test_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
 
     # Collect datasets in a dataset dictionary
     dataset = DatasetDict(

--- a/src/scripts/create_sentipolc16.py
+++ b/src/scripts/create_sentipolc16.py
@@ -73,9 +73,9 @@ def main() -> None:
 
     # Collect datasets in a dataset dictionary
     dataset = DatasetDict(
-        train=Dataset.from_pandas(train_df, split=Split.TRAIN),
-        val=Dataset.from_pandas(val_df, split=Split.VALIDATION),
-        test=Dataset.from_pandas(test_df, split=Split.TEST),
+        train=Dataset.from_pandas(new_train_df, split=Split.TRAIN),
+        val=Dataset.from_pandas(new_val_df, split=Split.VALIDATION),
+        test=Dataset.from_pandas(new_test_df, split=Split.TEST),
     )
 
     # Create dataset ID

--- a/src/scripts/create_sst5.py
+++ b/src/scripts/create_sst5.py
@@ -1,6 +1,7 @@
 """Create the SST5-mini sentiment dataset and upload it to the HF Hub."""
 
 import pandas as pd
+from constants import MAX_NUM_CHARS_IN_DOCUMENT, MIN_NUM_CHARS_IN_DOCUMENT  # noqa
 from datasets import Dataset, DatasetDict, Split, load_dataset
 from huggingface_hub import HfApi
 from requests import HTTPError
@@ -57,6 +58,25 @@ def main() -> None:
     train_df = train_df.reset_index(drop=True)
     val_df = val_df.reset_index(drop=True)
     test_df = test_df.reset_index(drop=True)
+
+    # Only work with samples where the document is not very large or small
+    # We do it after we have made the splits to ensure that the dataset is minimally
+    # affected.
+    new_train_df = train_df.copy()
+    new_train_df["text_len"] = new_train_df.text.str.len()
+    new_train_df = new_train_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+    new_val_df = val_df.copy()
+    new_val_df["text_len"] = new_val_df.text.str.len()
+    new_val_df = new_val_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
+    new_test_df = test_df.copy()
+    new_test_df["text_len"] = new_test_df.text.str.len()
+    new_test_df = new_test_df.query("text_len >= @MIN_NUM_CHARS_IN_DOCUMENT").query(
+        "text_len <= @MAX_NUM_CHARS_IN_DOCUMENT"
+    )
 
     # Collect datasets in a dataset dictionary
     dataset = DatasetDict(

--- a/src/scripts/create_swerec.py
+++ b/src/scripts/create_swerec.py
@@ -4,6 +4,7 @@ import io
 
 import pandas as pd
 import requests
+from constants import MAX_NUM_CHARS_IN_DOCUMENT, MIN_NUM_CHARS_IN_DOCUMENT  # noqa
 from datasets import Split
 from datasets.arrow_dataset import Dataset
 from datasets.dataset_dict import DatasetDict


### PR DESCRIPTION
### Fixed
- Now recognises models with the pipeline tags `image-text-to-text`,
  `audio-text-to-text` and `video-text-to-text` as generative models, which mistakenly
  were detected as encoder models before.