### PR TITLE
Fix/stride and max length in rc

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      # - id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.3
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Prevent special case when negative stride occurred when an encoder model is being
-  evaluated on the reading comprehension task.
+- When evaluating encoder models on reading comprehension datasets, we now also truncate
+  the question in case the model's maximum context length is very small.
 
 ## [v16.6.0] - 2025-11-04
 

--- a/src/euroeval/task_group_utils/question_answering.py
+++ b/src/euroeval/task_group_utils/question_answering.py
@@ -5,7 +5,10 @@ import typing as t
 from collections import defaultdict
 
 import numpy as np
-from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+from transformers.tokenization_utils_base import (
+    PreTrainedTokenizerBase,
+    TruncationStrategy,
+)
 from transformers.trainer import Trainer
 
 from ..exceptions import InvalidBenchmark
@@ -439,20 +442,16 @@ def prepare_test_examples(
     # using a stride. This results in one example possible giving several features when
     # a context is long, each of those features having a context that overlaps a bit
     # the context of the previous feature.
-    try:
-        tokenised_examples = tokeniser(
-            text=examples["question"],
-            text_pair=examples["context"],
-            truncation="only_second",
-            max_length=max_length,
-            stride=stride,
-            return_overflowing_tokens=True,
-            return_offsets_mapping=True,
-            padding="max_length",
-        )
-    except Exception:
-        breakpoint()
-        pass
+    tokenised_examples = tokeniser(
+        text=examples["question"],
+        text_pair=examples["context"],
+        truncation=TruncationStrategy.LONGEST_FIRST,
+        max_length=max_length,
+        stride=stride,
+        return_overflowing_tokens=True,
+        return_offsets_mapping=True,
+        padding="max_length",
+    )
 
     # Since one example might give us several features if it has a long context, we
     # need a map from a feature to its corresponding example. This key gives us just


### PR DESCRIPTION
### Fixed

- When evaluating encoder models on reading comprehension datasets, we now also truncate
  the question in case the model's maximum context length is very small.