### PR TITLE
Fix/truncate prompts if they are too long

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,5 +117,5 @@ site/
 docs/datasets/dataset_example_commands.txt
 
 # Various graphics
-gfx/euroeval-italian.png
-gfx/euroeval-italian.xcf
+gfx/euroeval-*.png
+gfx/euroeval-*.xcf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: debug-statements
+      # - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.5
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      # - id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.5
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   generation.
 - Handle if a LiteLLM model does not support specifying maxItems in the JSON schema
   during structured generation.
+- Truncate prompts to decoder model's maximum sequence length if the model's maximum
+  sequence length is smaller than 5,000 tokens.
 
 
 ## [v15.6.1] - 2025-04-14

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -415,6 +415,7 @@ class VLLMModel(HuggingFaceEncoderModel):
         num_attempts = 3
         for _ in range(num_attempts):
             try:
+                breakpoint()
                 raw_outputs = self._model.generate(
                     prompts=prompts,
                     sampling_params=sampling_params,
@@ -447,7 +448,6 @@ class VLLMModel(HuggingFaceEncoderModel):
                         ),
                     )
                     if len(prompts) != len(tokenized_prompts.input_ids):
-                        breakpoint()
                         raise InvalidBenchmark(
                             f"Expected {len(prompts):,} prompts, but got "
                             f"{len(tokenized_prompts.input_ids):,}."
@@ -455,7 +455,6 @@ class VLLMModel(HuggingFaceEncoderModel):
                     prompts = self._tokenizer.batch_decode(
                         sequences=tokenized_prompts.input_ids, skip_special_tokens=True
                     )
-                    breakpoint()
                 else:
                     raise InvalidBenchmark(
                         f"An error occurred during vLLM generation: {str(e)}"

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -455,6 +455,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                     prompts = self._tokenizer.batch_decode(
                         sequences=tokenized_prompts.input_ids, skip_special_tokens=True
                     )
+                    breakpoint()
                 else:
                     raise InvalidBenchmark(
                         f"An error occurred during vLLM generation: {str(e)}"

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -436,7 +436,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                     re.search(pattern, str(e), flags=re.IGNORECASE) is not None
                     for pattern in truncate_error_messages
                 ):
-                    logger.debug(
+                    logger.info(
                         "Prompts are too long, so truncating them and trying again..."
                     )
                     tokenized_prompts = self._tokenizer(

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -429,8 +429,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                 sleep(1)
             except ValueError as e:
                 # Truncate the prompts if they are too long for the model
-                truncate_error_messages = [r"prompt (length [0-9]+) is longer than"]
-                breakpoint()
+                truncate_error_messages = [r"prompt \(length [0-9]+\) is longer than"]
                 if any(
                     re.search(pattern, str(e), flags=re.IGNORECASE) is not None
                     for pattern in truncate_error_messages

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -430,7 +430,7 @@ class VLLMModel(HuggingFaceEncoderModel):
             except ValueError as e:
                 # Truncate the prompts if they are too long for the model
                 truncate_error_messages = [
-                    r"prompt \(length [0-9]+\) is longer than the maximum length"
+                    r"prompt \(length [0-9]+\) is longer than the maximum model length"
                 ]
                 if any(
                     re.search(pattern, str(e), flags=re.IGNORECASE) is not None

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -480,6 +480,7 @@ class VLLMModel(HuggingFaceEncoderModel):
 
         # Sanity check
         if len(completions) != len(prompts):
+            breakpoint()
             raise InvalidBenchmark(
                 f"Expected {len(prompts):,} completions, but got {len(completions):,}."
             )

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -434,10 +434,10 @@ class VLLMModel(HuggingFaceEncoderModel):
                     re.search(pattern, str(e), flags=re.IGNORECASE) is not None
                     for pattern in truncate_error_messages
                 ):
-                    log_once(
-                        "Prompts are too long, so truncating them and trying again...",
-                        level=logging.DEBUG,
+                    logger.debug(
+                        "Prompts are too long, so truncating them and trying again..."
                     )
+                    breakpoint()
                     tokenized_prompts = self._tokenizer(text=prompts, truncation=True)
                     prompts = self._tokenizer.batch_decode(
                         sequences=tokenized_prompts["input_ids"],

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -442,6 +442,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                         truncation=True,
                         max_length=self._tokenizer.model_max_length + max_tokens,
                     )
+                    breakpoint()
                     prompts = self._tokenizer.batch_decode(
                         sequences=tokenized_prompts["input_ids"],
                         skip_special_tokens=True,

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -429,10 +429,11 @@ class VLLMModel(HuggingFaceEncoderModel):
                 sleep(1)
             except ValueError as e:
                 # Truncate the prompts if they are too long for the model
-                if re.search(
-                    pattern=r"prompt (length [0-9]+) is longer than",
-                    string=str(e),
-                    flags=re.IGNORECASE,
+                truncate_error_messages = [r"prompt (length [0-9]+) is longer than"]
+                breakpoint()
+                if any(
+                    re.search(pattern, str(e), flags=re.IGNORECASE) is not None
+                    for pattern in truncate_error_messages
                 ):
                     log_once(
                         "Prompts are too long, so truncating them and trying again...",

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -429,7 +429,9 @@ class VLLMModel(HuggingFaceEncoderModel):
                 sleep(1)
             except ValueError as e:
                 # Truncate the prompts if they are too long for the model
-                truncate_error_messages = [r"prompt \(length [0-9]+\) is longer than"]
+                truncate_error_messages = [
+                    r"prompt \(length [0-9]+\) is longer than the maximum length"
+                ]
                 if any(
                     re.search(pattern, str(e), flags=re.IGNORECASE) is not None
                     for pattern in truncate_error_messages
@@ -440,9 +442,8 @@ class VLLMModel(HuggingFaceEncoderModel):
                     tokenized_prompts = self._tokenizer(
                         text=prompts,
                         truncation=True,
-                        max_length=self._tokenizer.model_max_length + max_tokens,
+                        max_length=self._tokenizer.model_max_length - max_tokens,
                     )
-                    breakpoint()
                     prompts = self._tokenizer.batch_decode(
                         sequences=tokenized_prompts["input_ids"],
                         skip_special_tokens=True,

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -440,7 +440,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                     tokenized_prompts = self._tokenizer(
                         text=prompts,
                         truncation=True,
-                        max_length=self._tokenizer.max_model_length + max_tokens,
+                        max_length=self._tokenizer.model_max_length + max_tokens,
                     )
                     prompts = self._tokenizer.batch_decode(
                         sequences=tokenized_prompts["input_ids"],

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -478,6 +478,12 @@ class VLLMModel(HuggingFaceEncoderModel):
         )
         completions = [completion.strip() for completion in completions]
 
+        # Sanity check
+        if len(completions) != len(prompts):
+            raise InvalidBenchmark(
+                f"Expected {len(prompts):,} completions, but got {len(completions):,}."
+            )
+
         # Add logprobs scores to the output
         if self.buffer["first_label_token_mapping"]:
             scores: list[list[list[tuple[str, float]]]] = [

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -446,9 +446,14 @@ class VLLMModel(HuggingFaceEncoderModel):
                             self._tokenizer.model_max_length - max_tokens, 0
                         ),
                     )
+                    if len(prompts) != len(tokenized_prompts.input_ids):
+                        breakpoint()
+                        raise InvalidBenchmark(
+                            f"Expected {len(prompts):,} prompts, but got "
+                            f"{len(tokenized_prompts.input_ids):,}."
+                        )
                     prompts = self._tokenizer.batch_decode(
-                        sequences=tokenized_prompts["input_ids"],
-                        skip_special_tokens=True,
+                        sequences=tokenized_prompts.input_ids, skip_special_tokens=True
                     )
                 else:
                     raise InvalidBenchmark(

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -444,9 +444,10 @@ class VLLMModel(HuggingFaceEncoderModel):
                         sequences=tokenized_prompts["input_ids"],
                         skip_special_tokens=True,
                     )
-                raise InvalidBenchmark(
-                    f"An error occurred during vLLM generation: {str(e)}"
-                )
+                else:
+                    raise InvalidBenchmark(
+                        f"An error occurred during vLLM generation: {str(e)}"
+                    )
         else:
             raise InvalidBenchmark(
                 f"Could not generate sequences after {num_attempts} attempts."

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -437,8 +437,11 @@ class VLLMModel(HuggingFaceEncoderModel):
                     logger.debug(
                         "Prompts are too long, so truncating them and trying again..."
                     )
-                    breakpoint()
-                    tokenized_prompts = self._tokenizer(text=prompts, truncation=True)
+                    tokenized_prompts = self._tokenizer(
+                        text=prompts,
+                        truncation=True,
+                        max_length=self._tokenizer.max_model_length + max_tokens,
+                    )
                     prompts = self._tokenizer.batch_decode(
                         sequences=tokenized_prompts["input_ids"],
                         skip_special_tokens=True,

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -442,7 +442,9 @@ class VLLMModel(HuggingFaceEncoderModel):
                     tokenized_prompts = self._tokenizer(
                         text=prompts,
                         truncation=True,
-                        max_length=max(self._tokenizer.model_max_length - max_tokens, 0),
+                        max_length=max(
+                            self._tokenizer.model_max_length - max_tokens, 0
+                        ),
                     )
                     prompts = self._tokenizer.batch_decode(
                         sequences=tokenized_prompts["input_ids"],

--- a/src/euroeval/generation.py
+++ b/src/euroeval/generation.py
@@ -131,6 +131,7 @@ def generate_single_iteration(
     )
 
     all_preds: list[str] = list()
+    breakpoint()
 
     if len(non_cached_dataset) > 0:
         itr: t.Iterable

--- a/src/euroeval/generation.py
+++ b/src/euroeval/generation.py
@@ -215,6 +215,7 @@ def generate_single_iteration(
             "The dataset must have either a 'label', 'labels', or 'target_text' column"
         )
 
+    breakpoint()
     itr_scores: dict[str, float] = model.compute_metrics(
         model_outputs_and_labels=(all_preds, ground_truth)
     )

--- a/src/euroeval/generation.py
+++ b/src/euroeval/generation.py
@@ -215,7 +215,6 @@ def generate_single_iteration(
             "The dataset must have either a 'label', 'labels', or 'target_text' column"
         )
 
-    breakpoint()
     itr_scores: dict[str, float] = model.compute_metrics(
         model_outputs_and_labels=(all_preds, ground_truth)
     )

--- a/src/euroeval/generation.py
+++ b/src/euroeval/generation.py
@@ -131,7 +131,6 @@ def generate_single_iteration(
     )
 
     all_preds: list[str] = list()
-    breakpoint()
 
     if len(non_cached_dataset) > 0:
         itr: t.Iterable


### PR DESCRIPTION
### Fixed
- Truncate prompts to decoder model's maximum sequence length if the model's maximum
  sequence length is smaller than 5,000 tokens.