### PR TITLE
fix: raise vLLM worker RPC timeouts to prevent EngineDeadError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Raised the default vLLM worker RPC timeouts
+  (`VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS` and `VLLM_ENGINE_ITERATION_TIMEOUT_S`)
+  from 300s to 1800s so that large models on slow hardware no longer crash
+  mid-evaluation with `EngineDeadError: RPC call to sample_tokens timed out`.
+  The engine-dead case is also now caught and reported as an `InvalidBenchmark`
+  error instead of an opaque crash.
 - Fixed a bug where `load_custom_datasets_module` would attempt to load a module
   spec from the current working directory when an empty path was passed as the
   custom datasets file, emitting a spurious "Could not load the spec for the

--- a/src/euroeval/__init__.py
+++ b/src/euroeval/__init__.py
@@ -108,6 +108,13 @@ os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 os.environ["VLLM_ALLOW_LONG_MAX_MODEL_LEN"] = "1"
 
 
+# Raise the vLLM worker RPC timeouts. The defaults (300s) can be exceeded by very
+# large models on slow/saturated hardware, causing the engine to die mid-evaluation
+# with a `TimeoutError: RPC call to sample_tokens timed out`.
+os.environ.setdefault("VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS", "1800")
+os.environ.setdefault("VLLM_ENGINE_ITERATION_TIMEOUT_S", "1800")
+
+
 # Avoid the "Unclosed client session" error when evaluating Ollama models with LiteLLM.
 # The error comes from the `aiohttp` package, and this environment variable forces the
 # use of `httpx` instead.

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -820,6 +820,18 @@ class VLLMModel(HuggingFaceEncoderModel):
                     raise InvalidBenchmark(
                         f"An error occurred during vLLM generation: {str(e)}"
                     ) from e
+            except Exception as e:
+                # The vLLM v1 engine raises `EngineDeadError` when a worker RPC
+                # times out. The engine cannot be reused once dead, so surface a
+                # clean benchmark error instead of an opaque crash.
+                if type(e).__name__ == "EngineDeadError" or "RPC call" in str(e):
+                    raise InvalidBenchmark(
+                        "The vLLM engine died during generation, likely due to a "
+                        "worker RPC timeout. Consider raising "
+                        "`VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS` or reducing the "
+                        f"batch size. Underlying error: {str(e)}"
+                    ) from e
+                raise
         else:
             raise InvalidBenchmark(
                 f"Could not generate sequences after {num_attempts} attempts."


### PR DESCRIPTION
## Summary
- Large models (e.g. `mistralai/Mistral-Small-4-119B-2603`) on slow/saturated GPUs exceed vLLM v1's default 300s `sample_tokens` RPC timeout, killing the engine mid-evaluation with `EngineDeadError: RPC call to sample_tokens timed out`.
- Raise `VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS` and `VLLM_ENGINE_ITERATION_TIMEOUT_S` defaults to 1800s via `setdefault` (users can still override).
- Catch `EngineDeadError` in `VLLMModel.generate` and surface it as `InvalidBenchmark` with an actionable message instead of letting the bare traceback escape.

## Test plan
- [ ] Re-run the failing 119B Mistral evaluation on the affected VM and confirm it no longer dies with `EngineDeadError`.
- [ ] Confirm a user-set `VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS` is still respected (setdefault behavior).
- [ ] Simulate an engine-dead condition and verify it now surfaces as `InvalidBenchmark` rather than an opaque crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)