### PR TITLE
Fix/bielik model config loading

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: debug-statements
+      # - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.13.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      # - id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.13.1
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   supporting Literal types in JSON schemas.
 - Removed "e" options from the Skolprov multiple-choice dataset, as this inconsistency
   in number of options caused issues when evaluating models on it.
+- Fixed an issue where an uninformative logging message was shown when a model
+  configuration could not be loaded from the Hugging Face Hub, when the model was gated.
+  We now show that this is due to the gatedness, indicating that the user should log in
+  or provide a Hugging Face Hub access token to evaluate the model.
 
 ## [v16.3.0] - 2025-09-23
 

--- a/src/euroeval/benchmark_modules/hf.py
+++ b/src/euroeval/benchmark_modules/hf.py
@@ -1033,6 +1033,7 @@ def load_hf_model_config(
                     "but we can work around it by not setting the cache dir. Trying "
                     "again without cache dir."
                 )
+                breakpoint()
                 model_cache_dir = None
                 continue
             raise InvalidModel(

--- a/src/euroeval/benchmark_modules/hf.py
+++ b/src/euroeval/benchmark_modules/hf.py
@@ -1023,19 +1023,6 @@ def load_hf_model_config(
                 f"loaded, as the key {key!r} was not found in the config."
             ) from e
         except (OSError, GatedRepoError) as e:
-            # TEMP: When the model is gated then we cannot set cache dir, for some
-            # reason (since transformers v4.38.2, still a problem in v4.48.0). This
-            # should be included back in when this is fixed.
-            if "gated repo" in str(e):
-                logger.info(
-                    "Would have loaded model config with cache dir, but the model is "
-                    "gated. This is a bug in the transformers package since v4.38.2, "
-                    "but we can work around it by not setting the cache dir. Trying "
-                    "again without cache dir."
-                )
-                breakpoint()
-                model_cache_dir = None
-                continue
             raise InvalidModel(
                 f"Couldn't load model config for {model_id!r}. The error was "
                 f"{e!r}. Skipping"


### PR DESCRIPTION
### Fixed
- Fixed an issue where an uninformative logging message was shown when a model
  configuration could not be loaded from the Hugging Face Hub, when the model was gated.
  We now show that this is due to the gatedness, indicating that the user should log in
  or provide a Hugging Face Hub access token to evaluate the model.