### PR TITLE
feat: Allow overriding allowed model types and gen types, and inv outpts

### DIFF
--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -444,7 +444,7 @@ class Benchmarker:
 
                 # Skip if the model type should not be benchmarked on this dataset
                 model_type = model_config.model_type
-                allowed_model_types = dataset_config.task.allowed_model_types
+                allowed_model_types = dataset_config.allowed_model_types
                 if model_type not in allowed_model_types:
                     logger.debug(
                         f"Skipping benchmarking {model_id} on "

--- a/src/euroeval/task_group_utils/sequence_classification.py
+++ b/src/euroeval/task_group_utils/sequence_classification.py
@@ -199,7 +199,7 @@ def extract_labels_from_generation(
         # word edit distance to the predicted label (if invalid model outputs are
         # allowed), or we raise an error
         if min(edit_distances) > 100:
-            if dataset_config.task.allow_invalid_model_outputs:
+            if dataset_config.allow_invalid_model_outputs:
                 logger.warning(
                     "No candidate labels found for the predicted label "
                     f"{predicted_label!r}, out of the candidate labels "

--- a/src/euroeval/tasks.py
+++ b/src/euroeval/tasks.py
@@ -88,7 +88,7 @@ SUMM = Task(
     default_num_few_shot_examples=1,
     default_max_generated_tokens=256,
     default_labels=[],
-    allowed_model_types=[ModelType.GENERATIVE],
+    default_allowed_model_types=[ModelType.GENERATIVE],
 )
 
 
@@ -136,14 +136,14 @@ EUROPEAN_VALUES = Task(
     default_num_few_shot_examples=0,
     default_max_generated_tokens=NUM_GENERATION_TOKENS_FOR_CLASSIFICATION,
     default_labels=["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"],
-    allowed_model_types=[ModelType.GENERATIVE],
-    allowed_generative_types=[
+    default_allowed_model_types=[ModelType.GENERATIVE],
+    default_allowed_generative_types=[
         GenerativeType.INSTRUCTION_TUNED,
         GenerativeType.REASONING,
     ],
     requires_zero_shot=True,
     uses_logprobs=True,
-    allow_invalid_model_outputs=False,
+    default_allow_invalid_model_outputs=False,
 )
 
 


### PR DESCRIPTION
This allows overriding the following task properties in a dataset config:

- `allowed_model_types`
- `allowed_generative_types`
- `allow_invalid_model_outputs`