### PR TITLE
Allow offline mode, bypassing HF repo_exists()

### DIFF
--- a/src/euroeval/custom_dataset_configs.py
+++ b/src/euroeval/custom_dataset_configs.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from types import ModuleType
 
 from huggingface_hub import HfApi
+from huggingface_hub.errors import OfflineModeIsEnabled as HfOfflineModeIsEnabled
 
 from .data_models import DatasetConfig
 from .hf_hub_utils import _list_repo_files, _repo_exists
@@ -92,7 +93,12 @@ def try_get_dataset_config_from_repo(
     """
     token = get_hf_token(api_key=api_key)
     hf_api = HfApi(token=token)
-    if not _repo_exists(hf_api=hf_api, dataset_id=dataset_id):
+
+    try:
+        if not _repo_exists(hf_api=hf_api, dataset_id=dataset_id):
+            return None
+    except HfOfflineModeIsEnabled as e:
+        log_once(message=str(e), level=logging.WARNING)
         return None
 
     repo_files = _list_repo_files(hf_api=hf_api, dataset_id=dataset_id, revision="main")


### PR DESCRIPTION
Suggested fix for #1657. Catches the HF exception that gets raised of HF_HUB_OFFLINE=1, and returns `None`. This behaviour makes sense imo, since setting that environment variable doesn't make sense if we want to fetch the dataset from Hugging Face.