### PR TITLE
Move Winogrande to section Common-sense Reasoning

### DIFF
--- a/docs/datasets/greek.md
+++ b/docs/datasets/greek.md
@@ -372,6 +372,8 @@ You can evaluate this dataset directly as follows:
 euroeval --model <model-id> --dataset global-mmlu-el
 ```
 
+## Common-sense Reasoning
+
 ### Winogrande-el
 
 This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2506.19468)

--- a/docs/datasets/slovak.md
+++ b/docs/datasets/slovak.md
@@ -375,6 +375,8 @@ You can evaluate this dataset directly as follows:
 euroeval --model <model-id> --dataset mmlu-sk
 ```
 
+## Common-sense Reasoning
+
 ### Winogrande-sk
 
 This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2506.19468)

--- a/docs/datasets/ukrainian.md
+++ b/docs/datasets/ukrainian.md
@@ -380,6 +380,8 @@ You can evaluate this dataset directly as follows:
 euroeval --model <model-id> --dataset global-mmlu-uk
 ```
 
+## Common-sense Reasoning
+
 ### Winogrande-uk
 
 This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2506.19468)


### PR DESCRIPTION
For a few languages Winogrande was listed as a knowledge dataset. This PR fixes this.