### PR TITLE
fix: force vLLM runner to 'generate' for benchmark models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Force vLLM to load benchmark models with `runner="generate"`. Some checkpoints
+  whose config also advertises a pooling/embedding head (e.g.
+  `norallm/norbloom-7b-scratch`) were otherwise auto-detected as pooling models,
+  causing `LLM.generate()` to raise
+  `LLM.generate() is only supported for generative models`. Every model that
+  reaches this code path is already classified as generative by EuroEval.
 - Raised the default vLLM worker RPC timeouts
   (`VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS` and `VLLM_ENGINE_ITERATION_TIMEOUT_S`)
   from 300s to 1800s so that large models on slow hardware no longer crash

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -1217,6 +1217,12 @@ def load_model(
         model = LLM(
             model=model_location,
             tokenizer=model_location,
+            # Force vLLM to load the model as generative. Some checkpoints (e.g.
+            # ones whose config also advertises a pooling/embedding head) are
+            # otherwise auto-detected as pooling models, which makes
+            # `LLM.generate` raise. Every model that reaches this path has
+            # already been classified as generative by EuroEval.
+            runner="generate",
             gpu_memory_utilization=benchmark_config.gpu_memory_utilization,
             max_model_len=max_model_len,
             max_num_batched_tokens=max_model_len,


### PR DESCRIPTION
## Summary

- Some checkpoints whose config also advertises a pooling/embedding head get auto-detected by vLLM as pooling models. `LLM.generate()` then raises `LLM.generate() is only supported for generative models. Try passing --runner generate ...`, killing the benchmark before any data is processed.
- Every model that reaches this code path is already classified as generative by EuroEval (we raise earlier if `generative_type is None`), so we explicitly pass `runner=\"generate\"` to vLLM's `LLM` constructor.

Fixes #1787 (`norallm/norbloom-7b-scratch`).

## Test plan

- [ ] Re-run the evaluation for `norallm/norbloom-7b-scratch` to confirm it loads and benchmarks successfully.
- [ ] Spot-check that a regular generative model (e.g. a small Llama variant) still loads and runs as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)