### PR TITLE
Adding Dutch proverbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [v17.2.0] - 2026-04-17
-
 ### Added
 
 - Added a benchmark for the purpose of testing the knowledge of Dutch proverbs.
   The dataset consists of brief scenarios and two possible proverbs for
   the Large Language Model to select from.
   The dataset was created manually and reviewed by native Dutch speakers.
+
+## [v17.2.0] - 2026-04-17
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [v17.2.0] - 2026-04-17
 
+### Added
+
+- Added a benchmark for the purpose of testing the knowledge of Dutch proverbs.
+  The dataset consists of brief scenarios and two possible proverbs for
+  the Large Language Model to select from.
+  The dataset was created manually and reviewed by native Dutch speakers.
+
 ### Changed
 
 - Now overrides vLLM's pinned `transformers<5` dependency with `transformers>=5.5.0`, to

--- a/docs/datasets/dutch.md
+++ b/docs/datasets/dutch.md
@@ -743,6 +743,46 @@ You can evaluate this dataset directly as follows:
 euroeval --model <model-id> --dataset arc-nl
 ```
 
+### Unofficial: Dutch Proverbs
+
+This dataset contains scenarios in Dutch with two accompanying proverbs: one that
+fits the scenario and one that fits less or not at all.
+The dataset was created for the [GPT-NL](https://gpt-nl.nl/) project, _Work
+Package_ Evaluation \& Benchmarking. All samples were created manually and have been reviewed.
+
+The dataset consists of 32 / 0 / 98 samples for training,
+validation and testing, respectively. This means the dataset is not suitable for
+encoder models that need to be trained on the dataset.
+
+Here are a few examples from the training split:
+
+```json
+{
+  "text": "Scenario: Nadat er twee treinen geannuleerd waren, zat de volgende stampensvol. De mensen stonden in het gangpad tegen elkaar aan.\nWelk spreekwoord past hier het beste bij?\na. Als sardientjes in een blik\nb. Er gaan vele makke schapen in een hok",
+  "label": "a"
+}
+```
+
+```json
+{
+  "text": "Scenario: Het nieuwe hippe merk e-bike was een grote hit, ze waren bijna overal uitverkocht en de besteltijd liep op tot een half jaar.\nWelk spreekwoord past hier het beste bij?\na. Als warme broodjes over de toonbank gaan\nb. Als er één schaap over de dam is, volgen er meer",
+  "label": "a"
+}
+```
+
+```json
+{
+  "text": "Scenario: Jaime kon niet eens meer rechtdoor lopen na het avondje feesten. Haar vriendin had de autosleutels maar afgenomen.\nWelk spreekwoord past hier het beste bij?\na. Iemand van de sokken rijden\nb. Boven zijn theewater zijn",
+  "label": "b"
+}
+```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset dutch-proverbs
+```
+
 ### Unofficial: INCLUDE-nl
 
 This dataset is part of [INCLUDE](https://doi.org/10.48550/arXiv.2411.19799), a

--- a/docs/datasets/dutch.md
+++ b/docs/datasets/dutch.md
@@ -777,6 +777,32 @@ Here are a few examples from the training split:
 }
 ```
 
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+
+- Prefix prompt:
+
+  ```text
+  Hieronder staan meerkeuzevragen (met antwoorden).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Vraag: {text}
+  Antwoord: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Vraag: {text}
+  
+  Beantwoord de bovenstaande vraag met {labels_str}, en niets anders.
+  ```
+
 You can evaluate this dataset directly as follows:
 
 ```bash

--- a/src/euroeval/dataset_configs/dutch.py
+++ b/src/euroeval/dataset_configs/dutch.py
@@ -127,6 +127,17 @@ DUTCH_COLA_FULL_CONFIG = DatasetConfig(
     unofficial=True,
 )
 
+DUTCH_PROVERBS_CONFIG = DatasetConfig(
+    name="dutch-proverbs",
+    pretty_name="Dutch proverbs",
+    source="EuroEval/dutch-proverbs",
+    task=KNOW,
+    languages=[DUTCH],
+    labels=["a", "b"],
+    val_split=None,
+    unofficial=True,
+)
+
 ARC_NL_CONFIG = DatasetConfig(
     name="arc-nl",
     pretty_name="ARC-nl",

--- a/src/euroeval/dataset_configs/dutch.py
+++ b/src/euroeval/dataset_configs/dutch.py
@@ -129,7 +129,7 @@ DUTCH_COLA_FULL_CONFIG = DatasetConfig(
 
 DUTCH_PROVERBS_CONFIG = DatasetConfig(
     name="dutch-proverbs",
-    pretty_name="Dutch proverbs",
+    pretty_name="Dutch Proverbs",
     source="EuroEval/dutch-proverbs",
     task=KNOW,
     languages=[DUTCH],

--- a/src/scripts/create_dutch_proverbs.py
+++ b/src/scripts/create_dutch_proverbs.py
@@ -1,0 +1,79 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets==3.5.0",
+#     "huggingface-hub==0.24.0",
+#     "requests==2.32.3",
+# ]
+# ///
+
+
+"""Create a Dutch proverbs dataset from the GPT-NL proverb dataset."""
+
+import random
+from typing import Any
+
+import datasets
+from huggingface_hub import HfApi
+from requests import HTTPError
+
+
+def main() -> None:
+    """Create the Dutch proverbs dataset and upload it to the HF Hub."""
+    # Define the base download URL
+    source_dataset_id = "GPT-NL/dutch-proverbs"
+    dataset_id_euroeval = "EuroEval/dutch-proverbs"
+
+    # Set a seed
+    random.seed(42)
+
+    # Download the dataset
+    dataset = datasets.load_dataset(source_dataset_id)
+
+    # format the questions for the benchmark
+    dataset = dataset.map(format, remove_columns=dataset["train"].column_names)
+
+    # remove the dataset from Hugging Face Hub if it already exists
+    try:
+        api = HfApi()
+        api.delete_repo(dataset_id_euroeval, repo_type="dataset", missing_ok=True)
+    except HTTPError:
+        pass
+
+    dataset.push_to_hub(dataset_id_euroeval, private=True)
+
+
+def format(row: dict[str, Any]) -> dict[str, str]:
+    """Format the dataset rows into promptable questions.
+
+    The question for the model is to evaluate which proverbs fits the
+    given sentence best.
+
+    Args:
+        row:
+            A row of the original dataset containing multiple columns
+
+    Returns:
+        A dict with the prepared question in `text` and the correct answer in `label`
+    """
+    text = f"Scenario: {row['scenario']}\n"
+    text += "Welk spreekwoord past hier het beste bij?\n"
+
+    # Avoid correct or incorrect proverb to always have the same label
+    if random.random() < 0.5:
+        option_a = row["correct_proverb"]
+        option_b = row["incorrect_proverb"]
+        label = "a"
+    else:
+        option_a = row["incorrect_proverb"]
+        option_b = row["correct_proverb"]
+        label = "b"
+
+    text += f"a. {option_a}\n"
+    text += f"b. {option_b}"
+
+    return {"text": text, "label": label}
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/create_dutch_proverbs.py
+++ b/src/scripts/create_dutch_proverbs.py
@@ -10,12 +10,11 @@
 
 """Create a Dutch proverbs dataset from the GPT-NL proverb dataset."""
 
-import random
-from typing import Any
-
 import datasets
+import random
 from huggingface_hub import HfApi
 from requests import HTTPError
+from typing import Any
 
 
 def main() -> None:


### PR DESCRIPTION
This PR adds a benchmark for the purpose of testing the knowledge of Dutch proverbs. The accompanying dataset was created in the context of the [GPT-NL project](https://gpt-nl.nl/).

The dataset consists of brief scenarios and two possible proverbs for the Large Language Model to select from. The dataset was created manually and reviewed by native Dutch speakers.