### PR TITLE
Fix/mistral3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,11 +43,10 @@ jobs:
       - name: Install uv and set up Python
         uses: astral-sh/setup-uv@v4
         with:
-          enable-cache: true
           python-version: ${{ matrix.python-version }}
 
       - name: Install Dependencies
-        run: uv sync --no-dev --extra test --reinstall-package euroeval
+        run: uv sync --no-dev --extra test
 
       - name: Start Ollama server
         run: curl -fsSL https://ollama.com/install.sh | sh
@@ -75,7 +74,6 @@ jobs:
       - name: Install uv and set up Python
         uses: astral-sh/setup-uv@v4
         with:
-          enable-cache: true
           python-version: ${{ matrix.python-version }}
 
       - name: Install Dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Dependencies
-        run: uv sync --no-dev --extra test
+        run: uv sync --no-dev --extra test --reinstall-package euroeval
 
       - name: Start Ollama server
         run: curl -fsSL https://ollama.com/install.sh | sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: debug-statements
+      # - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      # - id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.2
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Now catches `TypeError` when trying to generate with vLLM, and retries 3 times before
   giving up on evaluating the dataset.
 - A bug in `transformers` caused models with the `image-text-to-text` pipeline tag to
-  not be detected as generative models. This has been fixed now.
+  not be detected as generative models. This has been patched now, and will be fixed
+  properly when [this transformers
+  PR](https://github.com/huggingface/transformers/pull/37107) has been merged.
 
 
 ## [v15.4.1] - 2025-03-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Changed
+- Changed the name of the German 'mlsum' summarisation dataset to 'mlsum-de', to reflect
+  that it is the German version of the dataset, and to avoid confusion with the Spanish
+  'mlsum-es' dataset.
+
 ### Fixed
 - Evaluating a specific model revision did not work for adapter models, as there was a
   confusion between the revision of the adapter and the revision of the base model. We

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   warn the user.
 - Now catches `TypeError` when trying to generate with vLLM, and retries 3 times before
   giving up on evaluating the dataset.
+- A bug in `transformers` caused models with the `image-text-to-text` pipeline tag to
+  not be detected as generative models. This has been fixed now.
 
 
 ## [v15.4.1] - 2025-03-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   not be detected as generative models. This has been patched now, and will be fixed
   properly when [this transformers
   PR](https://github.com/huggingface/transformers/pull/37107) has been merged.
+- Now uses `fp16` instead of `bf16` when evaluating decoder models on GPUs with CUDA
+  compatibility < 8.0. This was contributed by [@marksverdhei](https://github.com/marksverdhei) ✨
 
 
 ## [v15.4.1] - 2025-03-25

--- a/docs/datasets/spanish.md
+++ b/docs/datasets/spanish.md
@@ -475,7 +475,7 @@ $ euroeval --model <model-id> --dataset hellaswag-es
 
 ## Summarization
 
-### MLSum-es-mini
+### MLSum-es
 
 The dataset was published in [this paper](https://aclanthology.org/2020.emnlp-main.647/) and is obtained from online newspapers.
 

--- a/src/euroeval/benchmark_modules/hf.py
+++ b/src/euroeval/benchmark_modules/hf.py
@@ -35,6 +35,9 @@ from transformers import (
     Trainer,
 )
 from transformers.modelcard import TASK_MAPPING
+from transformers.models.auto.modeling_auto import (
+    MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES,
+)
 from urllib3.exceptions import RequestError
 
 from ..constants import (
@@ -780,6 +783,12 @@ def get_model_repo_info(
             tags += base_model_info.tags or list()
             tags = list(set(tags))
 
+    # TEMP: This extends the `TASK_MAPPING` dictionary to include the missing
+    # 'image-text-to-text' pipeline tag. This will be added as part of `TASK_MAPPING`
+    # when this PR has been merged in and published:
+    # https://github.com/huggingface/transformers/pull/37107
+    TASK_MAPPING["image-text-to-text"] = MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES
+
     # Get the pipeline tag for the model. If it is not specified, then we determine it
     # by checking the model's architecture as written in the model's Hugging Face config
     pipeline_tag = model_info.pipeline_tag
@@ -809,7 +818,6 @@ def get_model_repo_info(
             pipeline_tag = "text-generation"
         else:
             pipeline_tag = "fill-mask"
-    breakpoint()
 
     if benchmark_config.only_allow_safetensors:
         repo_files = hf_api.list_repo_files(repo_id=model_id, revision=revision)

--- a/src/euroeval/benchmark_modules/hf.py
+++ b/src/euroeval/benchmark_modules/hf.py
@@ -809,6 +809,7 @@ def get_model_repo_info(
             pipeline_tag = "text-generation"
         else:
             pipeline_tag = "fill-mask"
+    breakpoint()
 
     if benchmark_config.only_allow_safetensors:
         repo_files = hf_api.list_repo_files(repo_id=model_id, revision=revision)

--- a/src/euroeval/dataset_configs.py
+++ b/src/euroeval/dataset_configs.py
@@ -1467,9 +1467,9 @@ NORDJYLLAND_NEWS_CONFIG = DatasetConfig(
     max_generated_tokens=256,
 )
 
-MLSUM_CONFIG = DatasetConfig(
-    name="mlsum",
-    pretty_name="the truncated version of the German summarisation dataset MLSum",
+MLSUM_DE_CONFIG = DatasetConfig(
+    name="mlsum-de",
+    pretty_name="the truncated version of the German summarisation dataset MLSum-de",
     huggingface_id="EuroEval/mlsum-mini",
     task=SUMM,
     languages=[DE],
@@ -1484,7 +1484,7 @@ MLSUM_CONFIG = DatasetConfig(
 
 MLSUM_ES_CONFIG = DatasetConfig(
     name="mlsum-es",
-    pretty_name="the truncated version of the Spanish summarisation dataset MLSum",
+    pretty_name="the truncated version of the Spanish summarisation dataset MLSum-es",
     huggingface_id="EuroEval/mlsum-es-mini",
     task=SUMM,
     languages=[ES],

--- a/src/scripts/create_mlsum_de.py
+++ b/src/scripts/create_mlsum_de.py
@@ -8,7 +8,7 @@
 # ]
 # ///
 
-"""Create the German MLSum-mini summarisation dataset."""
+"""Create the German MLSum-de-mini summarisation dataset."""
 
 import pandas as pd
 from constants import MAX_NUM_CHARS_IN_ARTICLE, MIN_NUM_CHARS_IN_ARTICLE

--- a/src/scripts/create_mlsum_es.py
+++ b/src/scripts/create_mlsum_es.py
@@ -8,7 +8,7 @@
 # ]
 # ///
 
-"""Create the Spanish MLSum-mini summarisation dataset."""
+"""Create the Spanish MLSum-es-mini summarisation dataset."""
 
 import pandas as pd
 from constants import MAX_NUM_CHARS_IN_ARTICLE, MIN_NUM_CHARS_IN_ARTICLE

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -10,5 +10,5 @@ def test_all_objects_in_constants_are_constants() -> None:
         if name.startswith("__") or name in {"TaskGroup"}:
             continue
         assert name.isupper() and isinstance(
-            getattr(constants, name), (Task, int, str, list, dict)
+            getattr(constants, name), (Task, int, float, str, list, dict)
         )


### PR DESCRIPTION
### Fixes
- A bug in `transformers` caused models with the `image-text-to-text` pipeline tag to
  not be detected as generative models. This has been patched now, and will be fixed
  properly when [this transformers PR](https://github.com/huggingface/transformers/pull/37107) has been merged.

### Changed
- Changed the name of the German 'mlsum' summarisation dataset to 'mlsum-de', to reflect
  that it is the German version of the dataset, and to avoid confusion with the Spanish
  'mlsum-es' dataset.