### PR TITLE
feat: add concurrency group for ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   code-check:
     if: github.event.pull_request.draft == false


### PR DESCRIPTION
This PR adds a concurrency group to the CI workflow to prevent overlapping runs of the same workflow on different commits for the same branch.

If a previous commit in a PR has already triggered the CI workflow and is still running, any new commit to that PR will automatically cancel the ongoing workflow and start a fresh run from the latest commit.