### PR TITLE
Fix links to ChrF++ paper

### DIFF
--- a/docs/tasks/summarization.md
+++ b/docs/tasks/summarization.md
@@ -14,13 +14,13 @@ task.
 ## 📊 Metrics
 
 The primary metric used to evaluate the performance of a model on the summarization task
-is [CHRF3++](https://www.aclweb.org/anthology/W18-2346/), which measures the quality of
+is [CHRF3++](https://aclanthology.org/W17-4770/), which measures the quality of
 a summary by combining character-level n-gram F-scores with word order information. The
 "++" indicates that it uses bi-grams (word_order=2) in addition to unigrams, and we use
 beta=3 to weight precision and recall. CHRF is particularly well-suited for
 summarization as it is robust to paraphrasing and works well across different languages.
 
-We also report [CHRF4++](https://www.aclweb.org/anthology/W18-2346/), which uses
+We also report [CHRF4++](https://aclanthology.org/W17-4770/), which uses
 tri-grams (beta=4) for even more context-aware evaluation. Both metrics are computed
 using SacreBLEU and are reported as percentages. For both metrics, per-sentence scores
 are penalized if the predicted summary is not in the correct target language, in


### PR DESCRIPTION
The links to the ChrF++ paper in the [documentation](https://euroeval.com/tasks/summarization/) for the Summarization task are dead.

I looked up the paper and changed the links. Of course I'm not entirely sure that this exact paper is what the links used to point to, so please double check.