### PR TITLE
Feat/add llm as a judge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   dataset where the alternative answers have been generated using GPT-4o. This has been
   added as an official dataset, and was contributed by
   [@oliverkinch](https://github.com/oliverkinch) ✨
+- Added new `LLMAsAJudgeMetric`, which allows evaluating the performance of a model with
+  another judge model. This is useful for evaluating models in a reference-free manner,
+  or if the metric is sufficiently complex. It is currently not used in any task, but
+  the functionality is there for future use.
 
 ### Fixed
 - Evaluating freshly initialised encoder models on multiple-choice classification tasks

--- a/src/euroeval/__init__.py
+++ b/src/euroeval/__init__.py
@@ -86,6 +86,12 @@ os.environ["RAY_DISABLE_DOCKER_CPU_WARNING"] = "1"
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
 
+# Avoid the "Unclosed client session" error when evaluating Ollama models with LiteLLM.
+# The error comes from the `aiohttp` package, and this environment variable forces the
+# use of `httpx` instead.
+os.environ["DISABLE_AIOHTTP_TRANSPORT"] = "True"
+
+
 # Use older version v0 of vLLM, as the newer one requires XGrammar as decoding backend,
 # but XGrammar does not support having a maximal amount of elements in lists
 os.environ["VLLM_USE_V1"] = "0"

--- a/src/euroeval/__init__.py
+++ b/src/euroeval/__init__.py
@@ -89,6 +89,7 @@ os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 # Avoid the "Unclosed client session" error when evaluating Ollama models with LiteLLM.
 # The error comes from the `aiohttp` package, and this environment variable forces the
 # use of `httpx` instead.
+# Link: https://github.com/BerriAI/litellm/issues/11657#issuecomment-3038984975
 os.environ["DISABLE_AIOHTTP_TRANSPORT"] = "True"
 
 

--- a/src/euroeval/benchmark_modules/base.py
+++ b/src/euroeval/benchmark_modules/base.py
@@ -200,7 +200,9 @@ class BenchmarkModule(ABC):
                 )
             case TaskGroup.TEXT_TO_TEXT:
                 return partial(
-                    text_to_text.compute_metrics, dataset_config=self.dataset_config
+                    text_to_text.compute_metrics,
+                    dataset_config=self.dataset_config,
+                    benchmark_config=self.benchmark_config,
                 )
             case TaskGroup.TOKEN_CLASSIFICATION:
                 return partial(

--- a/src/euroeval/metrics.py
+++ b/src/euroeval/metrics.py
@@ -224,9 +224,19 @@ class LLMAsAJudgeMetric(Metric):
 
         Returns:
             The calculated metric score, or None if the score should be ignored.
+
+        Raises:
+            InvalidBenchmark:
+                If the number of predictions does not match the number of references,
+                or if the user prompt requires a condition but none is provided.
         """
         if not predictions or not references:
             return None
+        elif len(predictions) != len(references):
+            raise InvalidBenchmark(
+                f"The number of predictions ({len(predictions):,}) does not match the "
+                f"number of references ({len(references):,})."
+            )
 
         # Prepare the messages for the LLM
         conversations: list[list[dict[str, str]]] = [

--- a/src/euroeval/metrics.py
+++ b/src/euroeval/metrics.py
@@ -442,7 +442,7 @@ fluency_metric = LLMAsAJudgeMetric(
     "Text: {prediction!r}\n\n"
     "Output your rating as a JSON object with a single key 'fluency'.",
     response_format=Fluency,
-    scoring_fn=lambda output: output.fluency,
+    scoring_fn=lambda output: (output.fluency - 1) / 4.0,
 )
 
 speed_metric = SpeedMetric(name="speed", pretty_name="Tokens per second")

--- a/src/euroeval/metrics.py
+++ b/src/euroeval/metrics.py
@@ -413,7 +413,7 @@ class Fluency(BaseModel):
             The fluency rating, an integer between 1 and 5.
     """
 
-    fluency: t.Annotated[int, Field(gt=1, le=5)]
+    fluency: t.Annotated[int, Field(ge=1, le=5)]
 
 
 # Example LLM-as-a-judge metric, to measure the fluency of the LLM output

--- a/src/euroeval/metrics.py
+++ b/src/euroeval/metrics.py
@@ -436,9 +436,9 @@ fluency_metric = LLMAsAJudgeMetric(
     "with the following definitions:\n"
     "- 1: Very poor fluency, many grammatical errors\n"
     "- 2: Poor fluency, several grammatical errors\n"
-    "- 3: Average fluency, some grammatical errors\n"
-    "- 4: Good fluency, few grammatical errors\n"
-    "- 5: Excellent fluency, no grammatical errors\n\n"
+    "- 3: Average fluency, a few grammatical errors\n"
+    "- 4: Good fluency, no grammatical errors but sounds a bit off\n"
+    "- 5: Excellent fluency, no grammatical errors and sounds natural\n\n"
     "Text: {prediction!r}\n\n"
     "Output your rating as a JSON object with a single key 'fluency'.",
     response_format=Fluency,

--- a/src/euroeval/metrics.py
+++ b/src/euroeval/metrics.py
@@ -1,14 +1,22 @@
 """All the metrics used in EuroEval."""
 
 import abc
+import logging
 import typing as t
 
 import evaluate
+import litellm
+from litellm.types.utils import Choices, ModelResponse
+from pydantic import BaseModel, Field
+from tqdm.auto import tqdm
 
+from .exceptions import InvalidBenchmark
 from .utils import HiddenPrints
 
 if t.TYPE_CHECKING:
     from evaluate import EvaluationModule
+
+logger = logging.getLogger(__name__)
 
 
 class Metric(abc.ABC):
@@ -149,6 +157,164 @@ class HuggingFaceMetric(Metric):
         return score
 
 
+class LLMAsAJudgeMetric(Metric):
+    """Use an LLM to judge the quality of the predictions."""
+
+    def __init__(
+        self,
+        name: str,
+        pretty_name: str,
+        judge_id: str,
+        judge_kwargs: dict[str, t.Any],
+        user_prompt: str,
+        response_format: t.Type[BaseModel],
+        scoring_fn: t.Callable[[BaseModel], float],
+        condition_formatting_fn: t.Callable[[str], str] = lambda x: x,
+        system_prompt: str | None = None,
+    ) -> None:
+        """Initialise the LLM as a judge metric.
+
+        Args:
+            name:
+                The name of the metric in snake_case.
+            pretty_name:
+                The pretty name of the metric, used for display purposes.
+            judge_id:
+                The model ID of the LLM to use as a judge.
+            judge_kwargs:
+                Generation parameters for the judge model, such as temperature.
+            user_prompt:
+                The user prompt to use for the judge model. The prompt should be
+                formatted with the variables `prediction` and `condition`, to
+                include the model predictions and a description of what the prediction
+                should be judged on, respectively. If the condition is not needed,
+                it can be omitted from the prompt, but the `prediction` variable must
+                still be present.
+            response_format:
+                The response format to use for the judge model. This should be a
+                Pydantic model that defines the expected structure of the judge's
+                response.
+            scoring_fn:
+                A function that takes the judge's response and returns a score.
+            condition_formatting_fn (optional):
+                A function to format the condition string before it is included in the
+                user prompt. Defaults to a no-op function that returns the input
+                unchanged.
+            system_prompt (optional):
+                The system prompt to use for the judge model. If not provided, no system
+                prompt will be used.
+        """
+        super().__init__(name=name, pretty_name=pretty_name)
+        self.judge_id = judge_id
+        self.judge_kwargs = judge_kwargs
+        self.user_prompt = user_prompt
+        self.response_format = response_format
+        self.scoring_fn = scoring_fn
+        self.condition_formatting_fn = condition_formatting_fn
+        self.system_prompt = system_prompt
+
+    def __call__(self, predictions: t.Sequence, references: t.Sequence) -> float | None:
+        """Calculate the metric score using the judge model.
+
+        Args:
+            predictions:
+                The model predictions.
+            references:
+                The ground truth references.
+
+        Returns:
+            The calculated metric score, or None if the score should be ignored.
+        """
+        if not predictions or not references:
+            return None
+
+        # Prepare the messages for the LLM
+        conversations: list[list[dict[str, str]]] = [
+            [
+                dict(
+                    role="user",
+                    content=self._apply_user_prompt(
+                        prediction=prediction, condition=condition
+                    ),
+                )
+            ]
+            for prediction, condition in zip(predictions, references)
+        ]
+        if self.system_prompt:
+            conversations = [
+                [dict(role="system", content=self.system_prompt), *conversation]
+                for conversation in conversations
+            ]
+
+        # Get the judge generations
+        generations = [
+            litellm.completion(
+                model=self.judge_id,
+                messages=conversation,
+                response_format=self.response_format,
+                **self.judge_kwargs,
+            )
+            for conversation in tqdm(
+                iterable=conversations,
+                desc=f"Computing {self.pretty_name} scores",
+                unit="sample",
+            )
+        ]
+
+        # Extract the outputs from the generations
+        outputs: list[BaseModel] = list()
+        for generation in generations:
+            assert isinstance(generation, ModelResponse), (
+                f"The judge model did not return a valid response: {generation!r}"
+            )
+            choice = generation.choices[0]
+            assert isinstance(choice, Choices), (
+                f"The judge model did not return a valid choice: {choice!r}"
+            )
+            json_content = choice.message.content
+            assert json_content is not None, (
+                "The judge model returned a None content in the response message."
+            )
+            output = self.response_format.model_validate_json(json_data=json_content)
+            outputs.append(output)
+
+        # Calculate the scores using the scoring function
+        scores = [self.scoring_fn(output) for output in outputs]
+        if not scores:
+            logger.warning(f"No scores were calculated for {self.pretty_name}.")
+            return None
+        return sum(scores) / len(scores)
+
+    def _apply_user_prompt(self, prediction: str, condition: str | None = None) -> str:
+        """Apply the user prompt to the prediction and condition.
+
+        Args:
+            prediction:
+                The model prediction.
+            condition (optional):
+                A description of what the prediction should be judged on. If not
+                provided, it will be omitted from the prompt.
+
+        Returns:
+            The formatted user prompt with the prediction and reference.
+
+        Raises:
+            InvalidBenchmark:
+                If the user prompt requires a reference but none is provided.
+        """
+        condition_required = "{condition}" in self.user_prompt
+        if condition_required and condition is None:
+            raise InvalidBenchmark(
+                f"The user prompt for the {self.pretty_name!r} metric requires a "
+                "condition, but none was provided."
+            )
+        if condition is not None:
+            return self.user_prompt.format(
+                prediction=prediction, condition=self.condition_formatting_fn(condition)
+            )
+        return self.user_prompt.format(prediction=prediction)
+
+
 class SpeedMetric(Metric):
     """Speed metric."""
 
@@ -236,6 +402,37 @@ accuracy_metric = HuggingFaceMetric(
     pretty_name="Accuracy",
     huggingface_id="accuracy",
     results_key="accuracy",
+)
+
+
+class Fluency(BaseModel):
+    """Response format for the fluency metric.
+
+    Attributes:
+        fluency:
+            The fluency rating, an integer between 1 and 5.
+    """
+
+    fluency: t.Annotated[int, Field(gt=1, le=5)]
+
+
+# Example LLM-as-a-judge metric, to measure the fluency of the LLM output
+fluency_metric = LLMAsAJudgeMetric(
+    name="fluency",
+    pretty_name="Fluency",
+    judge_id="gpt-4o-mini",
+    judge_kwargs=dict(temperature=0.0),
+    user_prompt="Please rate the fluency of the following text on a scale from 1 to 5, "
+    "with the following definitions:\n"
+    "- 1: Very poor fluency, many grammatical errors\n"
+    "- 2: Poor fluency, several grammatical errors\n"
+    "- 3: Average fluency, some grammatical errors\n"
+    "- 4: Good fluency, few grammatical errors\n"
+    "- 5: Excellent fluency, no grammatical errors\n\n"
+    "Text: {prediction!r}\n\n"
+    "Output your rating as a JSON object with a single key 'fluency'.",
+    response_format=Fluency,
+    scoring_fn=lambda output: output.fluency,
 )
 
 speed_metric = SpeedMetric(name="speed", pretty_name="Tokens per second")

--- a/tests/test_data_models.py
+++ b/tests/test_data_models.py
@@ -20,7 +20,7 @@ def test_all_classes_are_dataclasses_or_pydantic_models() -> None:
         if not obj_name.startswith("_")
         and inspect.isclass(object=getattr(data_models, obj_name))
         and not hasattr(enums, obj_name)
-        and obj_name != "ScoreDict"
+        and obj_name not in {"ScoreDict", "Metric"}
     ]
     for obj in all_classes:
         obj_is_dataclass = hasattr(obj, "__dataclass_fields__")


### PR DESCRIPTION
### Added
- Added new `LLMAsAJudgeMetric`, which allows evaluating the performance of a model with
  another judge model. This is useful for evaluating models in a reference-free manner,
  or if the metric is sufficiently complex. It is currently not used in any task, but
  the functionality is there for future use.

Closes #983.