### PR TITLE
Document search

### DIFF
--- a/src/euroeval/dataset_configs/danish.py
+++ b/src/euroeval/dataset_configs/danish.py
@@ -6,6 +6,7 @@ from ..languages import DA
 from ..tasks import (
     COMMON_SENSE,
     COMPLETENESS_DETECTION,
+    DOCUMENT_SEARCH,
     EUROPEAN_VALUES,
     KNOW,
     LA,
@@ -230,4 +231,14 @@ CONTRACT_COMPLETENESS_DETECTION_CONFIG = DatasetConfig(
         Beskriv maksimalt 3 manglende elementer, eller skriv "Kontrakten er
         fuldstændig." hvis kontrakten ikke mangler noget.
     """,
+)
+
+DOCUMENT_SEARCH_CONFIG = DatasetConfig(
+    name="document-search",
+    pretty_name="the Danish legal benchmark dataset Document Search",
+    huggingface_id="EuroEval/legal-document-search",
+    task=DOCUMENT_SEARCH,
+    languages=[DA],
+    splits=["test"],
+    unofficial=True,
 )

--- a/src/euroeval/metrics/llm_as_a_judge.py
+++ b/src/euroeval/metrics/llm_as_a_judge.py
@@ -451,3 +451,47 @@ contract_completeness_metric = LLMAsAJudgeMetric(
     ),
     scoring_fn=compute_contract_completeness_f1,
 )
+
+
+class AnswerCorrectnessResponse(BaseModel):
+    """Represents the response structure for answer correctness evaluation."""
+
+    is_correct: bool
+
+
+def compute_answer_correctness(
+    output: BaseModel, dataset_sample: dict[str, t.Any]
+) -> float:
+    """Compute the answer correctness for a single output."""
+    return 1.0 if output.is_correct else 0.0
+
+
+document_search_metric = LLMAsAJudgeMetric(
+    name="answer_correctness",
+    pretty_name="Answer Correctness",
+    judge_id="gpt-4.1",
+    judge_kwargs=dict(temperature=0.0),
+    user_prompt=(
+        """
+        You are evaluating a language model's response to a question about a contract.
+        You will be provided with the actual answer to the question and the model's
+        predicted answer.
+
+        <actual-answer>
+        {condition}
+        </actual-answer>
+
+        <model-predicted-answer>
+        {prediction}
+        </model-predicted-answer>
+
+        Determine if the model's predicted answer is correct. Output your result as a
+        JSON object with the following key:
+
+        - "is_correct": A boolean indicating whether the model's predicted answer is
+          correct.
+        """
+    ),
+    response_format_kwargs=dict(is_correct=bool),
+    scoring_fn=compute_answer_correctness,
+)

--- a/src/euroeval/metrics/llm_as_a_judge.py
+++ b/src/euroeval/metrics/llm_as_a_judge.py
@@ -453,12 +453,6 @@ contract_completeness_metric = LLMAsAJudgeMetric(
 )
 
 
-class AnswerCorrectnessResponse(BaseModel):
-    """Represents the response structure for answer correctness evaluation."""
-
-    is_correct: bool
-
-
 def compute_answer_correctness(
     output: BaseModel, dataset_sample: dict[str, t.Any]
 ) -> float:

--- a/src/euroeval/tasks.py
+++ b/src/euroeval/tasks.py
@@ -185,3 +185,14 @@ COMPLETENESS_DETECTION = Task(
     default_labels=[],
     requires_zero_shot=True,
 )
+
+DOCUMENT_SEARCH = Task(
+    name="document-search",
+    task_group=TaskGroup.TEXT_TO_TEXT,
+    template_dict=LLM_AS_A_JUDGE_TEMPLATES,
+    metrics=[m.document_search_metric],
+    default_num_few_shot_examples=0,
+    default_max_generated_tokens=512,
+    default_labels=[],
+    requires_zero_shot=True,
+)

--- a/src/scripts/danish-legal/create_document_search.py
+++ b/src/scripts/danish-legal/create_document_search.py
@@ -1,0 +1,87 @@
+"""Create the Danish legal benchmark dataset Document Search."""
+
+import os
+
+import pandas as pd
+from datasets import Dataset, DatasetDict, Split, load_dataset
+from huggingface_hub import HfApi
+from openai import OpenAI
+from pydantic import BaseModel
+
+# Constants
+TEMPERATURE = 0.3
+MODEL = "gpt-4o"
+
+
+class QuestionAnswerResponse(BaseModel):
+    """Represents the response structure for question and answer generation."""
+
+    question: str
+    answer: str
+
+
+def main() -> None:
+    """Create the Danish legal benchmark dataset Document Search."""
+    # Load the contracts dataset
+    contracts_dataset = load_dataset("alexandrainst/contracts")
+
+    # Initialize OpenAI client
+    client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+
+    samples: list[dict[str, str]] = []
+
+    for contract in contracts_dataset["train"]:
+        contract_text = contract["content"]
+
+        # Generate a question and answer using OpenAI
+        question, answer = generate_question_answer(
+            client=client, contract=contract_text
+        )
+
+        text = f"{contract_text}\n\n{question}"
+        target_text = answer
+        samples.append({"text": text, "target_text": target_text})
+
+    # Convert samples to a DataFrame
+    df = pd.DataFrame(samples)
+    split = Dataset.from_pandas(df, split=Split.TEST)
+    dataset = DatasetDict(test=split)
+
+    # Upload dataset
+    dataset_id = "EuroEval/legal-document-search"
+    HfApi().delete_repo(dataset_id, repo_type="dataset", missing_ok=True)
+    dataset.push_to_hub(dataset_id, private=True)
+
+
+def generate_question_answer(client: OpenAI, contract: str) -> tuple[str, str]:
+    """Generate a question and answer for a contract."""
+    # Define the prompt for generating a question and answer in Danish
+    # TODO: Generate multiple question answer pairs for each contract?
+    # E.g.: "Generer n spørgsmål og svar til den følgende kontrakt."
+    prompt = (
+        "Læs den følgende kontrakt og generér et spørgsmål, der kan besvares "
+        "ved hjælp af oplysningerne i kontrakten. Svaret skal findes eksplicit "
+        "i kontraktteksten. Både spørgsmålet og svaret skal være på dansk.\n\n"
+        f"{contract}\n\nSpørgsmål:"
+    )
+
+    # Send the prompt to OpenAI
+    response = client.responses.parse(
+        model=MODEL,
+        input=[{"role": "user", "content": prompt}],
+        text_format=QuestionAnswerResponse,
+        temperature=TEMPERATURE,
+    ).output_parsed
+
+    if response is None:
+        raise ValueError("No response from OpenAI")
+
+    # Access the structured response
+    question = response.question
+    answer = response.answer
+
+    return question, answer
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Dataset creation script
Currently creates one question answer pair for each contract. We could instead create $n$ question answer pairs for each contract.

Should we just have one contract per sample, or should we have a list of contracts, such that we can evaluate context correctness?

The dataset is built upon [this contracts dataset](https://huggingface.co/datasets/alexandrainst/contracts), which currently simply consists of 10 synthetic contracts. The document search therefore also currently only have 10 samples. I will make a larger dataset later.

# Evaluation
Currently only answer correctness is computed.


1. **Answer Correctness**: The percentage of questions that the model answers correctly;
2. **Context Correctness**: The percentage of questions for which the model correctly
   identifies the document(s) that contain the answer;

