### PR TITLE
fix: Only call resolve_model_path if there is no internet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Fixed
+- Fixed another issue related to the `download_only` mode, causing model evaluations to
+  fail, as it could not find the model locally. This has been fixed now.
 
 
 ## [v16.2.1] - 2025-09-15

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -836,15 +836,18 @@ def load_model_and_tokeniser(
 
     clear_vllm()
 
-    # if we do not have an internet connection we need to give the path to the folder
-    # that contains the model weights and config files, otherwise vLLM will try to
-    # download them regardless if they are already present in the download_dir
-    model_path = resolve_model_path(download_dir)
-
     try:
         model = LLM(
-            model=model_id if internet_connection_available() else model_path,
-            tokenizer=model_id if internet_connection_available() else model_path,
+            model=(
+                model_id
+                if internet_connection_available()
+                else resolve_model_path(download_dir=download_dir)
+            ),
+            tokenizer=(
+                model_id
+                if internet_connection_available()
+                else resolve_model_path(download_dir=download_dir)
+            ),
             gpu_memory_utilization=benchmark_config.gpu_memory_utilization,
             max_model_len=min(true_max_model_len, MAX_CONTEXT_LENGTH),
             download_dir=download_dir,

--- a/src/euroeval/utils.py
+++ b/src/euroeval/utils.py
@@ -62,6 +62,10 @@ def resolve_model_path(download_dir: str) -> str:
 
     Returns:
         The path to the model.
+
+    Raises:
+        InvalidModel:
+            If the model path is not valid, or if required files are missing.
     """
     model_path = Path(download_dir)
     # Get the 'path safe' version of the model id, which is the last dir in the path


### PR DESCRIPTION
### Fixed
- Fixed another issue related to the `download_only` mode, causing model evaluations to
  fail, as it could not find the model locally. This has been fixed now.