### PR TITLE
fix: use processing_class instead of removed Trainer.tokenizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed a `'QuestionAnsweringTrainer' object has no attribute 'tokenizer'` crash
+  when evaluating encoder models on extractive QA datasets. The `Trainer.tokenizer`
+  attribute was removed in transformers v5; we now use the replacement
+  `processing_class` attribute.
 - Raised the default vLLM worker RPC timeouts
   (`VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS` and `VLLM_ENGINE_ITERATION_TIMEOUT_S`)
   from 300s to 1800s so that large models on slow hardware no longer crash

--- a/src/euroeval/task_group_utils/question_answering.py
+++ b/src/euroeval/task_group_utils/question_answering.py
@@ -59,9 +59,9 @@ class QuestionAnsweringTrainer(Trainer):
         )
 
         # Get the CLS token id for the tokeniser
-        if self.tokenizer is not None:
-            assert isinstance(self.tokenizer, PreTrainedTokenizerBase)
-            special_token_metadata = get_special_token_metadata(self.tokenizer)
+        if self.processing_class is not None:
+            assert isinstance(self.processing_class, PreTrainedTokenizerBase)
+            special_token_metadata = get_special_token_metadata(self.processing_class)
             self.cls_token_id = special_token_metadata["cls_token_id"]
 
         # Set the label names


### PR DESCRIPTION
## Summary

- `Trainer.tokenizer` was removed in transformers v5 (replaced by `processing_class`). `QuestionAnsweringTrainer.__init__` still referenced `self.tokenizer`, so every extractive-QA benchmark crashed at construction with `'QuestionAnsweringTrainer' object has no attribute 'tokenizer'`.
- Updates the three references in `src/euroeval/task_group_utils/question_answering.py` to use `self.processing_class`.

Fixes #1825 (encoder model `AiLab-IMCS-UL/lvbert` failing on the extractive QA benchmark).

## Test plan

- [ ] Re-run the evaluation for `AiLab-IMCS-UL/lvbert` to confirm the QA benchmark no longer errors.
- [ ] Spot-check another encoder QA-bearing evaluation to confirm no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)