### PR TITLE
Fix/do not info log when encoders cannot be benchmarked on generative tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed issue with benchmarking multiple generative models in the same evaluation
   command. This was caused by vLLM and Ray not being able to release GPU memory
   properly, but this seems to be released properly now.
+- Now only logs when encoder models are being benchmarked on generative tasks if the
+  `--verbose` flag is set (or `verbose=True` in the `Benchmarker` API).
 
 
 ## [v15.5.0] - 2025-04-07

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -19,7 +19,12 @@ from .data_loading import load_data
 from .data_models import BenchmarkConfigParams, BenchmarkResult
 from .dataset_configs import get_all_dataset_configs
 from .enums import Device, ModelType
-from .exceptions import HuggingFaceHubDown, InvalidBenchmark, InvalidModel
+from .exceptions import (
+    HuggingFaceHubDown,
+    InvalidBenchmark,
+    InvalidModel,
+    ModelNotSuitedForTask,
+)
 from .finetuning import finetune
 from .generation import generate
 from .model_config import get_model_config
@@ -447,32 +452,31 @@ class Benchmarker:
                 ):
                     raise benchmark_output_or_err
 
-                elif isinstance(benchmark_output_or_err, InvalidBenchmark):
-                    if benchmark_config.raise_errors:
-                        raise benchmark_output_or_err
-                    logger.info(
-                        f"{model_id} could not be benchmarked on "
-                        f"{dataset_config.pretty_name}. Skipping. The error message "
-                        f"raised was {benchmark_output_or_err.message!r}."
+                elif isinstance(benchmark_output_or_err, ModelNotSuitedForTask):
+                    logger.debug(
+                        f"The model {model_id!r} is not suited for the task "
+                        f"{dataset_config.task.name!r}, skipping."
                     )
                     num_finished_benchmarks += 1
                     continue
 
+                elif isinstance(benchmark_output_or_err, InvalidBenchmark):
+                    logger.info(benchmark_output_or_err.message)
+                    num_finished_benchmarks += 1
+                    continue
+
                 elif isinstance(benchmark_output_or_err, InvalidModel):
-                    if benchmark_config.raise_errors:
-                        raise benchmark_output_or_err
                     logger.info(benchmark_output_or_err.message)
 
-                    # Add the remaining number of benchmarks for the model to
-                    # our benchmark counter, since we're skipping the
-                    # rest of them
+                    # Add the remaining number of benchmarks for the model to our
+                    # benchmark counter, since we're skipping the rest of them
                     num_finished_benchmarks += (
                         len(dataset_configs) - dataset_configs.index(dataset_config) - 1
                     )
                     break
 
                 else:
-                    record = benchmark_output_or_err
+                    record: BenchmarkResult = benchmark_output_or_err
                     current_benchmark_results.append(record)
                     if benchmark_config.save_results:
                         record.append_to_results(results_path=self.results_path)

--- a/src/euroeval/exceptions.py
+++ b/src/euroeval/exceptions.py
@@ -17,20 +17,6 @@ class InvalidBenchmark(Exception):
         super().__init__(self.message)
 
 
-class ModelNotSuitedForTask(InvalidBenchmark):
-    """The model is not suited for the task."""
-
-    def __init__(self, message: str = "The model is not suited for the task.") -> None:
-        """Initialise the exception.
-
-        Args:
-            message:
-                The message to display.
-        """
-        self.message = message
-        super().__init__(self.message)
-
-
 class InvalidModel(Exception):
     """The model cannot be benchmarked on any datasets."""
 

--- a/src/euroeval/exceptions.py
+++ b/src/euroeval/exceptions.py
@@ -7,7 +7,21 @@ class InvalidBenchmark(Exception):
     def __init__(
         self, message: str = "This model cannot be benchmarked on the given dataset."
     ) -> None:
-        """Initialize the exception.
+        """Initialise the exception.
+
+        Args:
+            message:
+                The message to display.
+        """
+        self.message = message
+        super().__init__(self.message)
+
+
+class ModelNotSuitedForTask(InvalidBenchmark):
+    """The model is not suited for the task."""
+
+    def __init__(self, message: str = "The model is not suited for the task.") -> None:
+        """Initialise the exception.
 
         Args:
             message:
@@ -23,7 +37,7 @@ class InvalidModel(Exception):
     def __init__(
         self, message: str = "The model cannot be benchmarked on any datasets."
     ) -> None:
-        """Initialize the exception.
+        """Initialise the exception.
 
         Args:
             message:
@@ -39,7 +53,7 @@ class HuggingFaceHubDown(Exception):
     def __init__(
         self, message: str = "The Hugging Face Hub is currently down."
     ) -> None:
-        """Initialize the exception.
+        """Initialise the exception.
 
         Args:
             message:
@@ -55,7 +69,7 @@ class NoInternetConnection(Exception):
     def __init__(
         self, message: str = "There is currently no internet connection."
     ) -> None:
-        """Initialize the exception.
+        """Initialise the exception.
 
         Args:
             message:
@@ -71,7 +85,7 @@ class NaNValueInModelOutput(Exception):
     def __init__(
         self, message: str = "There is a NaN value in the model output."
     ) -> None:
-        """Initialize the exception.
+        """Initialise the exception.
 
         Args:
             message:
@@ -93,7 +107,7 @@ class FlashAttentionNotInstalled(Exception):
             "pip install flash-attn --no-build-isolation`."
         ),
     ) -> None:
-        """Initialize the exception.
+        """Initialise the exception.
 
         Args:
             message:
@@ -107,7 +121,7 @@ class NeedsExtraInstalled(InvalidModel):
     """The evaluation requires extra to be installed."""
 
     def __init__(self, extra: str) -> None:
-        """Initialize the exception.
+        """Initialise the exception.
 
         Args:
             extra:
@@ -126,7 +140,7 @@ class NeedsManualDependency(InvalidModel):
     """The evaluation requires a dependency to be manually installed."""
 
     def __init__(self, package: str) -> None:
-        """Initialize the exception.
+        """Initialise the exception.
 
         Args:
             package:
@@ -146,7 +160,7 @@ class NeedsAdditionalArgument(InvalidModel):
     def __init__(
         self, cli_argument: str, script_argument: str, run_with_cli: bool
     ) -> None:
-        """Initialize the exception.
+        """Initialise the exception.
 
         Args:
             cli_argument:
@@ -177,7 +191,7 @@ class NeedsEnvironmentVariable(InvalidModel):
     """The evaluation requires an environment variable to be set."""
 
     def __init__(self, env_var: str) -> None:
-        """Initialize the exception.
+        """Initialise the exception.
 
         Args:
             env_var:

--- a/src/euroeval/human_evaluation.py
+++ b/src/euroeval/human_evaluation.py
@@ -44,7 +44,7 @@ class HumanEvaluator:
         description: str,
         dummy_model_id: str = "mistralai/Mistral-7B-v0.1",
     ) -> None:
-        """Initialize the HumanEvaluator.
+        """Initialise the HumanEvaluator.
 
         Args:
             annotator_id:

--- a/src/euroeval/model_cache.py
+++ b/src/euroeval/model_cache.py
@@ -38,7 +38,7 @@ class ModelCache:
     def __init__(
         self, model_cache_dir: "Path", cache_name: str, max_generated_tokens: int
     ) -> None:
-        """Initialize the model output cache.
+        """Initialise the model output cache.
 
         Args:
             model_cache_dir:

--- a/src/euroeval/model_loading.py
+++ b/src/euroeval/model_loading.py
@@ -8,9 +8,8 @@ from .benchmark_modules import (
     LiteLLMModel,
     VLLMModel,
 )
-from .constants import GENERATIVE_DATASET_TASK_GROUPS
 from .enums import InferenceBackend, ModelType
-from .exceptions import InvalidModel, ModelNotSuitedForTask
+from .exceptions import InvalidModel
 
 if t.TYPE_CHECKING:
     from .benchmark_modules import BenchmarkModule
@@ -58,16 +57,6 @@ def load_model(
                 f"Cannot load model with model type {model_config.model_type!r} and "
                 f"inference backend {model_config.inference_backend!r}."
             )
-
-    # Refuse to benchmark non-generative models on generative tasks
-    if (
-        dataset_config.task.task_group in GENERATIVE_DATASET_TASK_GROUPS
-        and not model_config.model_type == ModelType.GENERATIVE
-    ):
-        raise ModelNotSuitedForTask(
-            f"Cannot benchmark non-generative model {model_config.model_id!r} on "
-            f"generative task {dataset_config.task.name!r}."
-        )
 
     model = model_class(
         model_config=model_config,

--- a/src/euroeval/model_loading.py
+++ b/src/euroeval/model_loading.py
@@ -10,7 +10,7 @@ from .benchmark_modules import (
 )
 from .constants import GENERATIVE_DATASET_TASK_GROUPS
 from .enums import InferenceBackend, ModelType
-from .exceptions import InvalidBenchmark, InvalidModel
+from .exceptions import InvalidModel, ModelNotSuitedForTask
 
 if t.TYPE_CHECKING:
     from .benchmark_modules import BenchmarkModule
@@ -64,7 +64,7 @@ def load_model(
         dataset_config.task.task_group in GENERATIVE_DATASET_TASK_GROUPS
         and not model_config.model_type == ModelType.GENERATIVE
     ):
-        raise InvalidBenchmark(
+        raise ModelNotSuitedForTask(
             f"Cannot benchmark non-generative model {model_config.model_id!r} on "
             f"generative task {dataset_config.task.name!r}."
         )

--- a/src/euroeval/task_utils/multiple_choice_classification.py
+++ b/src/euroeval/task_utils/multiple_choice_classification.py
@@ -41,8 +41,6 @@ class MultipleChoiceClassificationTrainer(Trainer):
         Returns:
             The metrics computed on the evaluation dataset.
         """
-        assert isinstance(eval_dataset, Dataset)
-
         eval_dataloader = self.get_eval_dataloader(eval_dataset)
 
         eval_loop = (

--- a/src/euroeval/task_utils/question_answering.py
+++ b/src/euroeval/task_utils/question_answering.py
@@ -46,7 +46,7 @@ class QuestionAnsweringTrainer(Trainer):
         callbacks: "list[TrainerCallback]",
         data_collator: "c.Callable",
     ) -> None:
-        """Initialize the trainer."""
+        """Initialise the trainer."""
         super().__init__(
             model=model,
             processing_class=processing_class,


### PR DESCRIPTION
### Fixed
- Now only logs when encoder models are being benchmarked on generative tasks if the
  `--verbose` flag is set (or `verbose=True` in the `Benchmarker` API).