### PR TITLE
fix: update placeholder in bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -55,7 +55,7 @@ body:
   attributes:
     label: EuroEval version
     description: What version of EuroEval are you using?
-    placeholder: Output of `pip list | grep EuroEval`
+    placeholder: Output of `pip list | grep euroeval`
   validations:
     required: true
 - type: input


### PR DESCRIPTION
This pull request makes a minor update to the bug report template to improve usability for users reporting issues.

* Updated the placeholder in the `EuroEval version` input field to use the correct lowercase package name (`euroeval`) for the `pip list | grep` command in `.github/ISSUE_TEMPLATE/bug.yaml`.

Example:

```shell
(Phi-4-mini-flash-reasoning) mathias@dev-gpu-5:~/euroevals/Phi-4-mini-flash-reasoning$ uv pip list | grep EuroEval
(Phi-4-mini-flash-reasoning) mathias@dev-gpu-5:~/euroevals/Phi-4-mini-flash-reasoning$ uv pip list | grep euroeval
euroeval                          15.14.0.dev0
```
