### PR TITLE
fix: Set labels for NorCommonSenseQA to include E

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added more info about SQuAD-nl in the documentation. This was contributed by
   [@Rijgersberg](https://github.com/Rijgersberg) ✨
 
+### Fixed
+- The "E" option for the NorCommonSenseQA dataset was not included in the refactor in
+  v15.6.0, leading to evaluation errors. This has been fixed now.
+
 
 ## [v15.6.0] - 2025-04-13
 ### Added

--- a/docs/datasets/dutch.md
+++ b/docs/datasets/dutch.md
@@ -310,13 +310,13 @@ Here are a few examples from the training split:
 This dataset is published
 [here](https://huggingface.co/datasets/GroNLP/squad-nl-v2.0) and is a machine translated
 dataset of the English [SQuAD](https://aclanthology.org/D16-1264/) and
-[XQuAD](https://aclanthology.org/2020.acl-main.421/) datasets, created for the 
-Dutch-language [DUMB](https://dumbench.nl/) benchmark. Google Translate was used to 
-translate the original datasets to Dutch. The test data 
-[was manually corrected](https://aclanthology.org/2023.emnlp-main.447/) by eight BSc 
-students as part of their thesis work. 
+[XQuAD](https://aclanthology.org/2020.acl-main.421/) datasets, created for the
+Dutch-language [DUMB](https://dumbench.nl/) benchmark. Google Translate was used to
+translate the original datasets to Dutch. The test data
+[was manually corrected](https://aclanthology.org/2023.emnlp-main.447/) by eight BSc
+students as part of their thesis work.
 
-The original SQuAD and XQuAD datasets are based on English Wikipedia articles and the 
+The original SQuAD and XQuAD datasets are based on English Wikipedia articles and the
 questions and answers are written by crowdworkers.
 
 Here are a few examples from the training split:

--- a/makefile
+++ b/makefile
@@ -81,21 +81,8 @@ test:  ## Run tests
 tree:  ## Print directory tree
 	@tree -a --gitignore -I .git .
 
-lint:  ## Lint the project
-	uv run ruff check . --fix --unsafe-fixes
-
-format:  ## Format the project
-	uv run ruff format .
-
-type-check:  ## Type-check the project
-	@uv run mypy . \
-		--install-types \
-		--non-interactive \
-		--ignore-missing-imports \
-		--show-error-codes \
-		--check-untyped-defs
-
-check: lint format type-check  ## Lint, format, and type-check the code
+check:  ## Lint, format, and type-check the code
+	@uv run pre-commit run --all-files
 
 bump-major:
 	@uv run python -m src.scripts.versioning --major

--- a/src/euroeval/data_models.py
+++ b/src/euroeval/data_models.py
@@ -388,8 +388,10 @@ class DatasetConfig:
             language.
         _prompt_label_mapping (optional):
             A mapping from the labels to another phrase which is used as a substitute
-            for the label in few-shot evaluation. Defaults to the template for the task
-            and language.
+            for the label in few-shot evaluation. If "auto" then the mapping will be set
+            to a 1:1 mapping between the labels and themselves. If None then the mapping
+            will be set to the default mapping for the task and language. Defaults to
+            None.
         unofficial (optional):
             Whether the dataset is unofficial. Defaults to False.
     """
@@ -405,7 +407,7 @@ class DatasetConfig:
     _num_few_shot_examples: int | None = None
     _max_generated_tokens: int | None = None
     _labels: list[str] | None = None
-    _prompt_label_mapping: dict[str, str] | None = None
+    _prompt_label_mapping: dict[str, str] | t.Literal["auto"] | None = None
     unofficial: bool = False
 
     @property
@@ -475,7 +477,9 @@ class DatasetConfig:
     @property
     def prompt_label_mapping(self) -> dict[str, str]:
         """Mapping from English labels to localised labels."""
-        if self._prompt_label_mapping is not None:
+        if self._prompt_label_mapping == "auto":
+            return {label: label for label in self.labels}
+        elif self._prompt_label_mapping is not None:
             return self._prompt_label_mapping
 
         main_language = self.languages[0]

--- a/src/euroeval/dataset_configs/norwegian.py
+++ b/src/euroeval/dataset_configs/norwegian.py
@@ -83,6 +83,7 @@ NOR_COMMON_SENSE_QA_CONFIG = DatasetConfig(
     huggingface_id="EuroEval/nor-common-sense-qa",
     task=COMMON_SENSE,
     languages=[NB, NN, NO],
+    _labels=["a", "b", "c", "d", "e"],
 )
 
 


### PR DESCRIPTION
### Fixed
- The "E" option for the NorCommonSenseQA dataset was not included in the refactor in
  v15.6.0, leading to evaluation errors. This has been fixed now.