### PR TITLE
Fix truncation of vLLM models

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      # - id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.10
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,9 +8,9 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: debug-statements
+      # - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.9
+    rev: v0.11.10
     hooks:
       - id: ruff
         args:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Fixed
+- When truncating prompts with vLLM models, we now correctly truncate them down below
+  the `MAX_CONTEXT_LENGTH` (set to 5,000 tokens). We have already ensured that all
+  prompts have less than 5,000 Gemma-3 tokens, but sometimes tokenizers add a few more
+  tokens.
 
 
 ## [v15.8.2] - 2025-05-12

--- a/src/euroeval/benchmark_modules/hf.py
+++ b/src/euroeval/benchmark_modules/hf.py
@@ -719,6 +719,16 @@ def get_model_repo_info(
 
     Returns:
         The information about the model, or None if the model could not be found.
+
+    Raises:
+        InvalidModel:
+            If the model could not be found.
+        NeedsAdditionalArgument:
+            If the API key is not set and the model is gated.
+        NoInternetConnection:
+            If there is no internet connection.
+        HuggingFaceHubDown:
+            If the Hugging Face Hub is down.
     """
     token = benchmark_config.api_key or os.getenv("HUGGINGFACE_API_KEY") or True
     hf_api = HfApi(token=token)

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -447,12 +447,12 @@ class VLLMModel(HuggingFaceEncoderModel):
                         "Prompts are too long, so truncating them and trying again..."
                     )
                     logger.debug(f"The error message was: {str(e)}")
-                    breakpoint()
                     tokenized_prompts = self._tokenizer(
                         text=prompts,
                         truncation=True,
-                        max_length=max(
-                            self._tokenizer.model_max_length - max_tokens, 0
+                        max_length=min(
+                            MAX_CONTEXT_LENGTH,
+                            max(self._tokenizer.model_max_length - max_tokens, 0),
                         ),
                     )
                     prompts = self._tokenizer.batch_decode(

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -450,9 +450,10 @@ class VLLMModel(HuggingFaceEncoderModel):
                     tokenized_prompts = self._tokenizer(
                         text=prompts,
                         truncation=True,
-                        max_length=min(
-                            MAX_CONTEXT_LENGTH,
-                            max(self._tokenizer.model_max_length - max_tokens, 0),
+                        max_length=max(
+                            min(self._tokenizer.model_max_length, MAX_CONTEXT_LENGTH)
+                            - max_tokens,
+                            0,
                         ),
                     )
                     prompts = self._tokenizer.batch_decode(

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -447,6 +447,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                         "Prompts are too long, so truncating them and trying again..."
                     )
                     logger.debug(f"The error message was: {str(e)}")
+                    breakpoint()
                     tokenized_prompts = self._tokenizer(
                         text=prompts,
                         truncation=True,


### PR DESCRIPTION
### Fixed
- When truncating prompts with vLLM models, we now correctly truncate them down below
  the `MAX_CONTEXT_LENGTH` (set to 5,000 tokens). We have already ensured that all
  prompts have less than 5,000 Gemma-3 tokens, but sometimes tokenizers add a few more
  tokens.