### PR TITLE
Feat/add no thinking parameter for gemini

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: debug-statements
+      # - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      # - id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.1
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   another judge model. This is useful for evaluating models in a reference-free manner,
   or if the metric is sufficiently complex. It is currently not used in any task, but
   the functionality is there for future use.
+- Add `@no-thinking` option for Gemini-2.5 models, which disables the
+  reasoning mode for these models. This is useful for evaluating the base model without
+  reasoning, as the reasoning mode is enabled by default for these models.
 
 ### Fixed
 - Evaluating freshly initialised encoder models on multiple-choice classification tasks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Evaluating freshly initialised encoder models on multiple-choice classification tasks
   caused an error, as the id-to-label mapping was not set up correctly. This has been
   fixed now.
+- Now dynamically lowers the maximum amount of reasoning tokens for LiteLLM models if
+  they do not support the full 32,768 tokens.
 
 
 ## [v15.10.1] - 2025-06-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   another judge model. This is useful for evaluating models in a reference-free manner,
   or if the metric is sufficiently complex. It is currently not used in any task, but
   the functionality is there for future use.
-- Add `@no-thinking` option for Gemini-2.5 models, which disables the
-  reasoning mode for these models. This is useful for evaluating the base model without
-  reasoning, as the reasoning mode is enabled by default for these models.
+- Add `@no-thinking` option for Gemini-2.5-flash and `@thinking` for
+  Gemini-2.5-flash-lite, which allows disabling and enabling the reasoning mode for
+  these models, respectively. These are different as the Gemini-2.5-flash model has
+  thinking enabled by default, while the Gemini-2.5-flash-lite model has it disabled by
+  default (see the defaults in the [Gemini-2.5
+  docs](https://ai.google.dev/gemini-api/docs/thinking#set-budget)).
 
 ### Fixed
 - Evaluating freshly initialised encoder models on multiple-choice classification tasks

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -143,17 +143,13 @@ NUM_PARAMS_MAPPING = {
 
 ALLOWED_PARAMS = {
     # OpenAI models
-    r"gpt-4.*": [],
     r"o[1-9](-mini|-preview)?(-[0-9]{4}-[0-9]{2}-[0-9]{2})?": ["low", "high"],
     # Anthropic models
-    r"(anthropic/)?claude-3-(haiku|sonnet|opus).*": [],
-    r"(anthropic/)?claude-3-5-.*": [],
     r"(anthropic/)?claude-3-7-sonnet.*": ["thinking"],
+    r"(anthropic/)?claude-(sonnet|opus)-4.*": ["thinking"],
     # Gemini models
-    r"(gemini/)?gemini-.*": [],
+    r"(gemini/)?gemini-2.5.*": ["no-thinking"],
     # xAI models
-    r"(xai/)?grok-2.*": [],
-    r"(xai/)?grok-3(-fast)?(-beta)?": [],
     r"(xai/)?grok-3-mini(-fast)?(-beta)?": ["low", "high"],
 }
 
@@ -373,7 +369,13 @@ class LiteLLMModel(BenchmarkModule):
                 f"Enabling thinking mode for model {self.model_config.model_id!r}",
                 level=logging.DEBUG,
             )
-        elif self.model_config.revision in {"low", "high"}:
+        elif self.model_config.revision == "no-thinking":
+            generation_kwargs["thinking"] = dict(type="disabled", budget_tokens=0)
+            log_once(
+                f"Disabling thinking mode for model {self.model_config.model_id!r}",
+                level=logging.DEBUG,
+            )
+        elif self.model_config.revision in {"low", "medium", "high"}:
             generation_kwargs["reasoning_effort"] = self.model_config.revision
             log_once(
                 f"Enabling reasoning effort {self.model_config.revision!r} for model "

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -559,8 +559,10 @@ class LiteLLMModel(BenchmarkModule):
                     f"error message was: {error_msg}."
                 )
             log_once(
-                f"The model {model_id!r} requires a higher thinking budget than "
-                f"{REASONING_MAX_TOKENS:,}, so setting it to {thinking_budget:,}.",
+                f"The model {model_id!r} can at most use {thinking_budget:,} tokens "
+                "for reasoning, which is less than the default of "
+                f"{REASONING_MAX_TOKENS:,} tokens. Setting the thinking budget to "
+                f"{thinking_budget:,} tokens.",
                 level=logging.DEBUG,
             )
             generation_kwargs["thinking"] = dict(

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -487,8 +487,9 @@ class LiteLLMModel(BenchmarkModule):
         no_json_schema_messages = ["Property keys should match pattern"]
         thinking_budget_pattern = re.compile(
             r"The thinking budget [0-9]+ is invalid. Please choose a value between "
-            r"[0-9]+ and ([0-9]+)."
+            r"[0-9]+ and ([0-9]+)\."
         )
+        breakpoint()
 
         if any(msg.lower() in error_msg for msg in stop_messages):
             log_once(

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -486,10 +486,9 @@ class LiteLLMModel(BenchmarkModule):
         max_items_messages = ["'maxItems' is not permitted."]
         no_json_schema_messages = ["Property keys should match pattern"]
         thinking_budget_pattern = re.compile(
-            r"The thinking budget [0-9]+ is invalid. Please choose a value between "
+            r"the thinking budget [0-9]+ is invalid. please choose a value between "
             r"[0-9]+ and ([0-9]+)\."
         )
-        breakpoint()
 
         if any(msg.lower() in error_msg for msg in stop_messages):
             log_once(

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -148,8 +148,8 @@ ALLOWED_PARAMS = {
     r"(anthropic/)?claude-3-7-sonnet.*": ["thinking"],
     r"(anthropic/)?claude-(sonnet|opus)-4.*": ["thinking"],
     # Gemini models
-    r"(gemini/)?gemini-2.5-flash-lite.*": ["thinking"],
-    r"(gemini/)?gemini-2.5-flash-[0-9].*": ["no-thinking"],
+    r"(gemini/)?gemini-2.5-flash-lite.*": ["no-thinking", "thinking"],
+    r"(gemini/)?gemini-2.5-flash-[0-9].*": ["no-thinking", "thinking"],
     # xAI models
     r"(xai/)?grok-3-mini(-fast)?(-beta)?": ["low", "high"],
 }
@@ -240,6 +240,8 @@ class LiteLLMModel(BenchmarkModule):
             )
         elif self.model_config.revision in {"thinking"}:
             type_ = GenerativeType.REASONING
+        elif self.model_config.revision in {"no-thinking"}:
+            type_ = GenerativeType.INSTRUCTION_TUNED
         elif re.fullmatch(
             pattern="|".join(REASONING_MODELS), string=self.model_config.model_id
         ):

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -148,7 +148,8 @@ ALLOWED_PARAMS = {
     r"(anthropic/)?claude-3-7-sonnet.*": ["thinking"],
     r"(anthropic/)?claude-(sonnet|opus)-4.*": ["thinking"],
     # Gemini models
-    r"(gemini/)?gemini-2.5.*": ["no-thinking"],
+    r"(gemini/)?gemini-2.5-flash-lite.*": ["thinking"],
+    r"(gemini/)?gemini-2.5-flash-[0-9].*": ["no-thinking"],
     # xAI models
     r"(xai/)?grok-3-mini(-fast)?(-beta)?": ["low", "high"],
 }

--- a/src/euroeval/metrics.py
+++ b/src/euroeval/metrics.py
@@ -382,7 +382,7 @@ f1_metric = HuggingFaceMetric(
     pretty_name="F1-score",
     huggingface_id="squad_v2",
     results_key="f1",
-    postprocessing_fn=lambda x: (100 * x, f"{x:.2%}"),
+    postprocessing_fn=lambda x: (x, f"{x:.2f}%"),
 )
 
 em_metric = HuggingFaceMetric(
@@ -390,7 +390,7 @@ em_metric = HuggingFaceMetric(
     pretty_name="Exact Match",
     huggingface_id="squad_v2",
     results_key="exact",
-    postprocessing_fn=lambda x: (100 * x, f"{x:.2%}"),
+    postprocessing_fn=lambda x: (x, f"{x:.2f}%"),
 )
 
 bert_score_metric = HuggingFaceMetric(


### PR DESCRIPTION
### Added
- Add `@no-thinking` option for Gemini-2.5-flash and `@thinking` for
  Gemini-2.5-flash-lite, which allows disabling and enabling the reasoning mode for
  these models, respectively. These are different as the Gemini-2.5-flash model has
  thinking enabled by default, while the Gemini-2.5-flash-lite model has it disabled by
  default (see the defaults in the [Gemini-2.5
  docs](https://ai.google.dev/gemini-api/docs/thinking#set-budget)).

### Fixed
- Now dynamically lowers the maximum amount of reasoning tokens for LiteLLM models if
  they do not support the full 32,768 tokens.