### PR TITLE
Fix/claude classification scores

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: debug-statements
+      # - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.13.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      # - id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.13.1
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- If a generative model consistently does not adhere to a given JSON schema, we disable
+  structured generation for that model. This was triggered by Claude models not
+  supporting Literal types in JSON schemas.
+
 ## [v16.3.0] - 2025-09-23
 
 ### Added

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -454,7 +454,8 @@ class LiteLLMModel(BenchmarkModule):
         requires_thinking_disabled_messages = ["thinking.type: Field required"]
         seed_pattern = re.compile(r"does not support parameters: \[.*'seed'.*\]")
         response_format_messages = [
-            "got an unexpected keyword argument 'response_format'"
+            "got an unexpected keyword argument 'response_format'",
+            "the model returned empty outputs",
         ]
 
         if any(msg.lower() in error_msg for msg in stop_messages):
@@ -714,7 +715,10 @@ class LiteLLMModel(BenchmarkModule):
         responses = await tqdm_async.gather(*requests, leave=False)
 
         # If the outputs are empty, convert them to exceptions
-        breakpoint()
+        if all(response.choices[0].message.content == "{}" for response in responses):
+            responses = [ValueError("The model returned empty outputs.")] * len(
+                responses
+            )
 
         # Separate the successful responses from the failed ones
         successes = [

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -715,7 +715,11 @@ class LiteLLMModel(BenchmarkModule):
         responses = await tqdm_async.gather(*requests, leave=False)
 
         # If the outputs are empty, convert them to exceptions
-        if all(response.choices[0].message.content == "{}" for response in responses):
+        if all(
+            not isinstance(response, Exception)
+            and response.choices[0].message.content == "{}"
+            for response in responses
+        ):
             responses = [ValueError("The model returned empty outputs.")] * len(
                 responses
             )

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -713,6 +713,9 @@ class LiteLLMModel(BenchmarkModule):
             ]
         responses = await tqdm_async.gather(*requests, leave=False)
 
+        # If the outputs are empty, convert them to exceptions
+        breakpoint()
+
         # Separate the successful responses from the failed ones
         successes = [
             (idx, response)
@@ -1443,8 +1446,7 @@ class LiteLLMModel(BenchmarkModule):
                 LITELLM_CLASSIFICATION_OUTPUT_KEY: (t.Literal[*localised_labels], ...)
             }
             pydantic_class = create_model("AnswerFormat", **keys_and_their_types)
-            # TEMP
-            # generation_kwargs["response_format"] = pydantic_class
+            generation_kwargs["response_format"] = pydantic_class
 
         # If the model is an Ollama reasoning model, we ensure that thinking is enabled
         if self.is_ollama and self.generative_type == GenerativeType.REASONING:

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -724,6 +724,7 @@ class LiteLLMModel(BenchmarkModule):
             for idx, response in enumerate(responses)
             if isinstance(response, Exception)
         ]
+        breakpoint()
 
         # Close connections
         for request in requests:

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -1444,7 +1444,8 @@ class LiteLLMModel(BenchmarkModule):
                 LITELLM_CLASSIFICATION_OUTPUT_KEY: (t.Literal[*localised_labels], ...)
             }
             pydantic_class = create_model("AnswerFormat", **keys_and_their_types)
-            generation_kwargs["response_format"] = pydantic_class
+            # TEMP
+            # generation_kwargs["response_format"] = pydantic_class
 
         # If the model is an Ollama reasoning model, we ensure that thinking is enabled
         if self.is_ollama and self.generative_type == GenerativeType.REASONING:

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -724,7 +724,6 @@ class LiteLLMModel(BenchmarkModule):
             for idx, response in enumerate(responses)
             if isinstance(response, Exception)
         ]
-        breakpoint()
 
         # Close connections
         for request in requests:


### PR DESCRIPTION
### Fixed

- If a generative model consistently does not adhere to a given JSON schema, we disable
  structured generation for that model. This was triggered by Claude models not
  supporting Literal types in JSON schemas.