### PR TITLE
Fix/benchmarking gated repos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: trailing-whitespace
       - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.9
+    rev: v0.15.11
     hooks:
       - id: ruff
         args:
@@ -34,7 +34,7 @@ repos:
     hooks:
     -   id: nbstripout
 -   repo: https://github.com/facebook/pyrefly-pre-commit
-    rev: 0.59.1
+    rev: 0.61.0
     hooks:
     -   id: pyrefly-check
         name: Pyrefly (type checking)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   completions. The issue was that the first label token mapping wasn't updated
   immediately after the dataset config changed, which has been fixed now.
 - Fixed a bug related to evaluating gated datasets on the Hugging Face Hub.
+- We now automatically detect if a dataset doesn't have a training split and force
+  zero-shot evaluation if so.
 
 ## [v17.1.0] - 2026-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a bug when evaluating a generative task that uses logprobs with partial
   completions. The issue was that the first label token mapping wasn't updated
   immediately after the dataset config changed, which has been fixed now.
+- Fixed a bug related to evaluating gated datasets on the Hugging Face Hub.
 
 ## [v17.1.0] - 2026-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Now overrides vLLM's pinned `transformers<5` dependency with `transformers>=5.5.0`, to
   allow compatibility with the latest models.
+- If evaluating a dataset on the Hugging Face Hub with both a YAML config and a Python
+  config, we first try the YAML one, and then try the Python one if the YAML one failed.
+  Previously the evaluation failed if the YAML config was invalid.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a bug related to evaluating gated datasets on the Hugging Face Hub.
 - We now automatically detect if a dataset doesn't have a training split and force
   zero-shot evaluation if so.
-- Fixed an issue when the label column of multiple choice datasets contain the full
+- Fixed an issue when the label column of multiple choice datasets contains the full
   choice text, rather than the a/b/c/d labels. We now convert such labels to the single
   letters.
 - Updated vLLM from v0.14.1 to v0.18.1 on macOS Apple Silicon, enabling structured

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a bug related to evaluating gated datasets on the Hugging Face Hub.
 - We now automatically detect if a dataset doesn't have a training split and force
   zero-shot evaluation if so.
+- Fixed an issue when the label column of multiple choice datasets contain the full
+  choice text, rather than the a/b/c/d labels. We now convert such labels to the single
+  letters.
 
 ## [v17.1.0] - 2026-03-24
 

--- a/makefile
+++ b/makefile
@@ -32,7 +32,6 @@ install: ## Install dependencies
 	@$(MAKE) --quiet install-uv
 	@$(MAKE) --quiet install-dependencies
 	@$(MAKE) --quiet setup-environment-variables
-	@$(MAKE) --quiet install-pre-commit
 	@echo "Installed the 'EuroEval' project."
 
 install-rust:

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -1638,16 +1638,19 @@ class LiteLLMModel(BenchmarkModule):
         )
 
         # Set up the `response_format` generation argument if we are dealing with a task
-        # using structured generation
-        if dataset_config.task.uses_structured_output:
-            if self.generative_type == GenerativeType.REASONING:
-                log_once(
-                    f"The model {self.model_config.model_id!r} is a reasoning model "
-                    "and thus does not support structured generation, so we do not "
-                    "enable it.",
-                    level=logging.DEBUG,
-                )
-            elif dataset_config.task.structured_output_format is not None:
+        # using structured generation and the model isn't a reasoning model
+        if self.generative_type == GenerativeType.REASONING and (
+            dataset_config.task.uses_structured_output
+            or (self.dataset_config.task.uses_logprobs and self.dataset_config.labels)
+        ):
+            log_once(
+                f"The model {self.model_config.model_id!r} is a reasoning model "
+                "and thus does not support structured generation, so we do not "
+                "enable it.",
+                level=logging.DEBUG,
+            )
+        elif dataset_config.task.uses_structured_output:
+            if dataset_config.task.structured_output_format is not None:
                 pydantic_class = dataset_config.task.structured_output_format
                 # TODO: here it would be nice to just input the pydantic class
                 # directly instead. However this caused problems with e.g.

--- a/src/euroeval/custom_dataset_configs.py
+++ b/src/euroeval/custom_dataset_configs.py
@@ -100,9 +100,11 @@ def try_get_dataset_config_from_repo(
 
     if "eval.yaml" in repo_files:
         try:
-            return load_yaml_config(
+            yaml_config = load_yaml_config(
                 hf_api=hf_api, dataset_id=dataset_id, cache_dir=cache_dir
             )
+            if yaml_config is not None:
+                return yaml_config
         except Exception as e:
             log_once(
                 f"Failed to load the YAML config for dataset {dataset_id} from "

--- a/src/euroeval/custom_dataset_configs.py
+++ b/src/euroeval/custom_dataset_configs.py
@@ -99,9 +99,17 @@ def try_get_dataset_config_from_repo(
     )
 
     if "eval.yaml" in repo_files:
-        return load_yaml_config(
-            hf_api=hf_api, dataset_id=dataset_id, cache_dir=cache_dir
-        )
+        try:
+            return load_yaml_config(
+                hf_api=hf_api, dataset_id=dataset_id, cache_dir=cache_dir
+            )
+        except Exception as e:
+            log_once(
+                f"Failed to load the YAML config for dataset {dataset_id} from "
+                f"{dataset_id}. The error was '{e}'. Trying the Python config "
+                "instead, if it exists.",
+                level=logging.ERROR,
+            )
 
     return load_python_config(
         hf_api=hf_api,

--- a/src/euroeval/custom_dataset_configs.py
+++ b/src/euroeval/custom_dataset_configs.py
@@ -107,9 +107,9 @@ def try_get_dataset_config_from_repo(
                 return yaml_config
         except Exception as e:
             log_once(
-                f"Failed to load the YAML config for dataset {dataset_id} from "
-                f"{dataset_id}. The error was '{e}'. Trying the Python config "
-                "instead, if it exists.",
+                f"Failed to load eval.yaml from dataset repository {dataset_id}. "
+                f"The error was '{e}'. Trying the Python config instead, if it "
+                "exists.",
                 level=logging.ERROR,
             )
 

--- a/src/euroeval/data_loading.py
+++ b/src/euroeval/data_loading.py
@@ -14,7 +14,7 @@ from numpy.random import Generator
 
 from .constants import SUPPORTED_FILE_FORMATS_FOR_LOCAL_DATASETS
 from .exceptions import HuggingFaceHubDown, InvalidBenchmark
-from .logging_utils import log, no_terminal_output
+from .logging_utils import log, log_once, no_terminal_output
 from .string_utils import unscramble
 from .tasks import EUROPEAN_VALUES
 from .utils import get_hf_token
@@ -44,6 +44,16 @@ def load_data(
         cache_dir=benchmark_config.cache_dir,
         api_key=benchmark_config.api_key,
     )
+
+    # If there is no training split in the dataset, we force zero-shot evaluation
+    if "train" not in dataset and benchmark_config.few_shot:
+        log_once(
+            "There is no training split in the dataset, so we cannot extract any "
+            "few-shot examples, even though you requested few-shot evaluation (it's "
+            "the default). We will therefore evaluate the model zero-shot.",
+            level=logging.WARNING,
+        )
+        benchmark_config.few_shot = False
 
     # Apply custom preprocessing function if configured
     if dataset_config.preprocessing_func is not None:

--- a/src/euroeval/data_loading.py
+++ b/src/euroeval/data_loading.py
@@ -14,7 +14,7 @@ from numpy.random import Generator
 
 from .constants import SUPPORTED_FILE_FORMATS_FOR_LOCAL_DATASETS
 from .exceptions import HuggingFaceHubDown, InvalidBenchmark
-from .logging_utils import log, log_once, no_terminal_output
+from .logging_utils import log, no_terminal_output
 from .string_utils import unscramble
 from .tasks import EUROPEAN_VALUES
 from .utils import get_hf_token
@@ -44,16 +44,6 @@ def load_data(
         cache_dir=benchmark_config.cache_dir,
         api_key=benchmark_config.api_key,
     )
-
-    # If there is no training split in the dataset, we force zero-shot evaluation
-    if "train" not in dataset and benchmark_config.few_shot:
-        log_once(
-            "There is no training split in the dataset, so we cannot extract any "
-            "few-shot examples, even though you requested few-shot evaluation (it's "
-            "the default). We will therefore evaluate the model zero-shot.",
-            level=logging.WARNING,
-        )
-        benchmark_config.few_shot = False
 
     # Apply custom preprocessing function if configured
     if dataset_config.preprocessing_func is not None:

--- a/src/euroeval/dataset_configs/__init__.py
+++ b/src/euroeval/dataset_configs/__init__.py
@@ -106,8 +106,10 @@ def get_all_dataset_configs(
                 split_strings.append(
                     f"test split '{dataset_config_or_none.test_split}'"
                 )
-            if split_strings:
+            if len(split_strings) > 1:
                 msg += f" with {', '.join(split_strings[:-1])} and {split_strings[-1]}"
+            elif split_strings:
+                msg += f" with {split_strings[0]}"
             msg += "."
             log_once(msg, level=logging.DEBUG)
 

--- a/src/euroeval/generation_utils.py
+++ b/src/euroeval/generation_utils.py
@@ -57,7 +57,7 @@ def extract_few_shot_examples(
             "There is no training split in the dataset, so we cannot extract any "
             "few-shot examples, even though you requested few-shot evaluation (it's "
             "the default). We will therefore evaluate the model zero-shot.",
-            level=logging.WARNING,
+            level=logging.DEBUG,
         )
         return list()
 

--- a/src/euroeval/generation_utils.py
+++ b/src/euroeval/generation_utils.py
@@ -52,6 +52,15 @@ def extract_few_shot_examples(
         InvalidBenchmark:
             If there are not enough short examples for few-shot learning.
     """
+    if "train" not in dataset:
+        log_once(
+            "There is no training split in the dataset, so we cannot extract any "
+            "few-shot examples, even though you requested few-shot evaluation (it's "
+            "the default). We will therefore evaluate the model zero-shot.",
+            level=logging.WARNING,
+        )
+        return list()
+
     if dataset_config.task.requires_zero_shot and benchmark_config.few_shot:
         msg = (
             "This task only allows zero-shot evaluation, so even though you have "

--- a/src/euroeval/preprocessing.py
+++ b/src/euroeval/preprocessing.py
@@ -189,7 +189,10 @@ def build_preprocessing_func(
                         example[target_column] = "abcdefghijklmnopqrstuvwxyz"[
                             choices.index(label)
                         ]
-                    example[target_column] = example[target_column].lower()
+                    if isinstance(example[target_column], int):
+                        example[target_column] = "abcdefghijklmnopqrstuvwxyz"[label]
+                    if isinstance(example[target_column], str):
+                        example[target_column] = example[target_column].lower()
                     return example
 
                 # If the label is the full choice string, then we convert it to the

--- a/src/euroeval/preprocessing.py
+++ b/src/euroeval/preprocessing.py
@@ -168,8 +168,35 @@ def build_preprocessing_func(
                 )
 
         for split_name, split in dataset.items():
-            # Handle input column (optionally merging with choices)
             if choices_cols is not None:
+
+                def _fix_mc_label_column(example: dict) -> dict:
+                    """Ensure multiple choice labels are lowercase letters.
+
+                    Args:
+                        example:
+                            The example to fix.
+
+                    Returns:
+                        The fixes example.
+                    """
+                    if isinstance(choices_column, list):
+                        choices = [example[col] for col in choices_column]
+                    else:
+                        choices = example[choices_column]
+                    label = example[target_column]
+                    if label in choices:
+                        example[target_column] = "abcdefghijklmnopqrstuvwxyz"[
+                            choices.index(label)
+                        ]
+                    example[target_column] = example[target_column].lower()
+                    return example
+
+                # If the label is the full choice string, then we convert it to the
+                # appropriate letter
+                split = split.map(_fix_mc_label_column)
+
+                # Handle input column (optionally merging with choices)
                 merge_fn = functools.partial(
                     merge_input_and_choices,
                     input_column=input_column,

--- a/src/euroeval/preprocessing.py
+++ b/src/euroeval/preprocessing.py
@@ -197,7 +197,8 @@ def build_preprocessing_func(
 
                 # If the label is the full choice string, then we convert it to the
                 # appropriate letter
-                split = split.map(_fix_mc_label_column)
+                if target_column is not None:
+                    split = split.map(_fix_mc_label_column)
 
                 # Handle input column (optionally merging with choices)
                 merge_fn = functools.partial(

--- a/src/euroeval/preprocessing.py
+++ b/src/euroeval/preprocessing.py
@@ -178,7 +178,7 @@ def build_preprocessing_func(
                             The example to fix.
 
                     Returns:
-                        The fixes example.
+                        The fixed example.
                     """
                     if isinstance(choices_column, list):
                         choices = [example[col] for col in choices_column]

--- a/src/euroeval/split_utils.py
+++ b/src/euroeval/split_utils.py
@@ -42,8 +42,7 @@ def get_repo_split_names(hf_api: HfApi, dataset_id: str) -> list[str] | None:
         and "splits" in dataset_info.card_data.dataset_info
     ):
         return [
-            split["name"]
-            for split in dataset_info.card_data.dataset_info["splits"]
+            split["name"] for split in dataset_info.card_data.dataset_info["splits"]
         ]
 
     # If we don't have access to the split names directly, we look at the data files,

--- a/src/euroeval/split_utils.py
+++ b/src/euroeval/split_utils.py
@@ -1,5 +1,7 @@
 """Utilities for detecting and mapping dataset splits."""
 
+from pathlib import Path
+
 from huggingface_hub import HfApi
 
 
@@ -20,7 +22,7 @@ def find_split(splits: list[str], keyword: str) -> str | None:
     return candidates[0] if candidates else None
 
 
-def get_repo_split_names(hf_api: HfApi, dataset_id: str) -> list[str]:
+def get_repo_split_names(hf_api: HfApi, dataset_id: str) -> list[str] | None:
     """Extract split names from a Hugging Face dataset repo.
 
     Args:
@@ -30,14 +32,35 @@ def get_repo_split_names(hf_api: HfApi, dataset_id: str) -> list[str]:
             The ID of the dataset to get the split names for.
 
     Returns:
-        A list of split names.
+        A list of split names, or None if the split names are not available.
     """
-    return [
-        split["name"]
-        for split in hf_api.dataset_info(repo_id=dataset_id).card_data.dataset_info[
-            "splits"
+    dataset_info = hf_api.dataset_info(repo_id=dataset_id)
+
+    if (
+        dataset_info.card_data is not None
+        and hasattr(dataset_info.card_data, "dataset_info")
+        and "splits" in dataset_info.card_data.dataset_info
+    ):
+        return [
+            split["name"]
+            for split in hf_api.dataset_info(repo_id=dataset_id).card_data.dataset_info[
+                "splits"
+            ]
         ]
-    ]
+
+    # If we don't have access to the split names directly, we look at the data files,
+    # since they tend to be of the form "data/test-00000-of-00001.parquet"
+    elif dataset_info.siblings is not None:
+        parquet_file_names = [
+            sibling.rfilename
+            for sibling in dataset_info.siblings
+            if sibling.rfilename.endswith(".parquet")
+        ]
+        split_names = [Path(fname).stem.split("-")[0] for fname in parquet_file_names]
+        if split_names:
+            return split_names
+
+    return None
 
 
 def get_repo_splits(
@@ -56,6 +79,8 @@ def get_repo_splits(
             the name of the matching split or None if no such split exists.
     """
     splits = get_repo_split_names(hf_api=hf_api, dataset_id=dataset_id)
+    if splits is None:
+        return None, None, None
     return (
         find_split(splits=splits, keyword="train"),
         find_split(splits=splits, keyword="val"),

--- a/src/euroeval/split_utils.py
+++ b/src/euroeval/split_utils.py
@@ -43,9 +43,7 @@ def get_repo_split_names(hf_api: HfApi, dataset_id: str) -> list[str] | None:
     ):
         return [
             split["name"]
-            for split in hf_api.dataset_info(repo_id=dataset_id).card_data.dataset_info[
-                "splits"
-            ]
+            for split in dataset_info.card_data.dataset_info["splits"]
         ]
 
     # If we don't have access to the split names directly, we look at the data files,

--- a/src/euroeval/tokenisation_utils.py
+++ b/src/euroeval/tokenisation_utils.py
@@ -412,19 +412,19 @@ def get_first_label_token_mapping(
         Boolean value indicating whether the model should output scores (if the mapping
         is outputted then the model will always output scores).
     """
-    if not (dataset_config.task.uses_logprobs and dataset_config.labels):
-        if log_metadata:
-            log_once(
-                "We will not use logprobs with the model, since the dataset does not "
-                "have labels.",
-                level=logging.DEBUG,
-            )
-        return False
-    elif generative_type == GenerativeType.REASONING:
+    if generative_type == GenerativeType.REASONING:
         if log_metadata:
             log_once(
                 f"The model {model_config.model_id!r} is a reasoning model and "
                 "thus does not support logprobs, so we do not enable it.",
+                level=logging.DEBUG,
+            )
+        return False
+    elif not (dataset_config.task.uses_logprobs and dataset_config.labels):
+        if log_metadata:
+            log_once(
+                "We will not use logprobs with the model, since the dataset does not "
+                "have labels.",
                 level=logging.DEBUG,
             )
         return False

--- a/tests/test_benchmarker.py
+++ b/tests/test_benchmarker.py
@@ -129,7 +129,6 @@ def test_benchmark_ollama(
     assert all(isinstance(result, BenchmarkResult) for result in benchmark_result)
 
 
-@pytest.mark.allow_hosts(["127.0.0.1"])
 @pytest.mark.depends(on=["test_benchmark_encoder"])
 def test_benchmark_encoder_no_internet(
     task: Task, language: Language, encoder_model_id: str
@@ -148,7 +147,6 @@ def test_benchmark_encoder_no_internet(
     condition=sys.platform == "linux" and not torch.cuda.is_available(),
     reason="Running on Ubuntu but no CUDA available",
 )
-@pytest.mark.allow_hosts(["127.0.0.1"])
 @pytest.mark.depends(on=["test_benchmark_generative"])
 def test_benchmark_generative_no_internet(
     task: Task, language: Language, generative_model_id: str
@@ -167,7 +165,6 @@ def test_benchmark_generative_no_internet(
     condition=sys.platform == "linux" and not torch.cuda.is_available(),
     reason="Running on Ubuntu but no CUDA available",
 )
-@pytest.mark.allow_hosts(["127.0.0.1"])
 @pytest.mark.skip(
     "Benchmarking adapter models without internet access are not implemented yet."
 )

--- a/tests/test_tokenisation_utils.py
+++ b/tests/test_tokenisation_utils.py
@@ -14,11 +14,7 @@ from euroeval.tokenisation_utils import (
 
 @pytest.mark.parametrize(
     argnames=["model_id", "expected"],
-    argvalues=[
-        ("AI-Sweden-Models/gpt-sw3-6.7b-v2", True),
-        ("01-ai/Yi-6B", True),
-        ("google-bert/bert-base-uncased", False),
-    ],
+    argvalues=[("01-ai/Yi-6B", True), ("google-bert/bert-base-uncased", False)],
 )
 def test_should_prompts_be_stripped(model_id: str, expected: bool, auth: str) -> None:
     """Test that a model ID is a generative model."""
@@ -43,11 +39,7 @@ def test_should_prompts_be_stripped(model_id: str, expected: bool, auth: str) ->
 
 @pytest.mark.parametrize(
     argnames=["model_id", "expected"],
-    argvalues=[
-        ("AI-Sweden-Models/gpt-sw3-6.7b-v2", False),
-        ("01-ai/Yi-6B", False),
-        ("common-pile/comma-v0.1-2t", True),
-    ],
+    argvalues=[("01-ai/Yi-6B", False), ("common-pile/comma-v0.1-2t", True)],
 )
 def test_should_prefix_space_be_added_to_labels(
     model_id: str, expected: bool, auth: str


### PR DESCRIPTION
### Changed

- If evaluating a dataset on the Hugging Face Hub with both a YAML config and a Python
  config, we first try the YAML one, and then try the Python one if the YAML one failed.
  Previously the evaluation failed if the YAML config was invalid.

### Fixed

- Fixed a bug related to evaluating gated datasets on the Hugging Face Hub.
- We now automatically detect if a dataset doesn't have a training split and force
  zero-shot evaluation if so.
- Fixed an issue when the label column of multiple choice datasets contain the full
  choice text, rather than the a/b/c/d labels. We now convert such labels to the single
  letters.