### PR TITLE
Set eval accumulation steps to avoid OOM when evaluating encoders

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: debug-statements
+      # - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.8
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      # - id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.8
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Fixed
+- If we run out of GPU memory during evaluation of encoder models, we now attempt to
+  evaluate on CPU instead.
 
 
 ## [v15.7.2] - 2025-05-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- If we run out of GPU memory during evaluation of encoder models, we now attempt to
-  evaluate on CPU instead.
+- Now uses `eval_accumulation_steps` (set to 32) when evaluating encoder models, to
+  avoid running out of memory during evaluation.
 
 
 ## [v15.7.2] - 2025-05-02

--- a/src/euroeval/finetuning.py
+++ b/src/euroeval/finetuning.py
@@ -234,6 +234,7 @@ def finetune_single_iteration(
         orig_eval_dataset=dataset["original_test"],
         metric_key_prefix="test",
     )
+    trainer.args.use_cpu = True
     with torch.inference_mode():
         while True:
             try:
@@ -241,15 +242,6 @@ def finetune_single_iteration(
                 break
             except TypeError:
                 evaluate_kwargs.pop("orig_eval_dataset")
-            except torch.OutOfMemoryError as e:
-                log_once(
-                    "Out of memory error during evaluation of model "
-                    f"{model_config.model_id!r}. Trying to evaluate on CPU.",
-                    level=logging.DEBUG,
-                )
-                if trainer.args.use_cpu:
-                    raise e
-                trainer.args.use_cpu = True
             except NaNValueInModelOutput as e:
                 del trainer
                 del model

--- a/src/euroeval/finetuning.py
+++ b/src/euroeval/finetuning.py
@@ -222,7 +222,6 @@ def finetune_single_iteration(
         trainer.add_callback(NeverLeaveProgressCallback)
 
     try:
-        breakpoint()
         trainer.train()
         with torch.inference_mode():
             try:
@@ -232,6 +231,7 @@ def finetune_single_iteration(
                     metric_key_prefix="test",
                 )
             except TypeError:
+                trainer.model.to("cpu")
                 test_scores = trainer.evaluate(
                     eval_dataset=dataset["test"], metric_key_prefix="test"
                 )

--- a/src/euroeval/finetuning.py
+++ b/src/euroeval/finetuning.py
@@ -222,7 +222,8 @@ def finetune_single_iteration(
         trainer.add_callback(NeverLeaveProgressCallback)
 
     try:
-        trainer.train()
+        # trainer.train()
+        trainer.args.use_cpu = True
         with torch.inference_mode():
             try:
                 test_scores = trainer.evaluate(
@@ -231,7 +232,6 @@ def finetune_single_iteration(
                     metric_key_prefix="test",
                 )
             except TypeError:
-                trainer.model.to("cpu")
                 test_scores = trainer.evaluate(
                     eval_dataset=dataset["test"], metric_key_prefix="test"
                 )

--- a/src/euroeval/finetuning.py
+++ b/src/euroeval/finetuning.py
@@ -226,6 +226,7 @@ def finetune_single_iteration(
         trainer.add_callback(NeverLeaveProgressCallback)
 
     try:
+        breakpoint()
         trainer.train()
         with torch.inference_mode():
             try:

--- a/src/euroeval/finetuning.py
+++ b/src/euroeval/finetuning.py
@@ -103,7 +103,6 @@ def finetune(
                 itr_scores = finetune_single_iteration(
                     model=model if model_already_initialized else None,
                     dataset=datasets[idx],
-                    iteration_idx=idx,
                     training_args=training_args,
                     model_config=model_config,
                     dataset_config=dataset_config,
@@ -158,7 +157,6 @@ def finetune(
 def finetune_single_iteration(
     model: BenchmarkModule | None,
     dataset: DatasetDict,
-    iteration_idx: int,
     training_args: TrainingArguments,
     model_config: "ModelConfig",
     dataset_config: "DatasetConfig",
@@ -171,8 +169,6 @@ def finetune_single_iteration(
             The model to use in the benchmark. If None then a new model will be loaded.
         dataset:
             The dataset to use for training and evaluation.
-        iteration_idx:
-            The index of the iteration.
         training_args:
             The training arguments.
         model_config:

--- a/src/euroeval/finetuning.py
+++ b/src/euroeval/finetuning.py
@@ -242,8 +242,10 @@ def finetune_single_iteration(
             except TypeError:
                 evaluate_kwargs.pop("orig_eval_dataset")
             except torch.OutOfMemoryError:
-                logger.debug(
-                    "Out of memory error during evaluation. Trying to evaluate on CPU."
+                log_once(
+                    "Out of memory error during evaluation of model "
+                    f"{model_config.model_id!r}. Trying to evaluate on CPU.",
+                    level=logging.DEBUG,
                 )
                 trainer.args.use_cpu = True
             except NaNValueInModelOutput as e:

--- a/src/euroeval/finetuning.py
+++ b/src/euroeval/finetuning.py
@@ -227,7 +227,7 @@ def finetune_single_iteration(
         try:
             test_scores = trainer.evaluate(
                 eval_dataset=dataset["test"],
-                orig_eval_dataset=dataset["original_test"],
+                # orig_eval_dataset=dataset["original_test"],
                 metric_key_prefix="test",
             )
         except TypeError:

--- a/src/euroeval/finetuning.py
+++ b/src/euroeval/finetuning.py
@@ -223,7 +223,7 @@ def finetune_single_iteration(
 
     # Train and evaluate the model
     with torch.inference_mode():
-        # trainer.train()
+        trainer.train()
         try:
             test_scores = trainer.evaluate(
                 eval_dataset=dataset["test"],

--- a/src/euroeval/finetuning.py
+++ b/src/euroeval/finetuning.py
@@ -227,7 +227,7 @@ def finetune_single_iteration(
         try:
             test_scores = trainer.evaluate(
                 eval_dataset=dataset["test"],
-                # orig_eval_dataset=dataset["original_test"],
+                orig_eval_dataset=dataset["original_test"],
                 metric_key_prefix="test",
             )
         except TypeError:

--- a/src/euroeval/finetuning.py
+++ b/src/euroeval/finetuning.py
@@ -295,6 +295,7 @@ def get_training_args(
         save_total_limit=1,
         per_device_train_batch_size=batch_size,
         per_device_eval_batch_size=batch_size,
+        eval_accumulation_steps=32,
         optim=OptimizerNames.ADAMW_TORCH,
         learning_rate=2e-5,
         warmup_ratio=0.01,

--- a/src/euroeval/finetuning.py
+++ b/src/euroeval/finetuning.py
@@ -221,9 +221,11 @@ def finetune_single_iteration(
     if benchmark_config.progress_bar:
         trainer.add_callback(NeverLeaveProgressCallback)
 
-    # Train and evaluate the model
+    # Train the model
+    trainer.train()
+
+    # Evaluate the model
     with torch.inference_mode():
-        trainer.train()
         try:
             test_scores = trainer.evaluate(
                 eval_dataset=dataset["test"],

--- a/src/euroeval/finetuning.py
+++ b/src/euroeval/finetuning.py
@@ -241,12 +241,14 @@ def finetune_single_iteration(
                 break
             except TypeError:
                 evaluate_kwargs.pop("orig_eval_dataset")
-            except torch.OutOfMemoryError:
+            except torch.OutOfMemoryError as e:
                 log_once(
                     "Out of memory error during evaluation of model "
                     f"{model_config.model_id!r}. Trying to evaluate on CPU.",
                     level=logging.DEBUG,
                 )
+                if trainer.args.use_cpu:
+                    raise e
                 trainer.args.use_cpu = True
             except NaNValueInModelOutput as e:
                 del trainer

--- a/src/euroeval/finetuning.py
+++ b/src/euroeval/finetuning.py
@@ -222,7 +222,7 @@ def finetune_single_iteration(
         trainer.add_callback(NeverLeaveProgressCallback)
 
     try:
-        # trainer.train()
+        trainer.train()
         trainer.args.use_cpu = True
         with torch.inference_mode():
             try:


### PR DESCRIPTION
### Fixed
- Now uses `eval_accumulation_steps` (set to 32) when evaluating encoder models, to
  avoid running out of memory during evaluation.