### PR TITLE
Fix docs for the ScandicQA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   PR](https://github.com/huggingface/transformers/pull/37107) has been merged.
 - Now uses `fp16` instead of `bf16` when evaluating decoder models on GPUs with CUDA
   compatibility < 8.0. This was contributed by [@marksverdhei](https://github.com/marksverdhei) ✨
+- Fixed docs for ScandiQA-da and ScandiQA-sv, where it was incorrectly stated that
+  the splits were made by considering the original train/validation/test splits.
 
 
 ## [v15.4.1] - 2025-03-25

--- a/docs/datasets/danish.md
+++ b/docs/datasets/danish.md
@@ -285,11 +285,10 @@ the translated contexts still contained the answer to the question, potentially 
 changing the answers slightly.
 
 The original full dataset consists of 6,810 / 500 / 500 samples for training,
-validation and testing, respectively. We use a 1,024 / 256 / 2,048 split for training,
-validation and testing, respectively (so 3,328 samples used in total). All validation
-samples in our version also belong to the original validation set, and all original test
-samples are included in our test set. The remaining 1,548 test samples in our version
-was sampled from the original training set.
+validation and testing, respectively (so 3,328 samples used in total).
+We use a 1,024 / 256 / 2,048 split for training, validation and testing, respectively,
+where the splits are made by randomly sampling from the full dataset without considering
+the original train/validation/test splits.
 
 Here are a few examples from the training split:
 

--- a/docs/datasets/swedish.md
+++ b/docs/datasets/swedish.md
@@ -231,11 +231,10 @@ the translated contexts still contained the answer to the question, potentially 
 changing the answers slightly.
 
 The original full dataset consists of 6,810 / 500 / 500 samples for training,
-validation and testing, respectively. We use a 1,024 / 256 / 2,048 split for training,
-validation and testing, respectively (so 3,328 samples used in total). All validation
-samples in our version also belong to the original validation set, and all original test
-samples are included in our test set. The remaining 1,548 test samples in our version
-was sampled from the original training set.
+validation and testing, respectively (so 3,328 samples used in total).
+We use a 1,024 / 256 / 2,048 split for training, validation and testing, respectively,
+where the splits are made by randomly sampling from the full dataset without considering
+the original train/validation/test splits.
 
 Here are a few examples from the training split:
 


### PR DESCRIPTION
Fixed docs for ScandiQA-da and ScandiQA-sv, where it was incorrectly stated that the splits were made by considering the original train/validation/test splits.