### PR TITLE
feat: Include inputs in debug file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   argument, which can be used to specify a custom Python file containing custom dataset
   definitions. It defaults to `custom_datasets.py` in the current working directory.
 
+### Changed
+
+- When evaluating models with the `--debug` flag (`debug=True` in the `Benchmarker`
+  API), we now include the full model inputs and outputs in the JSON file stored to the
+  current working directory, where we previously only included the model outputs.
+
 ## [v16.7.1] - 2025-11-18
 
 ### Fixed

--- a/src/euroeval/generation.py
+++ b/src/euroeval/generation.py
@@ -75,6 +75,7 @@ def generate(
         cache_name=cache_name,
         max_generated_tokens=dataset_config.max_generated_tokens,
         progress_bar=benchmark_config.progress_bar,
+        hash_inputs=not benchmark_config.debug,
     )
 
     scores: list[dict[str, float]] = list()

--- a/src/euroeval/metrics/llm_as_a_judge.py
+++ b/src/euroeval/metrics/llm_as_a_judge.py
@@ -138,6 +138,7 @@ class LLMAsAJudgeMetric(Metric):
             cache_name=f"{dataset_config.name}-model-outputs.json",
             max_generated_tokens=dataset_config.max_generated_tokens,
             progress_bar=benchmark_config.progress_bar,
+            hash_inputs=not benchmark_config.debug,
         )
         judge_cache.load()
 

--- a/src/euroeval/model_cache.py
+++ b/src/euroeval/model_cache.py
@@ -33,6 +33,8 @@ class ModelCache:
             The maximum number of tokens to generate for each example.
         progress_bar:
             Whether to show a progress bar when caching model outputs.
+        hash_inputs:
+            Whether to hash the model inputs to use as keys in the cache.
     """
 
     def __init__(
@@ -41,6 +43,7 @@ class ModelCache:
         cache_name: str,
         max_generated_tokens: int,
         progress_bar: bool,
+        hash_inputs: bool,
     ) -> None:
         """Initialise the model output cache.
 
@@ -53,12 +56,15 @@ class ModelCache:
                 The maximum number of tokens to generate for each example.
             progress_bar:
                 Whether to show a progress bar when caching model outputs.
+            hash_inputs:
+                Whether to hash the model inputs to use as keys in the cache.
         """
         self.model_cache_dir = model_cache_dir
         self.model_cache_dir.mkdir(parents=True, exist_ok=True)
         self.cache_path = self.model_cache_dir / cache_name.replace("/", "--")
         self.max_generated_tokens = max_generated_tokens
         self.progress_bar = progress_bar
+        self.hash_inputs = hash_inputs
 
     def load(self) -> None:
         """Load the model output cache."""
@@ -114,7 +120,10 @@ class ModelCache:
         Returns:
             The hashed key.
         """
-        return hashlib.md5(string=str(key).encode()).hexdigest()
+        if self.hash_inputs:
+            return hashlib.md5(string=str(key).encode()).hexdigest()
+        else:
+            return str(key)
 
     def __getitem__(
         self, key: str | c.Sequence[dict[str, str]]


### PR DESCRIPTION
### Changed

- When evaluating models with the `--debug` flag (`debug=True` in the `Benchmarker`
  API), we now include the full model inputs and outputs in the JSON file stored to the
  current working directory, where we previously only included the model outputs.

Fixes #1371 