### PR TITLE
Add more languages for the BeleBele dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Added
+- Added the BeleBele datasets for Finnish, Italian and Spanish. They are listed as unofficial for now.
 
 
 ## [v15.7.2] - 2025-05-02

--- a/src/euroeval/dataset_configs/finnish.py
+++ b/src/euroeval/dataset_configs/finnish.py
@@ -61,7 +61,6 @@ SCALA_FI_CONFIG = DatasetConfig(
 
 ### Unofficial datasets ###
 
-
 BELEBELE_FI_CONFIG = DatasetConfig(
     name="belebele-fi",
     pretty_name="the Finnish multiple choice reading comprehension dataset "

--- a/src/euroeval/dataset_configs/finnish.py
+++ b/src/euroeval/dataset_configs/finnish.py
@@ -2,7 +2,7 @@
 
 from ..data_models import DatasetConfig
 from ..languages import FI
-from ..tasks import LA, NER, RC, SENT, SUMM
+from ..tasks import LA, MCRC, NER, RC, SENT, SUMM
 
 ### Official datasets ###
 
@@ -60,3 +60,14 @@ SCALA_FI_CONFIG = DatasetConfig(
 )
 
 ### Unofficial datasets ###
+
+
+BELEBELE_FI_CONFIG = DatasetConfig(
+    name="belebele-fi",
+    pretty_name="the Finnish multiple choice reading comprehension dataset "
+    "BeleBele-fi, translated from the English BeleBele dataset",
+    huggingface_id="EuroEval/belebele-fi-mini",
+    task=MCRC,
+    languages=[FI],
+    unofficial=True,
+)

--- a/src/euroeval/dataset_configs/italian.py
+++ b/src/euroeval/dataset_configs/italian.py
@@ -2,7 +2,7 @@
 
 from ..data_models import DatasetConfig
 from ..languages import IT
-from ..tasks import COMMON_SENSE, KNOW, LA, NER, RC, SENT, SUMM
+from ..tasks import COMMON_SENSE, KNOW, LA, MCRC, NER, RC, SENT, SUMM
 
 ### Official datasets ###
 
@@ -76,6 +76,16 @@ WIKINEURAL_IT_CONFIG = DatasetConfig(
     "entity recognition dataset WikiNEuRal IT",
     huggingface_id="EuroEval/wikineural-mini-it",
     task=NER,
+    languages=[IT],
+    unofficial=True,
+)
+
+BELEBELE_IT_CONFIG = DatasetConfig(
+    name="belebele-it",
+    pretty_name="the Italian multiple choice reading comprehension dataset "
+    "BeleBele-it, translated from the English BeleBele dataset",
+    huggingface_id="EuroEval/belebele-it-mini",
+    task=MCRC,
     languages=[IT],
     unofficial=True,
 )

--- a/src/euroeval/dataset_configs/spanish.py
+++ b/src/euroeval/dataset_configs/spanish.py
@@ -2,7 +2,7 @@
 
 from ..data_models import DatasetConfig
 from ..languages import ES
-from ..tasks import COMMON_SENSE, KNOW, LA, NER, RC, SENT, SUMM
+from ..tasks import COMMON_SENSE, KNOW, LA, MCRC, NER, RC, SENT, SUMM
 
 ### Official datasets ###
 
@@ -73,6 +73,16 @@ XQUAD_ES_CONFIG = DatasetConfig(
     pretty_name="the Spanish version of the XQuAD reading comprehension dataset",
     huggingface_id="EuroEval/xquad-es",
     task=RC,
+    languages=[ES],
+    unofficial=True,
+)
+
+BELEBELE_ES_CONFIG = DatasetConfig(
+    name="belebele-es",
+    pretty_name="the Spanish multiple choice reading comprehension dataset "
+    "BeleBele-es, translated from the English BeleBele dataset",
+    huggingface_id="EuroEval/belebele-es-mini",
+    task=MCRC,
     languages=[ES],
     unofficial=True,
 )

--- a/src/scripts/create_belebele.py
+++ b/src/scripts/create_belebele.py
@@ -41,6 +41,9 @@ def main() -> None:
         "nl": "nld_Latn",
         "en": "eng_Latn",
         "fr": "fra_Latn",
+        "fi": "fin_Latn",
+        "it": "ita_Latn",
+        "es": "spa_Latn",
     }
     text_mapping = {
         "da": "Tekst",
@@ -51,6 +54,9 @@ def main() -> None:
         "nl": "Tekst",
         "en": "Text",
         "fr": "Texte",
+        "fi": "Teksti",
+        "it": "Testo",
+        "es": "Texto",
     }
     question_mapping = {
         "da": "Spørgsmål",
@@ -61,6 +67,9 @@ def main() -> None:
         "nl": "Vraag",
         "en": "Question",
         "fr": "Question",
+        "fi": "Kysymys",
+        "it": "Domanda",
+        "es": "Pregunta",
     }
     choices_mapping = {
         "da": "Svarmuligheder",
@@ -71,6 +80,9 @@ def main() -> None:
         "nl": "Antwoordopties",
         "en": "Choices",
         "fr": "Choix",
+        "fi": "Vaihtoehdot",
+        "it": "Opzioni",
+        "es": "Opciones",
     }
 
     for language in choices_mapping.keys():


### PR DESCRIPTION
Add the Finnish, Italian, and Spanish BeleBele datasets.

Documentation for these datasets will be added in https://github.com/EuroEval/EuroEval/pull/970