### PR TITLE
fix: Store revision to disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   due to a typo. This has been fixed now.
 - Now catches the error when an API model requires setting temperature to 1.0, and
   retries the evaluation with temperature set to 1.0.
+- When benchmarking a model with a revision (i.e., of the form `<model-id>@<revision>`),
+  we now correctly store this full model ID to the benchmark results on disk, including
+  the revision.
 
 
 ## [v15.6.1] - 2025-04-14

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -782,7 +782,11 @@ class Benchmarker:
                     dataset_languages=[
                         language.code for language in dataset_config.languages
                     ],
-                    model=model_config.model_id,
+                    model=(
+                        f"{model_config.model_id}@{model_config.revision}"
+                        if model_config.revision != "main"
+                        else model_config.model_id
+                    ),
                     results=results,
                     num_model_parameters=model.num_params,
                     max_sequence_length=model.model_max_length,


### PR DESCRIPTION
### Fixed
- When benchmarking a model with a revision (i.e., of the form `<model-id>@<revision>`),
  we now correctly store this full model ID to the benchmark results on disk, including
  the revision.