### PR TITLE
Add `--gpu-memory-utilization` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Added
+- Added `--gpu-memory-utilization` argument (`gpu_memory_utilization` in the
+  `Benchmarker` API), which can be lowered in case the user is experiencing OOM errors
+  when evaluating models. The default is 0.9 (same as previously), which means that vLLM
+  will reserve 90% of the GPU memory for itself, and leave 10% free for other processes.
 
 
 ## [v15.11.0] - 2025-07-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-### Changed
-- Lowered the maximum amount of reasoning tokens to use, from 32k to 4k, as this
-  corresponds to the "high" reasoning effort.
+
 
 
 ## [v15.11.0] - 2025-07-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Changed
+- Lowered the maximum amount of reasoning tokens to use, from 32k to 4k, as this
+  corresponds to the "high" reasoning effort.
 
 
 ## [v15.11.0] - 2025-07-15

--- a/src/euroeval/benchmark_config_factory.py
+++ b/src/euroeval/benchmark_config_factory.py
@@ -42,6 +42,7 @@ def build_benchmark_config(
     num_iterations: int,
     api_base: str | None,
     api_version: str | None,
+    gpu_memory_utilization: float,
     debug: bool,
     run_with_cli: bool,
     only_allow_safetensors: bool,
@@ -102,6 +103,11 @@ def build_benchmark_config(
             model on an inference API.
         api_version:
             The version of the API to use for a given inference API.
+        gpu_memory_utilization:
+            The GPU memory utilization to use for vLLM. A larger value will result in
+            faster evaluation, but at the risk of running out of GPU memory. Only reduce
+            this if you are running out of GPU memory. Only relevant if the model is
+            generative.
         debug:
             Whether to run the benchmark in debug mode.
         run_with_cli:
@@ -154,6 +160,7 @@ def build_benchmark_config(
         num_iterations=num_iterations,
         api_base=api_base,
         api_version=api_version,
+        gpu_memory_utilization=gpu_memory_utilization,
         debug=debug,
         run_with_cli=run_with_cli,
         only_allow_safetensors=only_allow_safetensors,

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -757,7 +757,7 @@ def load_model_and_tokenizer(
         model = LLM(
             model=model_id,
             tokenizer=model_id,
-            gpu_memory_utilization=0.9,
+            gpu_memory_utilization=0.5,
             max_model_len=min(true_max_model_len, MAX_CONTEXT_LENGTH),
             download_dir=download_dir,
             trust_remote_code=benchmark_config.trust_remote_code,

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -78,6 +78,7 @@ class Benchmarker:
         num_iterations: int = 10,
         api_base: str | None = None,
         api_version: str | None = None,
+        gpu_memory_utilization: float = 0.9,
         debug: bool = False,
         run_with_cli: bool = False,
         only_allow_safetensors: bool = False,
@@ -145,6 +146,11 @@ class Benchmarker:
                 to a model on an inference API. Defaults to None.
             api_version:
                 The version of the API to use. Defaults to None.
+            gpu_memory_utilization:
+                The GPU memory utilization to use for vLLM. Only relevant if the model
+                is generative. A larger value will result in faster evaluation, but at
+                the risk of running out of GPU memory. Only reduce this if you are
+                running out of GPU memory. Defaults to 0.9.
             debug:
                 Whether to output debug information. Defaults to False.
             run_with_cli:
@@ -192,6 +198,7 @@ class Benchmarker:
             num_iterations=num_iterations,
             api_base=api_base,
             api_version=api_version,
+            gpu_memory_utilization=gpu_memory_utilization,
             debug=debug,
             run_with_cli=run_with_cli,
             only_allow_safetensors=only_allow_safetensors,

--- a/src/euroeval/cli.py
+++ b/src/euroeval/cli.py
@@ -187,6 +187,14 @@ from .tasks import get_all_tasks
     "an inference API.",
 )
 @click.option(
+    "--gpu-memory-utilization",
+    default=0.9,
+    show_default=True,
+    help="The GPU memory utilization to use for vLLM. A larger value will result in "
+    "faster evaluation, but at the risk of running out of GPU memory. Only reduce this "
+    "if you are running out of GPU memory. Only relevant if the model is generative.",
+)
+@click.option(
     "--debug/--no-debug",
     default=False,
     show_default=True,
@@ -223,6 +231,7 @@ def benchmark(
     num_iterations: int,
     api_base: str | None,
     api_version: str | None,
+    gpu_memory_utilization: float,
     debug: bool,
     only_allow_safetensors: bool,
 ) -> None:
@@ -258,6 +267,7 @@ def benchmark(
         num_iterations=num_iterations,
         api_base=api_base,
         api_version=api_version,
+        gpu_memory_utilization=gpu_memory_utilization,
         debug=debug,
         run_with_cli=True,
         only_allow_safetensors=only_allow_safetensors,

--- a/src/euroeval/constants.py
+++ b/src/euroeval/constants.py
@@ -16,7 +16,7 @@ MAX_CONTEXT_LENGTH = 5_000
 
 # We need to raise the amount of tokens generated for reasoning models, to give them
 # time to think
-REASONING_MAX_TOKENS = 32_768
+REASONING_MAX_TOKENS = 4_096
 
 
 # The Hugging Face Hub pipeline tags used to classify models as generative

--- a/src/euroeval/constants.py
+++ b/src/euroeval/constants.py
@@ -16,7 +16,7 @@ MAX_CONTEXT_LENGTH = 5_000
 
 # We need to raise the amount of tokens generated for reasoning models, to give them
 # time to think
-REASONING_MAX_TOKENS = 4_096
+REASONING_MAX_TOKENS = 32_768
 
 
 # The Hugging Face Hub pipeline tags used to classify models as generative

--- a/src/euroeval/data_models.py
+++ b/src/euroeval/data_models.py
@@ -168,6 +168,11 @@ class BenchmarkConfig:
         api_version:
             The version of the API to use. Only relevant if `model` refers to a model on
             an inference API.
+        gpu_memory_utilization:
+            The GPU memory utilization to use for vLLM. A larger value will result in
+            faster evaluation, but at the risk of running out of GPU memory. Only reduce
+            this if you are running out of GPU memory. Only relevant if the model is
+            generative.
         debug:
             Whether to run the benchmark in debug mode.
         run_with_cli:
@@ -196,6 +201,7 @@ class BenchmarkConfig:
     num_iterations: int
     api_base: str | None
     api_version: str | None
+    gpu_memory_utilization: float
     debug: bool
     run_with_cli: bool
     only_allow_safetensors: bool
@@ -227,6 +233,7 @@ class BenchmarkConfigParams(pydantic.BaseModel):
     num_iterations: int
     api_base: str | None
     api_version: str | None
+    gpu_memory_utilization: float
     debug: bool
     run_with_cli: bool
     only_allow_safetensors: bool

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,6 +87,7 @@ def benchmark_config(
         num_iterations=1,
         api_base=None,
         api_version=None,
+        gpu_memory_utilization=0.9,
         debug=False,
         run_with_cli=True,
         only_allow_safetensors=False,


### PR DESCRIPTION
### Added
- Added `--gpu-memory-utilization` argument (`gpu_memory_utilization` in the
  `Benchmarker` API), which can be lowered in case the user is experiencing OOM errors
  when evaluating models. The default is 0.9 (same as previously), which means that vLLM
  will reserve 90% of the GPU memory for itself, and leave 10% free for other processes.