### PR TITLE
feat(evaluation-queue): validate eval results before reporting success

### DIFF
--- a/src/scripts/process_evaluation_queue.py
+++ b/src/scripts/process_evaluation_queue.py
@@ -63,6 +63,24 @@ _WGERMANIC = "West Germanic languages (Dutch, English, German)"
 # "Waiting for bug fix" statuses.
 ERROR_MARKER_RE = re.compile(r"<!--\s*errored-on:\s*v([^\s>-]+)\s*-->")
 
+# Patterns we treat as OOM in the captured euroeval output. When any of these
+# match we leave the issue unassigned and unmarked so a larger machine can pick
+# it up, rather than recording a hard error on the issue.
+OOM_PATTERN = re.compile(
+    r"cuda out of memory"
+    r"|cuda error:?\s*out of memory"
+    r"|outofmemoryerror"
+    r"|torch\.cuda\.outofmemoryerror"
+    r"|hip out of memory"
+    r"|killed.*\(out of memory\)",
+    re.IGNORECASE,
+)
+
+# euroeval emits a summary line like "errored 3 benchmarks" when individual
+# (dataset, language) combinations fail without crashing the whole run. We use
+# this to detect partial failures even when the subprocess exited 0.
+ERRORED_BENCHMARKS_RE = re.compile(r"errored\s+(\d+)\s+benchmarks?", re.IGNORECASE)
+
 
 LANGUAGE_GROUP_CODES: dict[str, list[str]] = {
     _BALTIC: ["lv", "lt"],
@@ -277,28 +295,42 @@ def process_issue(issue: dict, model_id: str, groups: list[str]) -> None:
     assign_issue(number=number)
 
     before = set(read_jsonl_lines(path=RESULTS_PATH))
-    ok, error_output = run_euroeval(model_id=model_id, languages=languages)
+    returncode, output = run_euroeval(model_id=model_id, languages=languages)
     after = read_jsonl_lines(path=RESULTS_PATH)
     new_lines = [line for line in after if line not in before]
 
-    if not ok:
+    num_errored = num_errored_benchmarks(output=output)
+    crashed = returncode != 0
+    produced_nothing = not new_lines
+    partial = num_errored > 0
+    failed = crashed or produced_nothing or partial
+
+    if failed and OOM_PATTERN.search(output):
+        unassign_issue(number=number)
+        logger.info(
+            f"#{number}: OOM detected in euroeval output; returning issue to "
+            "queue without marking it errored."
+        )
+        return
+
+    if failed:
         version = euroeval_version()
+        if crashed:
+            reason = f"euroeval exited with code {returncode}"
+        elif produced_nothing:
+            reason = "euroeval produced no new result lines"
+        else:
+            reason = f"euroeval reported {num_errored} errored benchmark(s)"
+        tail = output[-6000:].strip() or "(no output captured)"
         comment = (
-            f"Error encountered during evaluation:\n\n"
-            f"```bash\n{error_output or '(no output captured)'}\n```\n\n"
+            f"Error encountered during evaluation ({reason}):\n\n"
+            f"```bash\n{tail}\n```\n\n"
             f"EuroEval version: v{version}\n"
         )
         comment_on_issue(number=number, comment=comment)
         set_errored_marker(number=number, body=issue.get("body"), version=version)
         unassign_issue(number=number)
         logger.info(f"#{number}: marked errored on v{version}, returned to queue.")
-        return
-
-    if not new_lines:
-        logger.warning(
-            f"#{number}: no new lines produced in {RESULTS_PATH} -- leaving "
-            f"issue assigned for manual inspection."
-        )
         return
 
     payload = "\n".join(new_lines)
@@ -354,8 +386,11 @@ def read_jsonl_lines(path: Path) -> list[str]:
     ]
 
 
-def run_euroeval(model_id: str, languages: list[str]) -> tuple[bool, str]:
+def run_euroeval(model_id: str, languages: list[str]) -> tuple[int, str]:
     """Run the euroeval CLI for the given model and language list.
+
+    Output is streamed live to stderr (so the operator can follow progress on
+    long evaluations) while also being captured for post-run inspection.
 
     Args:
         model_id:
@@ -364,31 +399,48 @@ def run_euroeval(model_id: str, languages: list[str]) -> tuple[bool, str]:
             ISO codes of the languages to pass via ``--language``.
 
     Returns:
-        A ``(success, captured_stderr)`` pair. ``captured_stderr`` is
-        populated with the tail of the subprocess's combined output when
-        the run fails, so it can be posted back to the issue.
+        A ``(returncode, combined_output)`` pair. The output combines stdout
+        and stderr in interleaved order. A returncode of 127 signals that the
+        CLI was not found on PATH.
     """
     cmd = ["euroeval", "--model", model_id]
     for lang in languages:
         cmd += ["--language", lang]
     logger.info(f"Running: {' '.join(cmd)}")
+
     try:
-        subprocess.run(cmd, check=True)
-        return True, ""
-    except subprocess.CalledProcessError as e:
-        # Re-run with capture so we have a stack trace to report. The first
-        # run already crashed, so this is at worst a second crash on the
-        # same input -- far cheaper than the eval itself.
-        captured = subprocess.run(  # noqa: S603
-            cmd, capture_output=True, text=True, check=False
+        proc = subprocess.Popen(  # noqa: S603
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1
         )
-        output = (captured.stderr or "") + (captured.stdout or "")
-        logger.error(f"euroeval failed (exit {e.returncode}) for {model_id}.")
-        # Keep only the last ~6 KiB so the comment doesn't blow up.
-        return False, output[-6000:].strip()
     except FileNotFoundError:
         logger.error("`euroeval` CLI not found on PATH. Is it installed?")
-        return False, "`euroeval` CLI not found on PATH."
+        return 127, "`euroeval` CLI not found on PATH."
+
+    assert proc.stdout is not None
+    captured: list[str] = []
+    for line in proc.stdout:
+        sys.stderr.write(line)
+        sys.stderr.flush()
+        captured.append(line)
+    proc.wait()
+    return proc.returncode, "".join(captured)
+
+
+def num_errored_benchmarks(output: str) -> int:
+    """Return the number of errored benchmarks parsed from euroeval output.
+
+    Args:
+        output:
+            The full captured combined-output of the euroeval subprocess.
+
+    Returns:
+        The integer reported by the last ``errored N benchmarks`` line, or 0
+        if no such line is present.
+    """
+    last = 0
+    for m in ERRORED_BENCHMARKS_RE.finditer(output):
+        last = int(m.group(1))
+    return last
 
 
 def comment_on_issue(number: int, comment: str) -> None:

--- a/src/scripts/process_evaluation_queue.py
+++ b/src/scripts/process_evaluation_queue.py
@@ -32,9 +32,13 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from functools import lru_cache
 from pathlib import Path
 
 from huggingface_hub import HfApi
+
+from euroeval.data_models import BenchmarkResult
+from euroeval.dataset_configs import get_all_dataset_configs
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s"
@@ -63,19 +67,6 @@ _WGERMANIC = "West Germanic languages (Dutch, English, German)"
 # "Waiting for bug fix" statuses.
 ERROR_MARKER_RE = re.compile(r"<!--\s*errored-on:\s*v([^\s>-]+)\s*-->")
 
-# Patterns we treat as OOM in the captured euroeval output. When any of these
-# match we leave the issue unassigned and unmarked so a larger machine can pick
-# it up, rather than recording a hard error on the issue.
-OOM_PATTERN = re.compile(
-    r"cuda out of memory"
-    r"|cuda error:?\s*out of memory"
-    r"|outofmemoryerror"
-    r"|torch\.cuda\.outofmemoryerror"
-    r"|hip out of memory"
-    r"|killed.*\(out of memory\)",
-    re.IGNORECASE,
-)
-
 # euroeval emits a summary line like "errored 3 benchmarks" when individual
 # (dataset, language) combinations fail without crashing the whole run. We use
 # this to detect partial failures even when the subprocess exited 0.
@@ -93,6 +84,25 @@ LANGUAGE_GROUP_CODES: dict[str, list[str]] = {
     "Greek": ["el"],
     "Hungarian": ["hu"],
 }
+
+
+@lru_cache(maxsize=1)
+def official_dataset_language_pairs() -> set[tuple[str, str]]:
+    """Return all official dataset/language pairs used by EuroEval."""
+    all_dataset_configs = get_all_dataset_configs(
+        custom_datasets_file=Path(""),
+        dataset_ids=[],
+        api_key=None,
+        cache_dir=Path(".cache"),
+        trust_remote_code=False,
+        run_with_cli=False,
+    )
+    return {
+        (dataset_config.name, language.code)
+        for dataset_config in all_dataset_configs.values()
+        if not dataset_config.unofficial
+        for language in dataset_config.languages
+    }
 
 
 def main() -> None:
@@ -300,18 +310,14 @@ def process_issue(issue: dict, model_id: str, groups: list[str]) -> None:
     new_lines = [line for line in after if line not in before]
 
     num_errored = num_errored_benchmarks(output=output)
+    missing_official = missing_official_dataset_language_pairs(
+        lines=new_lines, requested_languages=languages
+    )
     crashed = returncode != 0
     produced_nothing = not new_lines
     partial = num_errored > 0
-    failed = crashed or produced_nothing or partial
-
-    if failed and OOM_PATTERN.search(output):
-        unassign_issue(number=number)
-        logger.info(
-            f"#{number}: OOM detected in euroeval output; returning issue to "
-            "queue without marking it errored."
-        )
-        return
+    incomplete_official = bool(missing_official)
+    failed = crashed or produced_nothing or partial or incomplete_official
 
     if failed:
         version = euroeval_version()
@@ -319,6 +325,12 @@ def process_issue(issue: dict, model_id: str, groups: list[str]) -> None:
             reason = f"euroeval exited with code {returncode}"
         elif produced_nothing:
             reason = "euroeval produced no new result lines"
+        elif incomplete_official:
+            reason = (
+                "missing results for "
+                f"{len(missing_official)} official dataset-language pair(s): "
+                f"{format_dataset_language_pairs(dataset_language_pairs=missing_official)}"
+            )
         else:
             reason = f"euroeval reported {num_errored} errored benchmark(s)"
         tail = output[-6000:].strip() or "(no output captured)"
@@ -337,6 +349,41 @@ def process_issue(issue: dict, model_id: str, groups: list[str]) -> None:
     comment = f"Results for `{model_id}`:\n\n```jsonl\n{payload}\n```\n"
     comment_on_issue(number=number, comment=comment)
     logger.info(f"#{number}: posted {len(new_lines)} result line(s) as comment.")
+
+
+def missing_official_dataset_language_pairs(
+    lines: list[str], requested_languages: list[str]
+) -> set[tuple[str, str]]:
+    """Return missing official dataset/language pairs for the requested languages."""
+    expected_pairs = {
+        pair
+        for pair in official_dataset_language_pairs()
+        if pair[1] in set(requested_languages)
+    }
+    observed_pairs = result_dataset_language_pairs(lines=lines)
+    return expected_pairs - observed_pairs
+
+
+def result_dataset_language_pairs(lines: list[str]) -> set[tuple[str, str]]:
+    """Return dataset/language pairs parsed from benchmark-result JSONL lines."""
+    pairs: set[tuple[str, str]] = set()
+    for line in lines:
+        try:
+            parsed = BenchmarkResult.from_dict(config=json.loads(line))
+        except (TypeError, ValueError, json.JSONDecodeError):
+            continue
+        pairs.update((parsed.dataset, language) for language in parsed.languages)
+    return pairs
+
+
+def format_dataset_language_pairs(dataset_language_pairs: set[tuple[str, str]]) -> str:
+    """Return a compact stable string representation of dataset/language pairs."""
+    sorted_pairs = sorted(dataset_language_pairs)
+    preview = [f"{dataset}/{language}" for dataset, language in sorted_pairs[:10]]
+    suffix = ""
+    if len(sorted_pairs) > 10:
+        suffix = f" (+{len(sorted_pairs) - 10} more)"
+    return ", ".join(preview) + suffix
 
 
 def assign_issue(number: int) -> None:

--- a/tests/test_scripts/test_process_evaluation_queue.py
+++ b/tests/test_scripts/test_process_evaluation_queue.py
@@ -1,0 +1,126 @@
+"""Tests for scripts/process_evaluation_queue.py."""
+
+from pytest import MonkeyPatch
+
+from scripts import process_evaluation_queue as queue
+
+
+def test_process_issue_fails_when_official_results_are_missing(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The issue should be marked errored when official results are incomplete."""
+    comments: list[str] = []
+    marker_versions: list[str] = []
+    unassigned: list[int] = []
+    assigned: list[int] = []
+
+    lines_per_read = iter([["before"], ["before", '{"foo":"bar"}']])
+
+    monkeypatch.setattr(
+        target=queue, name="assign_issue", value=lambda number: assigned.append(number)
+    )
+    monkeypatch.setattr(
+        target=queue,
+        name="unassign_issue",
+        value=lambda number: unassigned.append(number),
+    )
+    monkeypatch.setattr(
+        target=queue,
+        name="read_jsonl_lines",
+        value=lambda path: next(lines_per_read, ["before"]),
+    )
+    monkeypatch.setattr(
+        target=queue,
+        name="run_euroeval",
+        value=lambda model_id, languages: (0, "all good"),
+    )
+    monkeypatch.setattr(
+        target=queue,
+        name="missing_official_dataset_language_pairs",
+        value=lambda lines, requested_languages: {("danish_ner", "da")},
+    )
+    monkeypatch.setattr(
+        target=queue, name="num_errored_benchmarks", value=lambda output: 0
+    )
+    monkeypatch.setattr(target=queue, name="euroeval_version", value=lambda: "99.0.0")
+    monkeypatch.setattr(
+        target=queue,
+        name="comment_on_issue",
+        value=lambda number, comment: comments.append(comment),
+    )
+    monkeypatch.setattr(
+        target=queue,
+        name="set_errored_marker",
+        value=lambda number, body, version: marker_versions.append(version),
+    )
+
+    queue.process_issue(
+        issue={"number": 17, "body": "body"},
+        model_id="foo/bar",
+        groups=[
+            "Scandinavian languages (Danish, Faroese, Icelandic, Norwegian, Swedish)"
+        ],
+    )
+
+    assert assigned == [17]
+    assert unassigned == [17]
+    assert marker_versions == ["99.0.0"]
+    assert len(comments) == 1
+    assert "missing results for 1 official dataset-language pair(s)" in comments[0]
+    assert "danish_ner/da" in comments[0]
+
+
+def test_process_issue_does_not_special_case_oom_anymore(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """OOM output should still be treated as a normal failure and commented."""
+    comments: list[str] = []
+    marker_versions: list[str] = []
+    unassigned: list[int] = []
+
+    lines_per_read = iter([["before"], ["before"]])
+
+    monkeypatch.setattr(target=queue, name="assign_issue", value=lambda number: None)
+    monkeypatch.setattr(
+        target=queue,
+        name="unassign_issue",
+        value=lambda number: unassigned.append(number),
+    )
+    monkeypatch.setattr(
+        target=queue,
+        name="read_jsonl_lines",
+        value=lambda path: next(lines_per_read, ["before"]),
+    )
+    monkeypatch.setattr(
+        target=queue,
+        name="run_euroeval",
+        value=lambda model_id, languages: (1, "RuntimeError: CUDA out of memory"),
+    )
+    monkeypatch.setattr(
+        target=queue,
+        name="missing_official_dataset_language_pairs",
+        value=lambda lines, requested_languages: set(),
+    )
+    monkeypatch.setattr(
+        target=queue, name="num_errored_benchmarks", value=lambda output: 0
+    )
+    monkeypatch.setattr(target=queue, name="euroeval_version", value=lambda: "99.0.0")
+    monkeypatch.setattr(
+        target=queue,
+        name="comment_on_issue",
+        value=lambda number, comment: comments.append(comment),
+    )
+    monkeypatch.setattr(
+        target=queue,
+        name="set_errored_marker",
+        value=lambda number, body, version: marker_versions.append(version),
+    )
+
+    queue.process_issue(
+        issue={"number": 42, "body": ""}, model_id="foo/bar", groups=["Greek"]
+    )
+
+    assert len(comments) == 1
+    assert "euroeval exited with code 1" in comments[0]
+    assert marker_versions == ["99.0.0"]
+    assert unassigned == [42]


### PR DESCRIPTION
## Summary
Most euroeval failures are caught internally and the subprocess exits 0, so the previous \`ok = returncode == 0\` check happily posted a comment even when no results were produced. This PR:

- Streams euroeval's combined output through stderr while also capturing it, preserving live progress.
- Treats a run as failed if the subprocess crashed, produced no new JSONL lines, or reported \`errored N benchmarks\` with N > 0.
- On failure, scans captured output for OOM patterns. If matched → return the issue to the queue unmarked (like #1705's pre-check).
- Otherwise → mark errored + post an error comment with the reason and the tail of captured output.

## Test plan
- [ ] Run against an issue where the eval succeeds → results comment posted as today.
- [ ] Force an OOM (e.g. set tiny GPU memory or run a huge model) → no comment, issue unassigned, log says "OOM detected … returning issue to queue".
- [ ] Force a non-OOM error (e.g. broken model) → error comment posted, \`errored-on:\` marker set, issue unassigned.
- [ ] Force a partial failure where some datasets error but euroeval exits 0 → treated as failure, error comment posted (not OOM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)