### PR TITLE
fix: Use LLM.generate if model is not instruction tuned

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: debug-statements
+      # - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      # - id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.2
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   rare, but *does* happen for very particular (model, dataset) pairs. If we are in this
   case, we now resort to choosing the label with closest word edit distance instead of
   relying on logprobs of the first token.
+- Now defaults to BF16 if the model is registered as using FP32, assuming that BF16 is
+  supported by the GPU.
 
 
 ## [v15.4.2] - 2025-03-31

--- a/docs/datasets/dutch.md
+++ b/docs/datasets/dutch.md
@@ -133,7 +133,7 @@ $ euroeval --model <model-id> --dataset dbrd
 
 ## Named Entity Recognition
 
-### CoNLL-2002-nl
+### CoNLL-nl
 
 This dataset was published in [this paper](https://aclanthology.org/W02-2024/) and
 consists of named entity recognition annotations of the Belgian newspaper "De Morgen" of

--- a/docs/datasets/english.md
+++ b/docs/datasets/english.md
@@ -81,7 +81,7 @@ $ euroeval --model <model-id> --dataset sst5
 
 ## Named Entity Recognition
 
-### CoNLL-2003-En
+### CoNLL-en
 
 This dataset was published in [this paper](https://aclanthology.org/W03-0419/) and was
 part of the CoNNL-2003 shared task. The data comes from the [Reuters

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -909,12 +909,21 @@ def load_model_and_tokenizer(
     dtype: str | torch.dtype = "auto"
 
     # Choose bf16 over fp16 if the model is a fp32 model and the GPU supports it
-    if hf_model_config.torch_dtype == torch.float32 and torch.cuda.is_bf16_supported():
-        logger.info(
-            "You are loading a model with dtype FP32, which we will convert to "
-            "BF16 as FP32 is not supported by vLLM and BF16 is supported by your GPU."
-        )
-        dtype = torch.bfloat16
+    if hf_model_config.torch_dtype == torch.float32:
+        if torch.cuda.is_bf16_supported():
+            logger.info(
+                "You are loading a model with dtype FP32, which we will convert to "
+                "BF16 as FP32 is not supported by vLLM and BF16 is supported by your "
+                "GPU."
+            )
+            dtype = torch.bfloat16
+        else:
+            logger.info(
+                "You are loading a model with dtype FP32, which we will convert to "
+                "FP16 as FP32 is not supported by vLLM and BF16 is not supported by "
+                "your GPU."
+            )
+            dtype = torch.float16
 
     # If the model is a quantized model, we need to set the dtype to float16
     if quantization is not None and hf_model_config.torch_dtype != torch.float16:

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -399,6 +399,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                         use_tqdm=(not input_is_a_test),
                         lora_request=self.buffer.get("lora_request"),
                     )
+                breakpoint()
                 break
             except TypeError as e:
                 logger.debug(

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -399,6 +399,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                         use_tqdm=(not input_is_a_test),
                         lora_request=self.buffer.get("lora_request"),
                     )
+                    breakpoint()
                 break
             except TypeError as e:
                 logger.debug(

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -399,7 +399,6 @@ class VLLMModel(HuggingFaceEncoderModel):
                         use_tqdm=(not input_is_a_test),
                         lora_request=self.buffer.get("lora_request"),
                     )
-                    breakpoint()
                 break
             except TypeError as e:
                 logger.debug(

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -992,7 +992,7 @@ def load_model_and_tokenizer(
     try:
         model = LLM(
             model=model_id,
-            tokenizer=model_id,
+            tokenizer=tokenizer,
             gpu_memory_utilization=0.95,
             max_model_len=min(true_max_model_len, MAX_CONTEXT_LENGTH),
             download_dir=download_dir,

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -383,6 +383,7 @@ class VLLMModel(HuggingFaceEncoderModel):
         num_attempts = 3
         for _ in range(num_attempts):
             try:
+                breakpoint()
                 if self.buffer.get("instruction_model", False):
                     raw_outputs = self._model.chat(
                         messages=[

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -394,11 +394,12 @@ class VLLMModel(HuggingFaceEncoderModel):
                     )
                 else:
                     raw_outputs = self._model.generate(
-                        prompts=prompts,
+                        prompts,
                         sampling_params=sampling_params,
                         use_tqdm=(not input_is_a_test),
                         lora_request=self.buffer.get("lora_request"),
                     )
+                    breakpoint()
                 break
             except TypeError as e:
                 logger.debug(

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -383,14 +383,22 @@ class VLLMModel(HuggingFaceEncoderModel):
         num_attempts = 3
         for _ in range(num_attempts):
             try:
-                raw_outputs = self._model.chat(
-                    messages=[
-                        [dict(role="user", content=prompt)] for prompt in prompts
-                    ],
-                    sampling_params=sampling_params,
-                    use_tqdm=(not input_is_a_test),
-                    lora_request=self.buffer.get("lora_request"),
-                )
+                if self.buffer.get("instruction_model", False):
+                    raw_outputs = self._model.chat(
+                        messages=[
+                            [dict(role="user", content=prompt)] for prompt in prompts
+                        ],
+                        sampling_params=sampling_params,
+                        use_tqdm=(not input_is_a_test),
+                        lora_request=self.buffer.get("lora_request"),
+                    )
+                else:
+                    raw_outputs = self._model.generate(
+                        prompts=prompts,
+                        sampling_params=sampling_params,
+                        use_tqdm=(not input_is_a_test),
+                        lora_request=self.buffer.get("lora_request"),
+                    )
                 break
             except TypeError as e:
                 logger.debug(

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -1176,7 +1176,7 @@ def get_end_of_reasoning_token_id(
         )
     else:
         model_output = model.generate(
-            messages=[prompt],
+            prompts=[prompt],
             sampling_params=SamplingParams(max_tokens=3, temperature=0.0),
             use_tqdm=False,
         )

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -991,6 +991,7 @@ def load_model_and_tokenizer(
             enable_lora=model_config.adapter_base_model_id is not None,
             max_lora_rank=256,
         )
+        breakpoint()
     except (ValueError, OSError) as e:
         if "awaiting a review from the repo authors" in str(e):
             raise InvalidModel(

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -383,7 +383,6 @@ class VLLMModel(HuggingFaceEncoderModel):
         num_attempts = 3
         for _ in range(num_attempts):
             try:
-                breakpoint()
                 if self.buffer.get("instruction_model", False):
                     raw_outputs = self._model.chat(
                         messages=[
@@ -395,7 +394,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                     )
                 else:
                     raw_outputs = self._model.generate(
-                        prompts,
+                        prompts=prompts,
                         sampling_params=sampling_params,
                         use_tqdm=(not input_is_a_test),
                         lora_request=self.buffer.get("lora_request"),

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -383,6 +383,7 @@ class VLLMModel(HuggingFaceEncoderModel):
         num_attempts = 3
         for _ in range(num_attempts):
             try:
+                breakpoint()
                 if self.buffer.get("instruction_model", False):
                     raw_outputs = self._model.chat(
                         messages=[
@@ -399,7 +400,6 @@ class VLLMModel(HuggingFaceEncoderModel):
                         use_tqdm=(not input_is_a_test),
                         lora_request=self.buffer.get("lora_request"),
                     )
-                breakpoint()
                 break
             except TypeError as e:
                 logger.debug(

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -992,7 +992,7 @@ def load_model_and_tokenizer(
     try:
         model = LLM(
             model=model_id,
-            tokenizer=tokenizer,
+            tokenizer=model_id,
             gpu_memory_utilization=0.95,
             max_model_len=min(true_max_model_len, MAX_CONTEXT_LENGTH),
             download_dir=download_dir,

--- a/src/euroeval/task_utils/sequence_classification.py
+++ b/src/euroeval/task_utils/sequence_classification.py
@@ -199,7 +199,6 @@ def get_closest_logprobs_labels(
 
                 # Get the candidate labels that starts with the generated label
                 if isinstance(first_label_token_mapping, dict):
-                    breakpoint()
                     if any(
                         candidate_label not in first_label_token_mapping
                         for candidate_label in candidate_labels

--- a/src/euroeval/task_utils/sequence_classification.py
+++ b/src/euroeval/task_utils/sequence_classification.py
@@ -230,6 +230,7 @@ def get_closest_logprobs_labels(
                 # we warn the user.
                 if len(candidate_output_labels) == 1:
                     output_label = candidate_output_labels.pop()
+                    breakpoint()
                     break
                 elif len(candidate_output_labels) > 1:
                     if label_idx == 0:

--- a/src/euroeval/task_utils/sequence_classification.py
+++ b/src/euroeval/task_utils/sequence_classification.py
@@ -209,6 +209,7 @@ def get_closest_logprobs_labels(
                             "issue to the EuroEval team at "
                             "github.com/EuroEval/EuroEval/issues."
                         )
+                    breakpoint()
 
                     candidate_output_labels = {
                         candidate_label

--- a/src/euroeval/task_utils/sequence_classification.py
+++ b/src/euroeval/task_utils/sequence_classification.py
@@ -228,9 +228,9 @@ def get_closest_logprobs_labels(
                 # the current one is the first one, however, since we're using greedy
                 # sampling. In case this happens for a label that is not the first one,
                 # we warn the user.
+                breakpoint()
                 if len(candidate_output_labels) == 1:
                     output_label = candidate_output_labels.pop()
-                    breakpoint()
                     break
                 elif len(candidate_output_labels) > 1:
                     if label_idx == 0:

--- a/src/euroeval/task_utils/sequence_classification.py
+++ b/src/euroeval/task_utils/sequence_classification.py
@@ -199,6 +199,7 @@ def get_closest_logprobs_labels(
 
                 # Get the candidate labels that starts with the generated label
                 if isinstance(first_label_token_mapping, dict):
+                    breakpoint()
                     if any(
                         candidate_label not in first_label_token_mapping
                         for candidate_label in candidate_labels
@@ -209,7 +210,6 @@ def get_closest_logprobs_labels(
                             "issue to the EuroEval team at "
                             "github.com/EuroEval/EuroEval/issues."
                         )
-                    breakpoint()
 
                     candidate_output_labels = {
                         candidate_label

--- a/src/euroeval/task_utils/sequence_classification.py
+++ b/src/euroeval/task_utils/sequence_classification.py
@@ -213,7 +213,8 @@ def get_closest_logprobs_labels(
                     candidate_output_labels = {
                         candidate_label
                         for candidate_label in candidate_labels
-                        if generated_label == first_label_token_mapping[candidate_label]
+                        if generated_label
+                        in {candidate_label, first_label_token_mapping[candidate_label]}
                     }
                 else:
                     candidate_output_labels = {
@@ -228,7 +229,6 @@ def get_closest_logprobs_labels(
                 # the current one is the first one, however, since we're using greedy
                 # sampling. In case this happens for a label that is not the first one,
                 # we warn the user.
-                breakpoint()
                 if len(candidate_output_labels) == 1:
                     output_label = candidate_output_labels.pop()
                     break
@@ -248,6 +248,11 @@ def get_closest_logprobs_labels(
                             "Please report this issue to the EuroEval team at "
                             "github.com/EuroEval/EuroEval/issues."
                         )
+                elif len(candidate_output_labels) == 0:
+                    logger.debug(
+                        f"No candidate label found for the generated label "
+                        f"{generated_label!r}. The generated label is thus ignored."
+                    )
 
             if output_label is not None:
                 output_labels.append(output_label)

--- a/src/euroeval/utils.py
+++ b/src/euroeval/utils.py
@@ -621,18 +621,19 @@ def get_first_label_token_mapping(
     # If there are labels associated with the dataset, and that the first token of each
     # label is distinct, then we can safely use the logprobs
     if output_scores and dataset_config.labels:
-        # Get the local labels
         local_labels = [
             dataset_config.prompt_label_mapping[label].strip()
             for label in dataset_config.labels
         ]
-        if should_prefix_space_be_added_to_labels(
-            labels_to_be_generated=local_labels, tokenizer=tokenizer
-        ):
-            local_labels = [f" {label}" for label in local_labels]
 
-        # Get the first token of each label
-        first_tokens = [tokenizer.tokenize(text=label)[0] for label in local_labels]
+        # Get the first token of each label, where we add a prefix space if needed
+        add_prefix_space = should_prefix_space_be_added_to_labels(
+            labels_to_be_generated=local_labels, tokenizer=tokenizer
+        )
+        first_tokens = [
+            tokenizer.tokenize(text=f" {label}" if add_prefix_space else label)[0]
+            for label in local_labels
+        ]
         first_tokens = [
             re.sub(
                 pattern=r"^[^a-zæøåüöä]+|[^a-zæøåüöä]+$", repl="", string=token.lower()

--- a/src/euroeval/utils.py
+++ b/src/euroeval/utils.py
@@ -7,6 +7,7 @@ import importlib.util
 import logging
 import os
 import random
+import re
 import sys
 import typing as t
 import warnings
@@ -620,6 +621,7 @@ def get_first_label_token_mapping(
     # If there are labels associated with the dataset, and that the first token of each
     # label is distinct, then we can safely use the logprobs
     if output_scores and dataset_config.labels:
+        # Get the local labels
         local_labels = [
             dataset_config.prompt_label_mapping[label].strip()
             for label in dataset_config.labels
@@ -628,6 +630,14 @@ def get_first_label_token_mapping(
             labels_to_be_generated=local_labels, tokenizer=tokenizer
         ):
             local_labels = [f" {label}" for label in local_labels]
+        local_labels = [
+            re.sub(
+                pattern=r"^[^a-zæøåüöä]+|[^a-zæøåüöä]+$", repl="", string=label.lower()
+            )
+            for label in local_labels
+        ]
+
+        # Get the first token of each label
         first_tokens = [tokenizer.tokenize(text=label)[0] for label in local_labels]
         if len(first_tokens) == len(set(first_tokens)):
             log_once(

--- a/src/euroeval/utils.py
+++ b/src/euroeval/utils.py
@@ -358,7 +358,6 @@ def should_prompts_be_stripped(
     return strip_prompts
 
 
-# TODO: This is currently not used - maybe remove.
 def should_prefix_space_be_added_to_labels(
     labels_to_be_generated: list[str], tokenizer: "PreTrainedTokenizer"
 ) -> bool:
@@ -622,11 +621,14 @@ def get_first_label_token_mapping(
     # label is distinct, then we can safely use the logprobs
     if output_scores and dataset_config.labels:
         local_labels = [
-            dataset_config.prompt_label_mapping[label]
+            dataset_config.prompt_label_mapping[label].strip()
             for label in dataset_config.labels
         ]
+        if should_prefix_space_be_added_to_labels(
+            labels_to_be_generated=local_labels, tokenizer=tokenizer
+        ):
+            local_labels = [f" {label}" for label in local_labels]
         first_tokens = [tokenizer.tokenize(text=label)[0] for label in local_labels]
-        breakpoint()
         if len(first_tokens) == len(set(first_tokens)):
             log_once(
                 "The model will output scores, since the first tokens of the labels "

--- a/src/euroeval/utils.py
+++ b/src/euroeval/utils.py
@@ -626,6 +626,7 @@ def get_first_label_token_mapping(
             for label in dataset_config.labels
         ]
         first_tokens = [tokenizer.tokenize(text=label)[0] for label in local_labels]
+        breakpoint()
         if len(first_tokens) == len(set(first_tokens)):
             log_once(
                 "The model will output scores, since the first tokens of the labels "

--- a/src/euroeval/utils.py
+++ b/src/euroeval/utils.py
@@ -630,15 +630,18 @@ def get_first_label_token_mapping(
             labels_to_be_generated=local_labels, tokenizer=tokenizer
         ):
             local_labels = [f" {label}" for label in local_labels]
-        local_labels = [
-            re.sub(
-                pattern=r"^[^a-zæøåüöä]+|[^a-zæøåüöä]+$", repl="", string=label.lower()
-            )
-            for label in local_labels
-        ]
 
         # Get the first token of each label
         first_tokens = [tokenizer.tokenize(text=label)[0] for label in local_labels]
+        first_tokens = [
+            re.sub(
+                pattern=r"^[^a-zæøåüöä]+|[^a-zæøåüöä]+$", repl="", string=token.lower()
+            )
+            for token in first_tokens
+        ]
+
+        # Build a mapping from labels to the first token in each label if the first
+        # tokens are distinct
         if len(first_tokens) == len(set(first_tokens)):
             log_once(
                 "The model will output scores, since the first tokens of the labels "


### PR DESCRIPTION
### Fixed
- Now uses `LLM.generate` if the model is not instruction tuned, as opposed to `LLM.chat`.
- Now defaults to BF16 if the model is registered as using FP32, assuming that BF16 is
  supported by the GPU.