### PR TITLE
fix: Parse safetensors metadata for adapter models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- v16.15.0 introduced an error related to the parsing of safetensors metadata from
+  adapter models. This has now been fixed.
+
 ## [v16.15.0] - 2026-02-18
 
 ### Added

--- a/src/euroeval/benchmark_modules/hf.py
+++ b/src/euroeval/benchmark_modules/hf.py
@@ -152,15 +152,15 @@ class HuggingFaceEncoderModel(BenchmarkModule):
         Returns:
             The number of parameters in the model.
         """
-        # No need to try to use the API if we have no internet.
-        if internet_connection_available():
-            num_params_or_none = get_num_params_from_safetensors_metadata(
-                model_id=self.model_config.model_id,
-                revision=self.model_config.revision,
-                api_key=self.benchmark_config.api_key,
-            )
-            if num_params_or_none is not None:
-                return num_params_or_none
+        num_params_or_none = get_num_params_from_safetensors_metadata(
+            model_id=(
+                self.model_config.adapter_base_model_id or self.model_config.model_id
+            ),
+            revision=self.model_config.revision,
+            api_key=self.benchmark_config.api_key,
+        )
+        if num_params_or_none is not None:
+            return num_params_or_none
 
         if (
             hasattr(self._model.config, "num_params")

--- a/src/euroeval/safetensors_utils.py
+++ b/src/euroeval/safetensors_utils.py
@@ -1,12 +1,13 @@
 """Utility functions related to parsing of safetensors metadata of models."""
 
 import logging
+from pathlib import Path
 
 from huggingface_hub import get_safetensors_metadata
 from huggingface_hub.errors import NotASafetensorsRepoError
 
 from .logging_utils import log_once
-from .utils import get_hf_token
+from .utils import get_hf_token, internet_connection_available
 
 
 def get_num_params_from_safetensors_metadata(
@@ -26,6 +27,11 @@ def get_num_params_from_safetensors_metadata(
     Returns:
         The number of parameters, or None if the metadata could not be found.
     """
+    # We cannot determine the number of parameters if there is no internet connection
+    # or if the model is stored locally
+    if not internet_connection_available() or Path(model_id).exists():
+        return None
+
     try:
         metadata = get_safetensors_metadata(
             repo_id=model_id, revision=revision, token=get_hf_token(api_key=api_key)


### PR DESCRIPTION
### Fixed

- v16.15.0 introduced an error related to the parsing of safetensors metadata from
  adapter models. This has now been fixed.