### PR TITLE
fix: Up MAX_CONTEXT_LENGTH to 6000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added more info about SQuAD-nl in the documentation. This was contributed by
   [@Rijgersberg](https://github.com/Rijgersberg) ✨
 
+### Fixed
+- Increased the maximal context length from the previous 5,000 to 6,000, as some of the
+  datasets have prompts in the 5,000's
+
 
 ## [v15.6.0] - 2025-04-13
 ### Added

--- a/docs/datasets/dutch.md
+++ b/docs/datasets/dutch.md
@@ -310,13 +310,13 @@ Here are a few examples from the training split:
 This dataset is published
 [here](https://huggingface.co/datasets/GroNLP/squad-nl-v2.0) and is a machine translated
 dataset of the English [SQuAD](https://aclanthology.org/D16-1264/) and
-[XQuAD](https://aclanthology.org/2020.acl-main.421/) datasets, created for the 
-Dutch-language [DUMB](https://dumbench.nl/) benchmark. Google Translate was used to 
-translate the original datasets to Dutch. The test data 
-[was manually corrected](https://aclanthology.org/2023.emnlp-main.447/) by eight BSc 
-students as part of their thesis work. 
+[XQuAD](https://aclanthology.org/2020.acl-main.421/) datasets, created for the
+Dutch-language [DUMB](https://dumbench.nl/) benchmark. Google Translate was used to
+translate the original datasets to Dutch. The test data
+[was manually corrected](https://aclanthology.org/2023.emnlp-main.447/) by eight BSc
+students as part of their thesis work.
 
-The original SQuAD and XQuAD datasets are based on English Wikipedia articles and the 
+The original SQuAD and XQuAD datasets are based on English Wikipedia articles and the
 questions and answers are written by crowdworkers.
 
 Here are a few examples from the training split:

--- a/src/euroeval/constants.py
+++ b/src/euroeval/constants.py
@@ -11,7 +11,7 @@ DUMMY_FILL_VALUE = 100
 # benchmark. We will still report the models' true maximum context length in the
 # metadata, but we won't use it for evaluation, as vLLM needs to allocate memory for
 # all tokens in the context.
-MAX_CONTEXT_LENGTH = 5_000
+MAX_CONTEXT_LENGTH = 6_000
 
 
 # We need to raise the amount of tokens generated for reasoning models, to give them


### PR DESCRIPTION
### Fixed
- Increased the maximal context length from the previous 5,000 to 6,000, as some of the
  datasets have prompts in the 5,000's