### PR TITLE
fix: count model loading failures as errored not skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Fixed validation error when loading benchmark results with `languages` field stored as
   a JSON-encoded string (e.g. `'"bg"'` instead of `["bg"]`). This occurred when mixing
   EEE format results with legacy format results.
+- Fixed model loading failures (e.g., shape mismatches, CUDA errors) incorrectly being
+  counted as "skipped" benchmarks instead of "errored". The queue processor now correctly
+  detects these as failures and applies the `evaluation-failed` label to GitHub issues.
 
 ### Changed
 

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -806,9 +806,9 @@ class Benchmarker:
                             log(e.message, level=logging.ERROR)
 
                             # Add the remaining number of benchmarks for the model to
-                            # our benchmark counter, since we're skipping the rest of
+                            # our benchmark counter, since we're erroring on the rest of
                             # them
-                            num_skipped_benchmarks += (
+                            num_errored_benchmarks += (
                                 len(dataset_configs)
                                 - dataset_configs.index(dataset_config)
                                 - 1


### PR DESCRIPTION
## Problem

When a model fails to load (e.g., RuntimeError shape mismatches, CUDA errors), the error is caught as an `InvalidModel` exception. However, the remaining benchmarks were incorrectly counted as 'skipped' instead of 'errored'.

Example error:
```
RuntimeError: Worker failed with error 'mat1 and mat2 shapes cannot be multiplied (8192x4096 and 8192x3840)'
The model 'google/gemma-4-12B' could not be loaded...
Skipped 232 benchmarks
```

This caused the queue processor to treat these as intentional skips rather than failures, so issues weren't getting the `evaluation-failed` label.

## Root Cause

In `src/euroeval/benchmarker.py` lines 803-816, when `load_model` raises `InvalidModel` and `raise_errors=False`, the code counted the remaining benchmarks as `num_skipped_benchmarks` instead of `num_errored_benchmarks`.

This was inconsistent with how `InvalidModel` is handled when returned from `_benchmark_single` (lines 860-868), where it's correctly counted as errored.

## Solution

Changed line 811 from `num_skipped_benchmarks` to `num_errored_benchmarks`, so model loading failures are now reported as:
```
errored N benchmarks
```
instead of:
```
skipped N benchmarks
```

This allows the queue processor to correctly detect failures and apply the `evaluation-failed` label.

## Changes

- `src/euroeval/benchmarker.py`: Changed benchmark counter from `num_skipped_benchmarks` to `num_errored_benchmarks` when model loading fails