### PR TITLE
fix: narrow Mistral tokeniser fallback to mistralai/* repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Narrowed the Mistral-common tokeniser fallback in the vLLM benchmark module so
+  it only fires for actual `mistralai/*` repositories. Previously, any
+  `ValueError` whose message happened to mention `MistralCommonBackend` (e.g.
+  the unsupported-kwargs error raised when `AutoTokenizer` auto-routes a
+  non-Mistral repo through it) would send tokeniser loading down a
+  Mistral-only path against the wrong repository, producing a misleading "No
+  tokenizer file found" error.
 - Raised the default vLLM worker RPC timeouts
   (`VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS` and `VLLM_ENGINE_ITERATION_TIMEOUT_S`)
   from 300s to 1800s so that large models on slow hardware no longer crash

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -1403,7 +1403,13 @@ def load_tokeniser(
             sleep(5)
             continue
         except (KeyError, ValueError) as e:
-            if "mistral" in str(e).lower():
+            # Only fall back to the Mistral-common tokeniser for actual
+            # mistralai/* repositories. Otherwise an unrelated error that merely
+            # mentions `MistralCommonBackend` (e.g. an unsupported-kwargs
+            # `ValueError` raised when `AutoTokenizer` auto-routes through it)
+            # would send us down a Mistral-only code path against a non-Mistral
+            # repo, producing a misleading "No tokenizer file found" error.
+            if "mistral" in str(e).lower() and model_id.startswith("mistralai/"):
                 tokeniser = MistralCommonTokenizer.from_pretrained(
                     model_id,
                     padding_side="left",


### PR DESCRIPTION
## Summary

- The vLLM tokeniser loader caught any `ValueError` whose message contained `"mistral"` and retried with `MistralCommonTokenizer`. With recent transformers/`mistral-common`, `AutoTokenizer` can auto-route through `MistralCommonBackend` for some non-Mistral repos and raise a kwargs-related `ValueError` mentioning `MistralCommonBackend`. That sends tokeniser loading down a Mistral-only path against the wrong repository and surfaces a misleading "No tokenizer file found" error.
- Restrict the fallback to repos whose ID starts with `mistralai/`, so unrelated tokeniser failures now surface their real underlying error.

Refs #1775 (`gordicaleksa/SlovenianGPT`). This won't make SlovenianGPT load on its own — that model still trips the `AutoTokenizer` auto-routing — but it stops the failure from being misattributed and clears the path for a targeted fix.

## Test plan

- [ ] Re-run a `mistralai/*` model evaluation to confirm the Mistral fallback still triggers when needed.
- [ ] Re-run the `gordicaleksa/SlovenianGPT` evaluation and confirm the error message now reflects the real `AutoTokenizer` failure rather than the misleading Mistral one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)