### PR TITLE
fix(types): make all ty diagnostics pass without behaviour changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          # `pull_request_target` checks out the base branch by default; check out
+          # the PR head so CI validates the proposed changes, not `main`. Combined
+          # with `persist-credentials: false` so the PR code never sees the token.
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Install uv and set up Python
@@ -47,6 +51,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          # `pull_request_target` checks out the base branch by default; check out
+          # the PR head so CI validates the proposed changes, not `main`. Combined
+          # with `persist-credentials: false` so the PR code never sees the token.
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Install uv and set up Python
@@ -83,6 +91,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          # `pull_request_target` checks out the base branch by default; check out
+          # the PR head so CI validates the proposed changes, not `main`. Combined
+          # with `persist-credentials: false` so the PR code never sees the token.
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Install uv and set up Python

--- a/src/euroeval/task_group_utils/question_answering.py
+++ b/src/euroeval/task_group_utils/question_answering.py
@@ -67,7 +67,7 @@ class QuestionAnsweringTrainer(Trainer):
         # Set the label names
         self.label_names = ["start_positions", "end_positions"]
 
-    def evaluate(
+    def evaluate(  # ty: ignore[invalid-method-override]
         self,
         eval_dataset: "Dataset | dict[str, Dataset] | None" = None,
         ignore_keys: list[str] | None = None,
@@ -92,7 +92,7 @@ class QuestionAnsweringTrainer(Trainer):
             The metrics computed on the evaluation dataset.
         """
         eval_dataloader = self.get_eval_dataloader(
-            eval_dataset if eval_dataset is not None else None  # type: ignore[arg-type]
+            eval_dataset if eval_dataset is not None else None  # ty: ignore[invalid-argument-type]
         )
 
         # Temporarily disable metric computation, we will do it in the loop here.
@@ -129,7 +129,7 @@ class QuestionAnsweringTrainer(Trainer):
             )
             assert self.compute_metrics is not None
 
-            new_metrics = self.compute_metrics(EvalPrediction(*preds_and_labels))  # type: ignore[arg-type]
+            new_metrics = self.compute_metrics(EvalPrediction(*preds_and_labels))  # ty: ignore[invalid-argument-type]
             metrics.update(new_metrics)
 
             # Prefix all keys with metric_key_prefix + '_'
@@ -189,8 +189,8 @@ def compute_metrics(
     results: dict[str, float] = dict()
     for metric in dataset_config.task.metrics:
         score: float | None = metric(
-            predictions=predictions,  # type: ignore[arg-type]
-            references=labels,  # type: ignore[arg-type]
+            predictions=predictions,  # ty: ignore[invalid-argument-type]
+            references=labels,  # ty: ignore[invalid-argument-type]
             dataset=dataset,
             dataset_config=dataset_config,
             benchmark_config=benchmark_config,
@@ -245,7 +245,10 @@ def prepare_train_examples(
     # and will make the truncation of the context fail (the tokenized question will
     # take a lots of space). So we remove that left whitespace
 
-    examples["question"] = [q.lstrip() for q in examples["question"]]
+    examples["question"] = [
+        q.lstrip()
+        for q in examples["question"]  # ty: ignore[not-iterable]
+    ]
 
     # Extract special token metadata from the tokeniser
     special_token_metadata = get_special_token_metadata(tokeniser=tokeniser)
@@ -258,16 +261,23 @@ def prepare_train_examples(
     # If the tokeniser is not adding special tokens, then we add them manually
     if not has_cls_token and not has_sep_token:
         examples["question"] = [
-            f"{cls_token}{q}{sep_token}" for q in examples["question"]
+            f"{cls_token}{q}{sep_token}"
+            for q in examples["question"]  # ty: ignore[not-iterable]
         ]
 
-        examples["context"] = [f"{c}{sep_token}" for c in examples["context"]]
+        examples["context"] = [
+            f"{c}{sep_token}"
+            for c in examples["context"]  # ty: ignore[not-iterable]
+        ]
 
     # Set the stride used during tokenisation, when the context is long enough to be
     # split into several features. Since we are always keeping the question tokens, we
     # need to make sure that the stride does not exceed the resulting maximum context
     # length.
-    max_question_tokens = max(len(tokeniser(q).input_ids) for q in examples["question"])
+    max_question_tokens = max(
+        len(tokeniser(q).input_ids)
+        for q in examples["question"]  # ty: ignore[not-iterable]
+    )
     num_special_tokens = int(has_cls_token) + int(has_sep_token)
     stride = tokeniser.model_max_length // 4
     stride = min(
@@ -330,7 +340,7 @@ def prepare_train_examples(
         # One example can give several spans, this is the index of the example
         # containing this span of text.
         sample_index = sample_mapping[i]
-        answers = examples["answers"][sample_index]
+        answers = examples["answers"][sample_index]  # ty: ignore[not-subscriptable]
 
         # If no answers are given, set the cls_index as answer.
         if len(answers["answer_start"]) == 0:
@@ -410,7 +420,10 @@ def prepare_test_examples(
     # and will make the truncation of the context fail (the tokenised question will
     # take a lots of space). So we remove that left whitespace
 
-    examples["question"] = [q.lstrip() for q in examples["question"]]
+    examples["question"] = [
+        q.lstrip()
+        for q in examples["question"]  # ty: ignore[not-iterable]
+    ]
 
     # Extract special token metadata from the tokeniser
     special_token_metadata = get_special_token_metadata(tokeniser=tokeniser)
@@ -422,16 +435,23 @@ def prepare_test_examples(
     # If the tokeniser is not adding special tokens, then we add them manually
     if not has_cls_token and not has_sep_token:
         examples["question"] = [
-            f"{cls_token}{q}{sep_token}" for q in examples["question"]
+            f"{cls_token}{q}{sep_token}"
+            for q in examples["question"]  # ty: ignore[not-iterable]
         ]
 
-        examples["context"] = [f"{c}{sep_token}" for c in examples["context"]]
+        examples["context"] = [
+            f"{c}{sep_token}"
+            for c in examples["context"]  # ty: ignore[not-iterable]
+        ]
 
     # Set the stride used during tokenisation, when the context is long enough to be
     # split into several features. Since we are always keeping the question tokens, we
     # need to make sure that the stride does not exceed the resulting maximum context
     # length.
-    max_question_tokens = max(len(tokeniser(q).input_ids) for q in examples["question"])
+    max_question_tokens = max(
+        len(tokeniser(q).input_ids)
+        for q in examples["question"]  # ty: ignore[not-iterable]
+    )
     num_special_tokens = int(has_cls_token) + int(has_sep_token)
     stride = tokeniser.model_max_length // 4
     stride = min(
@@ -475,7 +495,9 @@ def prepare_test_examples(
         # containing this span of text.
         sample_index = sample_mapping[i]
 
-        tokenised_examples.id.append(examples["id"][sample_index])
+        tokenised_examples.id.append(
+            examples["id"][sample_index]  # ty: ignore[not-subscriptable]
+        )
 
         # Set to (-1, -1) the offset_mapping that are not part of the context so it's
         # easy to determine if a token position is part of the context or not.

--- a/src/euroeval/yaml_config.py
+++ b/src/euroeval/yaml_config.py
@@ -234,7 +234,11 @@ def load_dataset_config_from_yaml(
     kwargs.setdefault("bootstrap_samples", True)
     kwargs.setdefault("unofficial", False)
     kwargs.setdefault("input_column", "text")
-    return DatasetConfig(task=task_obj, languages=language_objs, **kwargs)
+    return DatasetConfig(
+        task=task_obj,
+        languages=language_objs,
+        **kwargs,  # ty: ignore[invalid-argument-type]
+    )
 
 
 def promote_field_spec_fields(raw: dict[str, object]) -> None:

--- a/tests/test_bias_metrics.py
+++ b/tests/test_bias_metrics.py
@@ -121,8 +121,8 @@ def test_accuracy_ambig_accepts_numpy_ints(
         predictions=preds,  # ty: ignore[invalid-argument-type]
         references=[],
         dataset=ds,
-        dataset_config=None,  # ty: ignore[invalid-argument-type]
-        benchmark_config=None,  # ty: ignore[invalid-argument-type]
+        dataset_config=None,
+        benchmark_config=None,
     ) == pytest.approx(1.0)
 
 


### PR DESCRIPTION
## Summary

Brings `uv run ty check` (the `ty-check` pre-commit hook) from **40 diagnostics** to **`All checks passed!`** locally, with **no runtime behaviour changes**, and fixes a CI checkout misconfiguration that was masking the failure.

## Type-checker fixes (behaviour-preserving)

| File | Diagnostics | Fix |
|------|-------------|-----|
| `src/euroeval/yaml_config.py` | 22 × `invalid-argument-type` on `DatasetConfig(..., **kwargs)` | One `# ty: ignore[invalid-argument-type]` on the `**kwargs` line. ty can't verify a heterogeneous-union `dict` against each per-field parameter type. |
| `src/euroeval/task_group_utils/question_answering.py` | 16 (override, arg-type, not-iterable, not-subscriptable) | The existing `# type: ignore[...]` comments are **mypy-style and ty does not honour them** (mypy isn't configured in this repo). Converted them to `# ty: ignore[...]` with ty's codes; added a suppression for the `Trainer.evaluate` override signal and for the `BatchEncoding`-indexing `not-iterable`/`not-subscriptable` false positives from incomplete `transformers` stubs. |
| `tests/test_bias_metrics.py` | 2 × `unused-ignore-comment` | Removed the two now-unused `# ty: ignore` directives. |

## CI fix

The `CI` workflow triggers on `pull_request_target` with a bare `actions/checkout`, so it checked out the **base branch (`main`)** instead of the PR head — meaning `code-check`/pytest validated `main`, not the proposed changes. This is also how the `ty` hook added in #1852 landed on `main` while `main` still fails `ty check`.

All three checkout steps now use `ref: ${{ github.event.pull_request.head.sha }}` (keeping `persist-credentials: false`).

## Caveats

- **This PR's own `code-check` will stay red until merge.** Under `pull_request_target`, GitHub uses the workflow file *and* base code from `main`, so both the type fixes and the checkout fix only take effect for PRs opened after this lands on `main`.
- **`benchmark_modules/vllm.py` left untouched (by request).** Three `# ty: ignore` comments there are needed on macOS (older/CPU vLLM) but flagged `unused-ignore-comment` on the Linux CI env. They were intentionally left as-is; they may keep the Linux `code-check` red until separately resolved (e.g. `unused-ignore-comment = "ignore"` in `[tool.ty.rules]`, or platform-gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)