### PR TITLE
fix: More robust pipeline tag classification

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: trailing-whitespace
       - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.13
+    rev: v0.14.14
     hooks:
       - id: ruff
         args:
@@ -34,7 +34,7 @@ repos:
     hooks:
     -   id: nbstripout
 -   repo: https://github.com/facebook/pyrefly-pre-commit
-    rev: 0.49.0
+    rev: 0.50.0
     hooks:
     -   id: pyrefly-check
         name: Pyrefly (type checking)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - We now up the vLLM maximum context length for reasoning models, from 8,192 to
   16,384, to accommodate for reasoning tokens for some datasets that have long documents.
 
+### Fixed
+
+- Fixed an issue where a model was incorrectly classified as an encoder model if it had
+  no pipeline tag on the Hugging Face Hub and it relied on a custom implementation that
+  isn't integrated into the `transformers` library.
+
 ## [v16.11.0] - 2026-01-21
 
 ### Added

--- a/src/euroeval/benchmark_modules/hf.py
+++ b/src/euroeval/benchmark_modules/hf.py
@@ -876,8 +876,9 @@ def get_model_repo_info(
             for tag in GENERATIVE_PIPELINE_TAGS
             for class_name in TASK_MAPPING.get(tag, dict()).values()  # type: ignore[attr-defined]
         ]
-        if class_names is not None and any(
-            class_name in generative_class_names for class_name in class_names
+        if class_names is not None and (
+            any(class_name in generative_class_names for class_name in class_names)
+            or any("ForCausalLM" in class_name for class_name in class_names)
         ):
             pipeline_tag = "text-generation"
         else:


### PR DESCRIPTION
### Fixed

- Fixed an issue where a model was incorrectly classified as an encoder model if it had
  no pipeline tag on the Hugging Face Hub and it relied on a custom implementation that
  isn't integrated into the `transformers` library.