### PR TITLE
feat(evaluation-queue): skip oversized models via safetensors header

### DIFF
--- a/src/scripts/process_evaluation_queue.py
+++ b/src/scripts/process_evaluation_queue.py
@@ -43,6 +43,8 @@ from huggingface_hub.errors import (
     SafetensorsParsingError,
 )
 
+from euroeval.string_utils import split_model_id
+
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s"
 )
@@ -359,8 +361,9 @@ def estimated_model_bytes(model_id: str) -> int | None:
         The total weight bytes across all tensors, or None when the repo is
         not a safetensors repo or the metadata cannot be parsed.
     """
-    repo, _, revision = model_id.partition("@")
-    revision = revision or None
+    components = split_model_id(model_id=model_id)
+    repo = components.model_id
+    revision = components.revision
     token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_API_KEY")
     try:
         meta = get_safetensors_metadata(repo_id=repo, revision=revision, token=token)
@@ -376,15 +379,36 @@ def estimated_model_bytes(model_id: str) -> int | None:
 
     total = 0
     for dtype, count in meta.parameter_count.items():
-        bytes_per = DTYPE_BYTES.get(dtype.upper())
-        if bytes_per is None:
+        dtype_bits = _dtype_bits(dtype=dtype)
+        if dtype_bits is None:
             logger.debug(
                 f"Unknown safetensors dtype {dtype!r} for {model_id}; "
                 "assuming 2 bytes/param."
             )
-            bytes_per = 2
-        total += count * bytes_per
+            dtype_bits = 16
+        total += (count * dtype_bits + 7) // 8
     return total
+
+
+def _dtype_bits(dtype: str) -> int | None:
+    """Infer the number of bits used by a safetensors dtype string.
+
+    Args:
+        dtype:
+            The safetensors dtype string.
+
+    Returns:
+        The bit-width, or None when it cannot be inferred.
+    """
+    normalized_dtype = dtype.upper()
+    if normalized_dtype in DTYPE_BYTES:
+        return DTYPE_BYTES[normalized_dtype] * 8
+
+    for match in re.findall(pattern=r"\d+", string=normalized_dtype):
+        bits = int(match)
+        if bits > 0:
+            return bits
+    return None
 
 
 def process_issue(issue: dict, model_id: str, groups: list[str]) -> None:

--- a/src/scripts/process_evaluation_queue.py
+++ b/src/scripts/process_evaluation_queue.py
@@ -34,7 +34,14 @@ import urllib.parse
 import urllib.request
 from pathlib import Path
 
-from huggingface_hub import HfApi
+from huggingface_hub import HfApi, get_safetensors_metadata
+from huggingface_hub.errors import (
+    GatedRepoError,
+    HfHubHTTPError,
+    NotASafetensorsRepoError,
+    RepositoryNotFoundError,
+    SafetensorsParsingError,
+)
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s"
@@ -62,6 +69,31 @@ _WGERMANIC = "West Germanic languages (Dutch, English, German)"
 # The frontend parses this marker on issue bodies to display "Error" /
 # "Waiting for bug fix" statuses.
 ERROR_MARKER_RE = re.compile(r"<!--\s*errored-on:\s*v([^\s>-]+)\s*-->")
+
+# Bytes-per-parameter for each safetensors dtype string. Used to compute the
+# weight footprint of a model from its safetensors header before deciding
+# whether it can fit on the local GPU.
+DTYPE_BYTES: dict[str, int] = {
+    "F64": 8,
+    "I64": 8,
+    "U64": 8,
+    "F32": 4,
+    "I32": 4,
+    "U32": 4,
+    "F16": 2,
+    "BF16": 2,
+    "I16": 2,
+    "U16": 2,
+    "F8_E4M3": 1,
+    "F8_E5M2": 1,
+    "I8": 1,
+    "U8": 1,
+    "BOOL": 1,
+}
+
+# Multiplier applied to weight bytes to leave room for activations, KV cache,
+# and framework overhead when judging whether a model fits in GPU memory.
+GPU_FIT_OVERHEAD = 1.2
 
 
 LANGUAGE_GROUP_CODES: dict[str, list[str]] = {
@@ -130,12 +162,31 @@ def main() -> None:
     candidates.sort(key=lambda c: (c[0], c[1], c[2]))
     logger.info(f"Found {len(candidates)} processable issue(s).")
 
+    gpu_bytes = gpu_total_memory_bytes()
+    if gpu_bytes is None:
+        logger.info(
+            "Could not determine local GPU memory; skipping the GPU-fit pre-check."
+        )
+    else:
+        logger.info(f"Local GPU memory: {gpu_bytes / (1024**3):.1f} GiB.")
+
     for is_errored, param_count, num_groups, issue, model_id, groups in candidates:
         status = "retry of errored eval" if is_errored else "fresh"
         logger.info(
             f"#{issue['number']}: queueing {model_id!r} ({param_count} params, "
             f"{num_groups} group(s), {status})."
         )
+        if gpu_bytes is not None:
+            needed = estimated_model_bytes(model_id=model_id)
+            if needed is not None and int(needed * GPU_FIT_OVERHEAD) > gpu_bytes:
+                logger.info(
+                    f"#{issue['number']}: skipping -- model {model_id!r} needs "
+                    f"~{needed / (1024**3):.1f} GiB of weights "
+                    f"(× {GPU_FIT_OVERHEAD} overhead), which exceeds the local "
+                    f"GPU memory of {gpu_bytes / (1024**3):.1f} GiB. Leaving the "
+                    "issue unassigned so a larger machine can pick it up."
+                )
+                continue
         try:
             process_issue(issue=issue, model_id=model_id, groups=groups)
         except Exception as e:  # noqa: BLE001
@@ -254,6 +305,86 @@ def huggingface_param_count(info: object) -> int:
     if isinstance(total, int) and total > 0:
         return total
     return sys.maxsize
+
+
+def gpu_total_memory_bytes() -> int | None:
+    """Return the total memory of the largest local GPU in bytes.
+
+    Honors the ``EUROEVAL_GPU_MEMORY_BYTES`` env var for overrides (useful in
+    tests). Otherwise shells out to ``nvidia-smi`` and reports the largest
+    device on the host.
+
+    Returns:
+        The total memory in bytes, or None if it cannot be determined.
+    """
+    override = os.environ.get("EUROEVAL_GPU_MEMORY_BYTES")
+    if override:
+        try:
+            return int(override)
+        except ValueError:
+            logger.warning(f"Ignoring invalid EUROEVAL_GPU_MEMORY_BYTES={override!r}.")
+    try:
+        out = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=memory.total", "--format=csv,noheader,nounits"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+    values: list[int] = []
+    for line in out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            values.append(int(line))
+        except ValueError:
+            continue
+    if not values:
+        return None
+    return max(values) * 1024 * 1024  # nvidia-smi reports MiB
+
+
+def estimated_model_bytes(model_id: str) -> int | None:
+    """Estimate the weight footprint of a model in bytes.
+
+    Reads the safetensors header(s) so that quantised checkpoints (int8, fp8,
+    int4) are sized correctly rather than assumed to be fp16/bf16.
+
+    Args:
+        model_id:
+            The Hugging Face repo id, optionally suffixed with ``@<revision>``.
+
+    Returns:
+        The total weight bytes across all tensors, or None when the repo is
+        not a safetensors repo or the metadata cannot be parsed.
+    """
+    repo, _, revision = model_id.partition("@")
+    revision = revision or None
+    token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_API_KEY")
+    try:
+        meta = get_safetensors_metadata(repo_id=repo, revision=revision, token=token)
+    except (
+        NotASafetensorsRepoError,
+        SafetensorsParsingError,
+        RepositoryNotFoundError,
+        GatedRepoError,
+        HfHubHTTPError,
+    ) as e:
+        logger.debug(f"safetensors metadata unavailable for {model_id}: {e}")
+        return None
+
+    total = 0
+    for dtype, count in meta.parameter_count.items():
+        bytes_per = DTYPE_BYTES.get(dtype.upper())
+        if bytes_per is None:
+            logger.debug(
+                f"Unknown safetensors dtype {dtype!r} for {model_id}; "
+                "assuming 2 bytes/param."
+            )
+            bytes_per = 2
+        total += count * bytes_per
+    return total
 
 
 def process_issue(issue: dict, model_id: str, groups: list[str]) -> None:

--- a/tests/test_scripts/test_process_evaluation_queue.py
+++ b/tests/test_scripts/test_process_evaluation_queue.py
@@ -1,0 +1,76 @@
+"""Tests for process_evaluation_queue utilities."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.scripts import process_evaluation_queue
+
+
+@pytest.mark.parametrize(
+    argnames=["dtype", "count", "expected_bytes"],
+    argvalues=[
+        ("INT4", 3, 2),
+        ("custom_8", 9, 9),
+        ("something16_else", 1, 2),
+        ("unknown_dtype", 5, 10),
+    ],
+)
+def test_estimated_model_bytes_dtype_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    dtype: str,
+    count: int,
+    expected_bytes: int,
+) -> None:
+    """Unknown dtypes should use numeric fallback, then BF16 fallback."""
+
+    def fake_get_safetensors_metadata(
+        *, repo_id: str, revision: str | None = None, token: str | None = None
+    ) -> SimpleNamespace:
+        _ = repo_id, revision, token
+        return SimpleNamespace(parameter_count={dtype: count})
+
+    monkeypatch.setattr(
+        process_evaluation_queue,
+        "get_safetensors_metadata",
+        fake_get_safetensors_metadata,
+    )
+    bytes_needed = process_evaluation_queue.estimated_model_bytes(
+        model_id="org/model-name"
+    )
+    assert bytes_needed == expected_bytes
+
+
+@pytest.mark.parametrize(
+    argnames=["model_id"],
+    argvalues=[
+        ("org/model#low@rev",),
+        ("org/model@rev#low",),
+    ],
+)
+def test_estimated_model_bytes_handles_model_id_extras(
+    monkeypatch: pytest.MonkeyPatch, model_id: str
+) -> None:
+    """Model id parsing should handle # and @ in either order."""
+    calls: list[dict[str, str | None]] = []
+
+    def fake_get_safetensors_metadata(
+        *, repo_id: str, revision: str | None = None, token: str | None = None
+    ) -> SimpleNamespace:
+        calls.append(
+            {
+                "repo_id": repo_id,
+                "revision": revision,
+                "token": token,
+            }
+        )
+        return SimpleNamespace(parameter_count={"BF16": 1})
+
+    monkeypatch.setattr(
+        process_evaluation_queue,
+        "get_safetensors_metadata",
+        fake_get_safetensors_metadata,
+    )
+    assert process_evaluation_queue.estimated_model_bytes(model_id=model_id) == 2
+    assert calls[0]["repo_id"] == "org/model"
+    assert calls[0]["revision"] == "rev"


### PR DESCRIPTION
## Summary
- Reads each candidate model's safetensors header and computes dtype-aware weight bytes (handles int8/fp8/int4 correctly).
- Compares the estimate (× 1.2 overhead for activations/KV cache) against the local GPU memory reported by `nvidia-smi`.
- If the model is too large, the issue is left **unassigned** so a larger machine can pick it up — no status change, no comment.
- Pre-check is skipped silently when GPU memory cannot be determined or the repo is not safetensors, preserving today's behavior.
- `EUROEVAL_GPU_MEMORY_BYTES` env var overrides the detected value (useful in tests).

## Test plan
- [ ] Run on a machine without `nvidia-smi` → log says "Could not determine local GPU memory" and queue proceeds as before.
- [ ] Set `EUROEVAL_GPU_MEMORY_BYTES=1000000000` and run against a queue containing a 7B model → that issue is logged as skipped and left unassigned.
- [ ] Set `EUROEVAL_GPU_MEMORY_BYTES=100000000000` → queue proceeds to evaluate the model as before.
- [ ] Issue with a model that has no safetensors weights → log notes the metadata is unavailable and the issue is processed (no false skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)