### PR TITLE
Fix 1296

### DIFF
--- a/docs/datasets/polish.md
+++ b/docs/datasets/polish.md
@@ -194,7 +194,7 @@ Here are a few examples from the training split:
 
 ```json
 {
-    "text": "Papierową śmierć zafundowaliśmy zafundowali śmy już kilku osobom.",
+    "text": "Papierową śmierć zafundowaliśmy już kilku osobom.",
     "label": "correct"
 }
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,10 @@ testpaths = [
     "tests",
     "src/euroeval",
 ]
+pythonpath = [
+    "src",
+    "src/scripts",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/src/scripts/load_ud_pos.py
+++ b/src/scripts/load_ud_pos.py
@@ -382,7 +382,7 @@ def load_ltdt_pos() -> Dict[str, pd.DataFrame]:
 
 def _load_file_or_url(url_or_path: str) -> list[str]:
     parsed = urlparse(url_or_path)
-    if parsed.scheme.lower in ("http", "https"):
+    if parsed.scheme.lower() in ("http", "https"):
         return requests.get(url_or_path).text.split("\n")
     else:
         with open(url_or_path, "r") as f:
@@ -417,25 +417,16 @@ def _filter_token_rage(data_dict: dict[str, list]) -> dict[str, list]:
     for i in range(len(data_dict["ids"])):
         match = _RX_RANGE.match(data_dict["ids"][i])
         if match is not None:
-            if range_start > 0 or range_end > 0:
-                raise ValueError(
-                    "Error: Parsing error. Only single range can be specified at a time."
-                )
-            else:
-                _append_token_data(output, data_dict, i)
-                range_start = int(match.group(1))
-                range_end = int(match.group(2))
+            _append_token_data(output, data_dict, i)
+            range_start = int(match.group(1))
+            range_end = int(match.group(2))
         else:
-            token_id = int(data_dict["ids"][i])
+            token_id = int(data_dict["ids"][i].split(".")[0])
             if token_id >= range_start and token_id <= range_end:
                 # Skip token if in range
                 continue
             else:
                 _append_token_data(output, data_dict, i)
-                if token_id > range_end:
-                    # No longer in range
-                    range_start = 0
-                    range_end = 0
 
     return output
 

--- a/tests/test_scripts/__init__.py
+++ b/tests/test_scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for scripts."""

--- a/tests/test_scripts/test_create_scala/__init__.py
+++ b/tests/test_scripts/test_create_scala/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for create_scala.py."""

--- a/tests/test_scripts/test_create_scala/test_create_scala.py
+++ b/tests/test_scripts/test_create_scala/test_create_scala.py
@@ -34,12 +34,30 @@ def _test_load_ud_pos(
             assert rx_yay.search(row["text"]) is not None
 
 
-def test_load_ud_pos_pl_aux_clitic(tst_data_path: Path) -> None:
+def test_load_ud_pos_pl_aux_clitic_01(tst_data_path: Path) -> None:
     _test_load_ud_pos(
         tst_data_path,
         "pl_pdb-ud-train.conllu.aux_clitic_01",
         ["postanowili", "śmy"],
         "postanowiliśmy",
+    )
+
+
+def test_load_ud_pos_pl_aux_clitic_02(tst_data_path: Path) -> None:
+    _test_load_ud_pos(
+        tst_data_path,
+        "pl_pdb-ud-train.conllu.aux_clitic_02",
+        ["nadział", "em"],
+        "nadziałem",
+    )
+
+
+def test_load_ud_pos_pl_aux_clitic_03(tst_data_path: Path) -> None:
+    _test_load_ud_pos(
+        tst_data_path,
+        "pl_pdb-ud-train.conllu.aux_clitic_02",
+        ["zarzucił", "em"],
+        "zarzuciłem",
     )
 
 

--- a/tests/test_scripts/test_create_scala/test_create_scala.py
+++ b/tests/test_scripts/test_create_scala/test_create_scala.py
@@ -1,5 +1,6 @@
 import re
 from pathlib import Path
+from re import Pattern
 
 import pytest
 from pytest import FixtureRequest
@@ -13,12 +14,13 @@ def tst_data_path(request: FixtureRequest) -> Path:
     return Path(request.fspath).parent / "test_data"
 
 
-def _test_load_ud_pos(
-    tst_data_path: Path, data_path: str, nay: list[str], yay: str
-) -> None:
-    rx_nay = [re.compile(rf"\b{n}\b", re.I) for n in nay]
-    rx_yay = re.compile(rf"\b{yay}\b", re.I)
+def _wb(s: str) -> Pattern:
+    return re.compile(rf"\b{s}\b", re.I)
 
+
+def _test_load_ud_pos(
+    tst_data_path: Path, data_path: str, nay: list[Pattern], yay: Pattern
+) -> None:
     df = load_ud_pos(
         str(tst_data_path / data_path),
         str(tst_data_path / "empty.file"),
@@ -28,18 +30,18 @@ def _test_load_ud_pos(
     ds = prepare_df(df["train"], "train")
     for row in ds:
         if row["label"] == "incorrect":
-            for rx in rx_nay:
+            for rx in nay:
                 assert rx.search(row["text"]) is None
         else:
-            assert rx_yay.search(row["text"]) is not None
+            assert yay.search(row["text"]) is not None
 
 
 def test_load_ud_pos_pl_aux_clitic_01(tst_data_path: Path) -> None:
     _test_load_ud_pos(
         tst_data_path,
         "pl_pdb-ud-train.conllu.aux_clitic_01",
-        ["postanowili", "śmy"],
-        "postanowiliśmy",
+        [_wb("postanowili"), _wb("śmy")],
+        _wb("postanowiliśmy"),
     )
 
 
@@ -47,8 +49,8 @@ def test_load_ud_pos_pl_aux_clitic_02(tst_data_path: Path) -> None:
     _test_load_ud_pos(
         tst_data_path,
         "pl_pdb-ud-train.conllu.aux_clitic_02",
-        ["nadział", "em"],
-        "nadziałem",
+        [_wb("nadział"), _wb("em")],
+        _wb("nadziałem"),
     )
 
 
@@ -56,12 +58,42 @@ def test_load_ud_pos_pl_aux_clitic_03(tst_data_path: Path) -> None:
     _test_load_ud_pos(
         tst_data_path,
         "pl_pdb-ud-train.conllu.aux_clitic_02",
-        ["zarzucił", "em"],
-        "zarzuciłem",
+        [_wb("zarzucił"), _wb("em")],
+        _wb("zarzuciłem"),
+    )
+
+
+def test_load_ud_pos_pl_aux_clitic_04(tst_data_path: Path) -> None:
+    _test_load_ud_pos(
+        tst_data_path,
+        "pl_pdb-ud-train.conllu.aux_clitic_03",
+        [_wb("chiał"), _wb("by"), _wb("m")],
+        _wb("chciałbym"),
+    )
+
+
+def test_load_ud_pos_pl_aux_clitic_05(tst_data_path: Path) -> None:
+    _test_load_ud_pos(
+        tst_data_path,
+        "pl_pdb-ud-train.conllu.aux_clitic_03",
+        [_wb("aby"), _wb("ś")],
+        _wb("abyś"),
     )
 
 
 def test_load_ud_pos_de_adp_det(tst_data_path: Path) -> None:
     _test_load_ud_pos(
-        tst_data_path, "de_gsd-ud-train.conllu.adp_det", ["in", "dem"], "im"
+        tst_data_path,
+        "de_gsd-ud-train.conllu.adp_det",
+        [_wb("in"), _wb("dem")],
+        _wb("im"),
+    )
+
+
+def test_load_ud_pos_en_case(tst_data_path: Path) -> None:
+    _test_load_ud_pos(
+        tst_data_path,
+        "en_gum-ud-train.conllu.case",
+        [re.compile(r"(^|\s)'($|\s)"), re.compile(r"\bGalois(\s|$)")],
+        re.compile(r"\bGalois'"),
     )

--- a/tests/test_scripts/test_create_scala/test_create_scala.py
+++ b/tests/test_scripts/test_create_scala/test_create_scala.py
@@ -1,0 +1,49 @@
+import re
+from pathlib import Path
+
+import pytest
+from pytest import FixtureRequest
+
+from scripts.create_scala import prepare_df
+from scripts.load_ud_pos import load_ud_pos
+
+
+@pytest.fixture
+def tst_data_path(request: FixtureRequest) -> Path:
+    return Path(request.fspath).parent / "test_data"
+
+
+def _test_load_ud_pos(
+    tst_data_path: Path, data_path: str, nay: list[str], yay: str
+) -> None:
+    rx_nay = [re.compile(rf"\b{n}\b", re.I) for n in nay]
+    rx_yay = re.compile(rf"\b{yay}\b", re.I)
+
+    df = load_ud_pos(
+        str(tst_data_path / data_path),
+        str(tst_data_path / "empty.file"),
+        str(tst_data_path / "empty.file"),
+    )
+
+    ds = prepare_df(df["train"], "train")
+    for row in ds:
+        if row["label"] == "incorrect":
+            for rx in rx_nay:
+                assert rx.search(row["text"]) is None
+        else:
+            assert rx_yay.search(row["text"]) is not None
+
+
+def test_load_ud_pos_pl_aux_clitic(tst_data_path: Path) -> None:
+    _test_load_ud_pos(
+        tst_data_path,
+        "pl_pdb-ud-train.conllu.aux_clitic_01",
+        ["postanowili", "śmy"],
+        "postanowiliśmy",
+    )
+
+
+def test_load_ud_pos_de_adp_det(tst_data_path: Path) -> None:
+    _test_load_ud_pos(
+        tst_data_path, "de_gsd-ud-train.conllu.adp_det", ["in", "dem"], "im"
+    )

--- a/tests/test_scripts/test_create_scala/test_data/de_gsd-ud-train.conllu.adp_det
+++ b/tests/test_scripts/test_create_scala/test_data/de_gsd-ud-train.conllu.adp_det
@@ -1,0 +1,13 @@
+# sent_id = train-s2
+# text = Die Kosten sind definitiv auch im Rahmen.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Number=Plur|PronType=Art	2	det	_	_
+2	Kosten	Kosten	NOUN	NN	Case=Nom|Number=Plur	3	nsubj:pass	_	_
+3	sind	sein	VERB	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	definitiv	definitiv	ADJ	ADJD	Degree=Pos	3	advmod	_	_
+5	auch	auch	ADV	ADV	_	3	advmod	_	_
+6-7	im	_	_	_	_	_	_	_	_
+6	in	in	ADP	APPR	_	8	case	_	_
+7	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
+8	Rahmen	Rahmen	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	3	obl	_	SpaceAfter=No
+9	.	.	PUNCT	$.	_	3	punct	_	_
+

--- a/tests/test_scripts/test_create_scala/test_data/en_gum-ud-train.conllu.case
+++ b/tests/test_scripts/test_create_scala/test_data/en_gum-ud-train.conllu.case
@@ -1,0 +1,71 @@
+# newpar
+# newpar_block = p (1 s)
+# sent_id = GUM_bio_galois-20
+# s_type = decl
+# s_prominence = 2
+# transition = continue
+# text = Much more detailed speculation based on these scant historical details has been interpolated by many of Galois' biographers (most notably by Eric Temple Bell in Men of Mathematics), such as the frequently repeated speculation that the entire incident was stage-managed by the police and royalist factions to eliminate a political enemy. [14]
+1	Much	much	ADV	RB	Degree=Pos	2	advmod	2:advmod	Discourse=adversative-contrast_m:70->57:3:_|Entity=(89-abstract-new-nnnnn-cf6-4-coref
+2	more	more	ADV	RBR	Degree=Cmp	3	advmod	3:advmod	_
+3	detailed	detailed	ADJ	JJ	Degree=Pos	4	amod	4:amod	MSeg=detail-ed
+4	speculation	speculation	NOUN	NN	Number=Sing	13	nsubj:pass	13:nsubj:pass	MSeg=speculat-ion
+5	based	base	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	4	acl	4:acl	Discourse=elaboration-attribute:71->70:0:syn-mdf-569+syn-nmn-570|MSeg=bas-ed
+6	on	on	ADP	IN	_	10	case	10:case	_
+7	these	this	DET	DT	Number=Plur|PronType=Dem	10	det	10:det	Entity=(90-abstract-acc:com-nnnnn-cf3-4-sgl
+8	scant	scant	ADJ	JJ	Degree=Pos	10	amod	10:amod	_
+9	historical	historical	ADJ	JJ	Degree=Pos	10	amod	10:amod	MSeg=histor-ic-al
+10	details	detail	NOUN	NNS	Number=Plur	5	obl	5:obl:on	Entity=90)89)|MSeg=detail-s
+11	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	aux	13:aux	Discourse=same-unit_m:72->70:1:_|MSeg=ha-s
+12	been	be	AUX	VBN	Tense=Past|VerbForm=Part	13	aux:pass	13:aux:pass	_
+13	interpolated	interpolate	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	MSeg=interpolat-ed
+14	by	by	ADP	IN	_	15	case	15:case	_
+15	many	many	ADJ	JJ	Degree=Pos	13	obl:agent	13:obl:agent	_
+16	of	of	ADP	IN	_	19	case	19:case	_
+17-18	Galois'	_	_	_	_	_	_	_	_
+17	Galois	Galois	PROPN	NNP	Number=Sing	19	nmod:poss	19:nmod:poss	Entity=(91-person-new-nnnnn-cf10-3-coref(4-person-giv:act-sssss-cf1*-1-coref-Évariste_Galois
+18	'	's	PART	POS	_	17	case	17:case	Entity=4)
+19	biographers	biographer	NOUN	NNS	Number=Plur	15	obl	15:obl:of	Entity=91)|MSeg=biograph-er-s
+20	(	(	PUNCT	-LRB-	_	24	punct	24:punct	Discourse=elaboration-additional:73->72:0:sem-mrnym-582-584,589-595+grf-prn-585,596|SpaceAfter=No
+21	most	most	ADV	RBS	Degree=Sup	22	advmod	22:advmod	_
+22	notably	notably	ADV	RB	Degree=Pos	24	orphan	22.1:advmod	MSeg=notab-ly
+22.1	interpolated	interpolate	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	_	_	13:parataxis	CopyOf=13
+23	by	by	ADP	IN	_	24	case	24:case	_
+24	Eric	Eric	PROPN	NNP	Number=Sing	13	parataxis	22.1:obl:agent	Bridge=91<92|Entity=(92-person-acc:inf-nnnnn-cf5-1,2,3,5,7-sgl-Eric_Temple_Bell|XML=<ref target:::"https://en.wikipedia.org/wiki/Eric_Temple_Bell">
+25	Temple	Temple	PROPN	NNP	Number=Sing	24	flat	24:flat	_
+26	Bell	Bell	PROPN	NNP	Number=Sing	24	flat	24:flat	XML=</ref>
+27	in	in	ADP	IN	_	28	case	28:case	_
+28	Men	Men	PROPN	NNP	Number=Sing	24	orphan	22.1:obl:in	Entity=(93-abstract-new-nnnnn-cf8-1,3-sgl-Men_of_Mathematics|XML=<ref target:::"https://en.wikipedia.org/wiki/Men_of_Mathematics">
+29	of	of	ADP	IN	_	30	case	30:case	_
+30	Mathematics	Mathematics	PROPN	NNP	Number=Sing	28	nmod	28:nmod:of	Entity=(94-abstract-new-nnnnn-cf9-1-sgl-Mathematics)93)92)|MSeg=Mathematic-s|SpaceAfter=No|XML=</ref>
+31	)	)	PUNCT	-RRB-	_	24	punct	24:punct	SpaceAfter=No
+32	,	,	PUNCT	,	_	38	punct	38:punct	_
+33	such	such	ADJ	JJ	ExtPos=ADP	38	case	38:case	Discourse=elaboration-additional:74->70:2:sem-mrnym-566-575,600-622+sem-synym-582-583,620-622
+34	as	as	ADP	IN	_	33	fixed	33:fixed	_
+35	the	the	DET	DT	Definite=Def|PronType=Art	38	det	38:det	Bridge=89<95|Entity=(95-abstract-acc:inf-nnnnn-cf4-4-sgl
+36	frequently	frequently	ADV	RB	Degree=Pos	37	advmod	37:advmod	MSeg=frequent-ly
+37	repeated	repeat	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	38	amod	38:amod	MSeg=repeat-ed
+38	speculation	speculation	NOUN	NN	Number=Sing	10	nmod	10:nmod:such_as	MSeg=speculat-ion
+39	that	that	SCONJ	IN	_	46	mark	46:mark	Discourse=elaboration-attribute:75->74:0:syn-mdf-603
+40	the	the	DET	DT	Definite=Def|PronType=Art	42	det	42:det	Entity=(96-event-acc:com-nnnnn-cf2-3-sgl
+41	entire	entire	ADJ	JJ	Degree=Pos	42	amod	42:amod	_
+42	incident	incident	NOUN	NN	Number=Sing	46	nsubj:pass	46:nsubj:pass	Entity=96)
+43	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	46	aux:pass	46:aux:pass	_
+44	stage	stage	NOUN	NN	Number=Sing	46	compound	46:compound	SpaceAfter=No|XML=<w>
+45	-	-	PUNCT	HYPH	_	44	punct	44:punct	SpaceAfter=No
+46	managed	manage	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	38	acl	38:acl:that	MSeg=manag-ed|XML=</w>
+47	by	by	ADP	IN	_	49	case	49:case	_
+48	the	the	DET	DT	Definite=Def|PronType=Art	49	det	49:det	Entity=(97-organization-new-nnnnn-cf7-2-sgl
+49	police	police	NOUN	NN	Number=Sing	46	obl:agent	46:obl:agent	Entity=97)
+50	and	and	CCONJ	CC	_	52	cc	52:cc	_
+51	royalist	royalist	ADJ	JJ	Degree=Pos	52	amod	52:amod	Entity=(98-organization-new-nnnnn-cf11-2-sgl|MSeg=roy-al-ist
+52	factions	faction	NOUN	NNS	Number=Plur	49	conj	46:obl:agent|49:conj:and	Entity=98)|MSeg=faction-s
+53	to	to	PART	TO	_	54	mark	54:mark	Discourse=purpose-goal:76->75:0:syn-inf-618+lex-indwd-619|PDTB=Implicit:Contingency.Purpose.Arg2-as-goal:in order:_:604-617:618-623
+54	eliminate	eliminate	VERB	VB	VerbForm=Inf	46	advcl	46:advcl:to	_
+55	a	a	DET	DT	Definite=Ind|PronType=Art	57	det	57:det	Entity=(4-person-giv:act-sssss-cf1*-3-coref-Évariste_Galois
+56	political	political	ADJ	JJ	Degree=Pos	57	amod	57:amod	MSeg=politic-al
+57	enemy	enemy	NOUN	NN	Number=Sing	54	obj	54:obj	Entity=4)95)|SpaceAfter=No
+58	.	.	PUNCT	.	_	13	punct	13:punct	_
+59	[	[	PUNCT	-LRB-	_	60	punct	60:punct	Discourse=explanation-evidence:77->74:1:grf-prn-624,626|SpaceAfter=No
+60	14	14	NUM	CD	NumForm=Digit|NumType=Card	13	dep	13:dep	Entity=(99-abstract-new-nnnnn-cf12-1-sgl)|SpaceAfter=No|XML=<ref></ref>
+61	]	]	PUNCT	-RRB-	_	60	punct	60:punct	_
+

--- a/tests/test_scripts/test_create_scala/test_data/pl_pdb-ud-train.conllu.aux_clitic_01
+++ b/tests/test_scripts/test_create_scala/test_data/pl_pdb-ud-train.conllu.aux_clitic_01
@@ -1,0 +1,12 @@
+# sent_id = dev-s239
+# text = Postanowiliśmy iść za tym pomysłem.
+# orig_file_sentence = 120-2-900063_morph_3.30-s#2420
+1-2	Postanowiliśmy	_	_	_	_	_	_	_	_
+1	Postanowili	postanowić	VERB	praet:pl:m1:perf	Animacy=Hum|Aspect=Perf|Gender=Masc|Mood=Ind|Number=Plur|Tense=Past|VerbForm=Fin|Voice=Act	0	root	0:root	_
+2	śmy	być	AUX	aglt:pl:pri:imperf:nwok	Aspect=Imp|Number=Plur|Person=1|Variant=Short	1	aux:clitic	1:aux:clitic	_
+3	iść	iść	VERB	inf:imperf	Aspect=Imp|VerbForm=Inf|Voice=Act	1	xcomp	1:xcomp	_
+4	za	za	ADP	prep:inst	AdpType=Prep	6	case	6:case	Case=Ins
+5	tym	ten	DET	adj:sg:inst:m3:pos	Animacy=Inan|Case=Ins|Gender=Masc|Number=Sing|PronType=Dem	6	det	6:det	_
+6	pomysłem	pomysł	NOUN	subst:sg:inst:m3	Animacy=Inan|Case=Ins|Gender=Masc|Number=Sing	3	obl:arg	3:obl:arg	SpaceAfter=No
+7	.	.	PUNCT	interp	PunctType=Peri	1	punct	1:punct	_
+

--- a/tests/test_scripts/test_create_scala/test_data/pl_pdb-ud-train.conllu.aux_clitic_02
+++ b/tests/test_scripts/test_create_scala/test_data/pl_pdb-ud-train.conllu.aux_clitic_02
@@ -1,0 +1,15 @@
+# sent_id = train-s1604
+# text = Nadziałem je na haczyk i zarzuciłem.
+# orig_file_sentence = 030-2-000000005_morph_1.47-s#103
+1-2	Nadziałem	_	_	_	_	_	_	_	_
+1	Nadział	nadziać	VERB	praet:sg:m1:perf	Animacy=Hum|Aspect=Perf|Gender=Masc|Mood=Ind|Number=Sing|Tense=Past|VerbForm=Fin|Voice=Act	0	root	0:root	_
+2	em	być	AUX	aglt:sg:pri:imperf:wok	Aspect=Imp|Number=Sing|Person=1|Variant=Long	1	aux:clitic	1:aux:clitic	_
+3	je	on	PRON	ppron3:sg:acc:n:ter:akc:npraep	Case=Acc|Gender=Neut|Number=Sing|Person=3|PrepCase=Npr|PronType=Prs|Variant=Long	1	obj	1:obj	_
+4	na	na	ADP	prep:acc	AdpType=Prep	5	case	5:case	Case=Acc
+5	haczyk	haczyk	NOUN	subst:sg:acc:m3	Animacy=Inan|Case=Acc|Gender=Masc|Number=Sing	1	obl:arg	1:obl:arg	_
+6	i	i	CCONJ	conj	_	7	cc	7:cc	_
+7-8	zarzuciłem	_	_	_	_	_	_	_	SpaceAfter=No
+7	zarzucił	zarzucić	VERB	praet:sg:m1:perf	Animacy=Hum|Aspect=Perf|Gender=Masc|Mood=Ind|Number=Sing|Tense=Past|VerbForm=Fin|Voice=Act	1	conj	0:root|1:conj	_
+8	em	być	AUX	aglt:sg:pri:imperf:wok	Aspect=Imp|Number=Sing|Person=1|Variant=Long	7	aux:clitic	7:aux:clitic	_
+9	.	.	PUNCT	interp	PunctType=Peri	1	punct	1:punct	_
+

--- a/tests/test_scripts/test_create_scala/test_data/pl_pdb-ud-train.conllu.aux_clitic_03
+++ b/tests/test_scripts/test_create_scala/test_data/pl_pdb-ud-train.conllu.aux_clitic_03
@@ -1,0 +1,17 @@
+# sent_id = train-s17446
+# text = Chciałbym abyś został tu przez cały dzień.
+# orig_file_sentence = PDB_projected_1365#1365
+1-3	Chciałbym	_	_	_	_	_	_	_	_
+1	Chciał	chcieć	VERB	praet:sg:m1:imperf	Animacy=Hum|Aspect=Imp|Gender=Masc|Mood=Ind|Number=Sing|Tense=Past|VerbForm=Fin|Voice=Act	0	root	0:root	_
+2	by	by	AUX	part	_	1	aux:cnd	1:aux:cnd	_
+3	m	być	AUX	aglt:sg:pri:imperf:nwok	Aspect=Imp|Number=Sing|Person=1|Variant=Short	1	aux:clitic	1:aux:clitic	_
+4-5	abyś	_	_	_	_	_	_	_	_
+4	aby	aby	SCONJ	comp	_	6	mark	6:mark	_
+5	ś	być	AUX	aglt:sg:sec:imperf:nwok	Aspect=Imp|Number=Sing|Person=2|Variant=Short	6	aux:clitic	6:aux:clitic	_
+6	został	zostać	VERB	praet:sg:m1:perf	Animacy=Hum|Aspect=Perf|Gender=Masc|Mood=Ind|Number=Sing|Tense=Past|VerbForm=Fin|Voice=Act	1	advcl	1:advcl	_
+7	tu	tu	ADV	adv	PronType=Dem	6	advmod	6:advmod	_
+8	przez	przez	ADP	prep:acc:nwok	AdpType=Prep|Variant=Short	10	case	10:case	Case=Acc
+9	cały	cały	ADJ	adj:sg:acc:m3:pos	Animacy=Inan|Case=Acc|Degree=Pos|Gender=Masc|Number=Sing	10	amod	10:amod	_
+10	dzień	dzień	NOUN	subst:sg:acc:m3	Animacy=Inan|Case=Acc|Gender=Masc|Number=Sing	6	obl	6:obl	SpaceAfter=No
+11	.	.	PUNCT	interp	PunctType=Peri	1	punct	1:punct	_
+


### PR DESCRIPTION
Fixes #1296.

This fix modifies creation of ScaLA dataset for all languages that use it.

Example: In the case below, testcase generator will ignore tokens `4` and `5` and it will only consider `4-5`. The rationale is, current generation logic is not able to handle such token combinations and generates invalid cases with wrong correct/incorrect labels.  

```
4-5	abyś	_	_	_	_	_	_	_	_
4	aby	aby	SCONJ	comp	_	6	mark	6:mark	_
5	ś	być	AUX	aglt:sg:sec:imperf:nwok	Aspect=Imp|Number=Sing|Person=2|Variant=Short	6	aux:clitic	6:aux:clitic	_
``

On top of that, I have extended pytest pythonpath to enable pytest for scripts.
