### PR TITLE
Feat/add hellaswag fi back in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Added
+- Add HellaSwag-fi back in, as the issue with the labels in the test split has been
+  fixed.
 
 
 ## [v15.7.2] - 2025-05-02

--- a/src/euroeval/dataset_configs/finnish.py
+++ b/src/euroeval/dataset_configs/finnish.py
@@ -2,7 +2,7 @@
 
 from ..data_models import DatasetConfig
 from ..languages import FI
-from ..tasks import LA, NER, RC, SENT, SUMM
+from ..tasks import COMMON_SENSE, LA, NER, RC, SENT, SUMM
 
 ### Official datasets ###
 
@@ -40,16 +40,14 @@ XLSUM_FI_CONFIG = DatasetConfig(
     languages=[FI],
 )
 
-# TODO: Include when this issue has been resolved:
-# https://github.com/EuroEval/EuroEval/issues/158#issuecomment-2846664885
-# HELLASWAG_FI_CONFIG = DatasetConfig(
-#     name="hellaswag-fi",
-#     pretty_name="the truncated version of the Finnish common-sense reasoning dataset "
-#     "HellaSwag-fi, translated from the English HellaSwag dataset",
-#     huggingface_id="EuroEval/hellaswag-fi-mini",
-#     task=COMMON_SENSE,
-#     languages=[FI],
-# )
+HELLASWAG_FI_CONFIG = DatasetConfig(
+    name="hellaswag-fi",
+    pretty_name="the truncated version of the Finnish common-sense reasoning dataset "
+    "HellaSwag-fi, translated from the English HellaSwag dataset",
+    huggingface_id="EuroEval/hellaswag-fi-mini",
+    task=COMMON_SENSE,
+    languages=[FI],
+)
 
 SCALA_FI_CONFIG = DatasetConfig(
     name="scala-fi",


### PR DESCRIPTION
### Added
- Add HellaSwag-fi back in, as the issue with the labels in the test split has been
  fixed.

Fixes #158