### PR TITLE
Fix/allow mistakes on most datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Changed
+- Previously we would abort an evaluation completely if the model outputted a single
+  invalid output on a classification task. As individual samples rarely have a great
+  influence on the overall score, we now just assign the first label to the sample and
+  continue the evaluation. This will be logged to the user, so that they are aware of
+  this. Some tasks are more sensitive to individual samples, such as European values,
+  where we still abort the evaluation if a single sample is invalid.
+
 ### Fixed
 - Fixed a bug causing encoders to fail when evaluating on the Exam-et dataset.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Previously we would abort an evaluation completely if the model outputted a single
   invalid output on a classification task. As individual samples rarely have a great
-  influence on the overall score, we now just assign the first label to the sample and
+  influence on the overall score, we now just assign the closest label to the sample and
   continue the evaluation. This will be logged to the user, so that they are aware of
   this. Some tasks are more sensitive to individual samples, such as European values,
   where we still abort the evaluation if a single sample is invalid.

--- a/src/euroeval/data_models.py
+++ b/src/euroeval/data_models.py
@@ -125,6 +125,9 @@ class Task:
             A list of generative model types that are allowed to be evaluated on this
             task. If None, all generative model types are allowed. Only relevant if
             `allowed_model_types` includes generative models.
+        allow_random_outputs (optional):
+            Whether to use a random output in case the model is unable to generate a
+            valid output. Only relevant for classification tasks. Defaults to True.
     """
 
     name: str
@@ -148,6 +151,7 @@ class Task:
             GenerativeType.REASONING,
         ]
     )
+    allow_random_outputs: bool = True
 
     def __post_init__(self) -> None:
         """Post-initialisation checks."""

--- a/src/euroeval/data_models.py
+++ b/src/euroeval/data_models.py
@@ -125,9 +125,12 @@ class Task:
             A list of generative model types that are allowed to be evaluated on this
             task. If None, all generative model types are allowed. Only relevant if
             `allowed_model_types` includes generative models.
-        allow_random_outputs (optional):
-            Whether to use a random output in case the model is unable to generate a
-            valid output. Only relevant for classification tasks. Defaults to True.
+        allow_invalid_model_outputs (optional):
+            Whether to allow invalid model outputs. This is only relevant for generative
+            models on classification tasks, where the model may generate an output
+            which is not one of the allowed labels. If True, the model output will be
+            mapped to the closest valid label. If False, the model output will be
+            considered incorrect and the evaluation will be aborted. Defaults to True.
     """
 
     name: str
@@ -151,7 +154,7 @@ class Task:
             GenerativeType.REASONING,
         ]
     )
-    allow_random_outputs: bool = True
+    allow_invalid_model_outputs: bool = True
 
     def __post_init__(self) -> None:
         """Post-initialisation checks."""

--- a/src/euroeval/task_group_utils/sequence_classification.py
+++ b/src/euroeval/task_group_utils/sequence_classification.py
@@ -198,13 +198,23 @@ def extract_labels_from_generation(
         # If no candidate labels were found, we assume that something is wrong with the
         # model output, and we raise an error
         if min(edit_distances) > 100:
-            raise InvalidBenchmark(
-                "No candidate labels found for the predicted label "
-                f"{predicted_label!r}, out of the candidate labels "
-                f"{sample_candidate_labels}. This likely means that the model output "
-                "is completely off, and we cannot extract any labels from it. Please "
-                "check the model output and the candidate labels."
-            )
+            if dataset_config.task.allow_random_outputs:
+                logger.warning(
+                    "No candidate labels found for the predicted label "
+                    f"{predicted_label!r}, out of the candidate labels "
+                    f"{sample_candidate_labels}. This likely means that the model "
+                    "output is completely off, but since random outputs are allowed, "
+                    "we will use the first candidate label "
+                    f"({sample_candidate_labels[0]!r}) as the output label."
+                )
+            else:
+                raise InvalidBenchmark(
+                    "No candidate labels found for the predicted label "
+                    f"{predicted_label!r}, out of the candidate labels "
+                    f"{sample_candidate_labels}. This likely means that the model "
+                    "output is completely off, and we cannot extract any labels from "
+                    "it. Please check the model output and the candidate labels."
+                )
 
         # Pick the label with the smallest word edit distance to the predicted label
         best_candidate_label = sample_candidate_labels[np.argmin(edit_distances).item()]

--- a/src/euroeval/tasks.py
+++ b/src/euroeval/tasks.py
@@ -142,7 +142,7 @@ EUROPEAN_VALUES = Task(
     ],
     requires_zero_shot=True,
     uses_logprobs=True,
-    allow_random_outputs=False,
+    allow_invalid_model_outputs=False,
 )
 
 

--- a/src/euroeval/tasks.py
+++ b/src/euroeval/tasks.py
@@ -142,6 +142,7 @@ EUROPEAN_VALUES = Task(
     ],
     requires_zero_shot=True,
     uses_logprobs=True,
+    allow_random_outputs=False,
 )
 
 


### PR DESCRIPTION
### Changed
- Previously we would abort an evaluation completely if the model outputted a single
  invalid output on a classification task. As individual samples rarely have a great
  influence on the overall score, we now just assign the closest label to the sample and
  continue the evaluation. This will be logged to the user, so that they are aware of
  this. Some tasks are more sensitive to individual samples, such as European values,
  where we still abort the evaluation if a single sample is invalid.