### PR TITLE
Fix/phi 4 output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      # - id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.11
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: debug-statements
+      # - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.11
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   tokens.
 - Fixed an issue regarding model existence check when benchmarking models on custom
   inference API servers.
+- Fixed an issue with Phi-4 models, as they output multiple end-of-reasoning tokens, and
+  it was previously cutting off at the first one, yielding faulty final answers. We now
+  cut off at the last end-of-reasoning token, which is the correct one.
 
 
 ## [v15.8.2] - 2025-05-12

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -497,10 +497,20 @@ class VLLMModel(HuggingFaceEncoderModel):
         completion_ids: list[list[int]] = [
             output.outputs[0].token_ids for output in raw_outputs
         ]
-        breakpoint()
         if self.end_of_reasoning_token_id in completion_ids[0]:
+            # Find the latest index of the end of reasoning token and slice
+            # the token IDs to only include the tokens after it
             completion_ids = [
-                token_ids[token_ids.index(self.end_of_reasoning_token_id) + 1 :]
+                token_ids[
+                    max(
+                        [
+                            i
+                            for i, x in enumerate(token_ids)
+                            if x == self.end_of_reasoning_token_id
+                        ]
+                    )
+                    + 1 :
+                ]
                 if self.end_of_reasoning_token_id in token_ids
                 else token_ids
                 for token_ids in completion_ids
@@ -512,6 +522,7 @@ class VLLMModel(HuggingFaceEncoderModel):
             skip_special_tokens=True,
         )
         completions = [completion.strip() for completion in completions]
+        breakpoint()
 
         # Sanity check
         if len(completions) != len(prompts):

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -497,6 +497,7 @@ class VLLMModel(HuggingFaceEncoderModel):
         completion_ids: list[list[int]] = [
             output.outputs[0].token_ids for output in raw_outputs
         ]
+        breakpoint()
         if self.end_of_reasoning_token_id in completion_ids[0]:
             completion_ids = [
                 token_ids[token_ids.index(self.end_of_reasoning_token_id) + 1 :]
@@ -1044,7 +1045,6 @@ def get_end_of_reasoning_token_id(
         use_tqdm=False,
     )
     completion = model_output[0].outputs[0].text
-    breakpoint()
 
     if tokenizer.bos_token is not None:
         if isinstance(tokenizer.bos_token, str):

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -497,6 +497,7 @@ class VLLMModel(HuggingFaceEncoderModel):
         completion_ids: list[list[int]] = [
             output.outputs[0].token_ids for output in raw_outputs
         ]
+        breakpoint()
         if self.end_of_reasoning_token_id in completion_ids[0]:
             completion_ids = [
                 token_ids[token_ids.index(self.end_of_reasoning_token_id) + 1 :]

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -522,7 +522,6 @@ class VLLMModel(HuggingFaceEncoderModel):
             skip_special_tokens=True,
         )
         completions = [completion.strip() for completion in completions]
-        breakpoint()
 
         # Sanity check
         if len(completions) != len(prompts):

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -497,7 +497,6 @@ class VLLMModel(HuggingFaceEncoderModel):
         completion_ids: list[list[int]] = [
             output.outputs[0].token_ids for output in raw_outputs
         ]
-        breakpoint()
         if self.end_of_reasoning_token_id in completion_ids[0]:
             completion_ids = [
                 token_ids[token_ids.index(self.end_of_reasoning_token_id) + 1 :]
@@ -1045,6 +1044,7 @@ def get_end_of_reasoning_token_id(
         use_tqdm=False,
     )
     completion = model_output[0].outputs[0].text
+    breakpoint()
 
     if tokenizer.bos_token is not None:
         if isinstance(tokenizer.bos_token, str):

--- a/tests/test_benchmark_modules/test_hf.py
+++ b/tests/test_benchmark_modules/test_hf.py
@@ -1,5 +1,6 @@
 """Unit tests for the `hf` module."""
 
+from copy import deepcopy
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -66,7 +67,8 @@ def test_safetensors_check(
     benchmark_config: BenchmarkConfig,
 ) -> None:
     """Test the safetensors availability check functionality."""
-    benchmark_config.only_allow_safetensors = only_allow_safetensors
+    cloned_benchmark_config = deepcopy(benchmark_config)
+    cloned_benchmark_config.only_allow_safetensors = only_allow_safetensors
     with (
         patch.object(HfApi, "list_repo_files") as mock_list_files,
         patch.object(HfApi, "model_info") as mock_model_info,
@@ -75,5 +77,9 @@ def test_safetensors_check(
         mock_model_info.return_value = MagicMock(
             id="test-model", tags=["test"], pipeline_tag="fill-mask"
         )
-        result = get_model_repo_info("test-model", "main", benchmark_config)
+        result = get_model_repo_info(
+            model_id="test-model",
+            revision="main",
+            benchmark_config=cloned_benchmark_config,
+        )
         assert (result is not None) == model_exists


### PR DESCRIPTION
### Fixed
- Fixed an issue with Phi-4 models, as they output multiple end-of-reasoning tokens, and
  it was previously cutting off at the first one, yielding faulty final answers. We now
  cut off at the last end-of-reasoning token, which is the correct one.