### PR TITLE
Fix/add missing arguments and add benchmark config tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed another issue related to the `download_only` mode, causing model evaluations to
   fail, as it could not find the model locally. This has been fixed now.
 
-### Removed
-- Removed the deprecated `Benchmarker.__call__` method.
-
 
 ## [v16.2.1] - 2025-09-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Fixed
+- Added missing benchmark arguments to the `Benchmarker.benchmark` method.
 
 
 ## [v16.2.1] - 2025-09-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed another issue related to the `download_only` mode, causing model evaluations to
   fail, as it could not find the model locally. This has been fixed now.
 
+### Removed
+- Removed the deprecated `Benchmarker.__call__` method.
+
 
 ## [v16.2.1] - 2025-09-15
 ### Fixed

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -463,64 +463,134 @@ class Benchmarker:
         # Get a new updated benchmark configuration, based on any changes to the
         # parameters
         benchmark_config_params = BenchmarkConfigParams(
-            task=task or self.benchmark_config_default_params.task,
-            dataset=dataset or self.benchmark_config_default_params.dataset,
+            task=(
+                task if task is not None else self.benchmark_config_default_params.task
+            ),
+            dataset=(
+                dataset
+                if dataset is not None
+                else self.benchmark_config_default_params.dataset
+            ),
             progress_bar=(
-                progress_bar or self.benchmark_config_default_params.progress_bar
+                progress_bar
+                if progress_bar is not None
+                else self.benchmark_config_default_params.progress_bar
             ),
             save_results=(
-                save_results or self.benchmark_config_default_params.save_results
+                save_results
+                if save_results is not None
+                else self.benchmark_config_default_params.save_results
             ),
-            language=language or self.benchmark_config_default_params.language,
+            language=(
+                language
+                if language is not None
+                else self.benchmark_config_default_params.language
+            ),
             model_language=(
-                model_language or self.benchmark_config_default_params.model_language
+                model_language
+                if model_language is not None
+                else self.benchmark_config_default_params.model_language
             ),
             dataset_language=(
                 dataset_language
-                or self.benchmark_config_default_params.dataset_language
+                if dataset_language is not None
+                else self.benchmark_config_default_params.dataset_language
             ),
-            device=device or self.benchmark_config_default_params.device,
-            batch_size=batch_size or self.benchmark_config_default_params.batch_size,
+            device=(
+                device
+                if device is not None
+                else self.benchmark_config_default_params.device
+            ),
+            batch_size=(
+                batch_size
+                if batch_size is not None
+                else self.benchmark_config_default_params.batch_size
+            ),
             raise_errors=(
-                raise_errors or self.benchmark_config_default_params.raise_errors
+                raise_errors
+                if raise_errors is not None
+                else self.benchmark_config_default_params.raise_errors
             ),
-            cache_dir=cache_dir or self.benchmark_config_default_params.cache_dir,
-            api_key=api_key or self.benchmark_config_default_params.api_key,
-            api_base=api_base or self.benchmark_config_default_params.api_base,
-            api_version=api_version or self.benchmark_config_default_params.api_version,
+            cache_dir=(
+                cache_dir
+                if cache_dir is not None
+                else self.benchmark_config_default_params.cache_dir
+            ),
+            api_key=(
+                api_key
+                if api_key is not None
+                else self.benchmark_config_default_params.api_key
+            ),
+            api_base=(
+                api_base
+                if api_base is not None
+                else self.benchmark_config_default_params.api_base
+            ),
+            api_version=(
+                api_version
+                if api_version is not None
+                else self.benchmark_config_default_params.api_version
+            ),
             trust_remote_code=(
                 trust_remote_code
-                or self.benchmark_config_default_params.trust_remote_code
+                if trust_remote_code is not None
+                else self.benchmark_config_default_params.trust_remote_code
             ),
             clear_model_cache=(
                 clear_model_cache
-                or self.benchmark_config_default_params.clear_model_cache
+                if clear_model_cache is not None
+                else self.benchmark_config_default_params.clear_model_cache
             ),
             evaluate_test_split=(
                 evaluate_test_split
-                or self.benchmark_config_default_params.evaluate_test_split
+                if evaluate_test_split is not None
+                else self.benchmark_config_default_params.evaluate_test_split
             ),
-            few_shot=few_shot or self.benchmark_config_default_params.few_shot,
+            few_shot=(
+                few_shot
+                if few_shot is not None
+                else self.benchmark_config_default_params.few_shot
+            ),
             num_iterations=(
-                num_iterations or self.benchmark_config_default_params.num_iterations
+                num_iterations
+                if num_iterations is not None
+                else self.benchmark_config_default_params.num_iterations
             ),
             requires_safetensors=(
                 requires_safetensors
-                or self.benchmark_config_default_params.requires_safetensors
+                if requires_safetensors is not None
+                else self.benchmark_config_default_params.requires_safetensors
             ),
             download_only=(
-                download_only or self.benchmark_config_default_params.download_only
+                download_only
+                if download_only is not None
+                else self.benchmark_config_default_params.download_only
             ),
             gpu_memory_utilization=(
                 gpu_memory_utilization
-                or self.benchmark_config_default_params.gpu_memory_utilization
+                if gpu_memory_utilization is not None
+                else self.benchmark_config_default_params.gpu_memory_utilization
             ),
             generative_type=(
-                generative_type or self.benchmark_config_default_params.generative_type
+                generative_type
+                if generative_type is not None
+                else self.benchmark_config_default_params.generative_type
             ),
-            force=force or self.benchmark_config_default_params.force,
-            verbose=verbose or self.benchmark_config_default_params.verbose,
-            debug=debug or self.benchmark_config_default_params.debug,
+            force=(
+                force
+                if force is not None
+                else self.benchmark_config_default_params.force
+            ),
+            verbose=(
+                verbose
+                if verbose is not None
+                else self.benchmark_config_default_params.verbose
+            ),
+            debug=(
+                debug
+                if debug is not None
+                else self.benchmark_config_default_params.debug
+            ),
             run_with_cli=self.benchmark_config_default_params.run_with_cli,
         )
         benchmark_config = build_benchmark_config(

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -959,6 +959,14 @@ class Benchmarker:
                     raise e
                 return e
 
+    def __call__(self, *args: t.Any, **kwds: t.Any) -> t.Any:  # noqa: ANN401
+        """Alias for `self.benchmark()`."""
+        logger.warning(
+            "Calling the `Benchmarker` class directly is deprecated. Please use the "
+            "`benchmark` function instead. This will be removed in a future version."
+        )
+        return self.benchmark(*args, **kwds)
+
 
 def model_has_been_benchmarked(
     model_id: str,

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -6,7 +6,6 @@ import logging
 import re
 import sys
 import typing as t
-from copy import deepcopy
 from pathlib import Path
 from shutil import rmtree
 from time import sleep
@@ -200,10 +199,10 @@ class Benchmarker:
             )
 
         self.benchmark_config_default_params = BenchmarkConfigParams(
-            progress_bar=progress_bar,
-            save_results=save_results,
             task=task,
             dataset=dataset,
+            progress_bar=progress_bar,
+            save_results=save_results,
             language=language,
             model_language=model_language,
             dataset_language=dataset_language,
@@ -212,21 +211,21 @@ class Benchmarker:
             raise_errors=raise_errors,
             cache_dir=cache_dir,
             api_key=api_key,
-            force=force,
-            verbose=verbose,
+            api_base=api_base,
+            api_version=api_version,
             trust_remote_code=trust_remote_code,
             clear_model_cache=clear_model_cache,
             evaluate_test_split=evaluate_test_split,
             few_shot=few_shot,
             num_iterations=num_iterations,
-            api_base=api_base,
-            api_version=api_version,
+            requires_safetensors=requires_safetensors,
+            download_only=download_only,
             gpu_memory_utilization=gpu_memory_utilization,
             generative_type=generative_type,
-            download_only=download_only,
+            verbose=verbose,
+            force=force,
             debug=debug,
             run_with_cli=run_with_cli,
-            requires_safetensors=requires_safetensors,
         )
 
         self.benchmark_config = build_benchmark_config(
@@ -332,8 +331,8 @@ class Benchmarker:
         raise_errors: bool | None = None,
         cache_dir: str | None = None,
         api_key: str | None = None,
-        force: bool | None = None,
-        verbose: bool | None = None,
+        api_base: str | None = None,
+        api_version: str | None = None,
         trust_remote_code: bool | None = None,
         clear_model_cache: bool | None = None,
         evaluate_test_split: bool | None = None,
@@ -341,6 +340,11 @@ class Benchmarker:
         num_iterations: int | None = None,
         requires_safetensors: bool | None = None,
         download_only: bool | None = None,
+        gpu_memory_utilization: float | None = None,
+        generative_type: GenerativeType | None = None,
+        force: bool | None = None,
+        verbose: bool | None = None,
+        debug: bool | None = None,
     ) -> list[BenchmarkResult]:
         """Benchmarks models on datasets.
 
@@ -393,13 +397,13 @@ class Benchmarker:
             api_key:
                 The API key to use for a given inference server. Defaults to the value
                 specified when initialising the benchmarker.
-            force:
-                Whether to force evaluations of models, even if they have been
-                benchmarked already. Defaults to the value specified when initialising
-                the benchmarker.
-            verbose:
-                Whether to output additional output. Defaults to the value specified
-                when initialising the benchmarker.
+            api_base:
+                The base URL for a given inference API. Only relevant if `model` refers
+                to a model on an inference API. Defaults to the value specified when
+                initialising the benchmarker.
+            api_version:
+                The version of the API to use. Defaults to the value specified when
+                initialising the benchmarker.
             trust_remote_code:
                 Whether to trust remote code when loading models. Defaults to the value
                 specified when initialising the benchmarker.
@@ -424,6 +428,27 @@ class Benchmarker:
             download_only:
                 Whether to only download the models without evaluating them. Defaults
                 to the value specified when initialising the benchmarker.
+            gpu_memory_utilization:
+                The GPU memory utilization to use for vLLM. Only relevant if the model
+                is generative. A larger value will result in faster evaluation, but at
+                the risk of running out of GPU memory. Only reduce this if you are
+                running out of GPU memory. Defaults to the value specified when
+                initialising the benchmarker.
+            generative_type:
+                The type of generative model to benchmark. Only relevant if the model is
+                generative. If not specified, then the type will be inferred based on
+                the tags of the model. Defaults to the value specified when initialising
+                the benchmarker.
+            force:
+                Whether to force evaluations of models, even if they have been
+                benchmarked already. Defaults to the value specified when initialising
+                the benchmarker.
+            verbose:
+                Whether to output additional output. Defaults to the value specified
+                when initialising the benchmarker.
+            debug:
+                Whether to output debug information. Defaults to the value specified
+                when initialising the benchmarker.
 
         Returns:
             A list of benchmark results.
@@ -435,28 +460,71 @@ class Benchmarker:
         if task is not None and dataset is not None:
             raise ValueError("Only one of `task` and `dataset` can be specified.")
 
-        benchmark_config = self._get_updated_benchmark_config(
-            task=task,
-            dataset=dataset,
-            progress_bar=progress_bar,
-            save_results=save_results,
-            language=language,
-            model_language=model_language,
-            dataset_language=dataset_language,
-            device=device,
-            batch_size=batch_size,
-            raise_errors=raise_errors,
-            cache_dir=cache_dir,
-            api_key=api_key,
-            force=force,
-            verbose=verbose,
-            trust_remote_code=trust_remote_code,
-            clear_model_cache=clear_model_cache,
-            evaluate_test_split=evaluate_test_split,
-            few_shot=few_shot,
-            num_iterations=num_iterations,
-            requires_safetensors=requires_safetensors,
-            download_only=download_only,
+        # Get a new updated benchmark configuration, based on any changes to the
+        # parameters
+        benchmark_config_params = BenchmarkConfigParams(
+            task=task or self.benchmark_config_default_params.task,
+            dataset=dataset or self.benchmark_config_default_params.dataset,
+            progress_bar=(
+                progress_bar or self.benchmark_config_default_params.progress_bar
+            ),
+            save_results=(
+                save_results or self.benchmark_config_default_params.save_results
+            ),
+            language=language or self.benchmark_config_default_params.language,
+            model_language=(
+                model_language or self.benchmark_config_default_params.model_language
+            ),
+            dataset_language=(
+                dataset_language
+                or self.benchmark_config_default_params.dataset_language
+            ),
+            device=device or self.benchmark_config_default_params.device,
+            batch_size=batch_size or self.benchmark_config_default_params.batch_size,
+            raise_errors=(
+                raise_errors or self.benchmark_config_default_params.raise_errors
+            ),
+            cache_dir=cache_dir or self.benchmark_config_default_params.cache_dir,
+            api_key=api_key or self.benchmark_config_default_params.api_key,
+            api_base=api_base or self.benchmark_config_default_params.api_base,
+            api_version=api_version or self.benchmark_config_default_params.api_version,
+            trust_remote_code=(
+                trust_remote_code
+                or self.benchmark_config_default_params.trust_remote_code
+            ),
+            clear_model_cache=(
+                clear_model_cache
+                or self.benchmark_config_default_params.clear_model_cache
+            ),
+            evaluate_test_split=(
+                evaluate_test_split
+                or self.benchmark_config_default_params.evaluate_test_split
+            ),
+            few_shot=few_shot or self.benchmark_config_default_params.few_shot,
+            num_iterations=(
+                num_iterations or self.benchmark_config_default_params.num_iterations
+            ),
+            requires_safetensors=(
+                requires_safetensors
+                or self.benchmark_config_default_params.requires_safetensors
+            ),
+            download_only=(
+                download_only or self.benchmark_config_default_params.download_only
+            ),
+            gpu_memory_utilization=(
+                gpu_memory_utilization
+                or self.benchmark_config_default_params.gpu_memory_utilization
+            ),
+            generative_type=(
+                generative_type or self.benchmark_config_default_params.generative_type
+            ),
+            force=force or self.benchmark_config_default_params.force,
+            verbose=verbose or self.benchmark_config_default_params.verbose,
+            debug=debug or self.benchmark_config_default_params.debug,
+            run_with_cli=self.benchmark_config_default_params.run_with_cli,
+        )
+        benchmark_config = build_benchmark_config(
+            benchmark_config_params=benchmark_config_params
         )
 
         adjust_logging_level(verbose=benchmark_config.verbose)
@@ -654,173 +722,6 @@ class Benchmarker:
             destroy_process_group()
         return current_benchmark_results
 
-    def _get_updated_benchmark_config(
-        self,
-        progress_bar: bool | None = None,
-        save_results: bool | None = None,
-        task: str | list[str] | None | None = None,
-        dataset: str | list[str] | None | None = None,
-        language: str | list[str] | None = None,
-        model_language: str | list[str] | None | None = None,
-        dataset_language: str | list[str] | None | None = None,
-        device: Device | None | None = None,
-        batch_size: int | None = None,
-        raise_errors: bool | None = None,
-        cache_dir: str | None = None,
-        api_key: str | None | None = None,
-        force: bool | None = None,
-        verbose: bool | None = None,
-        trust_remote_code: bool | None = None,
-        clear_model_cache: bool | None = None,
-        evaluate_test_split: bool | None = None,
-        few_shot: bool | None = None,
-        num_iterations: int | None = None,
-        api_base: str | None | None = None,
-        api_version: str | None | None = None,
-        debug: bool | None = None,
-        run_with_cli: bool | None = None,
-        requires_safetensors: bool | None = None,
-        download_only: bool | None = None,
-    ) -> "BenchmarkConfig":
-        """Get an updated benchmark configuration.
-
-        Args:
-            progress_bar:
-                Whether progress bars should be shown. If None, then this value will not
-                be updated.
-            save_results:
-                Whether to save the benchmark results to
-                'euroeval_benchmark_results.jsonl'. If None, then this value will not
-                be updated.
-            task:
-                The tasks benchmark the model(s) on. If None, then this value will not
-                be updated.
-            dataset:
-                The datasets to benchmark on. If None, then this value will not be
-                updated.
-            language:
-                The language codes of the languages to include, both for models and
-                datasets. If None, then this value will not be updated.
-            model_language:
-                The language codes of the languages to include for models. If None, then
-                this value will not be updated.
-            dataset_language:
-                The language codes of the languages to include for datasets. If None,
-                then this value will not be updated.
-            device:
-                The device to use for benchmarking. If None, then this value will not be
-                updated.
-            batch_size:
-                The batch size to use. If None, then this value will not be updated.
-            raise_errors:
-                Whether to raise errors instead of skipping the model evaluation. If
-                None, then this value will not be updated.
-            cache_dir:
-                Directory to store cached models. If None, then this value will not be
-                updated.
-            api_key:
-                The API key to use for a given inference server. If None, then this
-                value will not be updated.
-            force:
-                Whether to force evaluations of models, even if they have been
-                benchmarked already. If None, then this value will not be updated.
-            verbose:
-                Whether to output additional output. If None, then this value will not
-                be updated.
-            trust_remote_code:
-                Whether to trust remote code when loading models. If None, then this
-                value will not be updated.
-            clear_model_cache:
-                Whether to clear the model cache after benchmarking each model. If None,
-                then this value will not be updated.
-            evaluate_test_split:
-                Whether to evaluate the test split of the datasets. If None, then this
-                value will not be updated.
-            few_shot:
-                Whether to only evaluate the model using few-shot evaluation. If None,
-                then this value will not be updated.
-            num_iterations:
-                The number of times each model should be evaluated. If None, then this
-                value will not be updated.
-            api_base:
-                The base URL for a given inference API. If None, then this value will
-                not be updated.
-            api_version:
-                The version of the API to use. If None, then this value will not be
-                updated.
-            debug:
-                Whether to output debug information. If None, then this value will not
-                be updated.
-            run_with_cli:
-                Whether the benchmarker is being run from the command-line interface.
-                If None, then this value will not be updated.
-            requires_safetensors:
-                Whether to only allow models that use the safetensors format. If None,
-                then this value will not be updated.
-            download_only:
-                Whether to only download the models without evaluating them. If None,
-                then this value will not be updated.
-
-        Returns:
-            The updated benchmark configuration.
-        """
-        benchmark_config_params = deepcopy(self.benchmark_config_default_params)
-
-        if progress_bar is not None:
-            benchmark_config_params.progress_bar = progress_bar
-        if save_results is not None:
-            benchmark_config_params.save_results = save_results
-        if task is not None:
-            benchmark_config_params.task = task
-            benchmark_config_params.dataset = None
-        if dataset is not None:
-            benchmark_config_params.dataset = dataset
-            benchmark_config_params.task = None
-        if language is not None:
-            benchmark_config_params.language = language
-        if model_language is not None:
-            benchmark_config_params.model_language = model_language
-        if dataset_language is not None:
-            benchmark_config_params.dataset_language = dataset_language
-        if device is not None:
-            benchmark_config_params.device = device
-        if batch_size is not None:
-            benchmark_config_params.batch_size = batch_size
-        if raise_errors is not None:
-            benchmark_config_params.raise_errors = raise_errors
-        if cache_dir is not None:
-            benchmark_config_params.cache_dir = cache_dir
-        if api_key is not None:
-            benchmark_config_params.api_key = api_key
-        if force is not None:
-            benchmark_config_params.force = force
-        if verbose is not None:
-            benchmark_config_params.verbose = verbose
-        if trust_remote_code is not None:
-            benchmark_config_params.trust_remote_code = trust_remote_code
-        if clear_model_cache is not None:
-            benchmark_config_params.clear_model_cache = clear_model_cache
-        if evaluate_test_split is not None:
-            benchmark_config_params.evaluate_test_split = evaluate_test_split
-        if few_shot is not None:
-            benchmark_config_params.few_shot = few_shot
-        if num_iterations is not None:
-            benchmark_config_params.num_iterations = num_iterations
-        if api_base is not None:
-            benchmark_config_params.api_base = api_base
-        if api_version is not None:
-            benchmark_config_params.api_version = api_version
-        if debug is not None:
-            benchmark_config_params.debug = debug
-        if run_with_cli is not None:
-            benchmark_config_params.run_with_cli = run_with_cli
-        if requires_safetensors is not None:
-            benchmark_config_params.requires_safetensors = requires_safetensors
-        if download_only is not None:
-            benchmark_config_params.download_only = download_only
-
-        return build_benchmark_config(benchmark_config_params=benchmark_config_params)
-
     def _prepare_model_ids(self, model_id: list[str] | str) -> list[str]:
         """Prepare the model ID(s) to be benchmarked.
 
@@ -987,145 +888,6 @@ class Benchmarker:
                 elif benchmark_config.raise_errors:
                     raise e
                 return e
-
-    def __call__(
-        self,
-        model: list[str] | str,
-        task: str | list[str] | None = None,
-        dataset: list[str] | str | None = None,
-        progress_bar: bool | None = None,
-        save_results: bool | None = None,
-        language: str | list[str] | None = None,
-        model_language: str | list[str] | None = None,
-        dataset_language: str | list[str] | None = None,
-        device: Device | None = None,
-        batch_size: int | None = None,
-        raise_errors: bool | None = None,
-        cache_dir: str | None = None,
-        api_key: str | None = None,
-        force: bool | None = None,
-        verbose: bool | None = None,
-        trust_remote_code: bool | None = None,
-        clear_model_cache: bool | None = None,
-        evaluate_test_split: bool | None = None,
-        few_shot: bool | None = None,
-        num_iterations: int | None = None,
-        requires_safetensors: bool | None = None,
-    ) -> list[BenchmarkResult]:
-        """Benchmarks models on datasets.
-
-        Args:
-            model:
-                The full Hugging Face Hub path(s) to the pretrained transformer model.
-                The specific model version to use can be added after the suffix '@':
-                "model@v1.0.0". It can be a branch name, a tag name, or a commit id,
-                and defaults to the latest version if not specified.
-            task:
-                The tasks benchmark the model(s) on. Mutually exclusive with `dataset`.
-                If both `task` and `dataset` are None then all datasets will be
-                benchmarked. Defaults to None.
-            dataset:
-                The datasets to benchmark on. Mutually exclusive with `task`. If both
-                `task` and `dataset` are None then all datasets will be benchmarked.
-                Defaults to None.
-            progress_bar:
-                Whether progress bars should be shown. Defaults to the value specified
-                when initialising the benchmarker.
-            save_results:
-                Whether to save the benchmark results to
-                'euroeval_benchmark_results.jsonl'. Defaults to the value specified
-                when initialising the benchmarker.
-            language:
-                The language codes of the languages to include, both for models and
-                datasets. Here 'no' means both Bokmål (nb) and Nynorsk (nn). Set this to
-                'all' if all languages should be considered. Defaults to the value
-                specified when initialising the benchmarker.
-            model_language:
-                The language codes of the languages to include for models. If specified
-                then this overrides the `language` parameter for model languages.
-                Defaults to the value specified when initialising the benchmarker.
-            dataset_language:
-                The language codes of the languages to include for datasets. If
-                specified then this overrides the `language` parameter for dataset
-                languages. Defaults to the value specified when initialising the
-                benchmarker.
-            device:
-                The device to use for benchmarking. Defaults to the value specified when
-                initialising the benchmarker.
-            batch_size:
-                The batch size to use. Defaults to the value specified when initialising
-                the benchmarker.
-            raise_errors:
-                Whether to raise errors instead of skipping the model evaluation.
-            cache_dir:
-                Directory to store cached models. Defaults to the value specified when
-                initialising the benchmarker.
-            api_key:
-                The API key to use for a given inference server. Defaults to the value
-                specified when initialising the benchmarker.
-            force:
-                Whether to force evaluations of models, even if they have been
-                benchmarked already. Defaults to the value specified when initialising
-                the benchmarker.
-            verbose:
-                Whether to output additional output. Defaults to the value specified
-                when initialising the benchmarker.
-            trust_remote_code:
-                Whether to trust remote code when loading models. Defaults to the value
-                specified when initialising the benchmarker.
-            clear_model_cache:
-                Whether to clear the model cache after benchmarking each model. Defaults
-                to the value specified when initialising the benchmarker.
-            evaluate_test_split:
-                Whether to evaluate the test split of the datasets. Defaults to the
-                value specified when initialising the benchmarker.
-            few_shot:
-                Whether to only evaluate the model using few-shot evaluation. Only
-                relevant if the model is generative. Defaults to the value specified
-                when initialising the benchmarker.
-            num_iterations:
-                The number of times each model should be evaluated. This is only meant
-                to be used for power users, and scores will not be allowed on the
-                leaderboards if this is changed. Defaults to the value specified when
-                initialising the benchmarker.
-            requires_safetensors:
-                Whether to only allow models that use the safetensors format. Defaults
-                to the value specified when initialising the benchmarker.
-
-        Returns:
-            A list of benchmark results.
-
-        Raises:
-            ValueError:
-                If both `task` and `dataset` are specified.
-        """
-        logger.warning(
-            "Calling the `Benchmarker` class directly is deprecated. Please use the "
-            "`benchmark` function instead. This will be removed in a future version."
-        )
-        return self.benchmark(
-            model=model,
-            task=task,
-            dataset=dataset,
-            progress_bar=progress_bar,
-            save_results=save_results,
-            language=language,
-            model_language=model_language,
-            dataset_language=dataset_language,
-            device=device,
-            batch_size=batch_size,
-            raise_errors=raise_errors,
-            cache_dir=cache_dir,
-            api_key=api_key,
-            force=force,
-            verbose=verbose,
-            trust_remote_code=trust_remote_code,
-            clear_model_cache=clear_model_cache,
-            evaluate_test_split=evaluate_test_split,
-            few_shot=few_shot,
-            num_iterations=num_iterations,
-            requires_safetensors=requires_safetensors,
-        )
 
 
 def model_has_been_benchmarked(

--- a/src/euroeval/data_models.py
+++ b/src/euroeval/data_models.py
@@ -170,14 +170,16 @@ class BenchmarkConfig:
     """General benchmarking configuration, across datasets and models.
 
     Attributes:
-        model_languages:
-            The languages of the models to benchmark.
-        dataset_languages:
-            The languages of the datasets in the benchmark.
         tasks:
             The tasks benchmark the model(s) on.
         datasets:
             The datasets to benchmark on.
+        model_languages:
+            The languages of the models to benchmark.
+        dataset_languages:
+            The languages of the datasets in the benchmark.
+        device:
+            The device to use for benchmarking.
         batch_size:
             The batch size to use.
         raise_errors:
@@ -186,17 +188,16 @@ class BenchmarkConfig:
             Directory to store cached models and datasets.
         api_key:
             The API key to use for a given inference API.
-        force:
-            Whether to force the benchmark to run even if the results are already
-            cached.
+        api_base:
+            The base URL for a given inference API. Only relevant if `model` refers to a
+            model on an inference API.
+        api_version:
+            The version of the API to use. Only relevant if `model` refers to a model on
+            an inference API.
         progress_bar:
             Whether to show a progress bar.
         save_results:
             Whether to save the benchmark results to 'euroeval_benchmark_results.json'.
-        device:
-            The device to use for benchmarking.
-        verbose:
-            Whether to print verbose output.
         trust_remote_code:
             Whether to trust remote code when loading models from the Hugging Face Hub.
         clear_model_cache:
@@ -208,21 +209,11 @@ class BenchmarkConfig:
             if the model is generative.
         num_iterations:
             The number of iterations each model should be evaluated for.
-        api_base:
-            The base URL for a given inference API. Only relevant if `model` refers to a
-            model on an inference API.
-        api_version:
-            The version of the API to use. Only relevant if `model` refers to a model on
-            an inference API.
         gpu_memory_utilization:
             The GPU memory utilization to use for vLLM. A larger value will result in
             faster evaluation, but at the risk of running out of GPU memory. Only reduce
             this if you are running out of GPU memory. Only relevant if the model is
             generative.
-        debug:
-            Whether to run the benchmark in debug mode.
-        run_with_cli:
-            Whether the benchmark is being run with the CLI.
         requires_safetensors:
             Whether to only allow models that use the safetensors format.
         generative_type:
@@ -231,6 +222,15 @@ class BenchmarkConfig:
         download_only:
             Whether to only download the models, metrics and datasets without
             evaluating.
+        force:
+            Whether to force the benchmark to run even if the results are already
+            cached.
+        verbose:
+            Whether to print verbose output.
+        debug:
+            Whether to run the benchmark in debug mode.
+        run_with_cli:
+            Whether the benchmark is being run with the CLI.
     """
 
     model_languages: list[Language]
@@ -241,24 +241,24 @@ class BenchmarkConfig:
     raise_errors: bool
     cache_dir: str
     api_key: str | None
-    force: bool
+    api_base: str | None
+    api_version: str | None
     progress_bar: bool
     save_results: bool
     device: torch.device
-    verbose: bool
     trust_remote_code: bool
     clear_model_cache: bool
     evaluate_test_split: bool
     few_shot: bool
     num_iterations: int
-    api_base: str | None
-    api_version: str | None
     gpu_memory_utilization: float
-    debug: bool
-    run_with_cli: bool
     requires_safetensors: bool
     generative_type: GenerativeType | None
     download_only: bool
+    force: bool
+    verbose: bool
+    debug: bool
+    run_with_cli: bool
 
 
 class BenchmarkConfigParams(pydantic.BaseModel):
@@ -278,13 +278,13 @@ class BenchmarkConfigParams(pydantic.BaseModel):
     raise_errors: bool
     cache_dir: str
     api_key: str | None
+    api_base: str | None
+    api_version: str | None
     trust_remote_code: bool
     clear_model_cache: bool
     evaluate_test_split: bool
     few_shot: bool
     num_iterations: int
-    api_base: str | None
-    api_version: str | None
     requires_safetensors: bool
     download_only: bool
     gpu_memory_utilization: float

--- a/src/euroeval/data_models.py
+++ b/src/euroeval/data_models.py
@@ -266,10 +266,10 @@ class BenchmarkConfigParams(pydantic.BaseModel):
 
     model_config = pydantic.ConfigDict(protected_namespaces=())
 
-    progress_bar: bool
-    save_results: bool
     task: str | list[str] | None
     dataset: str | list[str] | None
+    progress_bar: bool
+    save_results: bool
     language: str | list[str]
     model_language: str | list[str] | None
     dataset_language: str | list[str] | None
@@ -278,8 +278,6 @@ class BenchmarkConfigParams(pydantic.BaseModel):
     raise_errors: bool
     cache_dir: str
     api_key: str | None
-    force: bool
-    verbose: bool
     trust_remote_code: bool
     clear_model_cache: bool
     evaluate_test_split: bool
@@ -287,12 +285,14 @@ class BenchmarkConfigParams(pydantic.BaseModel):
     num_iterations: int
     api_base: str | None
     api_version: str | None
+    requires_safetensors: bool
+    download_only: bool
     gpu_memory_utilization: float
     generative_type: GenerativeType | None
-    download_only: bool
+    force: bool
+    verbose: bool
     debug: bool
     run_with_cli: bool
-    requires_safetensors: bool
 
 
 class BenchmarkResult(pydantic.BaseModel):

--- a/src/euroeval/utils.py
+++ b/src/euroeval/utils.py
@@ -271,14 +271,15 @@ def internet_connection_available() -> bool:
         s = socket.create_connection(("1.1.1.1", 80))
         s.close()
         return True
-    # a bit ugly but we dont want to actually import the pytest-socket exceptions
-    # we catch all exceptions and check if the name matches any known errors
+
+    # We want to only catch exceptions related to socket connections, but as we cannot
+    # import these here as they're developer dependencies, we check the exception name
+    # instead. If the exception is not related to socket connections, we reraise it.
     except Exception as e:
         pytest_socket_errors = ["SocketConnectBlockedError", "SocketBlockedError"]
         if type(e).__name__ in pytest_socket_errors or isinstance(e, OSError):
             return False
-        else:
-            raise e
+        raise e
 
 
 class HiddenPrints:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,9 @@ from typing import Generator
 
 import pytest
 import torch
+from click import ParamType
 
+from euroeval.cli import benchmark
 from euroeval.data_models import BenchmarkConfig, ModelConfig, Task
 from euroeval.dataset_configs import SPEED_CONFIG, get_all_dataset_configs
 from euroeval.enums import InferenceBackend, ModelType
@@ -174,3 +176,10 @@ def model_config() -> Generator[ModelConfig, None, None]:
         model_cache_dir="cache_dir",
         adapter_base_model_id=None,
     )
+
+
+@pytest.fixture(scope="module")
+def cli_params() -> Generator[dict[str | None, ParamType], None, None]:
+    """Yields a dictionary of the CLI parameters."""
+    ctx = benchmark.make_context(info_name="testing", args=["--model", "test-model"])
+    yield {p.name: p.type for p in benchmark.get_params(ctx)}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,23 +1,11 @@
 """Tests for the `cli` module."""
 
-from typing import Generator
-
-import pytest
 from click.types import BOOL, FLOAT, INT, STRING, Choice, ParamType
 
-from euroeval.cli import benchmark
 
-
-@pytest.fixture(scope="module")
-def params() -> Generator[dict[str | None, ParamType], None, None]:
-    """Yields a dictionary of the CLI parameters."""
-    ctx = benchmark.make_context(info_name="testing", args=["--model", "test-model"])
-    yield {p.name: p.type for p in benchmark.get_params(ctx)}
-
-
-def test_cli_param_names(params: dict[str, ParamType]) -> None:
+def test_cli_param_names(cli_params: dict[str, ParamType]) -> None:
     """Test that the CLI parameters have the correct names."""
-    assert set(params.keys()) == {
+    assert set(cli_params.keys()) == {
         "model",
         "task",
         "language",
@@ -49,33 +37,33 @@ def test_cli_param_names(params: dict[str, ParamType]) -> None:
     }
 
 
-def test_cli_param_types(params: dict[str, ParamType]) -> None:
+def test_cli_param_types(cli_params: dict[str, ParamType]) -> None:
     """Test that the CLI parameters have the correct types."""
-    assert params["model"] == STRING
-    assert isinstance(params["dataset"], Choice)
-    assert isinstance(params["language"], Choice)
-    assert isinstance(params["model_language"], Choice)
-    assert isinstance(params["dataset_language"], Choice)
-    assert isinstance(params["task"], Choice)
-    assert isinstance(params["batch_size"], Choice)
-    assert params["progress_bar"] == BOOL
-    assert params["raise_errors"] == BOOL
-    assert params["verbose"] == BOOL
-    assert params["save_results"] == BOOL
-    assert params["cache_dir"] == STRING
-    assert params["api_key"] == STRING
-    assert params["force"] == BOOL
-    assert isinstance(params["device"], Choice)
-    assert params["trust_remote_code"] == BOOL
-    assert params["clear_model_cache"] == BOOL
-    assert params["evaluate_test_split"] == BOOL
-    assert params["few_shot"] == BOOL
-    assert params["num_iterations"] == INT
-    assert params["api_base"] == STRING
-    assert params["api_version"] == STRING
-    assert params["gpu_memory_utilization"] == FLOAT
-    assert params["debug"] == BOOL
-    assert params["help"] == BOOL
-    assert params["requires_safetensors"] == BOOL
-    assert isinstance(params["generative_type"], Choice)
-    assert params["download_only"] == BOOL
+    assert cli_params["model"] == STRING
+    assert isinstance(cli_params["dataset"], Choice)
+    assert isinstance(cli_params["language"], Choice)
+    assert isinstance(cli_params["model_language"], Choice)
+    assert isinstance(cli_params["dataset_language"], Choice)
+    assert isinstance(cli_params["task"], Choice)
+    assert isinstance(cli_params["batch_size"], Choice)
+    assert cli_params["progress_bar"] == BOOL
+    assert cli_params["raise_errors"] == BOOL
+    assert cli_params["verbose"] == BOOL
+    assert cli_params["save_results"] == BOOL
+    assert cli_params["cache_dir"] == STRING
+    assert cli_params["api_key"] == STRING
+    assert cli_params["force"] == BOOL
+    assert isinstance(cli_params["device"], Choice)
+    assert cli_params["trust_remote_code"] == BOOL
+    assert cli_params["clear_model_cache"] == BOOL
+    assert cli_params["evaluate_test_split"] == BOOL
+    assert cli_params["few_shot"] == BOOL
+    assert cli_params["num_iterations"] == INT
+    assert cli_params["api_base"] == STRING
+    assert cli_params["api_version"] == STRING
+    assert cli_params["gpu_memory_utilization"] == FLOAT
+    assert cli_params["debug"] == BOOL
+    assert cli_params["help"] == BOOL
+    assert cli_params["requires_safetensors"] == BOOL
+    assert isinstance(cli_params["generative_type"], Choice)
+    assert cli_params["download_only"] == BOOL

--- a/tests/test_data_models.py
+++ b/tests/test_data_models.py
@@ -318,7 +318,7 @@ class TestBenchmarkParametersAreConsistent:
         assert benchmark_config_params == cli_benchmark_params
 
     def test_config_params_is_the_same_as_benchmark_config(self) -> None:
-        """Test that `BenchmarkConfigParams` agrees with `benchmark_config`."""
+        """Test that `BenchmarkConfigParams` agrees with `BenchmarkConfig`."""
         benchmark_config_params = set(
             inspect.signature(BenchmarkConfigParams).parameters.keys()
         ) - {"dataset", "task", "language", "dataset_language", "model_language"}

--- a/tests/test_data_models.py
+++ b/tests/test_data_models.py
@@ -10,7 +10,7 @@ from click import ParamType
 
 from euroeval import __version__, data_models, enums
 from euroeval.benchmarker import Benchmarker
-from euroeval.data_models import BenchmarkConfigParams, BenchmarkResult
+from euroeval.data_models import BenchmarkConfig, BenchmarkConfigParams, BenchmarkResult
 from euroeval.metrics import HuggingFaceMetric, Metric
 
 
@@ -316,3 +316,13 @@ class TestBenchmarkParametersAreConsistent:
         ) - {"run_with_cli"}
         cli_benchmark_params = set(cli_params.keys()) - {"model", "help"}
         assert benchmark_config_params == cli_benchmark_params
+
+    def test_config_params_is_the_same_as_benchmark_config(self) -> None:
+        """Test that `BenchmarkConfigParams` agrees with `benchmark_config`."""
+        benchmark_config_params = set(
+            inspect.signature(BenchmarkConfigParams).parameters.keys()
+        ) - {"dataset", "task", "language", "dataset_language", "model_language"}
+        benchmark_config_fields = set(
+            inspect.signature(BenchmarkConfig).parameters.keys()
+        ) - {"datasets", "tasks", "dataset_languages", "model_languages"}
+        assert benchmark_config_params == benchmark_config_fields

--- a/tests/test_data_models.py
+++ b/tests/test_data_models.py
@@ -6,9 +6,11 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
+from click import ParamType
 
 from euroeval import __version__, data_models, enums
-from euroeval.data_models import BenchmarkResult
+from euroeval.benchmarker import Benchmarker
+from euroeval.data_models import BenchmarkConfigParams, BenchmarkResult
 from euroeval.metrics import HuggingFaceMetric, Metric
 
 
@@ -67,14 +69,6 @@ class TestMetric:
     ) -> None:
         """Test that the default value of `postprocessing_fn` is correct."""
         assert metric.postprocessing_fn(inputs) == expected
-
-
-# TODO
-@pytest.mark.skip("Not implemented")
-class TestBenchmarkConfigParams:
-    """Tests for the `BenchmarkConfigParams` class."""
-
-    pass
 
 
 class TestBenchmarkResult:
@@ -288,3 +282,37 @@ class TestBenchmarkResult:
         assert results_path.read_text() == f"\n{json_str}\n{json_str}"
 
         results_path.unlink(missing_ok=True)
+
+
+class TestBenchmarkParametersAreConsistent:
+    """Test that the same benchmark parameters are used everywhere."""
+
+    def test_config_params_is_the_same_as_benchmarker_init(self) -> None:
+        """Test that `BenchmarkConfigParams` agrees with `Benchmarker.__init__`."""
+        benchmark_config_params = set(
+            inspect.signature(BenchmarkConfigParams).parameters.keys()
+        )
+        benchmarker_init_params = set(
+            inspect.signature(Benchmarker.__init__).parameters.keys()
+        ) - {"self"}
+        assert benchmark_config_params == benchmarker_init_params
+
+    def test_config_params_is_the_same_as_benchmark_method(self) -> None:
+        """Test that `BenchmarkConfigParams` agrees with `Benchmarker.benchmark`."""
+        benchmark_config_params = set(
+            inspect.signature(BenchmarkConfigParams).parameters.keys()
+        ) - {"run_with_cli"}
+        benchmark_method_params = set(
+            inspect.signature(Benchmarker.benchmark).parameters.keys()
+        ) - {"self", "model"}
+        assert benchmark_config_params == benchmark_method_params
+
+    def test_config_params_is_the_same_as_cli(
+        self, cli_params: dict[str, ParamType]
+    ) -> None:
+        """Test that `BenchmarkConfigParams` agrees with the CLI."""
+        benchmark_config_params = set(
+            inspect.signature(BenchmarkConfigParams).parameters.keys()
+        ) - {"run_with_cli"}
+        cli_benchmark_params = set(cli_params.keys()) - {"model", "help"}
+        assert benchmark_config_params == cli_benchmark_params


### PR DESCRIPTION
### Fixed
- Added missing benchmark arguments to the `Benchmarker.benchmark` method.

Also added tests to check that the arguments in the CLI, `Benchmarker.__init__`, `Benchmarker.benchmark`, `BenchmarkConfigParams` and `BenchmarkConfig` are consistent.