### PR TITLE
Fix wrong number of samples for Serbian MMS

### DIFF
--- a/docs/datasets/serbian.md
+++ b/docs/datasets/serbian.md
@@ -12,7 +12,7 @@ This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2306.0
 The corpus consists of 79 manually selected datasets from over 350 datasets reported in the
 scientific literature based on strict quality criteria.
 
-The original dataset contains a single split with 6,165,262 samples. We use
+The original dataset contains a single split with 76,368 Serbian samples. We use
 1,024 / 256 / 2,048 samples for our training, validation and test splits, respectively.
 
 Here are a few examples from the training split:


### PR DESCRIPTION
Mention number of Serbian samples, not number of samples across all languages.