### PR TITLE
Feat/add validation split to winogrande datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Used 128 of the test samples from the Winogrande datasets for validation, as we
   previously did not use a validation split. This is done for all languages except
   Icelandic and Estonian, as these are manually translated and corrected splits from a
-  different source.
+  different source. Most of these are unofficial datasets and thus won't affect the
+  leaderboard rankings. The only languages for which these are official are Lithuanian
+  and Polish, which do not have official leaderboards yet - so no leaderboards are
+  affected by this change.
 
 ## [v16.3.0] - 2025-09-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   structured generation for that model. This was triggered by Claude models not
   supporting Literal types in JSON schemas.
 
+### Changed
+
+- Used 128 of the test samples from the Winogrande datasets for validation, as we
+  previously did not use a validation split. This is done for all languages except
+  Icelandic and Estonian, as these are manually translated and corrected splits from a
+  different source.
+
 ## [v16.3.0] - 2025-09-23
 
 ### Added

--- a/docs/datasets/danish.md
+++ b/docs/datasets/danish.md
@@ -988,7 +988,8 @@ and is a translated and filtered version of the English [Winogrande
 dataset](https://doi.org/10.1145/3474381).
 
 The original full dataset consists of 47 / 1,210 samples for training and testing, and
-we use the same splits.
+we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
+training, validation and testing, respectively.
 
 Here are a few examples from the training split:
 

--- a/docs/datasets/dutch.md
+++ b/docs/datasets/dutch.md
@@ -817,7 +817,8 @@ and is a translated and filtered version of the English [Winogrande
 dataset](https://doi.org/10.1145/3474381).
 
 The original full dataset consists of 47 / 1,210 samples for training and testing, and
-we use the same splits.
+we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
+training, validation and testing, respectively.
 
 Here are a few examples from the training split:
 

--- a/docs/datasets/english.md
+++ b/docs/datasets/english.md
@@ -854,7 +854,8 @@ euroeval --model <model-id> --dataset hellaswag
 
 This dataset was published in [this paper](https://doi.org/10.1145/3474381). The
 original full dataset consists of 47 / 1,210 samples for training and testing, and we
-use the same splits.
+use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
+training, validation and testing, respectively.
 
 Here are a few examples from the training split:
 

--- a/docs/datasets/finnish.md
+++ b/docs/datasets/finnish.md
@@ -625,7 +625,8 @@ and is a translated and filtered version of the English [Winogrande
 dataset](https://doi.org/10.1145/3474381).
 
 The original full dataset consists of 47 / 1,210 samples for training and testing, and
-we use the same splits.
+we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
+training, validation and testing, respectively.
 
 Here are a few examples from the training split:
 

--- a/docs/datasets/french.md
+++ b/docs/datasets/french.md
@@ -714,7 +714,8 @@ and is a translated and filtered version of the English [Winogrande
 dataset](https://doi.org/10.1145/3474381).
 
 The original full dataset consists of 47 / 1,210 samples for training and testing, and
-we use the same splits.
+we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
+training, validation and testing, respectively.
 
 Here are a few examples from the training split:
 

--- a/docs/datasets/german.md
+++ b/docs/datasets/german.md
@@ -832,7 +832,8 @@ and is a translated and filtered version of the English [Winogrande
 dataset](https://doi.org/10.1145/3474381).
 
 The original full dataset consists of 47 / 1,210 samples for training and testing, and
-we use the same splits.
+we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
+training, validation and testing, respectively.
 
 Here are a few examples from the training split:
 

--- a/docs/datasets/italian.md
+++ b/docs/datasets/italian.md
@@ -798,7 +798,8 @@ and is a translated and filtered version of the English [Winogrande
 dataset](https://doi.org/10.1145/3474381).
 
 The original full dataset consists of 47 / 1,210 samples for training and testing, and
-we use the same splits.
+we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
+training, validation and testing, respectively.
 
 Here are a few examples from the training split:
 

--- a/docs/datasets/latvian.md
+++ b/docs/datasets/latvian.md
@@ -551,7 +551,8 @@ and is a translated and filtered version of the English [Winogrande
 dataset](https://doi.org/10.1145/3474381).
 
 The original full dataset consists of 47 / 1,210 samples for training and testing, and
-we use the same splits.
+we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
+training, validation and testing, respectively.
 
 Here are a few examples from the training split:
 

--- a/docs/datasets/lithuanian.md
+++ b/docs/datasets/lithuanian.md
@@ -389,7 +389,8 @@ and is a translated and filtered version of the English [Winogrande
 dataset](https://doi.org/10.1145/3474381).
 
 The original full dataset consists of 47 / 1,210 samples for training and testing, and
-we use the same splits.
+we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
+training, validation and testing, respectively.
 
 Here are a few examples from the training split:
 

--- a/docs/datasets/norwegian.md
+++ b/docs/datasets/norwegian.md
@@ -1400,7 +1400,8 @@ and is a translated and filtered version of the English [Winogrande
 dataset](https://doi.org/10.1145/3474381).
 
 The original full dataset consists of 47 / 1,210 samples for training and testing, and
-we use the same splits.
+we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
+training, validation and testing, respectively.
 
 Here are a few examples from the training split:
 

--- a/docs/datasets/polish.md
+++ b/docs/datasets/polish.md
@@ -486,7 +486,8 @@ and is a translated and filtered version of the English [Winogrande
 dataset](https://doi.org/10.1145/3474381).
 
 The original full dataset consists of 47 / 1,210 samples for training and testing, and
-we use the same splits.
+we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
+training, validation and testing, respectively.
 
 Here are a few examples from the training split:
 

--- a/docs/datasets/portuguese.md
+++ b/docs/datasets/portuguese.md
@@ -589,7 +589,8 @@ and is a translated and filtered version of the English [Winogrande
 dataset](https://doi.org/10.1145/3474381).
 
 The original full dataset consists of 47 / 1,210 samples for training and testing, and
-we use the same splits.
+we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
+training, validation and testing, respectively.
 
 Here are a few examples from the training split:
 

--- a/docs/datasets/spanish.md
+++ b/docs/datasets/spanish.md
@@ -776,7 +776,8 @@ and is a translated and filtered version of the English [Winogrande
 dataset](https://doi.org/10.1145/3474381).
 
 The original full dataset consists of 47 / 1,210 samples for training and testing, and
-we use the same splits.
+we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
+training, validation and testing, respectively.
 
 Here are a few examples from the training split:
 

--- a/docs/datasets/swedish.md
+++ b/docs/datasets/swedish.md
@@ -861,7 +861,8 @@ and is a translated and filtered version of the English [Winogrande
 dataset](https://doi.org/10.1145/3474381).
 
 The original full dataset consists of 47 / 1,210 samples for training and testing, and
-we use the same splits.
+we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
+training, validation and testing, respectively.
 
 Here are a few examples from the training split:
 

--- a/src/euroeval/dataset_configs/danish.py
+++ b/src/euroeval/dataset_configs/danish.py
@@ -156,7 +156,6 @@ WINOGRANDE_DA_CONFIG = DatasetConfig(
     huggingface_id="EuroEval/winogrande-da",
     task=COMMON_SENSE,
     languages=[DA],
-    splits=["train", "test"],
     _labels=["a", "b"],
     unofficial=True,
 )

--- a/src/euroeval/dataset_configs/dutch.py
+++ b/src/euroeval/dataset_configs/dutch.py
@@ -149,7 +149,6 @@ WINOGRANDE_NL_CONFIG = DatasetConfig(
     huggingface_id="EuroEval/winogrande-nl",
     task=COMMON_SENSE,
     languages=[NL],
-    splits=["train", "test"],
     _labels=["a", "b"],
     unofficial=True,
 )

--- a/src/euroeval/dataset_configs/english.py
+++ b/src/euroeval/dataset_configs/english.py
@@ -132,7 +132,6 @@ WINOGRANDE_CONFIG = DatasetConfig(
     huggingface_id="EuroEval/winogrande-en",
     task=COMMON_SENSE,
     languages=[EN],
-    splits=["train", "test"],
     _labels=["a", "b"],
     unofficial=True,
 )

--- a/src/euroeval/dataset_configs/finnish.py
+++ b/src/euroeval/dataset_configs/finnish.py
@@ -108,7 +108,6 @@ WINOGRANDE_FI_CONFIG = DatasetConfig(
     huggingface_id="EuroEval/winogrande-fi",
     task=COMMON_SENSE,
     languages=[FI],
-    splits=["train", "test"],
     _labels=["a", "b"],
     unofficial=True,
 )

--- a/src/euroeval/dataset_configs/french.py
+++ b/src/euroeval/dataset_configs/french.py
@@ -120,7 +120,6 @@ WINOGRANDE_FR_CONFIG = DatasetConfig(
     huggingface_id="EuroEval/winogrande-fr",
     task=COMMON_SENSE,
     languages=[FR],
-    splits=["train", "test"],
     _labels=["a", "b"],
     unofficial=True,
 )

--- a/src/euroeval/dataset_configs/german.py
+++ b/src/euroeval/dataset_configs/german.py
@@ -137,7 +137,6 @@ WINOGRANDE_DE_CONFIG = DatasetConfig(
     huggingface_id="EuroEval/winogrande-de",
     task=COMMON_SENSE,
     languages=[DE],
-    splits=["train", "test"],
     _labels=["a", "b"],
     unofficial=True,
 )

--- a/src/euroeval/dataset_configs/italian.py
+++ b/src/euroeval/dataset_configs/italian.py
@@ -128,7 +128,6 @@ WINOGRANDE_IT_CONFIG = DatasetConfig(
     huggingface_id="EuroEval/winogrande-it",
     task=COMMON_SENSE,
     languages=[IT],
-    splits=["train", "test"],
     _labels=["a", "b"],
     unofficial=True,
 )

--- a/src/euroeval/dataset_configs/latvian.py
+++ b/src/euroeval/dataset_configs/latvian.py
@@ -88,7 +88,6 @@ WINOGRANDE_LV_CONFIG = DatasetConfig(
     huggingface_id="EuroEval/winogrande-lv",
     task=COMMON_SENSE,
     languages=[LV],
-    splits=["train", "test"],
     _labels=["a", "b"],
     unofficial=True,
 )

--- a/src/euroeval/dataset_configs/lithuanian.py
+++ b/src/euroeval/dataset_configs/lithuanian.py
@@ -57,6 +57,5 @@ WINOGRANDE_LT_CONFIG = DatasetConfig(
     huggingface_id="EuroEval/winogrande-lt",
     task=COMMON_SENSE,
     languages=[LT],
-    splits=["train", "test"],
     _labels=["a", "b"],
 )

--- a/src/euroeval/dataset_configs/norwegian.py
+++ b/src/euroeval/dataset_configs/norwegian.py
@@ -223,7 +223,6 @@ WINOGRANDE_NO_CONFIG = DatasetConfig(
     huggingface_id="EuroEval/winogrande-no",
     task=COMMON_SENSE,
     languages=[NB, NN, NO],
-    splits=["train", "test"],
     _labels=["a", "b"],
     unofficial=True,
 )

--- a/src/euroeval/dataset_configs/polish.py
+++ b/src/euroeval/dataset_configs/polish.py
@@ -61,7 +61,6 @@ WINOGRANDE_PL_CONFIG = DatasetConfig(
     huggingface_id="EuroEval/winogrande-pl",
     task=COMMON_SENSE,
     languages=[PL],
-    splits=["train", "test"],
     _labels=["a", "b"],
 )
 

--- a/src/euroeval/dataset_configs/portuguese.py
+++ b/src/euroeval/dataset_configs/portuguese.py
@@ -98,7 +98,6 @@ WINOGRANDE_PT_CONFIG = DatasetConfig(
     huggingface_id="EuroEval/winogrande-pt",
     task=COMMON_SENSE,
     languages=[PT],
-    splits=["train", "test"],
     _labels=["a", "b"],
     unofficial=True,
 )

--- a/src/euroeval/dataset_configs/spanish.py
+++ b/src/euroeval/dataset_configs/spanish.py
@@ -126,7 +126,6 @@ WINOGRANDE_ES_CONFIG = DatasetConfig(
     huggingface_id="EuroEval/winogrande-es",
     task=COMMON_SENSE,
     languages=[ES],
-    splits=["train", "test"],
     _labels=["a", "b"],
     unofficial=True,
 )

--- a/src/euroeval/dataset_configs/swedish.py
+++ b/src/euroeval/dataset_configs/swedish.py
@@ -137,7 +137,6 @@ WINOGRANDE_SV_CONFIG = DatasetConfig(
     huggingface_id="EuroEval/winogrande-sv",
     task=COMMON_SENSE,
     languages=[SV],
-    splits=["train", "test"],
     _labels=["a", "b"],
     unofficial=True,
 )

--- a/src/scripts/create_winogrande.py
+++ b/src/scripts/create_winogrande.py
@@ -10,6 +10,7 @@
 
 """Create the Winogrande datasets and upload them to the HF Hub."""
 
+import logging
 from collections import Counter
 
 import pandas as pd
@@ -21,8 +22,12 @@ from constants import (
     MIN_NUM_CHARS_IN_INSTRUCTION,
     MIN_NUM_CHARS_IN_OPTION,
 )
-from datasets import Dataset, DatasetDict, Split, load_dataset
+from datasets import Dataset, DatasetDict, Split, disable_progress_bars, load_dataset
 from huggingface_hub import HfApi
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
+logger = logging.getLogger("create_winogrande")
+
 
 LANGUAGES = [
     "da",
@@ -44,6 +49,7 @@ LANGUAGES = [
 
 def main() -> None:
     """Create the Winogrande datasets and upload them to the HF Hub."""
+    disable_progress_bars()
     repo_id = "aialt/MuBench"
 
     for language in LANGUAGES:
@@ -59,13 +65,25 @@ def main() -> None:
         assert isinstance(train_df, pd.DataFrame)
         assert isinstance(test_df, pd.DataFrame)
 
+        # Split test set into validation and test sets
+        val_size = 128
+        val_df = test_df.sample(n=val_size, random_state=42)
+        test_df = test_df.drop(val_df.index.tolist()).reset_index(drop=True)
+
         train_df = prepare_dataframe(df=train_df, language=language)
+        val_df = prepare_dataframe(df=val_df, language=language)
         test_df = prepare_dataframe(df=test_df, language=language)
 
         # Collect datasets in a dataset dictionary
         dataset = DatasetDict(
             train=Dataset.from_pandas(train_df, split=Split.TRAIN),
+            val=Dataset.from_pandas(val_df, split=Split.VALIDATION),
             test=Dataset.from_pandas(test_df, split=Split.TEST),
+        )
+        logger.info(
+            f"Final sizes for the Winogrande {language} dataset: "
+            f"{len(dataset['train'])} train, {len(dataset['val'])} val, "
+            f"{len(dataset['test'])} test"
         )
 
         # Push the dataset to the Hugging Face Hub


### PR DESCRIPTION
### Changed

- Used 128 of the test samples from the Winogrande datasets for validation, as we
  previously did not use a validation split. This is done for all languages except
  Icelandic and Estonian, as these are manually translated and corrected splits from a
  different source. Most of these are unofficial datasets and thus won't affect the
  leaderboard rankings. The only languages for which these are official are Lithuanian
  and Polish, which do not have official leaderboards yet - so no leaderboards are
  affected by this change.