### PR TITLE
Fix|Feat/ Load model in float16 for bfloat16 models on GPUs with CUDA capability < 8.0 

### DIFF
--- a/src/euroeval/constants.py
+++ b/src/euroeval/constants.py
@@ -54,3 +54,6 @@ METRIC_ATTRIBUTES_TAKING_UP_MEMORY = ["cached_bertscorer"]
 
 # Hugging Face Hub tags used to classify models as merge models
 MERGE_TAGS = ["merge", "mergekit"]
+
+# The minimum required CUDA compute capability for using bfloat16 in vLLM
+VLLM_BF16_MIN_CUDA_COMPUTE_CAPABILITY = 8.0

--- a/src/euroeval/utils.py
+++ b/src/euroeval/utils.py
@@ -206,6 +206,21 @@ def get_class_by_name(class_name: str | list[str], module_name: str) -> t.Type |
     return None
 
 
+def get_min_cuda_compute_capability() -> float | None:
+    """Gets the lowest cuda capability.
+
+    Returns:
+        Device capability as float, or None if CUDA is not available.
+    """
+    if not torch.cuda.is_available():
+        return None
+
+    device_range = range(torch.cuda.device_count())
+    capabilities = map(torch.cuda.get_device_capability, device_range)
+    min_compute_capability = min(capabilities)
+    return float(".".join(min_compute_capability))
+
+
 def kebab_to_pascal(kebab_string: str) -> str:
     """Converts a kebab-case string to PascalCase.
 


### PR DESCRIPTION
Resolves #864 

This PR adds a util function for checking device capability and a
check in the vLLM wrapper code for loading models in `torch.bfloat16` with CUDA capability < 8.0 GPUs.

