### PR TITLE
Fix/loading old benchmark results

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      # - id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.13.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: debug-statements
+      # - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.13.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Fixed
+- Fixed an issue where old evaluation records could not be loaded, as the format had
+  changed. We are now able to load old records again.
 
 
 ## [v16.1.1] - 2025-09-12

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -231,7 +231,14 @@ class Benchmarker:
                         result_dict = json.loads(line.strip())
 
                         # Fix for older records
-                        if "test" in result_dict["results"]["raw"]:
+                        has_old_raw_results = (
+                            "results" in result_dict
+                            and isinstance(result_dict["results"], dict)
+                            and "raw" in result_dict["results"]
+                            and isinstance(result_dict["results"]["raw"], dict)
+                            and "test" in result_dict["results"]["raw"]
+                        )
+                        if has_old_raw_results:
                             result_dict["results"]["raw"] = result_dict["results"][
                                 "raw"
                             ]["test"]

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -231,10 +231,12 @@ class Benchmarker:
                         result_dict = json.loads(line)
                         try:
                             result = BenchmarkResult.from_dict(result_dict)
-                        except Exception:
-                            breakpoint()
-                            pass
-                        benchmark_results.append(result)
+                            benchmark_results.append(result)
+                        except Exception as e:
+                            logger.error(
+                                "Error loading benchmark result from JSON line:\n"
+                                f"{line}\nError: {e}\nSkipping this line."
+                            )
             return benchmark_results
         else:
             return list()

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -229,6 +229,13 @@ class Benchmarker:
                 for line in f:
                     if line.strip():
                         result_dict = json.loads(line)
+
+                        # Fix for older records
+                        if "test" in result_dict["results"]["raw"]:
+                            result_dict["results"]["raw"] = result_dict["results"][
+                                "raw"
+                            ]["test"]
+
                         try:
                             result = BenchmarkResult.from_dict(result_dict)
                             benchmark_results.append(result)

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -224,12 +224,18 @@ class Benchmarker:
     def benchmark_results(self) -> list[BenchmarkResult]:
         """The benchmark results."""
         if self.results_path.exists():
+            benchmark_results: list[BenchmarkResult] = list()
             with self.results_path.open() as f:
-                return [
-                    BenchmarkResult.from_dict(json.loads(line))
-                    for line in f
-                    if line.strip()
-                ]
+                for line in f:
+                    if line.strip():
+                        result_dict = json.loads(line)
+                        try:
+                            result = BenchmarkResult.from_dict(result_dict)
+                        except Exception:
+                            breakpoint()
+                            pass
+                        benchmark_results.append(result)
+            return benchmark_results
         else:
             return list()
 

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -228,7 +228,7 @@ class Benchmarker:
             with self.results_path.open() as f:
                 for line in f:
                     if line.strip():
-                        result_dict = json.loads(line)
+                        result_dict = json.loads(line.strip())
 
                         # Fix for older records
                         if "test" in result_dict["results"]["raw"]:
@@ -236,14 +236,8 @@ class Benchmarker:
                                 "raw"
                             ]["test"]
 
-                        try:
-                            result = BenchmarkResult.from_dict(result_dict)
-                            benchmark_results.append(result)
-                        except Exception as e:
-                            logger.error(
-                                "Error loading benchmark result from JSON line:\n"
-                                f"{line}\nError: {e}\nSkipping this line."
-                            )
+                        result = BenchmarkResult.from_dict(result_dict)
+                        benchmark_results.append(result)
             return benchmark_results
         else:
             return list()

--- a/src/euroeval/metrics/huggingface.py
+++ b/src/euroeval/metrics/huggingface.py
@@ -176,7 +176,7 @@ bert_score_metric = HuggingFaceMetric(
     huggingface_id="bertscore",
     results_key="f1",
     compute_kwargs=dict(
-        model_type="microsoft/mdeberta-v3-base", device="auto", batch_size=1
+        model_type="microsoft/mdeberta-v3-base", device="cpu", batch_size=16
     ),
 )
 


### PR DESCRIPTION
### Fixed
- Fixed an issue where old evaluation records could not be loaded, as the format had
  changed. We are now able to load old records again.