### PR TITLE
fix: Disable structured generation if disabled logprobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   this file, making it possible to evaluate custom datasets by name only when using the
   `Benchmarker` API.
 
+### Fixed
+
+- Now disabled structured generation for classification tasks if we're disabling
+  logprobs, to force evaluation using raw outputs and word edit distance instead.
+
 ## [v16.5.0] - 2025-10-28
 
 ### Added

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -132,8 +132,8 @@ class VLLMModel(HuggingFaceEncoderModel):
                 dependency="nvcc",
                 instructions=(
                     "Please install the CUDA Toolkit from "
-                    "https://developer.nvidia.com/cuda-downloads or ensure that NVCC is "
-                    "available in your PATH."
+                    "https://developer.nvidia.com/cuda-downloads or ensure that NVCC "
+                    "is available in your PATH."
                 ),
             )
 
@@ -427,14 +427,16 @@ class VLLMModel(HuggingFaceEncoderModel):
             structured_outputs = StructuredOutputsParams(
                 json=structured_generation_schema
             )
-        elif self.dataset_config.task.uses_logprobs and self.dataset_config.labels:
+        elif (
+            self.dataset_config.task.uses_logprobs
+            and self.dataset_config.labels
+            and self.buffer.get("first_label_token_mapping", False)
+        ):
             choice_labels = [
                 self.dataset_config.prompt_label_mapping[label]
                 for label in self.dataset_config.labels
             ]
-            if "first_label_token_mapping" in self.buffer and isinstance(
-                self.buffer["first_label_token_mapping"], dict
-            ):
+            if isinstance(self.buffer["first_label_token_mapping"], dict):
                 choice_labels = [
                     self.buffer["first_label_token_mapping"][label]
                     for label in choice_labels


### PR DESCRIPTION
### Fixed

- Now disabled structured generation for classification tasks if we're disabling
  logprobs, to force evaluation using raw outputs and word edit distance instead.