### PR TITLE
fix: frontend leaderboard and queue UI improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ generative = [
     "vllm-metal; platform_system == 'Darwin'",
     # vLLM setup for Linux (assuming CUDA is available here)
     "bitsandbytes>=0.43.1; platform_system == 'Linux'",
-    "vllm[flashinfer]>=0.21.0; platform_system == 'Linux'",
+    "vllm>=0.21.0; platform_system == 'Linux'",
     "ray>=2.53.0; platform_system == 'Linux'",
 ]
 all = [
@@ -65,7 +65,7 @@ all = [
     "vllm-metal; platform_system == 'Darwin'",
     # vLLM setup for Linux (assuming CUDA is available here)
     "bitsandbytes>=0.43.1; platform_system == 'Linux'",
-    "vllm[flashinfer]>=0.21.0; platform_system == 'Linux'",
+    "vllm>=0.21.0; platform_system == 'Linux'",
     "ray>=2.53.0; platform_system == 'Linux'",
 ]
 leaderboards = [

--- a/src/frontend/components/EvaluationQueueView.vue
+++ b/src/frontend/components/EvaluationQueueView.vue
@@ -46,7 +46,13 @@ onMounted(refresh);
       </p>
 
       <ModelSubmitForm @submitted="onSubmitted" />
+    </div>
 
+    <div class="sidebar">
+      <HallOfFame />
+    </div>
+
+    <div class="queue-wrap">
       <QueueTable
         :entries="entries"
         :loading="loading"
@@ -54,10 +60,6 @@ onMounted(refresh);
         @refresh="refresh"
         @subscribe="onSubscribe"
       />
-    </div>
-
-    <div class="sidebar">
-      <HallOfFame />
     </div>
 
     <SubscribeRedirectModal
@@ -73,15 +75,25 @@ onMounted(refresh);
   max-width: 1200px;
   display: grid;
   grid-template-columns: minmax(0, 1fr) 260px;
-  gap: 2rem;
+  grid-template-areas:
+    "main sidebar"
+    "queue sidebar";
+  column-gap: 2rem;
   align-items: start;
 }
 
 .main {
+  grid-area: main;
+  min-width: 0;
+}
+
+.queue-wrap {
+  grid-area: queue;
   min-width: 0;
 }
 
 .sidebar {
+  grid-area: sidebar;
   position: sticky;
   top: 8rem;
   max-height: calc(100vh - 9rem);
@@ -104,10 +116,17 @@ h1 {
 @media (max-width: 900px) {
   .eq-view {
     grid-template-columns: 1fr;
+    grid-template-areas:
+      "main"
+      "sidebar"
+      "queue";
+    row-gap: 1.5rem;
   }
 
   .sidebar {
     position: static;
+    max-height: none;
+    overflow-y: visible;
   }
 }
 </style>

--- a/src/frontend/components/LeaderboardScatter.vue
+++ b/src/frontend/components/LeaderboardScatter.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 import type { LeaderboardTable } from "@/leaderboard";
 
 const props = defineProps<{
@@ -299,11 +299,39 @@ const hoverPos = ref<{ x: number; y: number; flipX: boolean; flipY: boolean }>({
   flipY: false,
 });
 
+// On touch/coarse-pointer devices we show a minimal tooltip (model ID only),
+// triggered by tap, and dismissed by tapping anywhere else.
+const isCoarsePointer = ref(false);
+let coarseMq: MediaQueryList | null = null;
+const onCoarseChange = (e: MediaQueryListEvent) => {
+  isCoarsePointer.value = e.matches;
+};
+const onDocPointerDown = (e: PointerEvent) => {
+  if (!hovered.value) return;
+  const target = e.target as Element | null;
+  if (target && target.closest(".point")) return;
+  hovered.value = null;
+};
+
+onMounted(() => {
+  if (typeof window === "undefined" || !window.matchMedia) return;
+  coarseMq = window.matchMedia("(pointer: coarse)");
+  isCoarsePointer.value = coarseMq.matches;
+  coarseMq.addEventListener?.("change", onCoarseChange);
+  document.addEventListener("pointerdown", onDocPointerDown);
+});
+
+onBeforeUnmount(() => {
+  coarseMq?.removeEventListener?.("change", onCoarseChange);
+  if (typeof document !== "undefined") {
+    document.removeEventListener("pointerdown", onDocPointerDown);
+  }
+});
+
 const TOOLTIP_W = 280; // approximate, kept in sync with .tooltip max-width
 const TOOLTIP_H = 240; // generous; the actual height depends on meta length
 
-const onMove = (e: MouseEvent, p: Point) => {
-  hovered.value = p;
+const positionFromEvent = (e: { clientX: number; clientY: number; currentTarget: EventTarget | null }, w: number, h: number) => {
   const target = e.currentTarget as SVGElement;
   const svg = target.ownerSVGElement as SVGSVGElement;
   const rect = svg.getBoundingClientRect();
@@ -312,22 +340,41 @@ const onMove = (e: MouseEvent, p: Point) => {
   hoverPos.value = {
     x,
     y,
-    // If there isn't room to the right of the cursor, anchor to its left.
-    flipX: x + 24 + TOOLTIP_W > rect.width,
-    flipY: y + 24 + TOOLTIP_H > rect.height,
+    flipX: x + 24 + w > rect.width,
+    flipY: y + 24 + h > rect.height,
   };
 };
 
+const onMove = (e: MouseEvent, p: Point) => {
+  if (isCoarsePointer.value) return;
+  hovered.value = p;
+  positionFromEvent(e, TOOLTIP_W, TOOLTIP_H);
+};
+
 const onLeave = () => {
+  if (isCoarsePointer.value) return;
   hovered.value = null;
+};
+
+const onPointClick = (e: MouseEvent, p: Point) => {
+  if (!isCoarsePointer.value) return;
+  if (hovered.value === p) {
+    hovered.value = null;
+    return;
+  }
+  hovered.value = p;
+  // Smaller tooltip on mobile — only the model line is shown.
+  positionFromEvent(e, 200, 40);
 };
 
 const tooltipStyle = computed(() => {
   const x = hoverPos.value.x;
   const y = hoverPos.value.y;
+  const w = isCoarsePointer.value ? 200 : TOOLTIP_W;
+  const h = isCoarsePointer.value ? 40 : TOOLTIP_H;
   return {
-    left: hoverPos.value.flipX ? `${Math.max(0, x - TOOLTIP_W - 12)}px` : `${x + 12}px`,
-    top: hoverPos.value.flipY ? `${Math.max(0, y - TOOLTIP_H - 12)}px` : `${y + 12}px`,
+    left: hoverPos.value.flipX ? `${Math.max(0, x - w - 12)}px` : `${x + 12}px`,
+    top: hoverPos.value.flipY ? `${Math.max(0, y - h - 12)}px` : `${y + 12}px`,
   };
 });
 </script>
@@ -480,6 +527,7 @@ const tooltipStyle = computed(() => {
               class="point"
               @mousemove="onMove($event, p)"
               @mouseleave="onLeave"
+              @click.stop="onPointClick($event, p)"
             />
             <circle
               v-else
@@ -490,6 +538,7 @@ const tooltipStyle = computed(() => {
               class="point"
               @mousemove="onMove($event, p)"
               @mouseleave="onLeave"
+              @click.stop="onPointClick($event, p)"
             />
           </template>
         </g>
@@ -498,21 +547,24 @@ const tooltipStyle = computed(() => {
       <div
         v-if="hovered"
         class="tooltip"
+        :class="{ compact: isCoarsePointer }"
         :style="tooltipStyle"
       >
         <div class="tt-model">{{ hovered.icon }} {{ hovered.label }}</div>
-        <div class="tt-row">
-          <span class="tt-label">Mean rank</span>
-          <span class="tt-value">{{ hovered.y.toFixed(2) }}</span>
-        </div>
-        <div class="tt-row">
-          <span class="tt-label">Kind</span>
-          <span class="tt-value">{{ KIND_LABEL[hovered.kind] }}</span>
-        </div>
-        <div v-for="m in hovered.meta" :key="m.label" class="tt-row">
-          <span class="tt-label">{{ m.label }}</span>
-          <span class="tt-value">{{ m.value }}</span>
-        </div>
+        <template v-if="!isCoarsePointer">
+          <div class="tt-row">
+            <span class="tt-label">Mean rank</span>
+            <span class="tt-value">{{ hovered.y.toFixed(2) }}</span>
+          </div>
+          <div class="tt-row">
+            <span class="tt-label">Kind</span>
+            <span class="tt-value">{{ KIND_LABEL[hovered.kind] }}</span>
+          </div>
+          <div v-for="m in hovered.meta" :key="m.label" class="tt-row">
+            <span class="tt-label">{{ m.label }}</span>
+            <span class="tt-value">{{ m.value }}</span>
+          </div>
+        </template>
       </div>
     </div>
   </div>
@@ -657,6 +709,20 @@ const tooltipStyle = computed(() => {
   width: 280px;
   max-width: calc(100% - 24px);
   z-index: 5;
+}
+
+.tooltip.compact {
+  width: auto;
+  max-width: calc(100% - 24px);
+  padding: 0.35rem 0.55rem;
+}
+
+.tooltip.compact .tt-model {
+  margin-bottom: 0;
+  border-bottom: 0;
+  padding-bottom: 0;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .tt-model {

--- a/src/frontend/components/LeaderboardTable.vue
+++ b/src/frontend/components/LeaderboardTable.vue
@@ -367,7 +367,7 @@ const reportBadEval = (modelId: string) => {
                 </span>
               </template>
               <input
-                v-else-if="i === 0"
+                v-else-if="col.key.toLowerCase() === 'model'"
                 v-model="colFilters[col.key]"
                 type="search"
                 class="lb-filter"

--- a/src/frontend/components/LeaderboardTable.vue
+++ b/src/frontend/components/LeaderboardTable.vue
@@ -325,14 +325,16 @@ const reportBadEval = (modelId: string) => {
       <button class="lb-reset" type="button" @click="resetFilters">
         Reset filters
       </button>
-      <div class="lb-pageinfo">
-        Page
-        <select v-model.number="page" aria-label="Page">
-          <option v-for="n in pageCount" :key="n" :value="n">{{ n }}</option>
-        </select>
-        of {{ pageCount }} · {{ sortedRows.length }} rows
+      <div class="lb-toolbar-right">
+        <slot name="actions" />
+        <div class="lb-pageinfo">
+          Page
+          <select v-model.number="page" aria-label="Page">
+            <option v-for="n in pageCount" :key="n" :value="n">{{ n }}</option>
+          </select>
+          of {{ pageCount }} · {{ sortedRows.length }} rows
+        </div>
       </div>
-      <slot name="actions" />
     </div>
 
     <div class="lb-scroll">
@@ -506,10 +508,17 @@ const reportBadEval = (modelId: string) => {
   background: var(--color-border);
 }
 
+.lb-toolbar-right {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
 .lb-pageinfo {
   color: var(--color-muted);
   font-size: 0.8rem;
-  margin-left: auto;
 }
 
 .lb-pageinfo select {

--- a/src/frontend/components/LeaderboardTable.vue
+++ b/src/frontend/components/LeaderboardTable.vue
@@ -332,6 +332,7 @@ const reportBadEval = (modelId: string) => {
         </select>
         of {{ pageCount }} · {{ sortedRows.length }} rows
       </div>
+      <slot name="actions" />
     </div>
 
     <div class="lb-scroll">

--- a/src/frontend/components/LeaderboardTable.vue
+++ b/src/frontend/components/LeaderboardTable.vue
@@ -533,11 +533,11 @@ const reportBadEval = (modelId: string) => {
   height: 44px;
 }
 
-/* First column (Model) stays left-aligned; widen it so long model IDs
-   fit on a single line. The table itself scrolls horizontally inside
-   `.lb-scroll` when the total column width exceeds the container. */
-.lb-table th:first-child,
-.lb-table td:first-child {
+/* Model column stays left-aligned; widen it so long model IDs fit on a
+   single line. The table itself scrolls horizontally inside `.lb-scroll`
+   when the total column width exceeds the container. */
+.lb-table th.kind-model,
+.lb-table td.kind-model {
   text-align: left;
   min-width: 360px;
   white-space: nowrap;

--- a/src/frontend/components/LeaderboardTable.vue
+++ b/src/frontend/components/LeaderboardTable.vue
@@ -219,6 +219,21 @@ const scoreHeatmapStyle = (
 const isHeatmapScoreCol = (col: Column): boolean =>
   props.heatmapScoreCols && col.kind === "score";
 
+// On multilingual leaderboards, the per-language columns are rank-like
+// (1 = best). Identify them as numeric columns that aren't one of the
+// fixed metadata columns.
+const NON_LANGUAGE_NUMBER_COLS = new Set([
+  "rank",
+  "parameters",
+  "vocabulary",
+  "context",
+  "european values",
+]);
+const isLanguageRankCol = (col: Column): boolean =>
+  props.heatmapScoreCols &&
+  col.kind === "number" &&
+  !NON_LANGUAGE_NUMBER_COLS.has(col.key.toLowerCase());
+
 const toggleSort = (idx: number) => {
   if (sortBy.value?.index === idx) {
     sortBy.value =
@@ -404,7 +419,7 @@ const reportBadEval = (modelId: string) => {
                 isTickCrossCol(table.columns[ci]) ? `cell-tc ${tickCrossClass(cell.text)}` : '',
               ]"
               :style="
-                isRankCol(table.columns[ci])
+                isRankCol(table.columns[ci]) || isLanguageRankCol(table.columns[ci])
                   ? rankHeatmapStyle(cell)
                   : isHeatmapScoreCol(table.columns[ci])
                     ? scoreHeatmapStyle(cell, table.columns[ci])

--- a/src/frontend/components/LeaderboardView.vue
+++ b/src/frontend/components/LeaderboardView.vue
@@ -168,38 +168,6 @@ const downloadCsv = async () => {
       >
         {{ t.label }}
       </button>
-      <div class="lb-actions">
-      <button
-        v-if="tab === 'generative' || tab === 'all_models'"
-        class="lb-download"
-        type="button"
-        :disabled="downloading"
-        :title="`Download ${activeStem}.csv`"
-        @click="downloadCsv"
-      >
-        <svg viewBox="0 0 16 16" aria-hidden="true">
-          <path
-            fill="currentColor"
-            d="M8 1.5a.75.75 0 0 1 .75.75v6.69l2.22-2.22a.75.75 0 1 1 1.06 1.06l-3.5 3.5a.75.75 0 0 1-1.06 0l-3.5-3.5a.75.75 0 1 1 1.06-1.06l2.22 2.22V2.25A.75.75 0 0 1 8 1.5zM2.75 12a.75.75 0 0 1 .75.75v1.25c0 .14.11.25.25.25h8.5c.14 0 .25-.11.25-.25v-1.25a.75.75 0 1 1 1.5 0v1.25c0 .97-.78 1.75-1.75 1.75h-8.5A1.75 1.75 0 0 1 2 14V12.75A.75.75 0 0 1 2.75 12z"
-          />
-        </svg>
-        {{ downloading ? "Downloading…" : "Download CSV" }}
-      </button>
-      <button
-        class="lb-embed"
-        type="button"
-        title="Embed this leaderboard on another site"
-        @click="embedOpen = true"
-      >
-        <svg viewBox="0 0 16 16" aria-hidden="true">
-          <path
-            fill="currentColor"
-            d="M4.78 5.22a.75.75 0 0 1 0 1.06L3.06 8l1.72 1.72a.75.75 0 1 1-1.06 1.06L1.47 8.53a.75.75 0 0 1 0-1.06L3.72 5.22a.75.75 0 0 1 1.06 0zm6.44 0a.75.75 0 0 1 1.06 0l2.25 2.25a.75.75 0 0 1 0 1.06l-2.25 2.25a.75.75 0 1 1-1.06-1.06L12.94 8l-1.72-1.72a.75.75 0 0 1 0-1.06zM9.55 2.04a.75.75 0 0 1 .41.98l-3 8a.75.75 0 1 1-1.4-.53l3-8a.75.75 0 0 1 .99-.45z"
-          />
-        </svg>
-        Embed
-      </button>
-      </div>
     </nav>
 
     <div v-if="embedOpen" class="embed-modal" @click.self="embedOpen = false">
@@ -235,6 +203,37 @@ const downloadCsv = async () => {
     <div v-else-if="error" class="lb-status error">{{ error }}</div>
     <template v-else>
       <template v-if="tab === 'generative' || tab === 'all_models'">
+        <div class="lb-actions">
+          <button
+            class="lb-download"
+            type="button"
+            :disabled="downloading"
+            :title="`Download ${activeStem}.csv`"
+            @click="downloadCsv"
+          >
+            <svg viewBox="0 0 16 16" aria-hidden="true">
+              <path
+                fill="currentColor"
+                d="M8 1.5a.75.75 0 0 1 .75.75v6.69l2.22-2.22a.75.75 0 1 1 1.06 1.06l-3.5 3.5a.75.75 0 0 1-1.06 0l-3.5-3.5a.75.75 0 1 1 1.06-1.06l2.22 2.22V2.25A.75.75 0 0 1 8 1.5zM2.75 12a.75.75 0 0 1 .75.75v1.25c0 .14.11.25.25.25h8.5c.14 0 .25-.11.25-.25v-1.25a.75.75 0 1 1 1.5 0v1.25c0 .97-.78 1.75-1.75 1.75h-8.5A1.75 1.75 0 0 1 2 14V12.75A.75.75 0 0 1 2.75 12z"
+              />
+            </svg>
+            {{ downloading ? "Downloading…" : "Download CSV" }}
+          </button>
+          <button
+            class="lb-embed"
+            type="button"
+            title="Embed this leaderboard on another site"
+            @click="embedOpen = true"
+          >
+            <svg viewBox="0 0 16 16" aria-hidden="true">
+              <path
+                fill="currentColor"
+                d="M4.78 5.22a.75.75 0 0 1 0 1.06L3.06 8l1.72 1.72a.75.75 0 1 1-1.06 1.06L1.47 8.53a.75.75 0 0 1 0-1.06L3.72 5.22a.75.75 0 0 1 1.06 0zm6.44 0a.75.75 0 0 1 1.06 0l2.25 2.25a.75.75 0 0 1 0 1.06l-2.25 2.25a.75.75 0 1 1-1.06-1.06L12.94 8l-1.72-1.72a.75.75 0 0 1 0-1.06zM9.55 2.04a.75.75 0 0 1 .41.98l-3 8a.75.75 0 1 1-1.4-.53l3-8a.75.75 0 0 1 .99-.45z"
+              />
+            </svg>
+            Embed
+          </button>
+        </div>
         <LeaderboardTable
           v-if="activeTable"
           :table="activeTable"
@@ -358,11 +357,11 @@ const downloadCsv = async () => {
 }
 
 .lb-actions {
-  margin-left: auto;
-  display: inline-flex;
+  display: flex;
+  justify-content: flex-end;
   align-items: center;
   gap: 0.4rem;
-  align-self: center;
+  margin-top: 0.5rem;
 }
 
 .lb-embed svg {

--- a/src/frontend/components/LeaderboardView.vue
+++ b/src/frontend/components/LeaderboardView.vue
@@ -203,42 +203,43 @@ const downloadCsv = async () => {
     <div v-else-if="error" class="lb-status error">{{ error }}</div>
     <template v-else>
       <template v-if="tab === 'generative' || tab === 'all_models'">
-        <div class="lb-actions">
-          <button
-            class="lb-download"
-            type="button"
-            :disabled="downloading"
-            :title="`Download ${activeStem}.csv`"
-            @click="downloadCsv"
-          >
-            <svg viewBox="0 0 16 16" aria-hidden="true">
-              <path
-                fill="currentColor"
-                d="M8 1.5a.75.75 0 0 1 .75.75v6.69l2.22-2.22a.75.75 0 1 1 1.06 1.06l-3.5 3.5a.75.75 0 0 1-1.06 0l-3.5-3.5a.75.75 0 1 1 1.06-1.06l2.22 2.22V2.25A.75.75 0 0 1 8 1.5zM2.75 12a.75.75 0 0 1 .75.75v1.25c0 .14.11.25.25.25h8.5c.14 0 .25-.11.25-.25v-1.25a.75.75 0 1 1 1.5 0v1.25c0 .97-.78 1.75-1.75 1.75h-8.5A1.75 1.75 0 0 1 2 14V12.75A.75.75 0 0 1 2.75 12z"
-              />
-            </svg>
-            {{ downloading ? "Downloading…" : "Download CSV" }}
-          </button>
-          <button
-            class="lb-embed"
-            type="button"
-            title="Embed this leaderboard on another site"
-            @click="embedOpen = true"
-          >
-            <svg viewBox="0 0 16 16" aria-hidden="true">
-              <path
-                fill="currentColor"
-                d="M4.78 5.22a.75.75 0 0 1 0 1.06L3.06 8l1.72 1.72a.75.75 0 1 1-1.06 1.06L1.47 8.53a.75.75 0 0 1 0-1.06L3.72 5.22a.75.75 0 0 1 1.06 0zm6.44 0a.75.75 0 0 1 1.06 0l2.25 2.25a.75.75 0 0 1 0 1.06l-2.25 2.25a.75.75 0 1 1-1.06-1.06L12.94 8l-1.72-1.72a.75.75 0 0 1 0-1.06zM9.55 2.04a.75.75 0 0 1 .41.98l-3 8a.75.75 0 1 1-1.4-.53l3-8a.75.75 0 0 1 .99-.45z"
-              />
-            </svg>
-            Embed
-          </button>
-        </div>
         <LeaderboardTable
           v-if="activeTable"
           :table="activeTable"
           :heatmap-score-cols="isMultilingual"
-        />
+        >
+          <template #actions>
+            <button
+              class="lb-download"
+              type="button"
+              :disabled="downloading"
+              :title="`Download ${activeStem}.csv`"
+              @click="downloadCsv"
+            >
+              <svg viewBox="0 0 16 16" aria-hidden="true">
+                <path
+                  fill="currentColor"
+                  d="M8 1.5a.75.75 0 0 1 .75.75v6.69l2.22-2.22a.75.75 0 1 1 1.06 1.06l-3.5 3.5a.75.75 0 0 1-1.06 0l-3.5-3.5a.75.75 0 1 1 1.06-1.06l2.22 2.22V2.25A.75.75 0 0 1 8 1.5zM2.75 12a.75.75 0 0 1 .75.75v1.25c0 .14.11.25.25.25h8.5c.14 0 .25-.11.25-.25v-1.25a.75.75 0 1 1 1.5 0v1.25c0 .97-.78 1.75-1.75 1.75h-8.5A1.75 1.75 0 0 1 2 14V12.75A.75.75 0 0 1 2.75 12z"
+                />
+              </svg>
+              {{ downloading ? "Downloading…" : "Download CSV" }}
+            </button>
+            <button
+              class="lb-embed"
+              type="button"
+              title="Embed this leaderboard on another site"
+              @click="embedOpen = true"
+            >
+              <svg viewBox="0 0 16 16" aria-hidden="true">
+                <path
+                  fill="currentColor"
+                  d="M4.78 5.22a.75.75 0 0 1 0 1.06L3.06 8l1.72 1.72a.75.75 0 1 1-1.06 1.06L1.47 8.53a.75.75 0 0 1 0-1.06L3.72 5.22a.75.75 0 0 1 1.06 0zm6.44 0a.75.75 0 0 1 1.06 0l2.25 2.25a.75.75 0 0 1 0 1.06l-2.25 2.25a.75.75 0 1 1-1.06-1.06L12.94 8l-1.72-1.72a.75.75 0 0 1 0-1.06zM9.55 2.04a.75.75 0 0 1 .41.98l-3 8a.75.75 0 1 1-1.4-.53l3-8a.75.75 0 0 1 .99-.45z"
+                />
+              </svg>
+              Embed
+            </button>
+          </template>
+        </LeaderboardTable>
         <div v-else class="lb-status">
           This leaderboard variant has no data.
         </div>
@@ -354,14 +355,6 @@ const downloadCsv = async () => {
   align-items: center;
   gap: 0.35rem;
   align-self: center;
-}
-
-.lb-actions {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  gap: 0.4rem;
-  margin-top: 0.5rem;
 }
 
 .lb-embed svg {

--- a/src/frontend/components/QueueTable.vue
+++ b/src/frontend/components/QueueTable.vue
@@ -1,20 +1,73 @@
 <script setup lang="ts">
 import { type QueueEntry } from "@/services/github";
 
-function displayLanguages(groups: string[]): string {
-  const langs: string[] = [];
-  for (const g of groups) {
-    const parenIndex = g.indexOf("(");
-    if (parenIndex !== -1) {
-      const inside = g.slice(parenIndex + 1).replace(")", "");
-      const parts = inside.split(",").map((s) => s.trim());
-      langs.push(...parts);
-    }
+const CATALAN_FLAG =
+  "<img src='data:image/svg+xml;utf8,<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 27 18\"><path fill=\"%23FCDD09\" d=\"M0 0h27v18H0z\"/><path fill=\"%23DA121A\" d=\"M0 2h27v2H0zM0 6h27v2H0zM0 10h27v2H0zM0 14h27v2H0z\"/></svg>' alt='Catalan' title='Catalan' style='height:0.9em;vertical-align:-0.05em;display:inline-block'>";
+
+const FLAGS: Record<string, string> = {
+  Albanian: "🇦🇱",
+  Belarusian: "🇧🇾",
+  Bosnian: "🇧🇦",
+  Bulgarian: "🇧🇬",
+  Catalan: CATALAN_FLAG,
+  Croatian: "🇭🇷",
+  Czech: "🇨🇿",
+  Danish: "🇩🇰",
+  Dutch: "🇳🇱",
+  English: "🇬🇧",
+  Estonian: "🇪🇪",
+  Faroese: "🇫🇴",
+  Finnish: "🇫🇮",
+  French: "🇫🇷",
+  German: "🇩🇪",
+  Greek: "🇬🇷",
+  Hungarian: "🇭🇺",
+  Icelandic: "🇮🇸",
+  Italian: "🇮🇹",
+  Latvian: "🇱🇻",
+  Lithuanian: "🇱🇹",
+  Norwegian: "🇳🇴",
+  Polish: "🇵🇱",
+  Portuguese: "🇵🇹",
+  Romanian: "🇷🇴",
+  Serbian: "🇷🇸",
+  Slovak: "🇸🇰",
+  Slovenian: "🇸🇮",
+  Spanish: "🇪🇸",
+  Swedish: "🇸🇪",
+  Ukrainian: "🇺🇦",
+};
+
+function languagesFromGroup(group: string): string[] {
+  const parenIndex = group.indexOf("(");
+  if (parenIndex !== -1) {
+    const inside = group.slice(parenIndex + 1).replace(")", "");
+    return inside.split(",").map((s) => s.trim());
   }
-  if (langs.length === 0) return "—"
-  return langs.sort((a, b) => a.localeCompare(b)).join(", ");
+  return [group.trim()];
 }
 
+function flagFor(language: string): string {
+  const flag = FLAGS[language];
+  if (flag) {
+    if (flag.startsWith("<")) return flag;
+    return `<span title="${language}">${flag}</span>`;
+  }
+  return language;
+}
+
+function displayLanguages(groups: string[]): string {
+  const langs = new Set<string>();
+  for (const g of groups) {
+    for (const l of languagesFromGroup(g)) langs.add(l);
+  }
+  if (langs.size === 0) return "—";
+  if (langs.size >= Object.keys(FLAGS).length) return "All languages";
+  return Array.from(langs)
+    .sort((a, b) => a.localeCompare(b))
+    .map(flagFor)
+    .join(" ");
+}
 function statusClass(status: string): string {
   return status.toLowerCase().replace(/\s+/g, "-");
 }
@@ -64,7 +117,7 @@ const emit = defineEmits<{
           </td>
           <td class="lg">
             <span v-if="e.languageGroups.length === 0" class="muted">—</span>
-            <span v-else>{{ displayLanguages(e.languageGroups) }}</span>
+            <span v-else v-html="displayLanguages(e.languageGroups)"></span>
           </td>
           <td style="text-align: center">
             <span

--- a/src/frontend/components/QueueTable.vue
+++ b/src/frontend/components/QueueTable.vue
@@ -98,9 +98,9 @@ const emit = defineEmits<{
       <thead>
         <tr>
           <th>Model</th>
-          <th>Languages</th>
+          <th class="lang-col">Languages</th>
           <th class="status-col" style="text-align: center">Status</th>
-          <th style="text-align: center">Evaluator</th>
+          <th class="evaluator-col" style="text-align: center">Evaluator</th>
           <th class="sub-col"></th>
         </tr>
       </thead>
@@ -115,7 +115,7 @@ const emit = defineEmits<{
               {{ e.modelId }}
             </a>
           </td>
-          <td class="lg">
+          <td class="lg lang-col">
             <span v-if="e.languageGroups.length === 0" class="muted">—</span>
             <span v-else v-html="displayLanguages(e.languageGroups)"></span>
           </td>
@@ -133,7 +133,7 @@ const emit = defineEmits<{
               {{ e.status }}
             </span>
           </td>
-          <td style="text-align: center">
+          <td class="evaluator-col" style="text-align: center">
             <a
               v-if="e.evaluator"
               :href="`https://github.com/${e.evaluator}`"
@@ -270,6 +270,33 @@ th.status-col {
   padding: 1.5rem 0;
   color: var(--color-text-muted, #777);
   text-align: center;
+}
+
+@media (max-width: 640px) {
+  .qtable th.lang-col,
+  .qtable td.lang-col,
+  .qtable th.evaluator-col,
+  .qtable td.evaluator-col {
+    display: none;
+  }
+
+  .qtable {
+    font-size: 0.85rem;
+  }
+
+  .qtable th,
+  .qtable td {
+    padding: 0.5rem 0.35rem;
+  }
+
+  th.status-col {
+    min-width: 0;
+  }
+
+  .subscribe {
+    padding: 0.25rem 0.45rem;
+    font-size: 0.75rem;
+  }
 }
 
 .msg.error {

--- a/src/frontend/leaderboard.ts
+++ b/src/frontend/leaderboard.ts
@@ -155,9 +155,8 @@ const parseNumberSafe = (s: string): number | null => {
 /**
  * Parse a single cell, given the column's inferred kind.
  */
-// Collapse the partial-open-source tick into the standard tick: we no longer
-// distinguish "fully open source" from "open-weight only", just open-weight
-// vs. closed.
+// Older CSVs may still carry the partial-open-source tick. The backend now
+// emits a plain boolean tick/cross, but normalize on read for forward compat.
 const normalizeIconText = (s: string): string => (s === "(✓)" ? "✓" : s);
 
 export function parseCell(raw: string, kind: CellKind): ParsedCell {
@@ -295,8 +294,7 @@ export function parseLeaderboard(csvText: string): LeaderboardTable {
     let titleHtml = sanitizeHtml(rawTitle);
     const sampleValues = dataRows.map((r) => r[idx] ?? "");
     const kind = inferKind(title, sampleValues);
-    // Rename the "Open" column to "Open-weight" — we no longer distinguish
-    // fully open-source from open-weight-only.
+    // Display the boolean "Open" column as "Open-weight".
     if (title.toLowerCase() === "open") {
       titleHtml = titleHtml.replace(/Open/i, "Open-weight");
       title = "Open-weight";

--- a/src/frontend/leaderboard.ts
+++ b/src/frontend/leaderboard.ts
@@ -317,50 +317,16 @@ export function parseLeaderboard(csvText: string): LeaderboardTable {
     .filter(({ c }) => c.kind !== "version")
     .map(({ i }) => i);
 
-  let visibleColumns = visibleColIndexes.map((i) => columns[i]);
+  const visibleColumns = visibleColIndexes.map((i) => columns[i]);
 
-  // Parse cells.
-  let parsedRows: Row[] = dataRows
+  // Parse cells. Column order follows the CSV (ground truth).
+  const parsedRows: Row[] = dataRows
     .filter((r) => r.length > 1 && stripTags(r[0]).trim() !== "")
     .map((r) => ({
       cells: visibleColIndexes.map((i) =>
         parseCell(r[i] ?? "", columns[i].kind),
       ),
     }));
-
-  // Reorder columns so the high-signal filter columns sit together near the
-  // left, before the more variable per-task / per-language score columns.
-  // Model stays first (it has special styling); everything not explicitly
-  // ranked here keeps its original relative order.
-  const PRIORITY_ORDER: string[] = [
-    "model",
-    "rank",
-    "european values",
-    "commercial",
-    "merge",
-    "open-weight",
-    "trained from scratch",
-    "parameters",
-    "vocabulary",
-    "context",
-  ];
-  const priorityIndex = (col: Column): number => {
-    const idx = PRIORITY_ORDER.indexOf(col.key.toLowerCase());
-    return idx === -1 ? PRIORITY_ORDER.length : idx;
-  };
-  const reorder = visibleColumns
-    .map((col, idx) => ({ col, idx }))
-    .sort((a, b) => {
-      const pa = priorityIndex(a.col);
-      const pb = priorityIndex(b.col);
-      if (pa !== pb) return pa - pb;
-      return a.idx - b.idx;
-    })
-    .map(({ idx }) => idx);
-  visibleColumns = reorder.map((i) => visibleColumns[i]);
-  parsedRows = parsedRows.map((r) => ({
-    cells: reorder.map((i) => r.cells[i]),
-  }));
 
   // Augment columns with min/max + distinct values.
   for (let c = 0; c < visibleColumns.length; c++) {

--- a/src/leaderboards/cache.py
+++ b/src/leaderboards/cache.py
@@ -91,7 +91,7 @@ class Cache:
             model_id: str = record["model"]
             if (match := re.search(r">(.+?)<", record["model"])) is not None:
                 model_id = match.group(1)
-            model_id = model_id.split("@")[0]
+            model_id = model_id.split("@")[0].split("#")[0]
             if "generative_type" in record:
                 cache.generative_type[model_id] = record["generative_type"]
             if "merge" in record:

--- a/src/leaderboards/cache.py
+++ b/src/leaderboards/cache.py
@@ -29,8 +29,8 @@ class Cache:
         anchor_tag:
             A mapping from model IDs to their anchor tag.
         open:
-            A mapping from model IDs to their openness status
-            (open-source, open-weight, or closed-source).
+            A mapping from model IDs to whether they are open (open-weight) or
+            closed.
         trained_from_scratch:
             A mapping from model IDs to whether they were trained from scratch.
     """
@@ -39,7 +39,7 @@ class Cache:
     merge: dict[str, bool] = field(default_factory=dict)
     commercially_licensed: dict[str, bool] = field(default_factory=dict)
     anchor_tag: dict[str, str] = field(default_factory=dict)
-    open: dict[str, str] = field(default_factory=dict)
+    open: dict[str, bool] = field(default_factory=dict)
     trained_from_scratch: dict[str, bool] = field(default_factory=dict)
 
     @classmethod
@@ -101,7 +101,10 @@ class Cache:
             if "commercially_licensed" in record:
                 cache.commercially_licensed[model_id] = record["commercially_licensed"]
             if "open" in record:
-                cache.open[model_id] = record["open"]
+                value = record["open"]
+                if isinstance(value, str):
+                    value = value in {"open-source", "open-weight"}
+                cache.open[model_id] = value
             if "trained_from_scratch" in record:
                 cache.trained_from_scratch[model_id] = record["trained_from_scratch"]
             if record["model"].startswith("<a href="):

--- a/src/leaderboards/cache.py
+++ b/src/leaderboards/cache.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 from tqdm.auto import tqdm
 
+from euroeval.string_utils import split_model_id
+
 logger = logging.getLogger(__name__)
 
 
@@ -91,7 +93,7 @@ class Cache:
             model_id: str = record["model"]
             if (match := re.search(r">(.+?)<", record["model"])) is not None:
                 model_id = match.group(1)
-            model_id = model_id.split("@")[0].split("#")[0]
+            model_id = split_model_id(model_id=model_id).model_id
             if "generative_type" in record:
                 cache.generative_type[model_id] = record["generative_type"]
             if "merge" in record:

--- a/src/leaderboards/leaderboard_generation.py
+++ b/src/leaderboards/leaderboard_generation.py
@@ -498,9 +498,9 @@ def generate_dataframe(
             ["generative_type", "model", "rank"]
             + orthogonal_cols
             + [
-                "open",
                 "commercial",
                 "merge",
+                "open",
                 "trained_from_scratch",
                 "parameters",
                 "vocabulary_size",
@@ -572,9 +572,9 @@ def generate_dataframe(
                 "generative_type",
                 "model",
                 "rank",
-                "open",
                 "commercial",
                 "merge",
+                "open",
                 "trained_from_scratch",
                 "parameters",
                 "vocabulary_size",

--- a/src/leaderboards/leaderboard_generation.py
+++ b/src/leaderboards/leaderboard_generation.py
@@ -495,9 +495,10 @@ def generate_dataframe(
             if dataset not in category_to_orthogonal_datasets[category]
         ]
         cols = (
-            ["generative_type", "model", "rank"]
+            ["model", "rank"]
             + orthogonal_cols
             + [
+                "generative_type",
                 "open",
                 "commercial",
                 "merge",
@@ -569,9 +570,9 @@ def generate_dataframe(
         df_simplified = df.copy()
         df_simplified = df[
             [
-                "generative_type",
                 "model",
                 "rank",
+                "generative_type",
                 "open",
                 "commercial",
                 "merge",

--- a/src/leaderboards/leaderboard_generation.py
+++ b/src/leaderboards/leaderboard_generation.py
@@ -534,13 +534,9 @@ def generate_dataframe(
             )
 
         # Replace Boolean values by ✓ and ✗
-        boolean_columns = ["commercial", "merge"]
+        boolean_columns = ["commercial", "merge", "open"]
         for col in boolean_columns:
             df[col] = df[col].apply(lambda x: "✓" if x else "✗")
-
-        # Convert open values to symbols
-        open_mapping = {"open-source": "✓", "open-weight": "(✓)", "closed-source": "✗"}
-        df["open"] = df["open"].map(open_mapping)
 
         # Convert trained_from_scratch values to symbols
         trained_mapping = {True: "✓", False: "✗"}

--- a/src/leaderboards/leaderboard_generation.py
+++ b/src/leaderboards/leaderboard_generation.py
@@ -495,16 +495,16 @@ def generate_dataframe(
             if dataset not in category_to_orthogonal_datasets[category]
         ]
         cols = (
-            ["model", "generative_type", "rank"]
+            ["generative_type", "model", "rank"]
             + orthogonal_cols
             + [
+                "open",
+                "commercial",
+                "merge",
+                "trained_from_scratch",
                 "parameters",
                 "vocabulary_size",
                 "context",
-                "commercial",
-                "merge",
-                "open",
-                "trained_from_scratch",
             ]
             + rank_cols[1:]
         )
@@ -573,16 +573,16 @@ def generate_dataframe(
         df_simplified = df.copy()
         df_simplified = df[
             [
-                "model",
                 "generative_type",
+                "model",
                 "rank",
+                "open",
+                "commercial",
+                "merge",
+                "trained_from_scratch",
                 "parameters",
                 "vocabulary_size",
                 "context",
-                "commercial",
-                "merge",
-                "open",
-                "trained_from_scratch",
             ]
         ]
         df_simplified = df_simplified.query(  # pyrefly: ignore[not-callable]

--- a/src/leaderboards/leaderboard_generation.py
+++ b/src/leaderboards/leaderboard_generation.py
@@ -498,9 +498,9 @@ def generate_dataframe(
             ["generative_type", "model", "rank"]
             + orthogonal_cols
             + [
+                "open",
                 "commercial",
                 "merge",
-                "open",
                 "trained_from_scratch",
                 "parameters",
                 "vocabulary_size",
@@ -572,9 +572,9 @@ def generate_dataframe(
                 "generative_type",
                 "model",
                 "rank",
+                "open",
                 "commercial",
                 "merge",
-                "open",
                 "trained_from_scratch",
                 "parameters",
                 "vocabulary_size",

--- a/src/leaderboards/result_processing.py
+++ b/src/leaderboards/result_processing.py
@@ -400,11 +400,11 @@ def is_trained_from_scratch(
             cache.trained_from_scratch[model_id] = value
         return value
 
-    # Check if model is open or closed-source
+    # Check if model is open or closed
     model_openness = cache.open.get(model_id)
 
-    # For closed-source models, auto-return "scratch" without prompting
-    if model_openness == "closed-source":
+    # For closed models, auto-return "scratch" without prompting
+    if model_openness is False:
         cache.trained_from_scratch[model_id] = True
         return True
 
@@ -414,7 +414,7 @@ def is_trained_from_scratch(
     ):
         return True
 
-    # For open/open-weight models, prompt user
+    # For open models, prompt user
     while True:
         msg = f"Was {model_id!r} trained from scratch? "
         if "/" in model_id:
@@ -480,8 +480,8 @@ def is_merge(record: dict, cache: Cache) -> bool:
     return has_merge_tag
 
 
-def is_open(record: dict, cache: Cache) -> str:
-    """Determine if a model is open-source, open-weight, or closed-source.
+def is_open(record: dict, cache: Cache) -> bool:
+    """Determine if a model is open (open-weight) or closed.
 
     Args:
         record:
@@ -490,8 +490,7 @@ def is_open(record: dict, cache: Cache) -> str:
             The cache.
 
     Returns:
-        The openness status of the model: "open-source", "open-weight", or
-        "closed-source".
+        Whether the model is open (open-weight). Closed models return False.
     """
     # If model ID is anchor tag, extract the actual model ID
     model_id = record["model"]
@@ -521,30 +520,19 @@ def is_open(record: dict, cache: Cache) -> str:
             cache.open[model_id] = value
         return value
 
-    # Assume closed-source if not found on HF Hub
+    # Assume closed if not found on HF Hub
     try:
         api = HfApi()
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=UserWarning)
             api.model_info(repo_id=model_id)
     except (RepositoryNotFoundError, HFValidationError):
-        cache.open[model_id] = "closed-source"
-        return "closed-source"
+        cache.open[model_id] = False
+        return False
 
-    # Ask user if it's open-source or open-weight
-    while True:
-        msg = f"Is {model_id!r} open-source [s] or open-weight [w]?"
-        if "/" in model_id:
-            msg += f" (https://hf.co/{model_id})"
-        msg += " [s/w] "
-        user_input = input(msg)
-        if user_input.lower() in {"open-source", "open source", "s"}:
-            cache.open[model_id] = "open-source"
-            return "open-source"
-        if user_input.lower() in {"open-weight", "open weight", "w"}:
-            cache.open[model_id] = "open-weight"
-            return "open-weight"
-        logger.error("Invalid input. Please try again.")
+    # Models found on the HF Hub are open-weight
+    cache.open[model_id] = True
+    return True
 
 
 def record_is_valid(

--- a/src/scripts/process_evaluation_queue.py
+++ b/src/scripts/process_evaluation_queue.py
@@ -228,7 +228,30 @@ def acquire_single_instance_lock() -> None:
     _LOCK_FD = fd
 
 
+QUEUE_PASS_SLEEP_SECONDS = 60 * 60
+
+
 def main() -> None:
+    """Process the queue forever, sleeping one hour between passes.
+
+    Credentials and the single-instance lock are acquired once for the
+    lifetime of the process, then :func:`process_queue_once` runs in a loop.
+    """
+    ensure_credentials()
+
+    # Held for the lifetime of the process; released by the kernel on exit.
+    acquire_single_instance_lock()
+
+    while True:
+        process_queue_once()
+        logger.info(
+            f"Queue pass complete; sleeping {QUEUE_PASS_SLEEP_SECONDS}s "
+            "before next pass."
+        )
+        time.sleep(QUEUE_PASS_SLEEP_SECONDS)
+
+
+def process_queue_once() -> None:
     """Process every unassigned model-evaluation-request issue once.
 
     Issues are sorted by (status priority asc, parameter count asc,
@@ -237,16 +260,11 @@ def main() -> None:
     errored evaluations, so that quicker work is picked up first and gated
     items are surfaced ahead of errored ones.
     """
-    ensure_credentials()
-
-    # Held for the lifetime of the process; released by the kernel on exit.
-    acquire_single_instance_lock()
-
     try:
         issues = list_open_unassigned_issues()
     except urllib.error.HTTPError as e:
         logger.error(f"Failed to list issues: {e}")
-        sys.exit(1)
+        return
 
     current_version = euroeval_version()
     current_v = version_tuple(v=current_version)
@@ -732,7 +750,13 @@ def process_issue(issue: dict, model_id: str, groups: list[str]) -> None:
             f"```bash\n{tail}\n```\n\n"
             f"EuroEval version: v{version}\n"
         )
-        comment_on_issue(number=number, comment=comment)
+        if issue_has_matching_error_comment(number=number, reason=reason):
+            logger.info(
+                f"#{number}: identical error already posted; "
+                "skipping duplicate comment."
+            )
+        else:
+            comment_on_issue(number=number, comment=comment)
         set_errored_marker(number=number, body=issue.get("body"), version=version)
         add_failed_label(number=number)
         unassign_issue(number=number)
@@ -939,6 +963,7 @@ def run_euroeval(model_id: str, languages: list[str]) -> tuple[int, str]:
     logger.info(f"Running: {' '.join(cmd)}")
 
     env = os.environ.copy()
+    env["FULL_LOG"] = "1"
     token = resolve_hf_token()
     if token:
         env.setdefault("HF_TOKEN", token)
@@ -982,6 +1007,38 @@ def num_errored_benchmarks(output: str) -> int:
     for m in ERRORED_BENCHMARKS_RE.finditer(output):
         last = int(m.group(1))
     return last
+
+
+def issue_has_matching_error_comment(number: int, reason: str) -> bool:
+    """Return True if an error comment with the same ``reason`` already exists.
+
+    The tail of subprocess output varies run-to-run (timestamps, ANSI),
+    so we match on the stable error-reason phrase rendered in the comment
+    header instead of doing an exact-body comparison.
+
+    Args:
+        number:
+            The issue number to inspect.
+        reason:
+            The reason string that would be used in a new error comment.
+
+    Returns:
+        True if any existing comment on the issue contains the same
+        ``Error encountered during evaluation (<reason>):`` header.
+    """
+    try:
+        comments = gh_request(
+            path=f"/repos/{REPO}/issues/{number}/comments", params={"per_page": "100"}
+        )
+    except urllib.error.HTTPError as e:
+        logger.warning(f"#{number}: could not list comments: {e}")
+        return False
+    if not isinstance(comments, list):
+        return False
+    marker = f"Error encountered during evaluation ({reason}):"
+    return any(
+        isinstance(c, dict) and marker in (c.get("body") or "") for c in comments
+    )
 
 
 def comment_on_issue(number: int, comment: str) -> None:

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -1,7 +1,6 @@
 """Tests for the `model_loading` module."""
 
 import os
-import sys
 from pathlib import Path
 from shutil import rmtree
 
@@ -39,8 +38,7 @@ def test_load_non_generative_model(
 
 
 @pytest.mark.skipif(
-    condition=sys.platform == "linux" and not torch.cuda.is_available(),
-    reason="Running on Ubuntu but no CUDA available",
+    condition=torch.cuda.is_available() is False, reason="CUDA not available"
 )
 def test_load_generative_model(
     generative_model_id: str, benchmark_config: BenchmarkConfig

--- a/uv.lock
+++ b/uv.lock
@@ -1157,8 +1157,8 @@ requires-dist = [
     { name = "tqdm", marker = "extra == 'leaderboards'", specifier = ">=4.66.0" },
     { name = "vllm", marker = "sys_platform == 'darwin' and extra == 'all'", git = "https://github.com/vllm-project/vllm.git?tag=v0.18.1" },
     { name = "vllm", marker = "sys_platform == 'darwin' and extra == 'generative'", git = "https://github.com/vllm-project/vllm.git?tag=v0.18.1" },
-    { name = "vllm", extras = ["flashinfer"], marker = "sys_platform == 'linux' and extra == 'all'", specifier = ">=0.21.0" },
-    { name = "vllm", extras = ["flashinfer"], marker = "sys_platform == 'linux' and extra == 'generative'", specifier = ">=0.21.0" },
+    { name = "vllm", marker = "sys_platform == 'linux' and extra == 'all'", specifier = ">=0.21.0" },
+    { name = "vllm", marker = "sys_platform == 'linux' and extra == 'generative'", specifier = ">=0.21.0" },
     { name = "vllm-metal", marker = "sys_platform == 'darwin' and extra == 'all'", git = "https://github.com/vllm-project/vllm-metal.git?tag=v0.1.0-20260404-164341" },
     { name = "vllm-metal", marker = "sys_platform == 'darwin' and extra == 'generative'", git = "https://github.com/vllm-project/vllm-metal.git?tag=v0.1.0-20260404-164341" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -218,15 +218,6 @@ wheels = [
 ]
 
 [[package]]
-name = "astdoc"
-version = "1.3.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ff/30/59731db1342957b1d035b16c515c75aeb0b3111159838e58e7a68256745a/astdoc-1.3.2.tar.gz", hash = "sha256:adcc6a5cecdbd23ea25b095bd3ebb183c2c73fae03499c3d8e0ae932d73e8bb2", size = 39697, upload-time = "2025-08-22T23:03:46.428Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/c2/b90bfe4fd68d5baf2ea7514f62bfd0c8ad20820a433d696a0dd49b13f08a/astdoc-1.3.2-py3-none-any.whl", hash = "sha256:68d4c19fbb9e78d9acde21806d9688ec403c9a5a87f09ec4695d8ad607df2056", size = 43440, upload-time = "2025-08-22T23:03:45.257Z" },
-]
-
-[[package]]
 name = "astor"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -242,29 +233,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
-]
-
-[[package]]
-name = "babel"
-version = "2.18.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
-]
-
-[[package]]
-name = "backrefs"
-version = "6.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/a6/e325ec73b638d3ede4421b5445d4a0b8b219481826cc079d510100af356c/backrefs-6.2.tar.gz", hash = "sha256:f44ff4d48808b243b6c0cdc6231e22195c32f77046018141556c66f8bab72a49", size = 7012303, upload-time = "2026-02-16T19:10:15.828Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/39/3765df263e08a4df37f4f43cb5aa3c6c17a4bdd42ecfe841e04c26037171/backrefs-6.2-py310-none-any.whl", hash = "sha256:0fdc7b012420b6b144410342caeb8adc54c6866cf12064abc9bb211302e496f8", size = 381075, upload-time = "2026-02-16T19:10:04.322Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/f0/35240571e1b67ffb19dafb29ab34150b6f59f93f717b041082cdb1bfceb1/backrefs-6.2-py311-none-any.whl", hash = "sha256:08aa7fae530c6b2361d7bdcbda1a7c454e330cc9dbcd03f5c23205e430e5c3be", size = 392874, upload-time = "2026-02-16T19:10:06.314Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/63/77e8c9745b4d227cce9f5e0a6f68041278c5f9b18588b35905f5f19c1beb/backrefs-6.2-py312-none-any.whl", hash = "sha256:c3f4b9cb2af8cda0d87ab4f57800b57b95428488477be164dd2b47be54db0c90", size = 398787, upload-time = "2026-02-16T19:10:08.274Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/71/c754b1737ad99102e03fa3235acb6cb6d3ac9d6f596cbc3e5f236705abd8/backrefs-6.2-py313-none-any.whl", hash = "sha256:12df81596ab511f783b7d87c043ce26bc5b0288cf3bb03610fe76b8189282b2b", size = 400747, upload-time = "2026-02-16T19:10:09.791Z" },
-    { url = "https://files.pythonhosted.org/packages/af/75/be12ba31a6eb20dccef2320cd8ccb3f7d9013b68ba4c70156259fee9e409/backrefs-6.2-py314-none-any.whl", hash = "sha256:e5f805ae09819caa1aa0623b4a83790e7028604aa2b8c73ba602c4454e665de7", size = 412602, upload-time = "2026-02-16T19:10:12.317Z" },
-    { url = "https://files.pythonhosted.org/packages/21/f8/d02f650c47d05034dcd6f9c8cf94f39598b7a89c00ecda0ecb2911bc27e9/backrefs-6.2-py39-none-any.whl", hash = "sha256:664e33cd88c6840b7625b826ecf2555f32d491800900f5a541f772c485f7cda7", size = 381077, upload-time = "2026-02-16T19:10:13.74Z" },
 ]
 
 [[package]]
@@ -352,15 +320,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/45/d1/a848ed8e8d4e236b9b16381768c9ae99d92890c24886bb4505aa9c3d2033/blake3-1.0.8-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2c3151955efb09ba58cd3e1263521e15e9e3866a40d6bd3556d86fc968e8f95", size = 386150, upload-time = "2025-10-14T06:47:10.363Z" },
     { url = "https://files.pythonhosted.org/packages/96/09/e3eb5d60f97c01de23d9f434e6e1fc117efb466eaa1f6ddbbbcb62580d6e/blake3-1.0.8-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:5eb25bca3cee2e0dd746a214784fb36be6a43640c01c55b6b4e26196e72d076c", size = 549120, upload-time = "2025-10-14T06:47:11.713Z" },
     { url = "https://files.pythonhosted.org/packages/14/ad/3d9661c710febb8957dd685fdb3e5a861aa0ac918eda3031365ce45789e2/blake3-1.0.8-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:ab4e1dea4fa857944944db78e8f20d99ee2e16b2dea5a14f514fb0607753ac83", size = 553264, upload-time = "2025-10-14T06:47:13.317Z" },
-]
-
-[[package]]
-name = "bracex"
-version = "2.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
 ]
 
 [[package]]
@@ -1124,7 +1083,6 @@ dev = [
     { name = "cryptography", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
     { name = "debugpy", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
     { name = "lxml", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
-    { name = "mkapi", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
     { name = "nbstripout", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
     { name = "pip", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
     { name = "pre-commit", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
@@ -1214,7 +1172,6 @@ dev = [
     { name = "cryptography", specifier = ">=44.0.0" },
     { name = "debugpy", specifier = ">=1.8.13" },
     { name = "lxml", specifier = ">=5.1.0" },
-    { name = "mkapi", specifier = ">=3.0.22" },
     { name = "nbstripout", specifier = ">=0.7.1" },
     { name = "pip", specifier = ">=24.3.1" },
     { name = "pre-commit", specifier = ">=4.5.1" },
@@ -1646,18 +1603,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3f/26/7622a41c39db9d7090225a4bf8368550e59694dcf7313b44f9a82b501209/gguf-0.18.0.tar.gz", hash = "sha256:b4659093d5d0dccdb5902a904d54b327f4052879fe5e90946ad5fce9f8018c2e", size = 107170, upload-time = "2026-02-27T15:05:39.254Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/0c/e0f1eae7535a97476fb903f65301e35da2a66182b8161066b7eb312b2cb8/gguf-0.18.0-py3-none-any.whl", hash = "sha256:af93f7ef198a265cbde5fa6a6b3101528bca285903949ab0a3e591cd993a1864", size = 114244, upload-time = "2026-02-27T15:05:37.991Z" },
-]
-
-[[package]]
-name = "ghp-import"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "python-dateutil", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
 ]
 
 [[package]]
@@ -2420,15 +2365,6 @@ wheels = [
 ]
 
 [[package]]
-name = "markdown"
-version = "3.10.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
-]
-
-[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2582,15 +2518,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mergedeep"
-version = "1.3.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
-]
-
-[[package]]
 name = "miniaudio"
 version = "1.61"
 source = { registry = "https://pypi.org/simple" }
@@ -2664,19 +2591,6 @@ image = [
 ]
 soundfile = [
     { name = "soundfile", marker = "sys_platform != 'darwin'" },
-]
-
-[[package]]
-name = "mkapi"
-version = "4.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "astdoc", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
-    { name = "jinja2", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/84/0b8514d277cde5f20463b6622b816270e93f569945d6fac93e26fc3fe094/mkapi-4.5.0.tar.gz", hash = "sha256:214c34c223d7e33ac966175365ef672d5133154784589416960333ce48a21265", size = 24183, upload-time = "2025-10-11T21:40:15.93Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/73/09023a08566a8ee09348fa373ea22d8d2f6410c0ee62f44b3ab3629d1e8e/mkapi-4.5.0-py3-none-any.whl", hash = "sha256:2747b69a4d9bd7d46312d604f9eeb51a740db5d345cd3d37cf03f38c9cfe98fd", size = 28421, upload-time = "2025-10-11T21:40:14.91Z" },
 ]
 
 [[package]]
@@ -3619,15 +3533,6 @@ wheels = [
 ]
 
 [[package]]
-name = "paginate"
-version = "0.5.7"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
-]
-
-[[package]]
 name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3676,15 +3581,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/6d/eed37d7ebc1e0bcd27b831c0cf1fe94881934316187c4b30d23f29ea0bd4/partial_json_parser-0.2.1.1.post7.tar.gz", hash = "sha256:86590e1ba6bcb6739a2dfc17d2323f028cb5884f4c6ce23db376999132c9a922", size = 10296, upload-time = "2025-11-17T07:27:41.202Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/32/658973117bf0fd82a24abbfb94fe73a5e86216e49342985e10acce54775a/partial_json_parser-0.2.1.1.post7-py3-none-any.whl", hash = "sha256:145119e5eabcf80cbb13844a6b50a85c68bf99d376f8ed771e2a3c3b03e653ae", size = 10877, upload-time = "2025-11-17T07:27:40.457Z" },
-]
-
-[[package]]
-name = "pathspec"
-version = "1.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
 ]
 
 [[package]]
@@ -4278,19 +4174,6 @@ crypto = [
 ]
 
 [[package]]
-name = "pymdown-extensions"
-version = "10.21.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
-    { name = "pyyaml", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
-]
-
-[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4489,18 +4372,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
-]
-
-[[package]]
-name = "pyyaml-env-tag"
-version = "1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyyaml", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
 ]
 
 [[package]]
@@ -6105,28 +5976,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "watchdog"
-version = "6.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
-    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
-    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
-    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
-    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
-    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
-]
-
-[[package]]
 name = "watchfiles"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -6180,18 +6029,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
     { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
     { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
-]
-
-[[package]]
-name = "wcmatch"
-version = "10.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "bracex", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Rearrange leaderboard columns and treat CSV order as ground truth; place Type after Rank and orthogonal metrics together
- Move Download/Embed buttons into the leaderboard toolbar tab row and reorder so the page indicator sits after action buttons
- Improve queue view: render languages as flags (collapsing to "All languages"), hide Languages/Evaluator columns on mobile, show Hall of Fame above queue on mobile
- Compact scatter tooltip on touch devices and anchor the leaderboard filter input to the Model column
- Backend: strip `#` suffix from model IDs in metadata cache, treat model openness as a boolean flag, loop queue processor hourly with FULL_LOG and dedupe error comments

## Test plan
- [x] Verify leaderboard column order matches CSV on desktop and mobile
- [x] Confirm Download/Embed buttons render in toolbar tab row
- [x] Check queue languages render as flags and collapse to "All languages" when appropriate
- [x] Verify mobile layout hides queue columns and shows Hall of Fame above queue
- [x] Test scatter tooltip on touch devices