### PR TITLE
fix: Close writer when removing HuggingFaceMetric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   model, so that this does not happen.
 - Now catches more errors when evaluating LiteLLM models, which were related to some
   generation parameters not being supported (such as stop sequences) for some models.
+- We now clean up metric writers when we're done with them, which prevents a "too many
+  open files" error when evaluating many models and datasets in a single run.
 
 ## [v16.3.0] - 2025-09-23
 

--- a/src/euroeval/metrics/huggingface.py
+++ b/src/euroeval/metrics/huggingface.py
@@ -142,6 +142,13 @@ class HuggingFaceMetric(Metric):
 
         return score
 
+    def __del__(self) -> None:
+        """Clean up the metric from memory."""
+        if self.metric is not None:
+            if self.metric.writer is not None:
+                self.metric.writer.close()
+            del self.metric
+
 
 mcc_metric = HuggingFaceMetric(
     name="mcc",


### PR DESCRIPTION
### Fixed
- We now clean up metric writers when we're done with them, which prevents a "too many
  open files" error when evaluating many models and datasets in a single run.