### PR TITLE
Fix/logprobs for classification tasks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: debug-statements
+      # - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      # - id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.2
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   which caused an error when evaluating it. This has been fixed now.
 - Now registers the Gemini-2.5-pro model series as reasoning models, as otherwise they
   did not generate any text as they were just generating reasoning tokens.
+- Previously, if there were multiple labels whose first tokens were identical and that
+  the (generative) model did not output the label as the first output token, we would
+  randomly choose one of the labels, resulting in an evaluation error. This is very
+  rare, but *does* happen for very particular (model, dataset) pairs. If we are in this
+  case, we now resort to choosing the label with closest word edit distance instead of
+  relying on logprobs of the first token.
 
 
 ## [v15.4.2] - 2025-03-31

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -174,14 +174,14 @@ class LiteLLMModel(BenchmarkModule):
 
         raise_if_wrong_params(model_config=model_config, allowed_params=ALLOWED_PARAMS)
 
-        self.first_label_token_mapping = get_first_label_token_mapping(
-            dataset_config=self.dataset_config, tokenizer=None
-        )
-
         super().__init__(
             model_config=model_config,
             dataset_config=dataset_config,
             benchmark_config=benchmark_config,
+        )
+
+        self.buffer["first_label_token_mapping"] = get_first_label_token_mapping(
+            dataset_config=self.dataset_config, tokenizer=None
         )
 
     @property
@@ -231,7 +231,7 @@ class LiteLLMModel(BenchmarkModule):
             api_version=self.benchmark_config.api_version,
         )
 
-        if self.first_label_token_mapping:
+        if self.buffer["first_label_token_mapping"]:
             generation_kwargs["logprobs"] = True
             generation_kwargs["top_logprobs"] = MAX_LOGPROBS
 
@@ -618,7 +618,7 @@ class LiteLLMModel(BenchmarkModule):
                 return partial(
                     sequence_classification.extract_labels_from_generation,
                     dataset_config=self.dataset_config,
-                    first_label_token_mapping=self.first_label_token_mapping,
+                    first_label_token_mapping=self.buffer["first_label_token_mapping"],
                 )
             case TaskGroup.TEXT_TO_TEXT:
                 return text_to_text.extract_labels_from_generation

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -233,6 +233,10 @@ class LiteLLMModel(BenchmarkModule):
         )
 
         if self.dataset_config.task.task_group in TASK_GROUPS_USING_LOGPROBS:
+            # If this is a text classification task then we need to ensure that we can
+            # distinguish between the labels when we only have access to the first
+            # token
+            breakpoint()
             generation_kwargs["logprobs"] = True
             generation_kwargs["top_logprobs"] = MAX_LOGPROBS
 

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -174,6 +174,10 @@ class LiteLLMModel(BenchmarkModule):
 
         raise_if_wrong_params(model_config=model_config, allowed_params=ALLOWED_PARAMS)
 
+        self.first_label_token_mapping = get_first_label_token_mapping(
+            dataset_config=self.dataset_config, tokenizer=None
+        )
+
         super().__init__(
             model_config=model_config,
             dataset_config=dataset_config,
@@ -227,12 +231,7 @@ class LiteLLMModel(BenchmarkModule):
             api_version=self.benchmark_config.api_version,
         )
 
-        output_scores = bool(
-            get_first_label_token_mapping(
-                dataset_config=self.dataset_config, tokenizer=None
-            )
-        )
-        if output_scores:
+        if self.first_label_token_mapping:
             generation_kwargs["logprobs"] = True
             generation_kwargs["top_logprobs"] = MAX_LOGPROBS
 
@@ -619,6 +618,7 @@ class LiteLLMModel(BenchmarkModule):
                 return partial(
                     sequence_classification.extract_labels_from_generation,
                     dataset_config=self.dataset_config,
+                    first_label_token_mapping=self.first_label_token_mapping,
                 )
             case TaskGroup.TEXT_TO_TEXT:
                 return text_to_text.extract_labels_from_generation

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -66,11 +66,7 @@ from ..task_utils import (
     token_classification,
 )
 from ..types import ExtractLabelsFunction
-from ..utils import (
-    check_if_model_should_output_scores,
-    create_model_cache_dir,
-    log_once,
-)
+from ..utils import create_model_cache_dir, get_first_label_token_mapping, log_once
 from .base import BenchmarkModule
 from .hf import HuggingFaceEncoderModel, load_hf_model_config, load_tokenizer
 
@@ -231,9 +227,12 @@ class LiteLLMModel(BenchmarkModule):
             api_version=self.benchmark_config.api_version,
         )
 
-        if check_if_model_should_output_scores(
-            dataset_config=self.dataset_config, tokenizer=None
-        ):
+        output_scores = bool(
+            get_first_label_token_mapping(
+                dataset_config=self.dataset_config, tokenizer=None
+            )
+        )
+        if output_scores:
             generation_kwargs["logprobs"] = True
             generation_kwargs["top_logprobs"] = MAX_LOGPROBS
 

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -180,10 +180,6 @@ class LiteLLMModel(BenchmarkModule):
             benchmark_config=benchmark_config,
         )
 
-        self.buffer["first_label_token_mapping"] = get_first_label_token_mapping(
-            dataset_config=self.dataset_config, tokenizer=None
-        )
-
     @property
     def generative_type(self) -> GenerativeType | None:
         """Get the generative type of the model.
@@ -229,6 +225,12 @@ class LiteLLMModel(BenchmarkModule):
             api_key=self.benchmark_config.api_key,
             api_base=self.benchmark_config.api_base,
             api_version=self.benchmark_config.api_version,
+        )
+
+        # Get the mapping from labels to the first token in the label. We call this each
+        # time we generate a new dataset since the dataset config can change
+        self.buffer["first_label_token_mapping"] = get_first_label_token_mapping(
+            dataset_config=self.dataset_config, tokenizer=None
         )
 
         if self.buffer["first_label_token_mapping"]:

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -37,12 +37,7 @@ from requests.exceptions import RequestException
 from tqdm.auto import tqdm
 from transformers import Trainer
 
-from ..constants import (
-    MAX_LOGPROBS,
-    REASONING_MAX_TOKENS,
-    TASK_GROUPS_USING_LOGPROBS,
-    TASKS_USING_JSON,
-)
+from ..constants import MAX_LOGPROBS, REASONING_MAX_TOKENS, TASKS_USING_JSON
 from ..data_models import (
     BenchmarkConfig,
     DatasetConfig,
@@ -71,7 +66,11 @@ from ..task_utils import (
     token_classification,
 )
 from ..types import ExtractLabelsFunction
-from ..utils import create_model_cache_dir, log_once
+from ..utils import (
+    check_if_model_should_output_scores,
+    create_model_cache_dir,
+    log_once,
+)
 from .base import BenchmarkModule
 from .hf import HuggingFaceEncoderModel, load_hf_model_config, load_tokenizer
 
@@ -232,11 +231,9 @@ class LiteLLMModel(BenchmarkModule):
             api_version=self.benchmark_config.api_version,
         )
 
-        if self.dataset_config.task.task_group in TASK_GROUPS_USING_LOGPROBS:
-            # If this is a text classification task then we need to ensure that we can
-            # distinguish between the labels when we only have access to the first
-            # token
-            breakpoint()
+        if check_if_model_should_output_scores(
+            dataset_config=self.dataset_config, tokenizer=None
+        ):
             generation_kwargs["logprobs"] = True
             generation_kwargs["top_logprobs"] = MAX_LOGPROBS
 

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -347,7 +347,7 @@ class VLLMModel(HuggingFaceEncoderModel):
         )
         sampling_params = SamplingParams(
             max_tokens=max_tokens,
-            logprobs=MAX_LOGPROBS if self.buffer["output_scores"] else None,
+            logprobs=MAX_LOGPROBS if self.buffer["first_label_token_mapping"] else None,
             temperature=0.0,
             stop=[stop_token for stop_token in stop_tokens if stop_token],
             logits_processors=[logits_processor] if logits_processor else None,
@@ -419,7 +419,7 @@ class VLLMModel(HuggingFaceEncoderModel):
         completions = [completion.strip() for completion in completions]
 
         # Add logprobs scores to the output
-        if self.buffer["output_scores"]:
+        if self.buffer["first_label_token_mapping"]:
             scores: list[list[list[tuple[str, float]]]] = [
                 [
                     [

--- a/src/euroeval/data_models.py
+++ b/src/euroeval/data_models.py
@@ -10,10 +10,9 @@ from dataclasses import dataclass, field
 import pydantic
 import torch
 
-from euroeval.utils import get_package_version
-
 from .enums import Device, InferenceBackend, ModelType, TaskGroup
 from .types import ScoreDict
+from .utils import get_package_version
 
 
 @dataclass

--- a/src/euroeval/task_utils/sequence_classification.py
+++ b/src/euroeval/task_utils/sequence_classification.py
@@ -198,6 +198,7 @@ def get_closest_logprobs_labels(
 
                 # Get the candidate labels that starts with the generated label
                 if isinstance(first_label_token_mapping, dict):
+                    breakpoint()
                     candidate_output_labels = {
                         candidate_label
                         for candidate_label in candidate_labels

--- a/src/euroeval/task_utils/sequence_classification.py
+++ b/src/euroeval/task_utils/sequence_classification.py
@@ -199,6 +199,12 @@ def get_closest_logprobs_labels(
 
                 # Get the candidate labels that starts with the generated label
                 if isinstance(first_label_token_mapping, dict):
+                    if any(
+                        candidate_label not in first_label_token_mapping
+                        for candidate_label in candidate_labels
+                    ):
+                        breakpoint()
+
                     candidate_output_labels = {
                         candidate_label
                         for candidate_label in candidate_labels

--- a/src/euroeval/task_utils/sequence_classification.py
+++ b/src/euroeval/task_utils/sequence_classification.py
@@ -10,6 +10,7 @@ import numpy as np
 from evaluate import EvaluationModule
 
 from ..data_models import BenchmarkConfig, GenerativeModelOutput
+from ..exceptions import InvalidBenchmark
 from ..utils import log_once, raise_if_model_output_contains_nan_values
 
 if t.TYPE_CHECKING:
@@ -225,7 +226,7 @@ def get_closest_logprobs_labels(
                     else:
                         output_label = candidate_output_labels.pop()
                         candidate_output_labels.add(output_label)
-                        log_once(
+                        raise InvalidBenchmark(
                             "Multiple candidate labels found for the generated label "
                             f"{generated_label!r}: {candidate_output_labels}. Since "
                             "this is not the first generated label, we cannot "
@@ -233,8 +234,7 @@ def get_closest_logprobs_labels(
                             f"forced to use the arbitrary {output_label!r} as the "
                             "output label, potentially resulting in worse performance. "
                             "Please report this issue to the EuroEval team at "
-                            "github.com/EuroEval/EuroEval/issues.",
-                            level=logging.WARNING,
+                            "github.com/EuroEval/EuroEval/issues."
                         )
 
             if output_label is not None:

--- a/src/euroeval/task_utils/sequence_classification.py
+++ b/src/euroeval/task_utils/sequence_classification.py
@@ -198,11 +198,10 @@ def get_closest_logprobs_labels(
 
                 # Get the candidate labels that starts with the generated label
                 if isinstance(first_label_token_mapping, dict):
-                    breakpoint()
                     candidate_output_labels = {
                         candidate_label
                         for candidate_label in candidate_labels
-                        if first_label_token_mapping[generated_label] == candidate_label
+                        if generated_label == first_label_token_mapping[candidate_label]
                     }
                 else:
                     candidate_output_labels = {

--- a/src/euroeval/task_utils/sequence_classification.py
+++ b/src/euroeval/task_utils/sequence_classification.py
@@ -203,7 +203,12 @@ def get_closest_logprobs_labels(
                         candidate_label not in first_label_token_mapping
                         for candidate_label in candidate_labels
                     ):
-                        breakpoint()
+                        raise InvalidBenchmark(
+                            "There is a label not present in the first label token "
+                            "mapping - this should never happen! Please report this "
+                            "issue to the EuroEval team at "
+                            "github.com/EuroEval/EuroEval/issues."
+                        )
 
                     candidate_output_labels = {
                         candidate_label

--- a/src/euroeval/utils.py
+++ b/src/euroeval/utils.py
@@ -628,7 +628,8 @@ def get_first_label_token_mapping(
         first_tokens = [tokenizer.tokenize(text=label)[0] for label in local_labels]
         if len(first_tokens) == len(set(first_tokens)):
             log_once(
-                "The model will output scores, since the labels are distinct.",
+                "The model will output scores, since the first tokens of the labels "
+                "are distinct.",
                 level=logging.DEBUG,
             )
             return {
@@ -637,8 +638,9 @@ def get_first_label_token_mapping(
             }
         else:
             log_once(
-                f"The model will not output scores, since the labels are not distinct. "
-                f"The first tokens for the labels {local_labels} are {first_tokens}"
+                "The model will not output scores, since the first tokens of the "
+                "labels are not distinct. The first tokens for the labels "
+                f"{local_labels} are {first_tokens}"
             )
             return False
 

--- a/src/euroeval/utils.py
+++ b/src/euroeval/utils.py
@@ -621,10 +621,11 @@ def get_first_label_token_mapping(
     # If there are labels associated with the dataset, and that the first token of each
     # label is distinct, then we can safely use the logprobs
     if dataset_config.labels:
-        first_tokens = [
-            tokenizer.tokenize(text=dataset_config.prompt_label_mapping[label])[0]
+        local_labels = [
+            dataset_config.prompt_label_mapping[label]
             for label in dataset_config.labels
         ]
+        first_tokens = [tokenizer.tokenize(text=label)[0] for label in local_labels]
         if len(first_tokens) == len(set(first_tokens)):
             log_once(
                 "The model will output scores, since the labels are distinct.",
@@ -632,13 +633,12 @@ def get_first_label_token_mapping(
             )
             return {
                 label: first_token
-                for label, first_token in zip(dataset_config.labels, first_tokens)
+                for label, first_token in zip(local_labels, first_tokens)
             }
         else:
             log_once(
                 f"The model will not output scores, since the labels are not distinct. "
-                f"The first tokens for the labels {dataset_config.labels} are "
-                f"{first_tokens}"
+                f"The first tokens for the labels {local_labels} are {first_tokens}"
             )
             return False
 

--- a/src/euroeval/utils.py
+++ b/src/euroeval/utils.py
@@ -622,6 +622,7 @@ def check_if_model_should_output_scores(
         first_tokens = [
             tokenizer.tokenize(text=label)[0] for label in dataset_config.labels
         ]
+        breakpoint()
         if len(first_tokens) == len(set(first_tokens)):
             log_once(
                 "The model will output scores, since the labels are distinct.",

--- a/src/euroeval/utils.py
+++ b/src/euroeval/utils.py
@@ -620,7 +620,8 @@ def check_if_model_should_output_scores(
     # label is distinct, then we can safely use the logprobs
     if dataset_config.labels:
         first_tokens = [
-            tokenizer.tokenize(text=label)[0] for label in dataset_config.labels
+            tokenizer.tokenize(text=dataset_config.prompt_label_mapping[label])[0]
+            for label in dataset_config.labels
         ]
         breakpoint()
         if len(first_tokens) == len(set(first_tokens)):

--- a/src/euroeval/utils.py
+++ b/src/euroeval/utils.py
@@ -23,7 +23,6 @@ from requests.exceptions import RequestException
 from transformers import PreTrainedTokenizer, PreTrainedTokenizerBase
 from transformers import logging as tf_logging
 
-from .constants import TASK_GROUPS_USING_LOGPROBS
 from .data_models import DatasetConfig
 from .exceptions import InvalidModel, NaNValueInModelOutput
 
@@ -594,6 +593,9 @@ def check_if_model_should_output_scores(
     Returns:
         Whether the model should output scores.
     """
+    # Importing here to avoid circular imports
+    from .constants import TASK_GROUPS_USING_LOGPROBS
+
     # If we do not have any tokenizer, then we cannot check if the model should output
     # scores and we just assume it should if the dataset supports it
     if tokenizer is None:

--- a/src/euroeval/utils.py
+++ b/src/euroeval/utils.py
@@ -12,7 +12,6 @@ import typing as t
 import warnings
 from functools import cache
 from pathlib import Path
-from types import TracebackType
 
 import litellm
 import numpy as np
@@ -20,16 +19,19 @@ import requests
 import torch
 from datasets.utils import disable_progress_bar
 from requests.exceptions import RequestException
-from transformers import PreTrainedTokenizer, PreTrainedTokenizerBase
 from transformers import logging as tf_logging
 
-from .data_models import DatasetConfig
 from .exceptions import InvalidModel, NaNValueInModelOutput
 
 if importlib.util.find_spec("ray") is not None:
     import ray
 
 if t.TYPE_CHECKING:
+    from types import TracebackType
+
+    from transformers import PreTrainedTokenizer, PreTrainedTokenizerBase
+
+    from .data_models import DatasetConfig
     from .types import Predictions
 
 
@@ -286,7 +288,7 @@ class HiddenPrints:
         self,
         exc_type: t.Type[BaseException],
         exc_val: BaseException,
-        exc_tb: TracebackType,
+        exc_tb: "TracebackType",
     ) -> None:
         """Exit the context manager."""
         sys.stdout.close()
@@ -580,7 +582,7 @@ def get_package_version(package_name: str) -> str | None:
 
 
 def check_if_model_should_output_scores(
-    dataset_config: DatasetConfig, tokenizer: PreTrainedTokenizer | None
+    dataset_config: "DatasetConfig", tokenizer: "PreTrainedTokenizer | None"
 ) -> bool:
     """Check if the model should output scores.
 


### PR DESCRIPTION
### Fixed
- Previously, if there were multiple labels whose first tokens were identical and that
  the (generative) model did not output the label as the first output token, we would
  randomly choose one of the labels, resulting in an evaluation error. This is very
  rare, but *does* happen for very particular (model, dataset) pairs. If we are in this
  case, we now resort to choosing the label with closest word edit distance instead of
  relying on logprobs of the first token.