### PR TITLE
feat: cache HF Hub lookups to avoid rate limiting

### DIFF
--- a/src/euroeval/custom_dataset_configs.py
+++ b/src/euroeval/custom_dataset_configs.py
@@ -13,11 +13,50 @@ from types import ModuleType
 
 from huggingface_hub import HfApi
 
+from .caching_utils import cache_arguments
 from .data_models import DatasetConfig
 from .logging_utils import log_once
 from .split_utils import get_repo_splits
 from .utils import get_hf_token
 from .yaml_config import load_yaml_config
+
+
+@cache_arguments("dataset_id", "revision")
+def _list_repo_files(hf_api: HfApi, dataset_id: str, revision: str) -> list[str]:
+    """Cached wrapper around ``HfApi.list_repo_files`` for dataset repos.
+
+    Args:
+        hf_api:
+            The Hugging Face API client.
+        dataset_id:
+            The dataset repo id.
+        revision:
+            The git revision to list files from.
+
+    Returns:
+        The list of file paths in the dataset repo at ``revision``.
+    """
+    return list(
+        hf_api.list_repo_files(
+            repo_id=dataset_id, repo_type="dataset", revision=revision
+        )
+    )
+
+
+@cache_arguments("dataset_id")
+def _repo_exists(hf_api: HfApi, dataset_id: str) -> bool:
+    """Cached wrapper around ``HfApi.repo_exists`` for dataset repos.
+
+    Args:
+        hf_api:
+            The Hugging Face API client.
+        dataset_id:
+            The dataset repo id.
+
+    Returns:
+        True if the dataset repo exists on the Hub, otherwise False.
+    """
+    return hf_api.repo_exists(repo_id=dataset_id, repo_type="dataset")
 
 
 def load_custom_datasets_module(custom_datasets_file: Path) -> ModuleType | None:
@@ -91,12 +130,10 @@ def try_get_dataset_config_from_repo(
     """
     token = get_hf_token(api_key=api_key)
     hf_api = HfApi(token=token)
-    if not hf_api.repo_exists(repo_id=dataset_id, repo_type="dataset"):
+    if not _repo_exists(hf_api=hf_api, dataset_id=dataset_id):
         return None
 
-    repo_files = list(
-        hf_api.list_repo_files(repo_id=dataset_id, repo_type="dataset", revision="main")
-    )
+    repo_files = _list_repo_files(hf_api=hf_api, dataset_id=dataset_id, revision="main")
 
     if "eval.yaml" in repo_files:
         try:
@@ -146,9 +183,7 @@ def load_python_config(
     Returns:
         The dataset config if it exists, otherwise None.
     """
-    repo_files = list(
-        hf_api.list_repo_files(repo_id=dataset_id, repo_type="dataset", revision="main")
-    )
+    repo_files = _list_repo_files(hf_api=hf_api, dataset_id=dataset_id, revision="main")
 
     if "euroeval_config.py" not in repo_files:
         log_once(

--- a/src/euroeval/custom_dataset_configs.py
+++ b/src/euroeval/custom_dataset_configs.py
@@ -13,50 +13,12 @@ from types import ModuleType
 
 from huggingface_hub import HfApi
 
-from .caching_utils import cache_arguments
 from .data_models import DatasetConfig
+from .hf_hub_utils import _list_repo_files, _repo_exists
 from .logging_utils import log_once
 from .split_utils import get_repo_splits
 from .utils import get_hf_token
 from .yaml_config import load_yaml_config
-
-
-@cache_arguments("dataset_id", "revision")
-def _list_repo_files(hf_api: HfApi, dataset_id: str, revision: str) -> list[str]:
-    """Cached wrapper around ``HfApi.list_repo_files`` for dataset repos.
-
-    Args:
-        hf_api:
-            The Hugging Face API client.
-        dataset_id:
-            The dataset repo id.
-        revision:
-            The git revision to list files from.
-
-    Returns:
-        The list of file paths in the dataset repo at ``revision``.
-    """
-    return list(
-        hf_api.list_repo_files(
-            repo_id=dataset_id, repo_type="dataset", revision=revision
-        )
-    )
-
-
-@cache_arguments("dataset_id")
-def _repo_exists(hf_api: HfApi, dataset_id: str) -> bool:
-    """Cached wrapper around ``HfApi.repo_exists`` for dataset repos.
-
-    Args:
-        hf_api:
-            The Hugging Face API client.
-        dataset_id:
-            The dataset repo id.
-
-    Returns:
-        True if the dataset repo exists on the Hub, otherwise False.
-    """
-    return hf_api.repo_exists(repo_id=dataset_id, repo_type="dataset")
 
 
 def load_custom_datasets_module(custom_datasets_file: Path) -> ModuleType | None:

--- a/src/euroeval/hf_hub_utils.py
+++ b/src/euroeval/hf_hub_utils.py
@@ -1,0 +1,43 @@
+"""Cached wrappers around the Hugging Face Hub API."""
+
+from huggingface_hub import HfApi
+
+from .caching_utils import cache_arguments
+
+
+@cache_arguments("dataset_id", "revision")
+def _list_repo_files(hf_api: HfApi, dataset_id: str, revision: str) -> list[str]:
+    """Cached wrapper around ``HfApi.list_repo_files`` for dataset repos.
+
+    Args:
+        hf_api:
+            The Hugging Face API client.
+        dataset_id:
+            The dataset repo id.
+        revision:
+            The git revision to list files from.
+
+    Returns:
+        The list of file paths in the dataset repo at ``revision``.
+    """
+    return list(
+        hf_api.list_repo_files(
+            repo_id=dataset_id, repo_type="dataset", revision=revision
+        )
+    )
+
+
+@cache_arguments("dataset_id")
+def _repo_exists(hf_api: HfApi, dataset_id: str) -> bool:
+    """Cached wrapper around ``HfApi.repo_exists`` for dataset repos.
+
+    Args:
+        hf_api:
+            The Hugging Face API client.
+        dataset_id:
+            The dataset repo id.
+
+    Returns:
+        True if the dataset repo exists on the Hub, otherwise False.
+    """
+    return hf_api.repo_exists(repo_id=dataset_id, repo_type="dataset")

--- a/src/euroeval/split_utils.py
+++ b/src/euroeval/split_utils.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 from huggingface_hub import HfApi
 
+from .caching_utils import cache_arguments
+
 
 def find_split(splits: list[str], keyword: str) -> str | None:
     """Return the shortest split name containing `keyword`, or None.
@@ -22,6 +24,7 @@ def find_split(splits: list[str], keyword: str) -> str | None:
     return candidates[0] if candidates else None
 
 
+@cache_arguments("dataset_id")
 def get_repo_split_names(hf_api: HfApi, dataset_id: str) -> list[str] | None:
     """Extract split names from a Hugging Face dataset repo.
 

--- a/src/scripts/process_evaluation_queue.py
+++ b/src/scripts/process_evaluation_queue.py
@@ -49,6 +49,17 @@ RESULTS_PATH = Path(
     os.environ.get("EUROEVAL_RESULTS_PATH", "euroeval_benchmark_results.jsonl")
 )
 
+# On-disk cache for Hugging Face Hub lookups so that repeated runs of the
+# queue processor (e.g. on a cron) do not re-hit the API for the same models
+# and trip rate limits.
+HF_CACHE_PATH = Path(
+    os.environ.get(
+        "EUROEVAL_QUEUE_HF_CACHE",
+        str(Path.home() / ".cache" / "euroeval" / "queue_hf_cache.json"),
+    )
+)
+HF_CACHE_TTL_SECONDS = 6 * 60 * 60
+
 _BALTIC = "Baltic languages (Latvian, Lithuanian)"
 _FINNIC = "Finnic languages (Estonian, Finnish)"
 _ROMANCE = "Romance languages (Catalan, French, Italian, Portuguese, Romanian, Spanish)"
@@ -116,12 +127,12 @@ def main() -> None:
             )
             continue
 
-        info = huggingface_model_info(model_id=model_id)
-        if info is None:
+        summary = cached_model_summary(model_id=model_id)
+        if summary is None:
             logger.info(f"#{number}: skipping -- model {model_id!r} not on HF Hub.")
             continue
 
-        param_count = huggingface_param_count(info=info)
+        param_count = summary["param_count"]
         is_errored = 1 if errored_v is not None else 0
         candidates.append(
             (is_errored, param_count, len(groups), issue, model_id, groups)
@@ -217,43 +228,83 @@ def errored_on_version(body: str | None) -> str | None:
     return m.group(1) if m else None
 
 
-def huggingface_model_info(model_id: str) -> object | None:
-    """Return HF Hub metadata for ``model_id``, or None if unavailable.
+def _load_hf_cache() -> dict[str, dict]:
+    """Read the on-disk HF Hub lookup cache, or return an empty dict.
+
+    Stale or malformed entries are silently dropped so callers always see a
+    well-formed mapping of model id -> cache entry.
+
+    Returns:
+        A dict mapping model id to a cache entry containing at least
+        ``timestamp`` and ``param_count``.
+    """
+    try:
+        data = json.loads(HF_CACHE_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return dict()
+    if not isinstance(data, dict):
+        return dict()
+    now = time.time()
+    fresh: dict[str, dict] = dict()
+    for key, value in data.items():
+        if not isinstance(value, dict):
+            continue
+        ts = value.get("timestamp")
+        if not isinstance(ts, (int, float)) or now - ts > HF_CACHE_TTL_SECONDS:
+            continue
+        fresh[key] = value
+    return fresh
+
+
+def _write_hf_cache(cache: dict[str, dict]) -> None:
+    """Persist ``cache`` to ``HF_CACHE_PATH`` atomically.
+
+    Args:
+        cache:
+            The mapping of model id to cache entry to persist.
+    """
+    try:
+        HF_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        tmp = HF_CACHE_PATH.with_suffix(HF_CACHE_PATH.suffix + ".tmp")
+        tmp.write_text(json.dumps(cache, indent=2), encoding="utf-8")
+        tmp.replace(HF_CACHE_PATH)
+    except OSError as e:
+        logger.warning(f"Could not write HF cache to {HF_CACHE_PATH}: {e}")
+
+
+def cached_model_summary(model_id: str) -> dict | None:
+    """Return a cached ``{exists, param_count}`` summary for a HF model id.
+
+    Looks up ``HF_CACHE_PATH`` first and falls back to ``HfApi.model_info``
+    only on cache miss or stale entry. Negative results (model not found) are
+    not cached so that typo corrections take effect immediately.
 
     Args:
         model_id:
             The Hugging Face repo id to look up.
 
     Returns:
-        The ``ModelInfo`` object returned by ``HfApi``, or None when the
-        lookup fails for any reason.
+        A dict with keys ``param_count`` (int, possibly ``sys.maxsize`` for
+        unknown), or None when the model is not on the Hub.
     """
+    cache = _load_hf_cache()
+    entry = cache.get(model_id)
+    if entry is not None and "param_count" in entry:
+        return {"param_count": int(entry["param_count"])}
+
     try:
-        return HfApi().model_info(repo_id=model_id)
+        info = HfApi().model_info(repo_id=model_id)
     except Exception as e:  # noqa: BLE001
         logger.warning(f"HF model lookup failed for {model_id}: {e}")
         return None
 
-
-def huggingface_param_count(info: object) -> int:
-    """Return the model's parameter count, or a large fallback if unknown.
-
-    Falls back to ``sys.maxsize`` so that models with unknown size are
-    deprioritised by the queue sorter.
-
-    Args:
-        info:
-            The ``ModelInfo`` object returned by ``HfApi``.
-
-    Returns:
-        The total parameter count when present and positive, otherwise
-        ``sys.maxsize``.
-    """
     safetensors = getattr(info, "safetensors", None)
     total = getattr(safetensors, "total", None) if safetensors else None
-    if isinstance(total, int) and total > 0:
-        return total
-    return sys.maxsize
+    param_count = total if isinstance(total, int) and total > 0 else sys.maxsize
+
+    cache[model_id] = {"timestamp": time.time(), "param_count": param_count}
+    _write_hf_cache(cache=cache)
+    return {"param_count": param_count}
 
 
 def process_issue(issue: dict, model_id: str, groups: list[str]) -> None:


### PR DESCRIPTION
## Summary
The queue processor hit `HfApi.model_info()` once per candidate per run, so a chatty cron tripped HF's API limits. This PR adds caching at two levels:

**Queue processor (persistent):**
- New `cached_model_summary()` backed by `~/.cache/euroeval/queue_hf_cache.json` (path overridable via `EUROEVAL_QUEUE_HF_CACHE`).
- 6-hour TTL for positive results; negatives are not cached so typo corrections take effect immediately.
- Replaces `huggingface_model_info()` + `huggingface_param_count()` in the main loop.

**Package (in-process):**
- `cache_arguments(\"dataset_id\")` on `get_repo_split_names`.
- Cached wrappers `_list_repo_files` and `_repo_exists` in `custom_dataset_configs.py`, eliminating duplicate Hub calls when loading custom datasets across many (dataset, model) combinations in one run.

## Test plan
- [ ] Run the queue twice in quick succession against the same backlog → second run has no HF traffic for already-seen models (verify via `pip install responses` or by checking the cache file).
- [ ] `rm ~/.cache/euroeval/queue_hf_cache.json` → next run repopulates it.
- [ ] Edit a queue issue's model id from a typo to a real one → still resolves on the next run (negatives not cached).
- [ ] Run a benchmark touching a single custom HF dataset across multiple models → HF dataset lookups happen exactly once for that dataset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)