### PR TITLE
feat: Mark LifeInTheUK and IdiomsNo as official datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Added the English knowledge dataset Life in the UK. This was contributed by
+- Added the English knowledge dataset Life in the UK, which has been added as an
+  official dataset, replacing the existing English knowledge dataset MMLU, which in turn
+  has been marked as unofficial now. This was contributed by
   [@oliverkinch](https://github.com/oliverkinch) ✨
-- Added the Idioms-no dataset, which is a multiple-choice question dataset, where the
-  alternative answers have been generated using GPT-4o. This was contributed by
+- Added the Norwegian knowledge dataset Idioms-no, which is a multiple-choice question
+  dataset where the alternative answers have been generated using GPT-4o. This has been
+  added as an official dataset, and was contributed by
   [@oliverkinch](https://github.com/oliverkinch) ✨
 
 ### Fixed

--- a/src/euroeval/dataset_configs/english.py
+++ b/src/euroeval/dataset_configs/english.py
@@ -49,10 +49,10 @@ CNN_DAILYMAIL_CONFIG = DatasetConfig(
     languages=[EN],
 )
 
-MMLU_CONFIG = DatasetConfig(
-    name="mmlu",
-    pretty_name="the truncated version of the English knowledge dataset MMLU",
-    huggingface_id="EuroEval/mmlu-mini",
+LIFE_IN_THE_UK_CONFIG = DatasetConfig(
+    name="life-in-the-uk",
+    pretty_name="the English knowledge dataset Life in the UK",
+    huggingface_id="EuroEval/life-in-the-uk",
     task=KNOW,
     languages=[EN],
 )
@@ -87,10 +87,10 @@ BELEBELE_CONFIG = DatasetConfig(
     unofficial=True,
 )
 
-LIFE_IN_THE_UK_CONFIG = DatasetConfig(
-    name="life-in-the-uk",
-    pretty_name="the English knowledge dataset Life in the UK",
-    huggingface_id="EuroEval/life-in-the-uk",
+MMLU_CONFIG = DatasetConfig(
+    name="mmlu",
+    pretty_name="the truncated version of the English knowledge dataset MMLU",
+    huggingface_id="EuroEval/mmlu-mini",
     task=KNOW,
     languages=[EN],
     unofficial=True,

--- a/src/euroeval/dataset_configs/norwegian.py
+++ b/src/euroeval/dataset_configs/norwegian.py
@@ -76,6 +76,14 @@ NRK_QUIZ_QA_CONFIG = DatasetConfig(
     languages=[NB, NN, NO],
 )
 
+IDIOMS_NO_CONFIG = DatasetConfig(
+    name="idioms-no",
+    pretty_name="the Norwegian knowledge dataset Idioms-no",
+    huggingface_id="EuroEval/idioms-no",
+    task=KNOW,
+    languages=[NB, NN, NO],
+)
+
 NOR_COMMON_SENSE_QA_CONFIG = DatasetConfig(
     name="nor-common-sense-qa",
     pretty_name="the truncated version of the Norwegian common-sense reasoning dataset "
@@ -173,15 +181,6 @@ BELEBELE_NO_CONFIG = DatasetConfig(
     "BeleBele-no, translated from the English BeleBele dataset",
     huggingface_id="EuroEval/belebele-no-mini",
     task=MCRC,
-    languages=[NB, NN, NO],
-    unofficial=True,
-)
-
-IDIOMS_NO_CONFIG = DatasetConfig(
-    name="idioms-no",
-    pretty_name="the Norwegian knowledge dataset Idioms-no",
-    huggingface_id="EuroEval/idioms-no",
-    task=KNOW,
     languages=[NB, NN, NO],
     unofficial=True,
 )


### PR DESCRIPTION
Mark the new LifeInTheUK and IdiomsNo as official. On the English side, this replaces MMLU as the official knowledge dataset, prioritising cultural knowledge over academic knowledge.

We might re-include academic knowledge as a separate task later on.