### PR TITLE
fix: Convert Column to list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Fixed
+- There was a breaking change in `datasets`, where feature indexing of datasets resulted
+  in a `Column` instance, rather than a `list` as previously. We now detect this and
+  convert the `Column` instance to a `list` before using it.
 
 
 ## [v15.11.0] - 2025-07-15

--- a/src/euroeval/generation.py
+++ b/src/euroeval/generation.py
@@ -223,7 +223,7 @@ def generate_single_iteration(
         ]
     elif "target_text" in non_cached_dataset.column_names:
         non_cached_labels = non_cached_dataset["target_text"]
-        if not isinstance(non_cached_dataset, list):
+        if not isinstance(non_cached_labels, list):
             non_cached_labels = list(non_cached_labels)
         cached_labels = cached_dataset["target_text"]
         if not isinstance(cached_labels, list):

--- a/src/euroeval/generation.py
+++ b/src/euroeval/generation.py
@@ -200,17 +200,35 @@ def generate_single_iteration(
         all_preds.extend(extracted_labels)
 
     if "label" in non_cached_dataset.column_names:
+        non_cached_labels = non_cached_dataset["label"]
+        if not isinstance(non_cached_labels, list):
+            non_cached_labels = list(non_cached_labels)
+        cached_labels = cached_dataset["label"]
+        if not isinstance(cached_labels, list):
+            cached_labels = list(cached_labels)
         ground_truth = [
             label.lower() if isinstance(label, str) else label
-            for label in non_cached_dataset["label"] + cached_dataset["label"]
+            for label in non_cached_labels + cached_labels
         ]
     elif "labels" in non_cached_dataset.column_names:
+        non_cached_labels = non_cached_dataset["labels"]
+        if not isinstance(non_cached_labels, list):
+            non_cached_labels = list(non_cached_labels)
+        cached_labels = cached_dataset["labels"]
+        if not isinstance(cached_labels, list):
+            cached_labels = list(cached_labels)
         ground_truth = [
             [label.lower() if isinstance(label, str) else label for label in label_list]
-            for label_list in non_cached_dataset["labels"] + cached_dataset["labels"]
+            for label_list in non_cached_labels + cached_labels
         ]
     elif "target_text" in non_cached_dataset.column_names:
-        ground_truth = non_cached_dataset["target_text"] + cached_dataset["target_text"]
+        non_cached_labels = non_cached_dataset["target_text"]
+        if not isinstance(non_cached_dataset, list):
+            non_cached_labels = list(non_cached_labels)
+        cached_labels = cached_dataset["target_text"]
+        if not isinstance(cached_labels, list):
+            cached_labels = list(cached_labels)
+        ground_truth = non_cached_labels + cached_labels
     else:
         raise ValueError(
             "The dataset must have either a 'label', 'labels', or 'target_text' column"


### PR DESCRIPTION
### Fixed
- There was a breaking change in `datasets`, where feature indexing of datasets resulted
  in a `Column` instance, rather than a `list` as previously. We now detect this and
  convert the `Column` instance to a `list` before using it.