### PR TITLE
Fix: Broken Tests

### DIFF
--- a/tests/test_benchmarker.py
+++ b/tests/test_benchmarker.py
@@ -148,7 +148,7 @@ def test_benchmark_ollama(
     assert all(isinstance(result, BenchmarkResult) for result in benchmark_result)
 
 
-@pytest.mark.disable_socket
+@pytest.mark.allow_hosts(["127.0.0.1"])
 @pytest.mark.depends(on=["test_benchmark_encoder"])
 def test_benchmark_encoder_no_internet(
     task: Task, language: Language, encoder_model_id: str

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -13,7 +13,7 @@ from euroeval.model_config import get_model_config
         ("Maltehb/aelaectra-danish-electra-small-cased", False),
         ("openai-community/gpt2", False),
         ("gpt-4o-mini", False),
-        ("claude-3-5-haiku-20251001", False),
+        ("claude-haiku-4-5-20251001", False),
         ("does-not-exist", True),
     ],
     ids=[

--- a/tests/test_tokenisation_utils.py
+++ b/tests/test_tokenisation_utils.py
@@ -45,7 +45,7 @@ def test_should_prompts_be_stripped(model_id: str, expected: bool, auth: str) ->
     argnames=["model_id", "expected"],
     argvalues=[
         ("AI-Sweden-Models/gpt-sw3-6.7b-v2", False),
-        ("01-ai/Yi-6B", True),
+        ("01-ai/Yi-6B", False),
         ("common-pile/comma-v0.1-2t", True),
     ],
 )


### PR DESCRIPTION
This PR fixes three test issues:

- The expected value for `01-ai/Yi-6B` in `test_should_prefix_space_be_added_to_labels` was incorrect, the tokenizer automatically adds a prefix space, so the expected value should be `False`, not `True`.
- The model ID for `anthropic-model` used `claude-3-5-haiku-20251001` in `test_get_model_config` which is deprecated, causing the test to be skipped. Updated to `claude-haiku-4-5-20251001`.
- The no-internet encoder test was failing because disable_socket blocked all socket connections including `localhost`, which is required for the test to run. Changed to `allow_hosts(["127.0.0.1"])` to block external connections while still allowing `localhost`.

All tests pass locally, except for the ones that require API keys.