### PR TITLE
feat: add core-model evaluation runner (backfill + dataset replacement)

### DIFF
--- a/src/leaderboards/evaluation_common.py
+++ b/src/leaderboards/evaluation_common.py
@@ -86,139 +86,6 @@ DTYPE_BYTES: dict[str, int] = {
 GPU_FIT_OVERHEAD = 1.2
 
 
-@lru_cache(maxsize=1)
-def official_dataset_language_pairs() -> set[tuple[str, str]]:
-    """Return all official dataset/language pairs used by EuroEval."""
-    all_dataset_configs = get_all_dataset_configs(
-        custom_datasets_file=Path(""),
-        dataset_ids=[],
-        api_key=None,
-        cache_dir=Path(".cache"),
-        trust_remote_code=False,
-        run_with_cli=False,
-    )
-    return {
-        (dataset_config.name, language.code)
-        for dataset_config in all_dataset_configs.values()
-        if not dataset_config.unofficial
-        for language in dataset_config.languages
-    }
-
-
-def resolve_hf_token() -> str | None:
-    """Return the HF token from env or the ``hf auth login`` cache."""
-    return (
-        os.environ.get("HF_TOKEN")
-        or os.environ.get("HUGGINGFACE_API_KEY")
-        or get_token()
-    )
-
-
-def gpu_total_memory_bytes() -> int | None:
-    """Return the total memory available for model weights on this host, in bytes.
-
-    Honors ``EUROEVAL_GPU_MEMORY_BYTES`` for overrides. Otherwise: when CUDA
-    is available and the host is not flagged as ``UNIFIED_MEMORY=1``, report
-    the largest CUDA device's total memory; otherwise report total system
-    RAM via ``psutil``.
-    """
-    override = os.environ.get("EUROEVAL_GPU_MEMORY_BYTES")
-    if override:
-        try:
-            return int(override)
-        except ValueError:
-            logger.warning(f"Ignoring invalid EUROEVAL_GPU_MEMORY_BYTES={override!r}.")
-
-    unified = os.environ.get("UNIFIED_MEMORY", "0") == "1"
-    if torch.cuda.is_available() and not unified:
-        sizes = [
-            torch.cuda.get_device_properties(i).total_memory
-            for i in range(torch.cuda.device_count())
-        ]
-        if sizes:
-            return max(sizes)
-    return int(psutil.virtual_memory().total)
-
-
-def estimated_model_bytes(model_id: str) -> int | None:
-    """Estimate the weight footprint of a model in bytes.
-
-    Reads the safetensors header(s) so quantised checkpoints are sized
-    correctly.
-
-    Args:
-        model_id:
-            The Hugging Face repo id, optionally suffixed with ``@<revision>``.
-
-    Returns:
-        The total weight bytes across all tensors, or None when the repo
-        is not a safetensors repo or metadata cannot be parsed.
-    """
-    components = split_model_id(model_id=model_id)
-    repo = components.model_id
-    revision = components.revision
-    token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_API_KEY")
-    try:
-        meta = get_safetensors_metadata(repo_id=repo, revision=revision, token=token)
-    except (
-        NotASafetensorsRepoError,
-        SafetensorsParsingError,
-        RepositoryNotFoundError,
-        GatedRepoError,
-        HfHubHTTPError,
-    ) as e:
-        logger.debug(f"safetensors metadata unavailable for {model_id}: {e}")
-        return None
-
-    total = 0
-    for dtype, count in meta.parameter_count.items():
-        dtype_bits = _dtype_bits(dtype=dtype)
-        if dtype_bits is None:
-            logger.debug(
-                f"Unknown safetensors dtype {dtype!r} for {model_id}; "
-                "assuming 2 bytes/param."
-            )
-            dtype_bits = 16
-        total += (count * dtype_bits + 7) // 8
-    return total
-
-
-def _dtype_bits(dtype: str) -> int | None:
-    """Infer the number of bits used by a safetensors dtype string.
-
-    Args:
-        dtype:
-            The safetensors dtype string.
-
-    Returns:
-        The bit-width, or None when it cannot be inferred.
-    """
-    normalized_dtype = dtype.upper()
-    if normalized_dtype in DTYPE_BYTES:
-        return DTYPE_BYTES[normalized_dtype] * 8
-
-    for match in re.findall(pattern=r"\d+", string=normalized_dtype):
-        bits = int(match)
-        if bits > 0:
-            return bits
-    return None
-
-
-def model_fits_locally(model_id: str, gpu_bytes: int | None) -> tuple[bool, int | None]:
-    """Return ``(fits, needed_bytes)`` for an open-weight model.
-
-    ``fits`` is True when either the GPU budget is unknown (caller should
-    skip the check), the model's safetensors footprint can't be measured,
-    or ``needed * GPU_FIT_OVERHEAD <= gpu_bytes``.
-    """
-    if gpu_bytes is None:
-        return True, None
-    needed = estimated_model_bytes(model_id=model_id)
-    if needed is None:
-        return True, None
-    return int(needed * GPU_FIT_OVERHEAD) <= gpu_bytes, needed
-
-
 def run_euroeval(
     model_id: str,
     languages: c.Sequence[str],
@@ -241,7 +108,7 @@ def run_euroeval(
         datasets (optional):
             Dataset ids to pass via repeated ``--dataset`` flags. When
             None or empty, no ``--dataset`` flag is passed and the CLI
-            uses its language-driven default.
+            uses its language-driven default. Defaults to None.
         evaluate_test_split (optional):
             When True pass ``--evaluate-test-split``; when False pass
             ``--evaluate-val-split``. Defaults to True.
@@ -328,3 +195,158 @@ def run_euroeval(
     proc.wait()
     output = b"".join(captured).decode("utf-8", errors="replace")
     return proc.returncode, output
+
+
+def model_fits_locally(model_id: str, gpu_bytes: int | None) -> tuple[bool, int | None]:
+    """Return whether an open-weight model fits the local memory budget.
+
+    Args:
+        model_id:
+            The HuggingFace repo id to size-check.
+        gpu_bytes:
+            The local memory budget in bytes, or None when unknown
+            (in which case the caller should skip the check).
+
+    Returns:
+        A ``(fits, needed_bytes)`` pair. ``fits`` is True when either
+        ``gpu_bytes`` is None, the model's safetensors footprint can't
+        be measured, or ``needed * GPU_FIT_OVERHEAD <= gpu_bytes``.
+        ``needed_bytes`` is the measured footprint, or None when it
+        couldn't be measured.
+    """
+    if gpu_bytes is None:
+        return True, None
+    needed = estimated_model_bytes(model_id=model_id)
+    if needed is None:
+        return True, None
+    return int(needed * GPU_FIT_OVERHEAD) <= gpu_bytes, needed
+
+
+def estimated_model_bytes(model_id: str) -> int | None:
+    """Estimate the weight footprint of a model in bytes.
+
+    Reads the safetensors header(s) so quantised checkpoints are sized
+    correctly.
+
+    Args:
+        model_id:
+            The HuggingFace repo id, optionally suffixed with ``@<revision>``.
+
+    Returns:
+        The total weight bytes across all tensors, or None when the repo
+        is not a safetensors repo or metadata cannot be parsed.
+    """
+    components = split_model_id(model_id=model_id)
+    repo = components.model_id
+    revision = components.revision
+    token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_API_KEY")
+    try:
+        meta = get_safetensors_metadata(repo_id=repo, revision=revision, token=token)
+    except (
+        NotASafetensorsRepoError,
+        SafetensorsParsingError,
+        RepositoryNotFoundError,
+        GatedRepoError,
+        HfHubHTTPError,
+    ) as e:
+        logger.debug(f"safetensors metadata unavailable for {model_id}: {e}")
+        return None
+
+    total = 0
+    for dtype, count in meta.parameter_count.items():
+        dtype_bits = _dtype_bits(dtype=dtype)
+        if dtype_bits is None:
+            logger.debug(
+                f"Unknown safetensors dtype {dtype!r} for {model_id}; "
+                "assuming 2 bytes/param."
+            )
+            dtype_bits = 16
+        total += (count * dtype_bits + 7) // 8
+    return total
+
+
+def _dtype_bits(dtype: str) -> int | None:
+    """Infer the number of bits used by a safetensors dtype string.
+
+    Args:
+        dtype:
+            The safetensors dtype string.
+
+    Returns:
+        The bit-width, or None when it cannot be inferred.
+    """
+    normalised_dtype = dtype.upper()
+    if normalised_dtype in DTYPE_BYTES:
+        return DTYPE_BYTES[normalised_dtype] * 8
+
+    for match in re.findall(pattern=r"\d+", string=normalised_dtype):
+        bits = int(match)
+        if bits > 0:
+            return bits
+    return None
+
+
+def gpu_total_memory_bytes() -> int | None:
+    """Return the total memory available for model weights on this host.
+
+    Honours ``EUROEVAL_GPU_MEMORY_BYTES`` for overrides. Otherwise: when CUDA
+    is available and the host is not flagged as ``UNIFIED_MEMORY=1``, report
+    the largest CUDA device's total memory; otherwise report total system
+    RAM via ``psutil``.
+
+    Returns:
+        The total memory in bytes, or None if the override is unparseable.
+    """
+    override = os.environ.get("EUROEVAL_GPU_MEMORY_BYTES")
+    if override:
+        try:
+            return int(override)
+        except ValueError:
+            logger.warning(f"Ignoring invalid EUROEVAL_GPU_MEMORY_BYTES={override!r}.")
+
+    unified = os.environ.get("UNIFIED_MEMORY", "0") == "1"
+    if torch.cuda.is_available() and not unified:
+        sizes = [
+            torch.cuda.get_device_properties(i).total_memory
+            for i in range(torch.cuda.device_count())
+        ]
+        if sizes:
+            return max(sizes)
+    return int(psutil.virtual_memory().total)
+
+
+@lru_cache(maxsize=1)
+def official_dataset_language_pairs() -> set[tuple[str, str]]:
+    """Return all official dataset/language pairs used by EuroEval.
+
+    Returns:
+        The ``(dataset_name, language_code)`` pairs for every official
+        (i.e. non-unofficial) dataset in :mod:`euroeval.dataset_configs`.
+    """
+    all_dataset_configs = get_all_dataset_configs(
+        custom_datasets_file=Path(""),
+        dataset_ids=[],
+        api_key=None,
+        cache_dir=Path(".cache"),
+        trust_remote_code=False,
+        run_with_cli=False,
+    )
+    return {
+        (dataset_config.name, language.code)
+        for dataset_config in all_dataset_configs.values()
+        if not dataset_config.unofficial
+        for language in dataset_config.languages
+    }
+
+
+def resolve_hf_token() -> str | None:
+    """Return the HF token from env or the ``hf auth login`` cache.
+
+    Returns:
+        The token string, or None if neither env nor cache yields one.
+    """
+    return (
+        os.environ.get("HF_TOKEN")
+        or os.environ.get("HUGGINGFACE_API_KEY")
+        or get_token()
+    )

--- a/src/scripts/evaluation_common.py
+++ b/src/scripts/evaluation_common.py
@@ -1,0 +1,330 @@
+"""Shared helpers for the queue processor and the core-model runner.
+
+Both ``process_evaluation_queue.py`` and ``run_core_model_evaluations.py``
+need to:
+
+* invoke the ``euroeval`` CLI with the same pty-streamed/captured stdout,
+* size-check open-weight models against the local GPU/RAM budget,
+* enumerate the official ``(dataset, language)`` pairs, and
+* resolve a HuggingFace token for the subprocess env.
+
+This module is the single home for that code so the two scripts stay in
+sync.
+"""
+
+from __future__ import annotations
+
+import collections.abc as c
+import logging
+import os
+import pty
+import re
+import select
+import subprocess
+import sys
+from functools import lru_cache
+from pathlib import Path
+
+import psutil
+import torch
+from huggingface_hub import get_safetensors_metadata, get_token
+from huggingface_hub.errors import (
+    GatedRepoError,
+    HfHubHTTPError,
+    NotASafetensorsRepoError,
+    RepositoryNotFoundError,
+    SafetensorsParsingError,
+)
+
+from euroeval.dataset_configs import get_all_dataset_configs
+from euroeval.string_utils import split_model_id
+
+logger = logging.getLogger(__name__)
+
+_BALTIC = "Baltic languages (Latvian, Lithuanian)"
+_FINNIC = "Finnic languages (Estonian, Finnish)"
+_ROMANCE = "Romance languages (Catalan, French, Italian, Portuguese, Romanian, Spanish)"
+_SCANDI = "Scandinavian languages (Danish, Faroese, Icelandic, Norwegian, Swedish)"
+_SLAVIC = (
+    "Slavic languages (Belarusian, Bulgarian, Bosnian, Croatian, Czech, Polish,"
+    " Serbian, Slovak, Slovenian, Ukrainian)"
+)
+_WGERMANIC = "West Germanic languages (Dutch, English, German)"
+
+LANGUAGE_GROUP_CODES: dict[str, list[str]] = {
+    _BALTIC: ["lv", "lt"],
+    _FINNIC: ["et", "fi"],
+    _ROMANCE: ["ca", "fr", "it", "pt", "ro", "es"],
+    _SCANDI: ["da", "fo", "is", "no", "sv"],
+    _SLAVIC: ["be", "bg", "bs", "hr", "cs", "pl", "sr", "sk", "sl", "uk"],
+    _WGERMANIC: ["nl", "en", "de"],
+    "Albanian": ["sq"],
+    "Greek": ["el"],
+    "Hungarian": ["hu"],
+}
+
+DTYPE_BYTES: dict[str, int] = {
+    "F64": 8,
+    "I64": 8,
+    "U64": 8,
+    "F32": 4,
+    "I32": 4,
+    "U32": 4,
+    "F16": 2,
+    "BF16": 2,
+    "I16": 2,
+    "U16": 2,
+    "F8_E4M3": 1,
+    "F8_E5M2": 1,
+    "I8": 1,
+    "U8": 1,
+    "BOOL": 1,
+}
+
+# Multiplier applied to weight bytes to leave room for activations, KV cache,
+# and framework overhead when judging whether a model fits in GPU memory.
+GPU_FIT_OVERHEAD = 1.2
+
+
+@lru_cache(maxsize=1)
+def official_dataset_language_pairs() -> set[tuple[str, str]]:
+    """Return all official dataset/language pairs used by EuroEval."""
+    all_dataset_configs = get_all_dataset_configs(
+        custom_datasets_file=Path(""),
+        dataset_ids=[],
+        api_key=None,
+        cache_dir=Path(".cache"),
+        trust_remote_code=False,
+        run_with_cli=False,
+    )
+    return {
+        (dataset_config.name, language.code)
+        for dataset_config in all_dataset_configs.values()
+        if not dataset_config.unofficial
+        for language in dataset_config.languages
+    }
+
+
+def resolve_hf_token() -> str | None:
+    """Return the HF token from env or the ``hf auth login`` cache."""
+    return (
+        os.environ.get("HF_TOKEN")
+        or os.environ.get("HUGGINGFACE_API_KEY")
+        or get_token()
+    )
+
+
+def gpu_total_memory_bytes() -> int | None:
+    """Return the total memory available for model weights on this host, in bytes.
+
+    Honors ``EUROEVAL_GPU_MEMORY_BYTES`` for overrides. Otherwise: when CUDA
+    is available and the host is not flagged as ``UNIFIED_MEMORY=1``, report
+    the largest CUDA device's total memory; otherwise report total system
+    RAM via ``psutil``.
+    """
+    override = os.environ.get("EUROEVAL_GPU_MEMORY_BYTES")
+    if override:
+        try:
+            return int(override)
+        except ValueError:
+            logger.warning(f"Ignoring invalid EUROEVAL_GPU_MEMORY_BYTES={override!r}.")
+
+    unified = os.environ.get("UNIFIED_MEMORY", "0") == "1"
+    if torch.cuda.is_available() and not unified:
+        sizes = [
+            torch.cuda.get_device_properties(i).total_memory
+            for i in range(torch.cuda.device_count())
+        ]
+        if sizes:
+            return max(sizes)
+    return int(psutil.virtual_memory().total)
+
+
+def estimated_model_bytes(model_id: str) -> int | None:
+    """Estimate the weight footprint of a model in bytes.
+
+    Reads the safetensors header(s) so quantised checkpoints are sized
+    correctly.
+
+    Args:
+        model_id:
+            The Hugging Face repo id, optionally suffixed with ``@<revision>``.
+
+    Returns:
+        The total weight bytes across all tensors, or None when the repo
+        is not a safetensors repo or metadata cannot be parsed.
+    """
+    components = split_model_id(model_id=model_id)
+    repo = components.model_id
+    revision = components.revision
+    token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_API_KEY")
+    try:
+        meta = get_safetensors_metadata(repo_id=repo, revision=revision, token=token)
+    except (
+        NotASafetensorsRepoError,
+        SafetensorsParsingError,
+        RepositoryNotFoundError,
+        GatedRepoError,
+        HfHubHTTPError,
+    ) as e:
+        logger.debug(f"safetensors metadata unavailable for {model_id}: {e}")
+        return None
+
+    total = 0
+    for dtype, count in meta.parameter_count.items():
+        dtype_bits = _dtype_bits(dtype=dtype)
+        if dtype_bits is None:
+            logger.debug(
+                f"Unknown safetensors dtype {dtype!r} for {model_id}; "
+                "assuming 2 bytes/param."
+            )
+            dtype_bits = 16
+        total += (count * dtype_bits + 7) // 8
+    return total
+
+
+def _dtype_bits(dtype: str) -> int | None:
+    """Infer the number of bits used by a safetensors dtype string.
+
+    Args:
+        dtype:
+            The safetensors dtype string.
+
+    Returns:
+        The bit-width, or None when it cannot be inferred.
+    """
+    normalized_dtype = dtype.upper()
+    if normalized_dtype in DTYPE_BYTES:
+        return DTYPE_BYTES[normalized_dtype] * 8
+
+    for match in re.findall(pattern=r"\d+", string=normalized_dtype):
+        bits = int(match)
+        if bits > 0:
+            return bits
+    return None
+
+
+def model_fits_locally(model_id: str, gpu_bytes: int | None) -> tuple[bool, int | None]:
+    """Return ``(fits, needed_bytes)`` for an open-weight model.
+
+    ``fits`` is True when either the GPU budget is unknown (caller should
+    skip the check), the model's safetensors footprint can't be measured,
+    or ``needed * GPU_FIT_OVERHEAD <= gpu_bytes``.
+    """
+    if gpu_bytes is None:
+        return True, None
+    needed = estimated_model_bytes(model_id=model_id)
+    if needed is None:
+        return True, None
+    return int(needed * GPU_FIT_OVERHEAD) <= gpu_bytes, needed
+
+
+def run_euroeval(
+    model_id: str,
+    languages: c.Sequence[str],
+    datasets: c.Sequence[str] | None = None,
+    evaluate_test_split: bool = True,
+    zero_shot: bool = False,
+    trust_remote_code: bool = True,
+    clear_model_cache: bool = True,
+) -> tuple[int, str]:
+    """Run the euroeval CLI for the given model, languages, and datasets.
+
+    Output is streamed live to stderr (so the operator can follow progress
+    on long evaluations) while also being captured for post-run inspection.
+
+    Args:
+        model_id:
+            The model identifier to evaluate.
+        languages:
+            ISO codes to pass via repeated ``--language`` flags.
+        datasets (optional):
+            Dataset ids to pass via repeated ``--dataset`` flags. When
+            None or empty, no ``--dataset`` flag is passed and the CLI
+            uses its language-driven default.
+        evaluate_test_split (optional):
+            When True pass ``--evaluate-test-split``; when False pass
+            ``--evaluate-val-split``. Defaults to True.
+        zero_shot (optional):
+            When True pass ``--zero-shot``; otherwise omit (CLI default
+            is few-shot). Defaults to False.
+        trust_remote_code (optional):
+            Pass ``--trust-remote-code``. Defaults to True.
+        clear_model_cache (optional):
+            Pass ``--clear-model-cache``. Defaults to True.
+
+    Returns:
+        A ``(returncode, combined_output)`` pair. A returncode of 127
+        signals that the CLI was not found on PATH.
+    """
+    cmd: list[str] = ["euroeval", "--model", model_id]
+    if clear_model_cache:
+        cmd.append("--clear-model-cache")
+    if trust_remote_code:
+        cmd.append("--trust-remote-code")
+    cmd.append(
+        "--evaluate-test-split" if evaluate_test_split else "--evaluate-val-split"
+    )
+    if zero_shot:
+        cmd.append("--zero-shot")
+    for lang in languages:
+        cmd += ["--language", lang]
+    for dataset in datasets or []:
+        cmd += ["--dataset", dataset]
+    logger.info(f"Running: {' '.join(cmd)}")
+
+    env = os.environ.copy()
+    env["FULL_LOG"] = "1"
+    token = resolve_hf_token()
+    if token:
+        env.setdefault("HF_TOKEN", token)
+        env.setdefault("HUGGINGFACE_API_KEY", token)
+
+    master_fd, slave_fd = pty.openpty()
+    try:
+        proc = subprocess.Popen(  # noqa: S603
+            cmd,
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            close_fds=True,
+            env=env,
+        )
+    except FileNotFoundError:
+        os.close(master_fd)
+        os.close(slave_fd)
+        logger.error("`euroeval` CLI not found on PATH. Is it installed?")
+        return 127, "`euroeval` CLI not found on PATH."
+    os.close(slave_fd)
+
+    captured: list[bytes] = []
+    try:
+        while True:
+            ready, _, _ = select.select([master_fd], [], [], 0.1)
+            if ready:
+                try:
+                    chunk = os.read(master_fd, 4096)
+                except OSError:
+                    break
+                if not chunk:
+                    break
+                sys.stderr.buffer.write(chunk)
+                sys.stderr.buffer.flush()
+                captured.append(chunk)
+            elif proc.poll() is not None:
+                try:
+                    while True:
+                        chunk = os.read(master_fd, 4096)
+                        if not chunk:
+                            break
+                        sys.stderr.buffer.write(chunk)
+                        sys.stderr.buffer.flush()
+                        captured.append(chunk)
+                except OSError:
+                    pass
+                break
+    finally:
+        os.close(master_fd)
+    proc.wait()
+    output = b"".join(captured).decode("utf-8", errors="replace")
+    return proc.returncode, output

--- a/src/scripts/process_evaluation_queue.py
+++ b/src/scripts/process_evaluation_queue.py
@@ -46,7 +46,11 @@ import urllib.request
 import uuid
 from pathlib import Path
 
-from evaluation_common import (
+from huggingface_hub import HfApi
+from huggingface_hub.errors import GatedRepoError, RepositoryNotFoundError
+
+from euroeval.data_models import BenchmarkResult
+from leaderboards.evaluation_common import (
     GPU_FIT_OVERHEAD,
     LANGUAGE_GROUP_CODES,
     estimated_model_bytes,
@@ -54,10 +58,6 @@ from evaluation_common import (
     official_dataset_language_pairs,
     run_euroeval,
 )
-from huggingface_hub import HfApi
-from huggingface_hub.errors import GatedRepoError, RepositoryNotFoundError
-
-from euroeval.data_models import BenchmarkResult
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s"

--- a/src/scripts/process_evaluation_queue.py
+++ b/src/scripts/process_evaluation_queue.py
@@ -36,34 +36,28 @@ import importlib.metadata
 import json
 import logging
 import os
-import pty
 import re
-import select
 import socket
-import subprocess
 import sys
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
 import uuid
-from functools import lru_cache
 from pathlib import Path
 
-import psutil
-import torch
-from huggingface_hub import HfApi, get_safetensors_metadata, get_token
-from huggingface_hub.errors import (
-    GatedRepoError,
-    HfHubHTTPError,
-    NotASafetensorsRepoError,
-    RepositoryNotFoundError,
-    SafetensorsParsingError,
+from evaluation_common import (
+    GPU_FIT_OVERHEAD,
+    LANGUAGE_GROUP_CODES,
+    estimated_model_bytes,
+    gpu_total_memory_bytes,
+    official_dataset_language_pairs,
+    run_euroeval,
 )
+from huggingface_hub import HfApi
+from huggingface_hub.errors import GatedRepoError, RepositoryNotFoundError
 
 from euroeval.data_models import BenchmarkResult
-from euroeval.dataset_configs import get_all_dataset_configs
-from euroeval.string_utils import split_model_id
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s"
@@ -96,16 +90,6 @@ HF_CACHE_PATH = Path(
 )
 HF_CACHE_TTL_SECONDS = 6 * 60 * 60
 
-_BALTIC = "Baltic languages (Latvian, Lithuanian)"
-_FINNIC = "Finnic languages (Estonian, Finnish)"
-_ROMANCE = "Romance languages (Catalan, French, Italian, Portuguese, Romanian, Spanish)"
-_SCANDI = "Scandinavian languages (Danish, Faroese, Icelandic, Norwegian, Swedish)"
-_SLAVIC = (
-    "Slavic languages (Belarusian, Bulgarian, Bosnian, Croatian, Czech, Polish,"
-    " Serbian, Slovak, Slovenian, Ukrainian)"
-)
-_WGERMANIC = "West Germanic languages (Dutch, English, German)"
-
 # Matches the "Model ID" section in an issue body (the form template renders
 # the model id as the line immediately following a "### Model ID" heading).
 MODEL_ID_BODY_RE = re.compile(r"(?:^|\n)#{1,6}\s*Model ID\s*\n+([^\n]+)")
@@ -133,62 +117,6 @@ ERRORED_BENCHMARKS_RE = re.compile(r"errored\s+(\d+)\s+benchmarks?", re.IGNORECA
 # and the subprocess lacks the necessary HF token / accepted access terms.
 # We treat this as "gated, please grant access" rather than as a code error.
 GATED_OUTPUT_RE = re.compile(r"is a gated repository", re.IGNORECASE)
-# Bytes-per-parameter for each safetensors dtype string. Used to compute the
-# weight footprint of a model from its safetensors header before deciding
-# whether it can fit on the local GPU.
-DTYPE_BYTES: dict[str, int] = {
-    "F64": 8,
-    "I64": 8,
-    "U64": 8,
-    "F32": 4,
-    "I32": 4,
-    "U32": 4,
-    "F16": 2,
-    "BF16": 2,
-    "I16": 2,
-    "U16": 2,
-    "F8_E4M3": 1,
-    "F8_E5M2": 1,
-    "I8": 1,
-    "U8": 1,
-    "BOOL": 1,
-}
-
-# Multiplier applied to weight bytes to leave room for activations, KV cache,
-# and framework overhead when judging whether a model fits in GPU memory.
-GPU_FIT_OVERHEAD = 1.2
-
-
-LANGUAGE_GROUP_CODES: dict[str, list[str]] = {
-    _BALTIC: ["lv", "lt"],
-    _FINNIC: ["et", "fi"],
-    _ROMANCE: ["ca", "fr", "it", "pt", "ro", "es"],
-    _SCANDI: ["da", "fo", "is", "no", "sv"],
-    _SLAVIC: ["be", "bg", "bs", "hr", "cs", "pl", "sr", "sk", "sl", "uk"],
-    _WGERMANIC: ["nl", "en", "de"],
-    "Albanian": ["sq"],
-    "Greek": ["el"],
-    "Hungarian": ["hu"],
-}
-
-
-@lru_cache(maxsize=1)
-def official_dataset_language_pairs() -> set[tuple[str, str]]:
-    """Return all official dataset/language pairs used by EuroEval."""
-    all_dataset_configs = get_all_dataset_configs(
-        custom_datasets_file=Path(""),
-        dataset_ids=[],
-        api_key=None,
-        cache_dir=Path(".cache"),
-        trust_remote_code=False,
-        run_with_cli=False,
-    )
-    return {
-        (dataset_config.name, language.code)
-        for dataset_config in all_dataset_configs.values()
-        if not dataset_config.unofficial
-        for language in dataset_config.languages
-    }
 
 
 def load_dotenv_into_environ() -> None:
@@ -756,102 +684,6 @@ def cached_model_summary(model_id: str) -> dict | None:
     return {"param_count": param_count, "gated": False, "gated_repo": gated_repo}
 
 
-def gpu_total_memory_bytes() -> int | None:
-    """Return the total memory available for model weights on this host, in bytes.
-
-    Honors the ``EUROEVAL_GPU_MEMORY_BYTES`` env var for overrides (useful in
-    tests). Otherwise mirrors ``alexandra_llm_inference.memory_utils``: when
-    CUDA is available and the host is not flagged as ``UNIFIED_MEMORY=1``,
-    report the largest CUDA device's total memory; otherwise (CPU-only host,
-    or unified-memory boxes like DGX Spark whose Grace-Blackwell pool is not
-    exposed via ``nvidia-smi --query-gpu=memory.total``) report total system
-    RAM via ``psutil``.
-
-    Returns:
-        The total memory in bytes, or None if the override is unparseable.
-    """
-    override = os.environ.get("EUROEVAL_GPU_MEMORY_BYTES")
-    if override:
-        try:
-            return int(override)
-        except ValueError:
-            logger.warning(f"Ignoring invalid EUROEVAL_GPU_MEMORY_BYTES={override!r}.")
-
-    unified = os.environ.get("UNIFIED_MEMORY", "0") == "1"
-    if torch.cuda.is_available() and not unified:
-        sizes = [
-            torch.cuda.get_device_properties(i).total_memory
-            for i in range(torch.cuda.device_count())
-        ]
-        if sizes:
-            return max(sizes)
-    return int(psutil.virtual_memory().total)
-
-
-def estimated_model_bytes(model_id: str) -> int | None:
-    """Estimate the weight footprint of a model in bytes.
-
-    Reads the safetensors header(s) so that quantised checkpoints (int8, fp8,
-    int4) are sized correctly rather than assumed to be fp16/bf16.
-
-    Args:
-        model_id:
-            The Hugging Face repo id, optionally suffixed with ``@<revision>``.
-
-    Returns:
-        The total weight bytes across all tensors, or None when the repo is
-        not a safetensors repo or the metadata cannot be parsed.
-    """
-    components = split_model_id(model_id=model_id)
-    repo = components.model_id
-    revision = components.revision
-    token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_API_KEY")
-    try:
-        meta = get_safetensors_metadata(repo_id=repo, revision=revision, token=token)
-    except (
-        NotASafetensorsRepoError,
-        SafetensorsParsingError,
-        RepositoryNotFoundError,
-        GatedRepoError,
-        HfHubHTTPError,
-    ) as e:
-        logger.debug(f"safetensors metadata unavailable for {model_id}: {e}")
-        return None
-
-    total = 0
-    for dtype, count in meta.parameter_count.items():
-        dtype_bits = _dtype_bits(dtype=dtype)
-        if dtype_bits is None:
-            logger.debug(
-                f"Unknown safetensors dtype {dtype!r} for {model_id}; "
-                "assuming 2 bytes/param."
-            )
-            dtype_bits = 16
-        total += (count * dtype_bits + 7) // 8
-    return total
-
-
-def _dtype_bits(dtype: str) -> int | None:
-    """Infer the number of bits used by a safetensors dtype string.
-
-    Args:
-        dtype:
-            The safetensors dtype string.
-
-    Returns:
-        The bit-width, or None when it cannot be inferred.
-    """
-    normalized_dtype = dtype.upper()
-    if normalized_dtype in DTYPE_BYTES:
-        return DTYPE_BYTES[normalized_dtype] * 8
-
-    for match in re.findall(pattern=r"\d+", string=normalized_dtype):
-        bits = int(match)
-        if bits > 0:
-            return bits
-    return None
-
-
 def process_issue(issue: dict, model_id: str, groups: list[str]) -> None:
     """Claim, evaluate, and report back on a single queue issue.
 
@@ -1131,114 +963,6 @@ def read_jsonl_lines(path: Path) -> list[str]:
         for line in path.read_text(encoding="utf-8").splitlines()
         if line.strip()
     ]
-
-
-def resolve_hf_token() -> str | None:
-    """Return the HF token from env or the ``hf auth login`` cache.
-
-    The queue script's parent process is authenticated via ``HfApi().whoami()``
-    in :func:`ensure_credentials`, so a token is reachable somewhere -- but
-    the euroeval subprocess only picks it up if ``HF_TOKEN`` /
-    ``HUGGINGFACE_API_KEY`` are set in its env, not from the cached login
-    file. Resolve it here so the caller can inject it into the subprocess.
-
-    Returns:
-        The token string, or None if neither env nor cache yields one.
-    """
-    return (
-        os.environ.get("HF_TOKEN")
-        or os.environ.get("HUGGINGFACE_API_KEY")
-        or get_token()
-    )
-
-
-def run_euroeval(model_id: str, languages: list[str]) -> tuple[int, str]:
-    """Run the euroeval CLI for the given model and language list.
-
-    Output is streamed live to stderr (so the operator can follow progress on
-    long evaluations) while also being captured for post-run inspection.
-
-    Args:
-        model_id:
-            The Hugging Face model id to evaluate.
-        languages:
-            ISO codes of the languages to pass via ``--language``.
-
-    Returns:
-        A ``(returncode, combined_output)`` pair. The output combines stdout
-        and stderr in interleaved order. A returncode of 127 signals that the
-        CLI was not found on PATH.
-    """
-    cmd = [
-        "euroeval",
-        "--model",
-        model_id,
-        "--clear-model-cache",
-        "--trust-remote-code",
-        "--evaluate-test-split",
-    ]
-    for lang in languages:
-        cmd += ["--language", lang]
-    logger.info(f"Running: {' '.join(cmd)}")
-
-    env = os.environ.copy()
-    env["FULL_LOG"] = "1"
-    token = resolve_hf_token()
-    if token:
-        env.setdefault("HF_TOKEN", token)
-        env.setdefault("HUGGINGFACE_API_KEY", token)
-
-    # Run euroeval under a pty so it sees a real terminal and renders
-    # carriage-return progress bars in place instead of as individual lines.
-    master_fd, slave_fd = pty.openpty()
-    try:
-        proc = subprocess.Popen(  # noqa: S603
-            cmd,
-            stdin=slave_fd,
-            stdout=slave_fd,
-            stderr=slave_fd,
-            close_fds=True,
-            env=env,
-        )
-    except FileNotFoundError:
-        os.close(master_fd)
-        os.close(slave_fd)
-        logger.error("`euroeval` CLI not found on PATH. Is it installed?")
-        return 127, "`euroeval` CLI not found on PATH."
-    os.close(slave_fd)
-
-    captured: list[bytes] = []
-    try:
-        while True:
-            ready, _, _ = select.select([master_fd], [], [], 0.1)
-            if ready:
-                try:
-                    chunk = os.read(master_fd, 4096)
-                except OSError:
-                    break
-                if not chunk:
-                    break
-                sys.stderr.buffer.write(chunk)
-                sys.stderr.buffer.flush()
-                captured.append(chunk)
-            elif proc.poll() is not None:
-                # Drain any final output the child wrote just before exiting.
-                try:
-                    while True:
-                        chunk = os.read(master_fd, 4096)
-                        if not chunk:
-                            break
-                        sys.stderr.buffer.write(chunk)
-                        sys.stderr.buffer.flush()
-                        captured.append(chunk)
-                except OSError:
-                    pass
-                break
-    finally:
-        os.close(master_fd)
-    proc.wait()
-    output = b"".join(captured).decode("utf-8", errors="replace")
-    return proc.returncode, output
 
 
 def num_errored_benchmarks(output: str) -> int:

--- a/src/scripts/run_core_model_evaluations.py
+++ b/src/scripts/run_core_model_evaluations.py
@@ -56,6 +56,7 @@ from leaderboards.evaluation_common import (
     run_euroeval,
 )
 from leaderboards.paths import CORE_MODELS_CONFIG, NEW_RESULTS_PATH, RESULTS_PATH
+from leaderboards.result_loading import convert_to_old_format
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s"
@@ -293,13 +294,18 @@ def load_existing_observations() -> set[tuple[str, str, str]]:
     Reads the merged result corpus the same way the leaderboard pipeline
     does -- ``results.tar.gz`` plus the optional ``new_results.jsonl`` --
     but without the destructive unlink that
-    ``leaderboards.result_loading.load_raw_results`` performs.
+    :func:`leaderboards.result_loading.load_raw_results` performs. Each
+    record is normalised via
+    :func:`leaderboards.result_loading.convert_to_old_format` so Every
+    Eval Ever (EEE) records (with ``model`` / ``dataset`` / ``languages``
+    nested under ``model_info`` and ``eval_library.additional_details``)
+    are flattened to top-level keys.
 
     Returns:
-        Every ``(model_id, dataset, language)`` triple in the merged result
-        corpus, with model ids stripped of leaderboard HTML anchors and
-        ``(zero-shot)`` / ``(val)`` variant suffixes so the keys line up
-        with the canonical ids in ``core_models.yaml``.
+        Every ``(model_id, dataset, language)`` triple in the merged
+        result corpus, with model ids unwrapped from any leaderboard
+        HTML anchor so the keys line up with the canonical ids in
+        ``core_models.yaml``.
     """
     lines: list[str] = []
     if RESULTS_PATH.exists():
@@ -311,7 +317,8 @@ def load_existing_observations() -> set[tuple[str, str, str]]:
         lines.extend(NEW_RESULTS_PATH.read_text(encoding="utf-8").splitlines())
 
     observations: set[tuple[str, str, str]] = set()
-    for line in lines:
+    parse_failures = 0
+    for line_idx, line in enumerate(lines):
         line = line.strip()
         if not line:
             continue
@@ -321,12 +328,26 @@ def load_existing_observations() -> set[tuple[str, str, str]]:
             if not record_text.strip():
                 continue
             try:
-                record = json.loads(record_text)
-            except json.JSONDecodeError:
+                raw_record = json.loads(record_text)
+            except json.JSONDecodeError as e:
+                parse_failures += 1
+                logger.warning(
+                    f"Skipping malformed JSON on result line {line_idx:,}: {e}; "
+                    f"snippet={record_text[:120]!r}."
+                )
                 continue
-            model = _strip_model_variant(model_id=str(record.get("model", "")))
+            try:
+                record = convert_to_old_format(record=raw_record)
+            except (KeyError, TypeError, ValueError) as e:
+                parse_failures += 1
+                logger.warning(
+                    f"Skipping unnormalisable EEE record on line {line_idx:,}: "
+                    f"{e}; snippet={record_text[:120]!r}."
+                )
+                continue
+            model = _strip_anchor(model_id=str(record.get("model", "")))
             dataset = record.get("dataset")
-            languages = record.get("languages") or []
+            languages = record.get("languages") or record.get("dataset_languages") or []
             if not model or not dataset:
                 continue
             for language in languages:
@@ -334,6 +355,11 @@ def load_existing_observations() -> set[tuple[str, str, str]]:
     logger.info(
         f"Loaded {len(observations):,} (model, dataset, language) observations."
     )
+    if parse_failures:
+        logger.warning(
+            f"Skipped {parse_failures:,} unparseable result record(s); see "
+            "earlier warnings for details."
+        )
     return observations
 
 
@@ -610,19 +636,23 @@ def all_known_language_codes() -> set[str]:
     return set(get_all_languages().keys())
 
 
-def _strip_model_variant(model_id: str) -> str:
-    """Strip leaderboard HTML anchors and ``(zero-shot)`` / ``(val)`` suffixes.
+def _strip_anchor(model_id: str) -> str:
+    """Strip a leaderboard HTML anchor wrapper from a model id.
+
+    ``BenchmarkResult.from_dict`` already removes the ``(val)`` /
+    ``(few-shot)`` variant suffixes, so we only need to defend against
+    anchor wrappers that older leaderboard exports may have left in
+    the record's ``model`` field.
 
     Args:
         model_id:
-            The result-record model id, possibly anchored or variant-suffixed.
+            The model id from a parsed :class:`BenchmarkResult`.
 
     Returns:
         The canonical model id, ready to compare against ``core_models.yaml``.
     """
     m = _ANCHOR_RE.search(model_id)
-    inner = m.group("inner").strip() if m else model_id
-    return _VARIANT_SUFFIX_RE.sub("", inner).strip()
+    return (m.group("inner").strip() if m else model_id).strip()
 
 
 def _prompt_api_providers() -> set[str]:
@@ -649,9 +679,6 @@ def _prompt_api_providers() -> set[str]:
     return selected
 
 
-# Strips trailing variant annotations on result-record model ids, e.g.
-# ``model (zero-shot)`` / ``model (val)`` / ``model (zero-shot, val)``.
-_VARIANT_SUFFIX_RE = re.compile(r"\s*\((?:zero-shot|val)(?:,\s*(?:zero-shot|val))*\)$")
 _ANCHOR_RE = re.compile(r"<a [^>]*>(?P<inner>[^<]+)</a>")
 
 

--- a/src/scripts/run_core_model_evaluations.py
+++ b/src/scripts/run_core_model_evaluations.py
@@ -45,16 +45,16 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import click
-from evaluation_common import (
+from yaml import safe_load
+
+from euroeval.dataset_configs import get_all_dataset_configs
+from euroeval.languages import get_all_languages
+from leaderboards.evaluation_common import (
     gpu_total_memory_bytes,
     model_fits_locally,
     official_dataset_language_pairs,
     run_euroeval,
 )
-from yaml import safe_load
-
-from euroeval.dataset_configs import get_all_dataset_configs
-from euroeval.languages import get_all_languages
 from leaderboards.paths import CORE_MODELS_CONFIG, NEW_RESULTS_PATH, RESULTS_PATH
 
 logging.basicConfig(
@@ -63,43 +63,120 @@ logging.basicConfig(
 logger = logging.getLogger("run_core_model_evaluations")
 
 
-# Mapping from short provider name (CLI/UI value) to the env var that
-# must be set and the predicate identifying API model ids belonging to
-# that provider.
-@dataclass(frozen=True)
-class _Provider:
-    name: str
-    env_var: str
-    matches: c.Callable[[str], bool]
+@click.command()
+@click.option(
+    "--dataset",
+    "datasets",
+    multiple=True,
+    help="Dataset id to run in dataset-replacement mode. Repeatable. When omitted, "
+    "the script runs in backfill mode against every official (dataset, language) "
+    "pair.",
+)
+@click.option(
+    "--include-api",
+    is_flag=True,
+    default=False,
+    help="Opt in to running API models. Without this flag every api: true entry "
+    "in core_models.yaml is silently skipped.",
+)
+@click.option(
+    "--api-providers",
+    default=None,
+    help="Comma-separated provider names to run (openai, anthropic, google, xai). "
+    "Skips the interactive prompt. Requires --include-api.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print the planned jobs and exit without invoking euroeval.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Re-run even (model, dataset, language) triples that already have a "
+    "result line.",
+)
+def main(
+    datasets: tuple[str, ...],
+    include_api: bool,
+    api_providers: str | None,
+    dry_run: bool,
+    force: bool,
+) -> None:
+    """Run EuroEval for the core model list.
 
+    Args:
+        datasets:
+            Dataset ids passed via ``--dataset``. When non-empty, the
+            script runs in dataset-replacement mode against exactly those
+            datasets; otherwise it runs in backfill mode.
+        include_api:
+            Whether to consider ``api: true`` entries at all.
+        api_providers:
+            Optional comma-separated provider filter; bypasses the prompt.
+        dry_run:
+            When True, print the planned jobs and return without running.
+        force:
+            When True, ignore previously recorded results.
 
-PROVIDERS: list[_Provider] = [
-    _Provider(
-        name="openai",
-        env_var="OPENAI_API_KEY",
-        matches=lambda m: m.startswith("openai/"),
-    ),
-    _Provider(
-        name="anthropic",
-        env_var="ANTHROPIC_API_KEY",
-        matches=lambda m: m.startswith("claude-") or m.startswith("anthropic/"),
-    ),
-    _Provider(
-        name="google",
-        env_var="GEMINI_API_KEY",
-        matches=lambda m: m.startswith("gemini/"),
-    ),
-    _Provider(
-        name="xai", env_var="XAI_API_KEY", matches=lambda m: m.startswith("xai/")
-    ),
-]
-PROVIDERS_BY_NAME: dict[str, _Provider] = {p.name: p for p in PROVIDERS}
+    Raises:
+        click.ClickException:
+            When ``--api-providers`` is passed without ``--include-api``,
+            when an unknown provider name is supplied, or when a selected
+            provider's env var is missing.
+    """
+    if api_providers and not include_api:
+        raise click.ClickException(
+            "--api-providers requires --include-api; pass both or neither."
+        )
 
+    target_datasets = list(datasets) or None
+    mode = "dataset-replacement" if target_datasets else "backfill"
+    logger.info(f"Mode: {mode}.")
+    if target_datasets:
+        logger.info(f"Target dataset(s): {', '.join(target_datasets)}.")
 
-# Strips trailing variant annotations on result-record model ids, e.g.
-# ``model (zero-shot)`` / ``model (val)`` / ``model (zero-shot, val)``.
-_VARIANT_SUFFIX_RE = re.compile(r"\s*\((?:zero-shot|val)(?:,\s*(?:zero-shot|val))*\)$")
-_ANCHOR_RE = re.compile(r"<a [^>]*>(?P<inner>[^<]+)</a>")
+    models = load_core_models()
+    logger.info(f"Loaded {len(models)} core model entries.")
+
+    selected_providers = select_api_providers(
+        candidate_models=models,
+        include_api=include_api,
+        api_providers_arg=api_providers,
+    )
+
+    observations: set[tuple[str, str, str]] = set()
+    if not force:
+        try:
+            observations = load_existing_observations()
+        except FileNotFoundError as e:
+            logger.warning(
+                f"Could not load existing results ({e}); proceeding as if none exist."
+            )
+
+    jobs = build_jobs(
+        models=models,
+        target_datasets=target_datasets,
+        selected_providers=selected_providers,
+        observations=observations,
+        force=force,
+    )
+    logger.info(f"Planned {len(jobs)} job(s) before size check.")
+
+    jobs = apply_size_filter(jobs=jobs)
+    logger.info(f"{len(jobs)} job(s) survive the size check.")
+
+    if dry_run:
+        for job in jobs:
+            tag = "api" if job.is_api else "open"
+            click.echo(
+                f"[{tag}] {job.model_id} :: {job.dataset} :: {', '.join(job.languages)}"
+            )
+        return
+
+    execute_jobs(jobs=jobs)
 
 
 @dataclass(frozen=True)
@@ -121,6 +198,15 @@ class Job:
     is_api: bool
 
 
+@dataclass(frozen=True)
+class _Provider:
+    """An API provider: its short name, required env var, and id predicate."""
+
+    name: str
+    env_var: str
+    matches: c.Callable[[str], bool]
+
+
 def load_core_models() -> list[CoreModelEntry]:
     """Parse ``core_models.yaml`` and return the model list.
 
@@ -139,132 +225,6 @@ def load_core_models() -> list[CoreModelEntry]:
             )
         )
     return entries
-
-
-def _strip_model_variant(model_id: str) -> str:
-    """Return ``model_id`` with leaderboard HTML anchors and variant suffix removed."""
-    m = _ANCHOR_RE.search(model_id)
-    inner = m.group("inner").strip() if m else model_id
-    return _VARIANT_SUFFIX_RE.sub("", inner).strip()
-
-
-def load_existing_observations() -> set[tuple[str, str, str]]:
-    """Return the set of ``(model_id, dataset, language)`` triples already benchmarked.
-
-    Reads the merged result corpus the same way the leaderboard pipeline
-    does -- ``results.tar.gz`` plus the optional ``new_results.jsonl`` --
-    but without the destructive unlink that
-    ``leaderboards.result_loading.load_raw_results`` performs.
-
-    Model ids are stripped of leaderboard HTML anchors and ``(zero-shot)``
-    / ``(val)`` variant suffixes so the keys line up with the canonical
-    ids in ``core_models.yaml``.
-    """
-    lines: list[str] = []
-    if RESULTS_PATH.exists():
-        with tarfile.open(RESULTS_PATH, "r:gz") as tar:
-            member_file = tar.extractfile(member="results/results.jsonl")
-            if member_file is not None:
-                lines.extend(member_file.read().decode(encoding="utf-8").splitlines())
-    if NEW_RESULTS_PATH.exists():
-        lines.extend(NEW_RESULTS_PATH.read_text(encoding="utf-8").splitlines())
-
-    observations: set[tuple[str, str, str]] = set()
-    for line in lines:
-        line = line.strip()
-        if not line:
-            continue
-        # Some lines pack multiple JSON objects back-to-back; split on '}{'
-        # the same way result_loading does.
-        for record_text in re.split(pattern=r"(?<=})(?={)", string=line):
-            if not record_text.strip():
-                continue
-            try:
-                record = json.loads(record_text)
-            except json.JSONDecodeError:
-                continue
-            model = _strip_model_variant(str(record.get("model", "")))
-            dataset = record.get("dataset")
-            languages = record.get("languages") or []
-            if not model or not dataset:
-                continue
-            for language in languages:
-                observations.add((model, str(dataset), str(language)))
-    logger.info(
-        f"Loaded {len(observations):,} (model, dataset, language) observations."
-    )
-    return observations
-
-
-def language_name_to_code(name: str) -> str | None:
-    """Map an English language name (lowercased) to its ISO code, or None.
-
-    The names come from ``core_models.yaml::pareto_languages``; values are
-    matched case-insensitively against
-    :func:`euroeval.languages.get_all_languages`.
-
-    Args:
-        name:
-            The English language name (case-insensitive).
-
-    Returns:
-        The ISO code for the language, or None when no match is found.
-    """
-    needle = name.strip().lower()
-    if not needle:
-        return None
-    for code, language in get_all_languages().items():
-        if language.name.lower() == needle:
-            return code
-    return None
-
-
-def all_known_language_codes() -> set[str]:
-    """Return every ISO code known to EuroEval.
-
-    Returns:
-        Every key from :func:`euroeval.languages.get_all_languages`.
-    """
-    return set(get_all_languages().keys())
-
-
-def codes_for_model(model: CoreModelEntry) -> set[str]:
-    """Return the ISO codes a model should be evaluated on.
-
-    API models cover every known language. Open-weight models cover the
-    ISO codes derived from their ``pareto_languages`` -- with one
-    exception: when the Pareto list is empty (typical for EU/OSAI
-    entries that haven't been benchmarked widely enough yet), fall back
-    to "all known languages" so the backfill run is what generates the
-    data the Pareto computation needs.
-    """
-    if model.is_api or not model.pareto_languages:
-        return all_known_language_codes()
-    codes: set[str] = set()
-    for name in model.pareto_languages:
-        code = language_name_to_code(name)
-        if code is None:
-            logger.debug(f"Could not map language name {name!r} to an ISO code.")
-            continue
-        codes.add(code)
-    return codes
-
-
-def dataset_language_codes(dataset_id: str) -> set[str]:
-    """Return ISO codes for a dataset, or an empty set if the dataset is unknown."""
-    configs = get_all_dataset_configs(
-        custom_datasets_file=Path(""),
-        dataset_ids=[dataset_id],
-        api_key=None,
-        cache_dir=Path(".cache"),
-        trust_remote_code=False,
-        run_with_cli=False,
-    )
-    config = configs.get(dataset_id)
-    if config is None:
-        logger.error(f"Unknown dataset id {dataset_id!r}; skipping.")
-        return set()
-    return {language.code for language in config.languages}
 
 
 def select_api_providers(
@@ -327,36 +287,54 @@ def select_api_providers(
     return selected
 
 
-def _prompt_api_providers() -> set[str]:
-    """Prompt the user interactively for which API providers to run.
+def load_existing_observations() -> set[tuple[str, str, str]]:
+    """Return the ``(model_id, dataset, language)`` triples already benchmarked.
+
+    Reads the merged result corpus the same way the leaderboard pipeline
+    does -- ``results.tar.gz`` plus the optional ``new_results.jsonl`` --
+    but without the destructive unlink that
+    ``leaderboards.result_loading.load_raw_results`` performs.
 
     Returns:
-        The set of selected provider names. May be empty if the user
-        deselects everything.
-
-    Raises:
-        click.ClickException:
-            When stdin is not a TTY (so we cannot prompt safely).
+        Every ``(model_id, dataset, language)`` triple in the merged result
+        corpus, with model ids stripped of leaderboard HTML anchors and
+        ``(zero-shot)`` / ``(val)`` variant suffixes so the keys line up
+        with the canonical ids in ``core_models.yaml``.
     """
-    if not sys.stdin.isatty():
-        raise click.ClickException(
-            "stdin is not a TTY; pass --api-providers to select providers "
-            "non-interactively (or omit --include-api)."
-        )
-    click.echo("Select API providers to evaluate (default: all):")
-    selected: set[str] = set()
-    for provider in PROVIDERS:
-        if click.confirm(f"  Include {provider.name}?", default=True):
-            selected.add(provider.name)
-    return selected
+    lines: list[str] = []
+    if RESULTS_PATH.exists():
+        with tarfile.open(RESULTS_PATH, "r:gz") as tar:
+            member_file = tar.extractfile(member="results/results.jsonl")
+            if member_file is not None:
+                lines.extend(member_file.read().decode(encoding="utf-8").splitlines())
+    if NEW_RESULTS_PATH.exists():
+        lines.extend(NEW_RESULTS_PATH.read_text(encoding="utf-8").splitlines())
 
-
-def provider_for_model_id(model_id: str) -> _Provider | None:
-    """Return the provider that owns an API model id, or None."""
-    for provider in PROVIDERS:
-        if provider.matches(model_id):
-            return provider
-    return None
+    observations: set[tuple[str, str, str]] = set()
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        # Some lines pack multiple JSON objects back-to-back; split on '}{'
+        # the same way result_loading does.
+        for record_text in re.split(pattern=r"(?<=})(?={)", string=line):
+            if not record_text.strip():
+                continue
+            try:
+                record = json.loads(record_text)
+            except json.JSONDecodeError:
+                continue
+            model = _strip_model_variant(model_id=str(record.get("model", "")))
+            dataset = record.get("dataset")
+            languages = record.get("languages") or []
+            if not model or not dataset:
+                continue
+            for language in languages:
+                observations.add((model, str(dataset), str(language)))
+    logger.info(
+        f"Loaded {len(observations):,} (model, dataset, language) observations."
+    )
+    return observations
 
 
 def build_jobs(
@@ -383,8 +361,8 @@ def build_jobs(
             When True, ignore ``observations`` and re-run even seen pairs.
 
     Returns:
-        One Job per (model, dataset) pair to evaluate, with languages
-        deduplicated and sorted.
+        One :class:`Job` per (model, dataset) pair to evaluate, with
+        languages deduplicated and sorted.
     """
     jobs: list[Job] = []
     official_pairs = official_dataset_language_pairs()
@@ -394,11 +372,13 @@ def build_jobs(
 
     target_dataset_codes: dict[str, set[str]] | None = None
     if target_datasets:
-        target_dataset_codes = {d: dataset_language_codes(d) for d in target_datasets}
+        target_dataset_codes = {
+            d: dataset_language_codes(dataset_id=d) for d in target_datasets
+        }
 
     for model in models:
         if model.is_api:
-            provider = provider_for_model_id(model.model_id)
+            provider = provider_for_model_id(model_id=model.model_id)
             if provider is None or provider.name not in selected_providers:
                 continue
         model_languages = codes_for_model(model=model)
@@ -431,7 +411,6 @@ def build_jobs(
                 )
             continue
 
-        # Backfill mode: every official pair the model is in scope for.
         for dataset, dataset_langs in official_by_dataset.items():
             langs = sorted(model_languages & dataset_langs)
             if not langs:
@@ -527,120 +506,176 @@ def execute_jobs(jobs: list[Job]) -> None:
             )
 
 
-@click.command()
-@click.option(
-    "--dataset",
-    "datasets",
-    multiple=True,
-    help="Dataset id to run in dataset-replacement mode. Repeatable. When omitted, "
-    "the script runs in backfill mode against every official (dataset, language) "
-    "pair.",
-)
-@click.option(
-    "--include-api",
-    is_flag=True,
-    default=False,
-    help="Opt in to running API models. Without this flag every api: true entry "
-    "in core_models.yaml is silently skipped.",
-)
-@click.option(
-    "--api-providers",
-    default=None,
-    help="Comma-separated provider names to run (openai, anthropic, google, xai). "
-    "Skips the interactive prompt. Requires --include-api.",
-)
-@click.option(
-    "--dry-run",
-    is_flag=True,
-    default=False,
-    help="Print the planned jobs and exit without invoking euroeval.",
-)
-@click.option(
-    "--force",
-    is_flag=True,
-    default=False,
-    help="Re-run even (model, dataset, language) triples that already have a "
-    "result line.",
-)
-def main(
-    datasets: tuple[str, ...],
-    include_api: bool,
-    api_providers: str | None,
-    dry_run: bool,
-    force: bool,
-) -> None:
-    """Run EuroEval for the core model list (backfill or dataset-replacement).
+def codes_for_model(model: CoreModelEntry) -> set[str]:
+    """Return the ISO codes a model should be evaluated on.
+
+    API models cover every known language. Open-weight models cover the
+    ISO codes derived from their ``pareto_languages`` -- with one
+    exception: when the Pareto list is empty (typical for EU/OSAI
+    entries that haven't been benchmarked widely enough yet), fall back
+    to "all known languages" so the backfill run is what generates the
+    data the Pareto computation needs.
 
     Args:
-        datasets:
-            Dataset ids passed via ``--dataset``. When non-empty, the
-            script runs in dataset-replacement mode against exactly those
-            datasets; otherwise it runs in backfill mode.
-        include_api:
-            Whether to consider ``api: true`` entries at all.
-        api_providers:
-            Optional comma-separated provider filter; bypasses the prompt.
-        dry_run:
-            When True, print the planned jobs and return without running.
-        force:
-            When True, ignore previously recorded results.
+        model:
+            The core-model entry whose language coverage to resolve.
+
+    Returns:
+        The ISO codes the model should be evaluated on.
+    """
+    if model.is_api or not model.pareto_languages:
+        return all_known_language_codes()
+    codes: set[str] = set()
+    for name in model.pareto_languages:
+        code = language_name_to_code(name=name)
+        if code is None:
+            logger.debug(f"Could not map language name {name!r} to an ISO code.")
+            continue
+        codes.add(code)
+    return codes
+
+
+def dataset_language_codes(dataset_id: str) -> set[str]:
+    """Return ISO codes for a dataset, or an empty set if the dataset is unknown.
+
+    Args:
+        dataset_id:
+            The dataset id to look up.
+
+    Returns:
+        The ISO codes the dataset covers, or an empty set when the id is
+        not a known dataset (logged at ERROR level).
+    """
+    configs = get_all_dataset_configs(
+        custom_datasets_file=Path(""),
+        dataset_ids=[dataset_id],
+        api_key=None,
+        cache_dir=Path(".cache"),
+        trust_remote_code=False,
+        run_with_cli=False,
+    )
+    config = configs.get(dataset_id)
+    if config is None:
+        logger.error(f"Unknown dataset id {dataset_id!r}; skipping.")
+        return set()
+    return {language.code for language in config.languages}
+
+
+def provider_for_model_id(model_id: str) -> _Provider | None:
+    """Return the API provider that owns a model id, or None.
+
+    Args:
+        model_id:
+            The model id to classify.
+
+    Returns:
+        The matching :class:`_Provider`, or None when no provider claims
+        the id (i.e. the model is not an API model).
+    """
+    for provider in PROVIDERS:
+        if provider.matches(model_id):
+            return provider
+    return None
+
+
+def language_name_to_code(name: str) -> str | None:
+    """Map an English language name to its ISO code, or None.
+
+    The names come from ``core_models.yaml::pareto_languages``; values are
+    matched case-insensitively against
+    :func:`euroeval.languages.get_all_languages`.
+
+    Args:
+        name:
+            The English language name (case-insensitive).
+
+    Returns:
+        The ISO code for the language, or None when no match is found.
+    """
+    needle = name.strip().lower()
+    if not needle:
+        return None
+    for code, language in get_all_languages().items():
+        if language.name.lower() == needle:
+            return code
+    return None
+
+
+def all_known_language_codes() -> set[str]:
+    """Return every ISO code known to EuroEval.
+
+    Returns:
+        Every key from :func:`euroeval.languages.get_all_languages`.
+    """
+    return set(get_all_languages().keys())
+
+
+def _strip_model_variant(model_id: str) -> str:
+    """Strip leaderboard HTML anchors and ``(zero-shot)`` / ``(val)`` suffixes.
+
+    Args:
+        model_id:
+            The result-record model id, possibly anchored or variant-suffixed.
+
+    Returns:
+        The canonical model id, ready to compare against ``core_models.yaml``.
+    """
+    m = _ANCHOR_RE.search(model_id)
+    inner = m.group("inner").strip() if m else model_id
+    return _VARIANT_SUFFIX_RE.sub("", inner).strip()
+
+
+def _prompt_api_providers() -> set[str]:
+    """Prompt the user interactively for which API providers to run.
+
+    Returns:
+        The selected provider names. May be empty if the user
+        deselects everything.
 
     Raises:
         click.ClickException:
-            When ``--api-providers`` is passed without ``--include-api``,
-            when an unknown provider name is supplied, or when a selected
-            provider's env var is missing.
+            When stdin is not a TTY (so we cannot prompt safely).
     """
-    if api_providers and not include_api:
+    if not sys.stdin.isatty():
         raise click.ClickException(
-            "--api-providers requires --include-api; pass both or neither."
+            "stdin is not a TTY; pass --api-providers to select providers "
+            "non-interactively (or omit --include-api)."
         )
+    click.echo("Select API providers to evaluate (default: all):")
+    selected: set[str] = set()
+    for provider in PROVIDERS:
+        if click.confirm(f"  Include {provider.name}?", default=True):
+            selected.add(provider.name)
+    return selected
 
-    target_datasets = list(datasets) or None
-    mode = "dataset-replacement" if target_datasets else "backfill"
-    logger.info(f"Mode: {mode}.")
-    if target_datasets:
-        logger.info(f"Target dataset(s): {', '.join(target_datasets)}.")
 
-    models = load_core_models()
-    logger.info(f"Loaded {len(models)} core model entries.")
+# Strips trailing variant annotations on result-record model ids, e.g.
+# ``model (zero-shot)`` / ``model (val)`` / ``model (zero-shot, val)``.
+_VARIANT_SUFFIX_RE = re.compile(r"\s*\((?:zero-shot|val)(?:,\s*(?:zero-shot|val))*\)$")
+_ANCHOR_RE = re.compile(r"<a [^>]*>(?P<inner>[^<]+)</a>")
 
-    selected_providers = select_api_providers(
-        candidate_models=models,
-        include_api=include_api,
-        api_providers_arg=api_providers,
-    )
 
-    observations: set[tuple[str, str, str]] = set()
-    if not force:
-        try:
-            observations = load_existing_observations()
-        except FileNotFoundError as e:
-            logger.warning(
-                f"Could not load existing results ({e}); proceeding as if none exist."
-            )
-
-    jobs = build_jobs(
-        models=models,
-        target_datasets=target_datasets,
-        selected_providers=selected_providers,
-        observations=observations,
-        force=force,
-    )
-    logger.info(f"Planned {len(jobs)} job(s) before size check.")
-
-    jobs = apply_size_filter(jobs=jobs)
-    logger.info(f"{len(jobs)} job(s) survive the size check.")
-
-    if dry_run:
-        for job in jobs:
-            tag = "api" if job.is_api else "open"
-            click.echo(
-                f"[{tag}] {job.model_id} :: {job.dataset} :: {', '.join(job.languages)}"
-            )
-        return
-
-    execute_jobs(jobs=jobs)
+PROVIDERS: list[_Provider] = [
+    _Provider(
+        name="openai",
+        env_var="OPENAI_API_KEY",
+        matches=lambda m: m.startswith("openai/"),
+    ),
+    _Provider(
+        name="anthropic",
+        env_var="ANTHROPIC_API_KEY",
+        matches=lambda m: m.startswith("claude-") or m.startswith("anthropic/"),
+    ),
+    _Provider(
+        name="google",
+        env_var="GEMINI_API_KEY",
+        matches=lambda m: m.startswith("gemini/"),
+    ),
+    _Provider(
+        name="xai", env_var="XAI_API_KEY", matches=lambda m: m.startswith("xai/")
+    ),
+]
+PROVIDERS_BY_NAME: dict[str, _Provider] = {p.name: p for p in PROVIDERS}
 
 
 if __name__ == "__main__":

--- a/src/scripts/run_core_model_evaluations.py
+++ b/src/scripts/run_core_model_evaluations.py
@@ -45,17 +45,18 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import click
-from yaml import safe_load
+from update_core_models import refresh_core_models
 
 from euroeval.dataset_configs import get_all_dataset_configs
 from euroeval.languages import get_all_languages
+from leaderboards.core_models import CoreModel
 from leaderboards.evaluation_common import (
     gpu_total_memory_bytes,
     model_fits_locally,
     official_dataset_language_pairs,
     run_euroeval,
 )
-from leaderboards.paths import CORE_MODELS_CONFIG, NEW_RESULTS_PATH, RESULTS_PATH
+from leaderboards.paths import NEW_RESULTS_PATH, RESULTS_PATH
 from leaderboards.result_loading import convert_to_old_format
 
 logging.basicConfig(
@@ -139,8 +140,8 @@ def main(
     if target_datasets:
         logger.info(f"Target dataset(s): {', '.join(target_datasets)}.")
 
-    models = load_core_models()
-    logger.info(f"Loaded {len(models)} core model entries.")
+    models = refresh_core_models()
+    logger.info(f"Refreshed core-model list: {len(models)} entries.")
 
     selected_providers = select_api_providers(
         candidate_models=models,
@@ -181,15 +182,6 @@ def main(
 
 
 @dataclass(frozen=True)
-class CoreModelEntry:
-    """A parsed entry from the ``models:`` list in ``core_models.yaml``."""
-
-    model_id: str
-    is_api: bool
-    pareto_languages: tuple[str, ...]
-
-
-@dataclass(frozen=True)
 class Job:
     """A single (model, dataset, languages) evaluation job."""
 
@@ -208,28 +200,8 @@ class _Provider:
     matches: c.Callable[[str], bool]
 
 
-def load_core_models() -> list[CoreModelEntry]:
-    """Parse ``core_models.yaml`` and return the model list.
-
-    Returns:
-        Every entry from the ``models:`` list, preserving file order.
-    """
-    with CORE_MODELS_CONFIG.open("r", encoding="utf-8") as f:
-        config = safe_load(f)
-    entries: list[CoreModelEntry] = []
-    for raw in config.get("models", []):
-        entries.append(
-            CoreModelEntry(
-                model_id=str(raw["id"]),
-                is_api=bool(raw.get("api", False)),
-                pareto_languages=tuple(raw.get("pareto_languages") or []),
-            )
-        )
-    return entries
-
-
 def select_api_providers(
-    candidate_models: c.Iterable[CoreModelEntry],
+    candidate_models: c.Iterable[CoreModel],
     include_api: bool,
     api_providers_arg: str | None,
 ) -> set[str]:
@@ -256,7 +228,7 @@ def select_api_providers(
     if not include_api:
         return set()
 
-    has_any_api = any(m.is_api for m in candidate_models)
+    has_any_api = any(m.api for m in candidate_models)
     if not has_any_api:
         logger.info("No API models in the candidate set; ignoring --include-api.")
         return set()
@@ -364,7 +336,7 @@ def load_existing_observations() -> set[tuple[str, str, str]]:
 
 
 def build_jobs(
-    models: list[CoreModelEntry],
+    models: list[CoreModel],
     target_datasets: list[str] | None,
     selected_providers: set[str],
     observations: set[tuple[str, str, str]],
@@ -403,7 +375,7 @@ def build_jobs(
         }
 
     for model in models:
-        if model.is_api:
+        if model.api:
             provider = provider_for_model_id(model_id=model.model_id)
             if provider is None or provider.name not in selected_providers:
                 continue
@@ -432,7 +404,7 @@ def build_jobs(
                         model_id=model.model_id,
                         dataset=dataset,
                         languages=tuple(langs),
-                        is_api=model.is_api,
+                        is_api=model.api,
                     )
                 )
             continue
@@ -454,7 +426,7 @@ def build_jobs(
                     model_id=model.model_id,
                     dataset=dataset,
                     languages=tuple(langs),
-                    is_api=model.is_api,
+                    is_api=model.api,
                 )
             )
     return jobs
@@ -532,7 +504,7 @@ def execute_jobs(jobs: list[Job]) -> None:
             )
 
 
-def codes_for_model(model: CoreModelEntry) -> set[str]:
+def codes_for_model(model: CoreModel) -> set[str]:
     """Return the ISO codes a model should be evaluated on.
 
     API models cover every known language. Open-weight models cover the
@@ -549,7 +521,7 @@ def codes_for_model(model: CoreModelEntry) -> set[str]:
     Returns:
         The ISO codes the model should be evaluated on.
     """
-    if model.is_api or not model.pareto_languages:
+    if model.api or not model.pareto_languages:
         return all_known_language_codes()
     codes: set[str] = set()
     for name in model.pareto_languages:

--- a/src/scripts/run_core_model_evaluations.py
+++ b/src/scripts/run_core_model_evaluations.py
@@ -1,0 +1,647 @@
+"""Run EuroEval for the core model list.
+
+Two related workflows live in this script:
+
+1. **Dataset-replacement mode** (``--dataset <id>`` [repeatable]) -- re-run
+   every core model whose language coverage overlaps a dataset's languages
+   on that dataset.
+2. **Backfill mode** (default) -- for every core model, run every official
+   ``(dataset, language)`` pair that the model has no result line for yet.
+
+Both modes share model selection, size-check, results lookup, and the API-
+provider prompt.
+
+Invoke as::
+
+    uv run src/scripts/run_core_model_evaluations.py [...]
+
+Required env vars (open-weight models)
+--------------------------------------
+HF_TOKEN          Resolved via :func:`evaluation_common.resolve_hf_token`,
+                  injected into the euroeval subprocess so gated repos
+                  with granted access can be downloaded.
+
+Required env vars (API models)
+------------------------------
+Only the providers the user picks need a key set; the script aborts up
+front if a selected provider's key is missing.
+
+OPENAI_API_KEY     OpenAI models (``openai/...``).
+ANTHROPIC_API_KEY  Anthropic models (``claude-...``).
+GEMINI_API_KEY     Google models (``gemini/...``).
+XAI_API_KEY        xAI models (``xai/...``).
+"""
+
+from __future__ import annotations
+
+import collections.abc as c
+import json
+import logging
+import os
+import re
+import sys
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import click
+from evaluation_common import (
+    gpu_total_memory_bytes,
+    model_fits_locally,
+    official_dataset_language_pairs,
+    run_euroeval,
+)
+from yaml import safe_load
+
+from euroeval.dataset_configs import get_all_dataset_configs
+from euroeval.languages import get_all_languages
+from leaderboards.paths import CORE_MODELS_CONFIG, NEW_RESULTS_PATH, RESULTS_PATH
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s"
+)
+logger = logging.getLogger("run_core_model_evaluations")
+
+
+# Mapping from short provider name (CLI/UI value) to the env var that
+# must be set and the predicate identifying API model ids belonging to
+# that provider.
+@dataclass(frozen=True)
+class _Provider:
+    name: str
+    env_var: str
+    matches: c.Callable[[str], bool]
+
+
+PROVIDERS: list[_Provider] = [
+    _Provider(
+        name="openai",
+        env_var="OPENAI_API_KEY",
+        matches=lambda m: m.startswith("openai/"),
+    ),
+    _Provider(
+        name="anthropic",
+        env_var="ANTHROPIC_API_KEY",
+        matches=lambda m: m.startswith("claude-") or m.startswith("anthropic/"),
+    ),
+    _Provider(
+        name="google",
+        env_var="GEMINI_API_KEY",
+        matches=lambda m: m.startswith("gemini/"),
+    ),
+    _Provider(
+        name="xai", env_var="XAI_API_KEY", matches=lambda m: m.startswith("xai/")
+    ),
+]
+PROVIDERS_BY_NAME: dict[str, _Provider] = {p.name: p for p in PROVIDERS}
+
+
+# Strips trailing variant annotations on result-record model ids, e.g.
+# ``model (zero-shot)`` / ``model (val)`` / ``model (zero-shot, val)``.
+_VARIANT_SUFFIX_RE = re.compile(r"\s*\((?:zero-shot|val)(?:,\s*(?:zero-shot|val))*\)$")
+_ANCHOR_RE = re.compile(r"<a [^>]*>(?P<inner>[^<]+)</a>")
+
+
+@dataclass(frozen=True)
+class CoreModelEntry:
+    """A parsed entry from the ``models:`` list in ``core_models.yaml``."""
+
+    model_id: str
+    is_api: bool
+    pareto_languages: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Job:
+    """A single (model, dataset, languages) evaluation job."""
+
+    model_id: str
+    dataset: str
+    languages: tuple[str, ...]
+    is_api: bool
+
+
+def load_core_models() -> list[CoreModelEntry]:
+    """Parse ``core_models.yaml`` and return the model list.
+
+    Returns:
+        Every entry from the ``models:`` list, preserving file order.
+    """
+    with CORE_MODELS_CONFIG.open("r", encoding="utf-8") as f:
+        config = safe_load(f)
+    entries: list[CoreModelEntry] = []
+    for raw in config.get("models", []):
+        entries.append(
+            CoreModelEntry(
+                model_id=str(raw["id"]),
+                is_api=bool(raw.get("api", False)),
+                pareto_languages=tuple(raw.get("pareto_languages") or []),
+            )
+        )
+    return entries
+
+
+def _strip_model_variant(model_id: str) -> str:
+    """Return ``model_id`` with leaderboard HTML anchors and variant suffix removed."""
+    m = _ANCHOR_RE.search(model_id)
+    inner = m.group("inner").strip() if m else model_id
+    return _VARIANT_SUFFIX_RE.sub("", inner).strip()
+
+
+def load_existing_observations() -> set[tuple[str, str, str]]:
+    """Return the set of ``(model_id, dataset, language)`` triples already benchmarked.
+
+    Reads the merged result corpus the same way the leaderboard pipeline
+    does -- ``results.tar.gz`` plus the optional ``new_results.jsonl`` --
+    but without the destructive unlink that
+    ``leaderboards.result_loading.load_raw_results`` performs.
+
+    Model ids are stripped of leaderboard HTML anchors and ``(zero-shot)``
+    / ``(val)`` variant suffixes so the keys line up with the canonical
+    ids in ``core_models.yaml``.
+    """
+    lines: list[str] = []
+    if RESULTS_PATH.exists():
+        with tarfile.open(RESULTS_PATH, "r:gz") as tar:
+            member_file = tar.extractfile(member="results/results.jsonl")
+            if member_file is not None:
+                lines.extend(member_file.read().decode(encoding="utf-8").splitlines())
+    if NEW_RESULTS_PATH.exists():
+        lines.extend(NEW_RESULTS_PATH.read_text(encoding="utf-8").splitlines())
+
+    observations: set[tuple[str, str, str]] = set()
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        # Some lines pack multiple JSON objects back-to-back; split on '}{'
+        # the same way result_loading does.
+        for record_text in re.split(pattern=r"(?<=})(?={)", string=line):
+            if not record_text.strip():
+                continue
+            try:
+                record = json.loads(record_text)
+            except json.JSONDecodeError:
+                continue
+            model = _strip_model_variant(str(record.get("model", "")))
+            dataset = record.get("dataset")
+            languages = record.get("languages") or []
+            if not model or not dataset:
+                continue
+            for language in languages:
+                observations.add((model, str(dataset), str(language)))
+    logger.info(
+        f"Loaded {len(observations):,} (model, dataset, language) observations."
+    )
+    return observations
+
+
+def language_name_to_code(name: str) -> str | None:
+    """Map an English language name (lowercased) to its ISO code, or None.
+
+    The names come from ``core_models.yaml::pareto_languages``; values are
+    matched case-insensitively against
+    :func:`euroeval.languages.get_all_languages`.
+
+    Args:
+        name:
+            The English language name (case-insensitive).
+
+    Returns:
+        The ISO code for the language, or None when no match is found.
+    """
+    needle = name.strip().lower()
+    if not needle:
+        return None
+    for code, language in get_all_languages().items():
+        if language.name.lower() == needle:
+            return code
+    return None
+
+
+def all_known_language_codes() -> set[str]:
+    """Return every ISO code known to EuroEval.
+
+    Returns:
+        Every key from :func:`euroeval.languages.get_all_languages`.
+    """
+    return set(get_all_languages().keys())
+
+
+def codes_for_model(model: CoreModelEntry) -> set[str]:
+    """Return the ISO codes a model should be evaluated on.
+
+    API models cover every known language. Open-weight models cover the
+    ISO codes derived from their ``pareto_languages`` -- with one
+    exception: when the Pareto list is empty (typical for EU/OSAI
+    entries that haven't been benchmarked widely enough yet), fall back
+    to "all known languages" so the backfill run is what generates the
+    data the Pareto computation needs.
+    """
+    if model.is_api or not model.pareto_languages:
+        return all_known_language_codes()
+    codes: set[str] = set()
+    for name in model.pareto_languages:
+        code = language_name_to_code(name)
+        if code is None:
+            logger.debug(f"Could not map language name {name!r} to an ISO code.")
+            continue
+        codes.add(code)
+    return codes
+
+
+def dataset_language_codes(dataset_id: str) -> set[str]:
+    """Return ISO codes for a dataset, or an empty set if the dataset is unknown."""
+    configs = get_all_dataset_configs(
+        custom_datasets_file=Path(""),
+        dataset_ids=[dataset_id],
+        api_key=None,
+        cache_dir=Path(".cache"),
+        trust_remote_code=False,
+        run_with_cli=False,
+    )
+    config = configs.get(dataset_id)
+    if config is None:
+        logger.error(f"Unknown dataset id {dataset_id!r}; skipping.")
+        return set()
+    return {language.code for language in config.languages}
+
+
+def select_api_providers(
+    candidate_models: c.Iterable[CoreModelEntry],
+    include_api: bool,
+    api_providers_arg: str | None,
+) -> set[str]:
+    """Resolve which API providers to run and verify their env vars.
+
+    Args:
+        candidate_models:
+            The full set of models in scope, used to check whether any API
+            models are present at all.
+        include_api:
+            Whether the user opted in to API evaluation. When False, no
+            providers are selected regardless of ``api_providers_arg``.
+        api_providers_arg:
+            Comma-separated list of provider names, or None to prompt.
+
+    Returns:
+        The set of provider names that should be evaluated.
+
+    Raises:
+        click.ClickException:
+            When a selected provider's env var is unset, or an unknown
+            provider name is given.
+    """
+    if not include_api:
+        return set()
+
+    has_any_api = any(m.is_api for m in candidate_models)
+    if not has_any_api:
+        logger.info("No API models in the candidate set; ignoring --include-api.")
+        return set()
+
+    if api_providers_arg is None:
+        selected = _prompt_api_providers()
+    else:
+        names = [n.strip().lower() for n in api_providers_arg.split(",") if n.strip()]
+        unknown = sorted(set(names) - PROVIDERS_BY_NAME.keys())
+        if unknown:
+            raise click.ClickException(
+                f"Unknown API provider(s): {', '.join(unknown)}. "
+                f"Valid: {', '.join(PROVIDERS_BY_NAME)}."
+            )
+        selected = set(names)
+
+    missing_env = [
+        PROVIDERS_BY_NAME[name].env_var
+        for name in sorted(selected)
+        if not os.environ.get(PROVIDERS_BY_NAME[name].env_var)
+    ]
+    if missing_env:
+        raise click.ClickException(
+            f"Selected API provider(s) require: {', '.join(missing_env)} -- "
+            "set the variable(s) and re-run."
+        )
+    if selected:
+        logger.info(f"API providers enabled: {', '.join(sorted(selected))}.")
+    return selected
+
+
+def _prompt_api_providers() -> set[str]:
+    """Prompt the user interactively for which API providers to run.
+
+    Returns:
+        The set of selected provider names. May be empty if the user
+        deselects everything.
+
+    Raises:
+        click.ClickException:
+            When stdin is not a TTY (so we cannot prompt safely).
+    """
+    if not sys.stdin.isatty():
+        raise click.ClickException(
+            "stdin is not a TTY; pass --api-providers to select providers "
+            "non-interactively (or omit --include-api)."
+        )
+    click.echo("Select API providers to evaluate (default: all):")
+    selected: set[str] = set()
+    for provider in PROVIDERS:
+        if click.confirm(f"  Include {provider.name}?", default=True):
+            selected.add(provider.name)
+    return selected
+
+
+def provider_for_model_id(model_id: str) -> _Provider | None:
+    """Return the provider that owns an API model id, or None."""
+    for provider in PROVIDERS:
+        if provider.matches(model_id):
+            return provider
+    return None
+
+
+def build_jobs(
+    models: list[CoreModelEntry],
+    target_datasets: list[str] | None,
+    selected_providers: set[str],
+    observations: set[tuple[str, str, str]],
+    force: bool,
+) -> list[Job]:
+    """Compute the (model, dataset, languages) jobs to schedule.
+
+    Args:
+        models:
+            Parsed core-model entries.
+        target_datasets:
+            Dataset ids for dataset-replacement mode, or None for backfill.
+        selected_providers:
+            Provider names that survived the env-var check; API models
+            belonging to other providers are silently skipped.
+        observations:
+            Already-recorded ``(model, dataset, language)`` triples; used
+            to drop jobs that nothing new would learn (unless ``force``).
+        force:
+            When True, ignore ``observations`` and re-run even seen pairs.
+
+    Returns:
+        One Job per (model, dataset) pair to evaluate, with languages
+        deduplicated and sorted.
+    """
+    jobs: list[Job] = []
+    official_pairs = official_dataset_language_pairs()
+    official_by_dataset: dict[str, set[str]] = {}
+    for dataset, language in official_pairs:
+        official_by_dataset.setdefault(dataset, set()).add(language)
+
+    target_dataset_codes: dict[str, set[str]] | None = None
+    if target_datasets:
+        target_dataset_codes = {d: dataset_language_codes(d) for d in target_datasets}
+
+    for model in models:
+        if model.is_api:
+            provider = provider_for_model_id(model.model_id)
+            if provider is None or provider.name not in selected_providers:
+                continue
+        model_languages = codes_for_model(model=model)
+        if not model_languages:
+            logger.info(
+                f"{model.model_id}: skipping -- no resolvable language coverage."
+            )
+            continue
+
+        if target_dataset_codes is not None:
+            for dataset, dataset_langs in target_dataset_codes.items():
+                langs = sorted(model_languages & dataset_langs)
+                if not langs:
+                    continue
+                if not force:
+                    langs = [
+                        lang
+                        for lang in langs
+                        if (model.model_id, dataset, lang) not in observations
+                    ]
+                if not langs:
+                    continue
+                jobs.append(
+                    Job(
+                        model_id=model.model_id,
+                        dataset=dataset,
+                        languages=tuple(langs),
+                        is_api=model.is_api,
+                    )
+                )
+            continue
+
+        # Backfill mode: every official pair the model is in scope for.
+        for dataset, dataset_langs in official_by_dataset.items():
+            langs = sorted(model_languages & dataset_langs)
+            if not langs:
+                continue
+            if not force:
+                langs = [
+                    lang
+                    for lang in langs
+                    if (model.model_id, dataset, lang) not in observations
+                ]
+            if not langs:
+                continue
+            jobs.append(
+                Job(
+                    model_id=model.model_id,
+                    dataset=dataset,
+                    languages=tuple(langs),
+                    is_api=model.is_api,
+                )
+            )
+    return jobs
+
+
+def apply_size_filter(jobs: list[Job]) -> list[Job]:
+    """Drop open-weight jobs whose model can't fit on the local GPU.
+
+    API jobs are passed through untouched (we cannot size-check them).
+    Open-weight models whose safetensors footprint cannot be measured
+    are also passed through; the queue script uses the same policy.
+
+    Args:
+        jobs:
+            The full job list before the size check.
+
+    Returns:
+        The jobs that should still be scheduled.
+    """
+    gpu_bytes = gpu_total_memory_bytes()
+    if gpu_bytes is None:
+        logger.info("Local memory budget unknown; skipping size pre-check.")
+        return jobs
+    logger.info(f"Local memory budget: {gpu_bytes / (1024**3):.1f} GiB.")
+
+    sized_cache: dict[str, bool] = {}
+    kept: list[Job] = []
+    for job in jobs:
+        if job.is_api:
+            kept.append(job)
+            continue
+        if job.model_id not in sized_cache:
+            fits, needed = model_fits_locally(
+                model_id=job.model_id, gpu_bytes=gpu_bytes
+            )
+            sized_cache[job.model_id] = fits
+            if not fits and needed is not None:
+                logger.info(
+                    f"{job.model_id}: skipping -- needs "
+                    f"~{needed / (1024**3):.1f} GiB of weights, exceeds local "
+                    f"budget of {gpu_bytes / (1024**3):.1f} GiB."
+                )
+        if sized_cache[job.model_id]:
+            kept.append(job)
+    return kept
+
+
+def execute_jobs(jobs: list[Job]) -> None:
+    """Run each job in sequence via the shared euroeval runner.
+
+    API jobs are run on the validation split with zero-shot prompting;
+    open-weight jobs use the defaults (test split, few-shot).
+
+    Args:
+        jobs:
+            The jobs to execute.
+    """
+    for index, job in enumerate(jobs, start=1):
+        logger.info(
+            f"[{index}/{len(jobs)}] euroeval --model {job.model_id} "
+            f"--dataset {job.dataset} --language {' --language '.join(job.languages)}"
+            f"{' (api, val, zero-shot)' if job.is_api else ''}"
+        )
+        returncode, _ = run_euroeval(
+            model_id=job.model_id,
+            languages=job.languages,
+            datasets=[job.dataset],
+            evaluate_test_split=not job.is_api,
+            zero_shot=job.is_api,
+        )
+        if returncode != 0:
+            logger.warning(
+                f"{job.model_id} / {job.dataset}: euroeval exited with "
+                f"code {returncode}; continuing."
+            )
+
+
+@click.command()
+@click.option(
+    "--dataset",
+    "datasets",
+    multiple=True,
+    help="Dataset id to run in dataset-replacement mode. Repeatable. When omitted, "
+    "the script runs in backfill mode against every official (dataset, language) "
+    "pair.",
+)
+@click.option(
+    "--include-api",
+    is_flag=True,
+    default=False,
+    help="Opt in to running API models. Without this flag every api: true entry "
+    "in core_models.yaml is silently skipped.",
+)
+@click.option(
+    "--api-providers",
+    default=None,
+    help="Comma-separated provider names to run (openai, anthropic, google, xai). "
+    "Skips the interactive prompt. Requires --include-api.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print the planned jobs and exit without invoking euroeval.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Re-run even (model, dataset, language) triples that already have a "
+    "result line.",
+)
+def main(
+    datasets: tuple[str, ...],
+    include_api: bool,
+    api_providers: str | None,
+    dry_run: bool,
+    force: bool,
+) -> None:
+    """Run EuroEval for the core model list (backfill or dataset-replacement).
+
+    Args:
+        datasets:
+            Dataset ids passed via ``--dataset``. When non-empty, the
+            script runs in dataset-replacement mode against exactly those
+            datasets; otherwise it runs in backfill mode.
+        include_api:
+            Whether to consider ``api: true`` entries at all.
+        api_providers:
+            Optional comma-separated provider filter; bypasses the prompt.
+        dry_run:
+            When True, print the planned jobs and return without running.
+        force:
+            When True, ignore previously recorded results.
+
+    Raises:
+        click.ClickException:
+            When ``--api-providers`` is passed without ``--include-api``,
+            when an unknown provider name is supplied, or when a selected
+            provider's env var is missing.
+    """
+    if api_providers and not include_api:
+        raise click.ClickException(
+            "--api-providers requires --include-api; pass both or neither."
+        )
+
+    target_datasets = list(datasets) or None
+    mode = "dataset-replacement" if target_datasets else "backfill"
+    logger.info(f"Mode: {mode}.")
+    if target_datasets:
+        logger.info(f"Target dataset(s): {', '.join(target_datasets)}.")
+
+    models = load_core_models()
+    logger.info(f"Loaded {len(models)} core model entries.")
+
+    selected_providers = select_api_providers(
+        candidate_models=models,
+        include_api=include_api,
+        api_providers_arg=api_providers,
+    )
+
+    observations: set[tuple[str, str, str]] = set()
+    if not force:
+        try:
+            observations = load_existing_observations()
+        except FileNotFoundError as e:
+            logger.warning(
+                f"Could not load existing results ({e}); proceeding as if none exist."
+            )
+
+    jobs = build_jobs(
+        models=models,
+        target_datasets=target_datasets,
+        selected_providers=selected_providers,
+        observations=observations,
+        force=force,
+    )
+    logger.info(f"Planned {len(jobs)} job(s) before size check.")
+
+    jobs = apply_size_filter(jobs=jobs)
+    logger.info(f"{len(jobs)} job(s) survive the size check.")
+
+    if dry_run:
+        for job in jobs:
+            tag = "api" if job.is_api else "open"
+            click.echo(
+                f"[{tag}] {job.model_id} :: {job.dataset} :: {', '.join(job.languages)}"
+            )
+        return
+
+    execute_jobs(jobs=jobs)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/update_core_models.py
+++ b/src/scripts/update_core_models.py
@@ -524,6 +524,25 @@ def main(dry_run: bool) -> None:
         dry_run:
             Print outputs instead of writing them.
     """
+    refresh_core_models(dry_run=dry_run)
+
+
+def refresh_core_models(dry_run: bool = False) -> list[CoreModel]:
+    """Rebuild the core-model list, update the YAML, and sync issue #1186.
+
+    Equivalent to invoking this script as a CLI, but callable in-process
+    so other tools (e.g. ``run_core_model_evaluations.py``) can ensure
+    the YAML and the GitHub issue are fresh before running downstream
+    work.
+
+    Args:
+        dry_run (optional):
+            When True, print the would-be issue body / diff comment and
+            skip the YAML and GitHub writes. Defaults to False.
+
+    Returns:
+        The freshly-built core-model list, regardless of ``dry_run``.
+    """
     with CORE_MODELS_CONFIG.open("r") as f:
         config = safe_load(f)
     issue_number = int(config["issue_number"])
@@ -546,13 +565,13 @@ def main(dry_run: bool) -> None:
 
     token = os.environ.get("GITHUB_TOKEN")
     if not token:
-        logger.warning("GITHUB_TOKEN not set — skipping GitHub update.")
+        logger.warning("GITHUB_TOKEN not set -- skipping GitHub update.")
         if dry_run:
             click.echo(new_body)
-        if not dry_run:
+        else:
             _write_yaml(CORE_MODELS_CONFIG, today, models)
             logger.info(f"Wrote {CORE_MODELS_CONFIG}.")
-        return
+        return models
 
     try:
         old_body = _get_issue_body(issue_number=issue_number, token=token)
@@ -568,7 +587,7 @@ def main(dry_run: bool) -> None:
         click.echo(new_body)
         click.echo("=== DIFF COMMENT ===")
         click.echo(comment)
-        return
+        return models
 
     if new_body.strip() != old_body.strip():
         _update_issue_body(issue_number=issue_number, body=new_body, token=token)
@@ -586,6 +605,7 @@ def main(dry_run: bool) -> None:
 
     _write_yaml(CORE_MODELS_CONFIG, today, models)
     logger.info(f"Wrote {CORE_MODELS_CONFIG}.")
+    return models
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- New script `src/scripts/run_core_model_evaluations.py` drives EuroEval over the core-model list in two modes:
  - **Backfill** (default): for every core model, run every official `(dataset, language)` pair not yet covered.
  - **Dataset-replacement** (`--dataset <id>`, repeatable): re-run every core model whose language coverage overlaps the target dataset, scoped to just that dataset.
- API models are opt-in via `--include-api`. Provider selection (interactive or `--api-providers openai,anthropic,google,xai`) gates which env vars are required (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `XAI_API_KEY`) and forces validation-split + zero-shot for API runs.
- Shared helpers used by both the queue processor and the new runner -- `LANGUAGE_GROUP_CODES`, `official_dataset_language_pairs`, the GPU-fit size check, the pty-streamed `run_euroeval`, and `resolve_hf_token` -- move to a new `src/scripts/evaluation_common.py` so the two scripts stay in sync.
- Open-weight core models with empty `pareto_languages` (typical for EU/OSAI entries not yet broadly benchmarked) are treated as "all known languages" rather than skipped, so the backfill run is what generates the data the Pareto computation needs.

## Test plan

- [x] `uv run src/scripts/run_core_model_evaluations.py --dry-run` (backfill) — 16,101 jobs planned, 14,424 survive the size check on a 64 GiB host.
- [x] `uv run src/scripts/run_core_model_evaluations.py --dataset scala-da --dry-run` — 69 jobs planned, 62 survive size check, all Danish.
- [x] `uv run src/scripts/run_core_model_evaluations.py --include-api --api-providers openai --dataset scala-da --dry-run` — adds the two OpenAI models tagged `[api]`.
- [x] `process_evaluation_queue.py` still imports cleanly after the refactor.
- [ ] End-to-end run of a single small open-weight job (not exercised in this PR — evals are expensive).
- [ ] End-to-end run of a single API job (not exercised in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)