### PR TITLE
Fix/flash attn conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Fixed
+- Now shows an informative message to remove `flash_attn` if it is installed, as it is
+  now built into other dependencies and conflicts with the other implementations.
 
 
 ## [v15.9.0] - 2025-05-31

--- a/src/euroeval/__init__.py
+++ b/src/euroeval/__init__.py
@@ -30,8 +30,9 @@ logging.basicConfig(
 ### Throw informative error if `flash_attn` is installed ###
 if "flash_attn" in sys.modules:
     logging.critical(
-        "The `flash_attn` package is not supported by EuroEval. Please uninstall it "
-        "using `pip uninstall flash_attn` and try again."
+        "The `flash_attn` package is not supported by EuroEval, as it is now built "
+        "into the other packages and it conflicts with the other implementations. "
+        "Please uninstall it using `pip uninstall flash_attn` and try again."
     )
     sys.exit(1)
 

--- a/src/euroeval/__init__.py
+++ b/src/euroeval/__init__.py
@@ -27,6 +27,16 @@ logging.basicConfig(
 
 
 ### STAGE 2 ###
+### Throw informative error if `flash_attn` is installed ###
+if "flash_attn" in sys.modules:
+    logging.critical(
+        "The `flash_attn` package is not supported by EuroEval. Please uninstall it "
+        "using `pip uninstall flash_attn` and try again."
+    )
+    sys.exit(1)
+
+
+### STAGE 2 ###
 ### Set the rest up ###
 
 import importlib.metadata  # noqa: E402

--- a/src/euroeval/__init__.py
+++ b/src/euroeval/__init__.py
@@ -37,7 +37,7 @@ if "flash_attn" in sys.modules:
     sys.exit(1)
 
 
-### STAGE 2 ###
+### STAGE 3 ###
 ### Set the rest up ###
 
 import importlib.metadata  # noqa: E402


### PR DESCRIPTION
### Fixed
- Now shows an informative message to remove `flash_attn` if it is installed, as it is
  now built into other dependencies and conflicts with the other implementations.