### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto_assign_reviewers.yaml
+++ b/.github/workflows/auto_assign_reviewers.yaml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   add-reviews:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: kentaro-m/auto-assign-action@v2.0.1


### PR DESCRIPTION
Potential fix for [https://github.com/EuroEval/EuroEval/security/code-scanning/11](https://github.com/EuroEval/EuroEval/security/code-scanning/11)

In general, to fix this problem you add an explicit `permissions` block either at the root of the workflow (applies to all jobs that don’t override it) or under the specific job. The block should grant only the minimal scopes needed by the job, such as `contents: read` and, if necessary, `pull-requests: write`.

For this specific workflow, the `add-reviews` job uses `kentaro-m/auto-assign-action` to auto-assign reviewers on pull requests. That action needs to modify pull requests (assigning reviewers/assignees) but does not need to write to repository contents. A safe minimal set is: `contents: read` (baseline read access equivalent to read-only default) and `pull-requests: write` so it can change PR metadata. We can define these permissions at the job level directly under `add-reviews:` so only this job gets them. Concretely, in `.github/workflows/auto_assign_reviewers.yaml`, insert a `permissions:` block between `add-reviews:` and `runs-on: ubuntu-latest`, without changing any other behavior.

No new imports or external methods are needed, since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
