### PR TITLE
fix: Disable 'seed' parameter if required for LiteLLMModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Now disables the `seed` parameter if the API inference model does not support it,
   which prevented evaluating some models.
 - Now correctly detects an API inference model as non-existing, even if LiteLLM *does*
-  see it as existing. We have an additional check during evaluation to ensure this now.
+  see it as existing.
 
 
 ## [v15.16.0] - 2025-08-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Now disables the `seed` parameter if the API inference model does not support it,
   which prevented evaluating some models.
 - Now correctly detects an API inference model as non-existing, even if LiteLLM *does*
-  see it as existing.
+  see it as existing. We have an additional check during evaluation to ensure this now.
 
 
 ## [v15.16.0] - 2025-08-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Now disables the `seed` parameter if the API inference model does not support it,
   which prevented evaluating some models.
+- Now correctly detects an API inference model as non-existing, even if LiteLLM *does*
+  see it as existing. We have an additional check during evaluation to ensure this now.
 
 
 ## [v15.16.0] - 2025-08-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Fixed
+- Now disables the `seed` parameter if the API inference model does not support it,
+  which prevented evaluating some models.
 
 
 ## [v15.16.0] - 2025-08-12

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -403,6 +403,7 @@ class LiteLLMModel(BenchmarkModule):
             r"[0-9]+ and ([0-9]+)\."
         )
         requires_thinking_disabled_messages = ["thinking.type: Field required"]
+        seed_messages = ["does not support parameters: ['seed']"]
 
         if any(msg.lower() in error_msg for msg in stop_messages):
             log_once(
@@ -494,6 +495,14 @@ class LiteLLMModel(BenchmarkModule):
                 level=logging.DEBUG,
             )
             generation_kwargs["thinking"] = dict(type="disabled")
+            return
+        elif any(msg.lower() in error_msg for msg in seed_messages):
+            log_once(
+                f"The model {model_id!r} does not support the `seed` parameter, so "
+                "disabling it.",
+                level=logging.DEBUG,
+            )
+            generation_kwargs.pop("seed", None)
             return
         elif isinstance(
             error, (Timeout, ServiceUnavailableError, InternalServerError, SystemError)

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -540,12 +540,6 @@ class LiteLLMModel(BenchmarkModule):
                 f"Encountered {type(error)} during generation: {error}."
             )
 
-        if isinstance(error, NotFoundError):
-            raise InvalidModel(
-                f"The model {model_id!r} was not found. Please check the model ID "
-                "and try again."
-            )
-
         if isinstance(error, RateLimitError):
             raise InvalidModel(
                 f"You have encountered your rate limit for model {model_id!r}. "
@@ -1006,8 +1000,6 @@ class LiteLLMModel(BenchmarkModule):
             whether the model exists.
         """
         model_id, _ = model_id.split("@") if "@" in model_id else (model_id, "main")
-        if model_id in litellm.model_list:
-            return True
 
         # Separate check for Ollama models
         if model_id.startswith("ollama/") or model_id.startswith("ollama_chat/"):

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -1042,7 +1042,7 @@ class LiteLLMModel(BenchmarkModule):
                     "seconds..."
                 )
                 sleep(10)
-            except (BadRequestError, NotFoundError):
+            except (BadRequestError, NotFoundError) as e:
                 candidate_models = [
                     candidate_model_id
                     for candidate_model_id in litellm.model_list
@@ -1056,12 +1056,14 @@ class LiteLLMModel(BenchmarkModule):
                             f"Could not find the model ID {model_id!r}. Did you mean "
                             f"{candidate_models[0]!r}?"
                         )
+                        logger.debug(f"The error was {e}.")
                     case _:
                         candidate_models_str = "', '".join(candidate_models)
                         logger.warning(
                             f"Could not find the model ID {model_id!r}. Did you mean "
                             f"any of the following model IDs: '{candidate_models_str}'?"
                         )
+                        logger.debug(f"The error was {e}.")
                 return False
         else:
             logger.error(

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -540,6 +540,12 @@ class LiteLLMModel(BenchmarkModule):
                 f"Encountered {type(error)} during generation: {error}."
             )
 
+        if isinstance(error, NotFoundError):
+            raise InvalidModel(
+                f"The model {model_id!r} was not found. Please check the model ID "
+                "and try again."
+            )
+
         if isinstance(error, RateLimitError):
             raise InvalidModel(
                 f"You have encountered your rate limit for model {model_id!r}. "


### PR DESCRIPTION
### Fixed
- Now disables the `seed` parameter if the API inference model does not support it,
  which prevented evaluating some models.
- Now correctly detects an API inference model as non-existing, even if LiteLLM *does*
  see it as existing. We have an additional check during evaluation to ensure this now.