### PR TITLE
Change to flex-attention, allow empty NER dictionaries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: debug-statements
+      # - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.13.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      # - id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.13.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: debug-statements
+      # - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.13.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: trailing-whitespace
       - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.0
+    rev: v0.13.1
     hooks:
       - id: ruff
         args:
@@ -34,7 +34,7 @@ repos:
     hooks:
     -   id: nbstripout
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.18.1
+    rev: v1.18.2
     hooks:
     -   id: mypy
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      # - id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.13.1
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Now gives a warning when a reasoning model does not get to finish its reasoning due to
   running out of the 8,192 reasoning tokens. In this case, we use an empty string as the
   model output, which will lead to lower scores.
+- Now allows changing the attention backend with vLLM, with the `VLLM_ATTENTION_BACKEND`
+  environment variable, which was previously hardcoded. Only relevant for generative
+  models running with vLLM.
+
+### Changed
+- Changed the default value of `gpu_memory_utilization` from 0.9 to 0.8, as the new
+  change to flex-attention needs a bit more buffer memory to avoid OOM errors. This can
+  always be changed with the `--gpu-memory-utilization` argument (or
+  `gpu_memory_utilization` in the `Benchmarker` API).
 
 ### Fixed
 - We now take invalid (model, dataset) combinations into account when computing the
@@ -28,6 +37,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   has been fixed now.
 - We're now allowing generative models to output empty dictionaries for the NER task, as
   this is a valid output (no entities found). Previously this caused an error.
+- Changed the default vLLM attention backend to flex-attention (previously flashinfer),
+  as flex-attention supports all model head sizes, whereas flashinfer only supports
+  head sizes of size 64, 128 and 256, causing some models not to work with flashinfer.
 
 
 ## [v16.2.2] - 2025-09-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Previously we did not detect that a model was already evaluated on a dataset if the
   dataset did not have a validation split (such as the European values dataset). This
   has been fixed now.
+- We're now allowing generative models to output empty dictionaries for the NER task, as
+  this is a valid output (no entities found). Previously this caused an error.
 
 
 ## [v16.2.2] - 2025-09-15

--- a/makefile
+++ b/makefile
@@ -52,7 +52,7 @@ install-uv:
 
 install-dependencies:
 	@uv python install 3.11
-	@uv sync --all-extras --python 3.11
+	@uv sync --all-extras --all-groups --python 3.11
 
 setup-environment-variables:
 	@uv run python src/scripts/fix_dot_env_file.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,8 @@ file = "LICENSE"
 euroeval = "euroeval.cli:benchmark"
 scandeval = "euroeval.cli:benchmark"
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest>=8.3.3",
     "pytest-cov>=5.0.0",
     "pre-commit>=3.8.0",

--- a/src/euroeval/__init__.py
+++ b/src/euroeval/__init__.py
@@ -106,7 +106,6 @@ os.environ["VLLM_USE_V1"] = "1"
 # Use the FlashInfer flash-attention backend for vLLM, unless the user has already
 # specified a different backend.
 if os.getenv("VLLM_ATTENTION_BACKEND") is None:
-    # os.environ["VLLM_ATTENTION_BACKEND"] = "FLASHINFER"
     os.environ["VLLM_ATTENTION_BACKEND"] = "FLEX_ATTENTION"
 
 

--- a/src/euroeval/__init__.py
+++ b/src/euroeval/__init__.py
@@ -104,6 +104,7 @@ os.environ["VLLM_USE_V1"] = "1"
 
 
 # Use the FlashInfer flash-attention backend for vLLM
+breakpoint()
 os.environ["VLLM_ATTENTION_BACKEND"] = "FLASHINFER"
 
 

--- a/src/euroeval/__init__.py
+++ b/src/euroeval/__init__.py
@@ -103,9 +103,11 @@ os.environ["DISABLE_AIOHTTP_TRANSPORT"] = "True"
 os.environ["VLLM_USE_V1"] = "1"
 
 
-# Use the FlashInfer flash-attention backend for vLLM
-breakpoint()
-os.environ["VLLM_ATTENTION_BACKEND"] = "FLASHINFER"
+# Use the FlashInfer flash-attention backend for vLLM, unless the user has already
+# specified a different backend.
+if os.getenv("VLLM_ATTENTION_BACKEND") is None:
+    # os.environ["VLLM_ATTENTION_BACKEND"] = "FLASHINFER"
+    os.environ["VLLM_ATTENTION_BACKEND"] = "FLEX_ATTENTION"
 
 
 # Set the HF_TOKEN env var to copy the HUGGINGFACE_API_KEY env var, as vLLM uses the

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -718,8 +718,9 @@ class LiteLLMModel(BenchmarkModule):
         # dictionary, then we convert those to exceptions, to disable structured
         # generation
         if "response_format" in generation_kwargs:
+            breakpoint()
             responses = [
-                RuntimeError("The model outputs empty dictionaries.")
+                ValueError("The model outputs empty dictionaries.")
                 if not isinstance(response, Exception)
                 and any(choice.message.content == "{}" for choice in response.choices)
                 else response

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -454,8 +454,7 @@ class LiteLLMModel(BenchmarkModule):
         requires_thinking_disabled_messages = ["thinking.type: Field required"]
         seed_pattern = re.compile(r"does not support parameters: \[.*'seed'.*\]")
         response_format_messages = [
-            "got an unexpected keyword argument 'response_format'",
-            "The model outputs empty dictionaries.",
+            "got an unexpected keyword argument 'response_format'"
         ]
 
         if any(msg.lower() in error_msg for msg in stop_messages):
@@ -713,19 +712,6 @@ class LiteLLMModel(BenchmarkModule):
                 if isinstance(input_, list)
             ]
         responses = await tqdm_async.gather(*requests, leave=False)
-
-        # If we are performing structured generation and the model just outputs an empty
-        # dictionary, then we convert those to exceptions, to disable structured
-        # generation
-        if "response_format" in generation_kwargs:
-            breakpoint()
-            responses = [
-                ValueError("The model outputs empty dictionaries.")
-                if not isinstance(response, Exception)
-                and any(choice.message.content == "{}" for choice in response.choices)
-                else response
-                for response in responses
-            ]
 
         # Separate the successful responses from the failed ones
         successes = [

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -947,7 +947,7 @@ def load_tokeniser(
     num_retries = 5
     for _ in range(num_retries):
         try:
-            # Mistral models need a custom tokeniser
+            # Mistral instruction-tuned models need a custom tokeniser
             if model_id.startswith("mistralai/") and "base" not in model_id.lower():
                 tokeniser = MistralCommonTokenizer.from_pretrained(
                     model_id,

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -947,6 +947,16 @@ def load_tokeniser(
     num_retries = 5
     for _ in range(num_retries):
         try:
+            # Mistral models need a custom tokeniser
+            if model_id.startswith("mistralai/") and "base" not in model_id.lower():
+                tokeniser = MistralCommonTokenizer.from_pretrained(
+                    model_id,
+                    padding_side="left",
+                    truncation_side="left",
+                    model_max_length=model_max_length,
+                    token=token,
+                )
+                break
             tokeniser = AutoTokenizer.from_pretrained(
                 model_id,
                 use_fast=False if model_config.param == "slow-tokenizer" else True,

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -611,7 +611,11 @@ class Benchmarker:
 
         # Get all the model configs
         model_configs: list[ModelConfig] = list()
-        for model_id in tqdm(iterable=model_ids, desc="Fetching model configurations"):
+        for model_id in tqdm(
+            iterable=model_ids,
+            desc="Fetching model configurations",
+            disable=not benchmark_config.verbose or not benchmark_config.progress_bar,
+        ):
             try:
                 model_config = get_model_config(
                     model_id=model_id, benchmark_config=benchmark_config

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -84,7 +84,7 @@ class Benchmarker:
         num_iterations: int = 10,
         api_base: str | None = None,
         api_version: str | None = None,
-        gpu_memory_utilization: float = 0.9,
+        gpu_memory_utilization: float = 0.8,
         generative_type: GenerativeType | None = None,
         debug: bool = False,
         run_with_cli: bool = False,

--- a/src/euroeval/cli.py
+++ b/src/euroeval/cli.py
@@ -188,7 +188,7 @@ from .tasks import get_all_tasks
 )
 @click.option(
     "--gpu-memory-utilization",
-    default=0.9,
+    default=0.8,
     show_default=True,
     help="The GPU memory utilization to use for vLLM. A larger value will result in "
     "faster evaluation, but at the risk of running out of GPU memory. Only reduce this "

--- a/src/euroeval/tokenisation_utils.py
+++ b/src/euroeval/tokenisation_utils.py
@@ -521,7 +521,14 @@ def has_chat_template(tokeniser: "PreTrainedTokenizer") -> bool:
     Returns:
         Whether the tokeniser has a chat template.
     """
-    if hasattr(tokeniser, "chat_template"):
+    if isinstance(tokeniser, MistralCommonTokenizer):
+        log_once(
+            "The tokeniser is a Mistral tokeniser, so assuming that the model is "
+            "instruction tuned.",
+            level=logging.DEBUG,
+        )
+        return True
+    elif hasattr(tokeniser, "chat_template"):
         has_template = tokeniser.chat_template is not None
         if has_template:
             log_once(
@@ -530,13 +537,6 @@ def has_chat_template(tokeniser: "PreTrainedTokenizer") -> bool:
                 level=logging.DEBUG,
             )
         return has_template
-    elif isinstance(tokeniser, MistralCommonTokenizer):
-        log_once(
-            "The tokeniser is a Mistral tokeniser, so assuming that the model is "
-            "instruction tuned.",
-            level=logging.DEBUG,
-        )
-        return True
     else:
         log_once(
             "We cannot find a chat template for the tokeniser, so assuming that the "

--- a/src/euroeval/utils.py
+++ b/src/euroeval/utils.py
@@ -462,7 +462,7 @@ def extract_json_dict_from_string(s: str) -> dict | None:
     Returns:
         The extracted JSON dictionary, or None if no JSON dictionary could be found.
     """
-    json_regex = r"\{[^{}]+?\}"
+    json_regex = r"\{[^{}]*?\}"
     if (json_match := re.search(pattern=json_regex, string=s, flags=re.DOTALL)) is None:
         logger.debug(
             "The model output does not contain any JSON dictionary, so cannot parse "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """General fixtures used throughout test modules."""
 
+import collections.abc as c
 import os
 import sys
 from typing import Generator
@@ -186,12 +187,12 @@ def cli_params() -> Generator[dict[str | None, ParamType], None, None]:
 
 
 @pytest.fixture(scope="session")
-def dataset_config() -> DatasetConfig:
+def dataset_config() -> c.Generator[DatasetConfig, None, None]:
     """Yields a dataset configuration used in tests."""
     yield DatasetConfig(
         name="dataset",
         pretty_name="Dataset",
         huggingface_id="dataset_id",
-        task="task",
-        languages=["da"],
+        task=SENT,
+        languages=[DA],
     )


### PR DESCRIPTION
### Added
- Now allows changing the attention backend with vLLM, with the `VLLM_ATTENTION_BACKEND`
  environment variable, which was previously hardcoded. Only relevant for generative
  models running with vLLM.

### Changed
- Changed the default value of `gpu_memory_utilization` from 0.9 to 0.8, as the new
  change to flex-attention needs a bit more buffer memory to avoid OOM errors. This can
  always be changed with the `--gpu-memory-utilization` argument (or
  `gpu_memory_utilization` in the `Benchmarker` API).

### Fixed
- We're now allowing generative models to output empty dictionaries for the NER task, as
  this is a valid output (no entities found). Previously this caused an error.
- Changed the default vLLM attention backend to flex-attention (previously flashinfer),
  as flex-attention supports all model head sizes, whereas flashinfer only supports
  head sizes of size 64, 128 and 256, causing some models not to work with flashinfer.