### PR TITLE
Chore: Fix 'tasks' link in datasets descriptions

### DIFF
--- a/docs/datasets/danish.md
+++ b/docs/datasets/danish.md
@@ -1,7 +1,7 @@
 # 🇩🇰 Danish
 
 This is an overview of all the datasets used in the Danish part of EuroEval. The
-datasets are grouped by their task - see the [task overview](/tasks) for more
+datasets are grouped by their task - see the [task overview](../tasks/README.md) for more
 information about what these constitute.
 
 ## Sentiment Classification

--- a/docs/datasets/dutch.md
+++ b/docs/datasets/dutch.md
@@ -1,7 +1,7 @@
 # 🇳🇱 Dutch
 
 This is an overview of all the datasets used in the Dutch part of EuroEval. The
-datasets are grouped by their task - see the [task overview](/tasks) for more
+datasets are grouped by their task - see the [task overview](../tasks/README.md) for more
 information about what these constitute.
 
 ## Sentiment Classification

--- a/docs/datasets/english.md
+++ b/docs/datasets/english.md
@@ -1,7 +1,7 @@
 # 🇬🇧 English
 
 This is an overview of all the datasets used in the English part of EuroEval. The
-datasets are grouped by their task - see the [task overview](/tasks) for more
+datasets are grouped by their task - see the [task overview](../tasks/README.md) for more
 information about what these constitute.
 
 ## Sentiment Classification

--- a/docs/datasets/estonian.md
+++ b/docs/datasets/estonian.md
@@ -1,7 +1,7 @@
 # 🇪🇪 Estonian
 
 This is an overview of all the datasets used in the Estonian part of EuroEval. The
-datasets are grouped by their task - see the [task overview](/tasks) for more
+datasets are grouped by their task - see the [task overview](../tasks/README.md) for more
 information about what these constitute.
 
 ## Sentiment Classification

--- a/docs/datasets/faroese.md
+++ b/docs/datasets/faroese.md
@@ -1,7 +1,7 @@
 # 🇫🇴 Faroese
 
 This is an overview of all the datasets used in the Faroese part of EuroEval. The
-datasets are grouped by their task - see the [task overview](/tasks) for more
+datasets are grouped by their task - see the [task overview](../tasks/README.md) for more
 information about what these constitute.
 
 ## Sentiment Classification

--- a/docs/datasets/finnish.md
+++ b/docs/datasets/finnish.md
@@ -1,7 +1,7 @@
 # 🇫🇮 Finnish
 
 This is an overview of all the datasets used in the Finnish part of EuroEval. The
-datasets are grouped by their task - see the [task overview](/tasks) for more
+datasets are grouped by their task - see the [task overview](../tasks/README.md) for more
 information about what these constitute.
 
 ## Sentiment Classification

--- a/docs/datasets/french.md
+++ b/docs/datasets/french.md
@@ -1,7 +1,7 @@
 # 🇫🇷 French
 
 This is an overview of all the datasets used in the French part of EuroEval. The
-datasets are grouped by their task - see the [task overview](/tasks) for more
+datasets are grouped by their task - see the [task overview](../tasks/README.md) for more
 information about what these constitute.
 
 ## Sentiment Classification

--- a/docs/datasets/german.md
+++ b/docs/datasets/german.md
@@ -1,7 +1,7 @@
 # 🇩🇪 German
 
 This is an overview of all the datasets used in the German part of EuroEval. The
-datasets are grouped by their task - see the [task overview](/tasks) for more
+datasets are grouped by their task - see the [task overview](../tasks/README.md) for more
 information about what these constitute.
 
 ## Sentiment Classification

--- a/docs/datasets/icelandic.md
+++ b/docs/datasets/icelandic.md
@@ -1,7 +1,7 @@
 # 🇮🇸 Icelandic
 
 This is an overview of all the datasets used in the Icelandic part of EuroEval. The
-datasets are grouped by their task - see the [task overview](/tasks) for more
+datasets are grouped by their task - see the [task overview](../tasks/README.md) for more
 information about what these constitute.
 
 ## Sentiment Classification

--- a/docs/datasets/italian.md
+++ b/docs/datasets/italian.md
@@ -1,7 +1,7 @@
 # 🇮🇹 Italian
 
 This is an overview of all the datasets used in the Italian part of EuroEval. The
-datasets are grouped by their task - see the [task overview](/tasks) for more
+datasets are grouped by their task - see the [task overview](../tasks/README.md) for more
 information about what these constitute.
 
 ## Sentiment Classification

--- a/docs/datasets/latvian.md
+++ b/docs/datasets/latvian.md
@@ -1,7 +1,7 @@
 # 🇱🇻 Latvian
 
 This is an overview of all the datasets used in the Latvian part of EuroEval. The
-datasets are grouped by their task - see the [task overview](/tasks) for more
+datasets are grouped by their task - see the [task overview](../tasks/README.md) for more
 information about what these constitute.
 
 ## Sentiment Classification

--- a/docs/datasets/lithuanian.md
+++ b/docs/datasets/lithuanian.md
@@ -1,7 +1,7 @@
 # 🇱🇹 Lithuanian
 
 This is an overview of all the datasets used in the Lithuanian part of EuroEval. The
-datasets are grouped by their task - see the [task overview](/tasks) for more
+datasets are grouped by their task - see the [task overview](../tasks/README.md) for more
 information about what these constitute.
 
 ## Sentiment Classification

--- a/docs/datasets/norwegian.md
+++ b/docs/datasets/norwegian.md
@@ -1,7 +1,7 @@
 # 🇳🇴 Norwegian
 
 This is an overview of all the datasets used in the Norwegian part of EuroEval. The
-datasets are grouped by their task - see the [task overview](/tasks) for more
+datasets are grouped by their task - see the [task overview](../tasks/README.md) for more
 information about what these constitute.
 
 ## Sentiment Classification

--- a/docs/datasets/polish.md
+++ b/docs/datasets/polish.md
@@ -1,7 +1,7 @@
 # 🇵🇱 Polish
 
 This is an overview of all the datasets used in the Polish part of EuroEval. The
-datasets are grouped by their task - see the [task overview](/tasks) for more
+datasets are grouped by their task - see the [task overview](../tasks/README.md) for more
 information about what these constitute.
 
 ## Sentiment Classification

--- a/docs/datasets/portuguese.md
+++ b/docs/datasets/portuguese.md
@@ -1,7 +1,7 @@
 # 🇵🇹 Portuguese
 
 This is an overview of all the datasets used in the European Portuguese part of
-EuroEval. The datasets are grouped by their task - see the [task overview](/tasks) for
+EuroEval. The datasets are grouped by their task - see the [task overview](../tasks/README.md) for
 more information about what these constitute.
 
 ## Sentiment Classification

--- a/docs/datasets/spanish.md
+++ b/docs/datasets/spanish.md
@@ -1,7 +1,7 @@
 # 🇪🇸 Spanish
 
 This is an overview of all the datasets used in the Spanish part of EuroEval. The
-datasets are grouped by their task - see the [task overview](/tasks) for more
+datasets are grouped by their task - see the [task overview](../tasks/README.md) for more
 information about what these constitute.
 
 ## Sentiment Classification

--- a/docs/datasets/swedish.md
+++ b/docs/datasets/swedish.md
@@ -1,7 +1,7 @@
 # 🇸🇪 Swedish
 
 This is an overview of all the datasets used in the Swedish part of EuroEval. The
-datasets are grouped by their task - see the [task overview](/tasks) for more
+datasets are grouped by their task - see the [task overview](../tasks/README.md) for more
 information about what these constitute.
 
 ## Sentiment Classification


### PR DESCRIPTION
I have fixed links to 'tasks' from datasets descriptions for all languages - it was pointing nowhere.