### PR TITLE
fix: Do not set budget_tokens=0 when disabling thinking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Fixed
+- Disabling thinking (with the `@no-thinking` suffix) did not work properly for
+  Anthropic models, as they don't support the `budget_tokens` parameter when thinking
+  is disabled. This has been fixed now, so that the `@no-thinking` suffix now works
+  properly for all models that support it.
 
 
 ## [v15.13.0] - 2025-07-21

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -361,7 +361,7 @@ class LiteLLMModel(BenchmarkModule):
                 level=logging.DEBUG,
             )
         elif self.model_config.revision == "no-thinking":
-            generation_kwargs["thinking"] = dict(type="disabled", budget_tokens=0)
+            generation_kwargs["thinking"] = dict(type="disabled")
             log_once(
                 f"Disabling thinking mode for model {self.model_config.model_id!r}",
                 level=logging.DEBUG,


### PR DESCRIPTION
### Fixed
- Disabling thinking (with the `@no-thinking` suffix) did not work properly for
  Anthropic models, as they don't support the `budget_tokens` parameter when thinking
  is disabled. This has been fixed now, so that the `@no-thinking` suffix now works
  properly for all models that support it.