### PR TITLE
Fix/grok empty outputs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: debug-statements
+      # - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.5
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      # - id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.5
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Increase the number of allowed reasoning tokens from 8,192 to 32,768 for reasoning
   models. This is done as several models did not stop reasoning before running out of
   tokens, yielding a blank output.
+- API models now use JSON schemas for the NER task if they support it, and if not then
+  they resort to standard JSON mode (which does not enforce a specific schema, just that
+  the output is JSON).
 
 ### Fixed
 - If we fail to extract labels using a generative model's logprobs, we now fall back to
@@ -32,6 +35,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a GPU memory error while computing the BERTScore for the summarisation task,
   resulting in a memory crash. We have now reduced the batch size to 1 for this task,
   making it slightly slower but more memory efficient.
+- Sometimes reasoning models will output the answer within the reasoning content and
+  leave the actual output blank - in this case, we use the reasoning content as the
+  content instead of the blank output.
 
 
 ## [v15.6.1] - 2025-04-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a GPU memory error while computing the BERTScore for the summarisation task,
   resulting in a memory crash. We have now reduced the batch size to 1 for this task,
   making it slightly slower but more memory efficient.
-- Sometimes reasoning models will output the answer within the reasoning content and
-  leave the actual output blank - in this case, we use the reasoning content as the
-  content instead of the blank output.
+- Disabled structured outputs for reasoning models, to ensure that they are allowed to
+  output reasoning tokens before they output the JSON object.
 
 
 ## [v15.6.1] - 2025-04-14

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -397,6 +397,7 @@ class LiteLLMModel(BenchmarkModule):
                 "reasoning. Returning an empty string."
             )
             return GenerativeModelOutput(sequences=[""])
+
         model_response_choices = model_response.choices[0]
         assert isinstance(model_response_choices, litellm.Choices)
         generated_message: litellm.Message = model_response_choices.message

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -332,7 +332,6 @@ class LiteLLMModel(BenchmarkModule):
                 model_response = litellm.completion(
                     messages=messages, max_retries=3, **generation_kwargs
                 )
-                breakpoint()
                 break
             except (BadRequestError, RateLimitError) as e:
                 if any(msg.lower() in str(e).lower() for msg in stop_messages):
@@ -400,8 +399,11 @@ class LiteLLMModel(BenchmarkModule):
             return GenerativeModelOutput(sequences=[""])
         model_response_choices = model_response.choices[0]
         assert isinstance(model_response_choices, litellm.Choices)
-        generation_output = model_response_choices.message["content"] or ""
-        generation_output = generation_output.strip()
+        generated_message: litellm.Message = model_response_choices.message
+        generation_output = (
+            generated_message.content or generated_message.reasoning_content or ""
+        ).strip()
+        breakpoint()
 
         # Structure the model output as a GenerativeModelOutput object
         model_output = GenerativeModelOutput(sequences=[generation_output])

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -266,7 +266,10 @@ class LiteLLMModel(BenchmarkModule):
             generation_kwargs["logprobs"] = True
             generation_kwargs["top_logprobs"] = MAX_LOGPROBS
 
-        if self.dataset_config.task in TASKS_USING_JSON:
+        if (
+            self.dataset_config.task in TASKS_USING_JSON
+            and self.generative_type != GenerativeType.REASONING
+        ):
             assert "json" in messages[0]["content"].lower(), (
                 "Prompt must contain 'json' for JSON tasks."
             )

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -407,7 +407,6 @@ class LiteLLMModel(BenchmarkModule):
         generation_output = (
             generated_message.content or generated_message.reasoning_content or ""
         ).strip()
-        breakpoint()
 
         # Structure the model output as a GenerativeModelOutput object
         model_output = GenerativeModelOutput(sequences=[generation_output])

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -288,8 +288,8 @@ class LiteLLMModel(BenchmarkModule):
                 generation_kwargs["response_format"] = dict(type="json_object")
                 log_once(
                     "Enabling structured JSON generation for model "
-                    f"{self.model_config.model_id!r} with no JSON schema, as the model "
-                    "does not support schemas.",
+                    f"{self.model_config.model_id!r} with no custom JSON schema, as "
+                    "the model does not support schemas.",
                     level=logging.DEBUG,
                 )
 

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -315,6 +315,7 @@ class LiteLLMModel(BenchmarkModule):
                 model_response = litellm.completion(
                     messages=messages, max_retries=3, **generation_kwargs
                 )
+                breakpoint()
                 break
             except (BadRequestError, RateLimitError) as e:
                 if any(msg.lower() in str(e).lower() for msg in stop_messages):

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -347,7 +347,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                 whitespace_pattern=r" ?",
             )
             log_once(
-                "Using structured generation with the schema "
+                "Using structured generation with the JSON schema "
                 f"{pydantic_class.model_json_schema()}",
                 level=logging.DEBUG,
             )


### PR DESCRIPTION
### Changed
- API models now use JSON schemas for the NER task if they support it, and if not then
  they resort to standard JSON mode (which does not enforce a specific schema, just that
  the output is JSON).

### Fixed
- Disabled structured outputs for reasoning models, to ensure that they are allowed to
  output reasoning tokens before they output the JSON object.