### PR TITLE
Fix transformers v5.2 deprecation warnings

### DIFF
--- a/src/euroeval/finetuning.py
+++ b/src/euroeval/finetuning.py
@@ -320,7 +320,7 @@ def get_training_args(
         eval_accumulation_steps=32,
         optim=OptimizerNames.ADAMW_TORCH,
         learning_rate=2e-5,
-        warmup_ratio=0.01,
+        warmup_steps=100,
         gradient_accumulation_steps=32 // batch_size,
         load_best_model_at_end=True,
         seed=4242 + iteration_idx,

--- a/src/euroeval/task_group_utils/question_answering.py
+++ b/src/euroeval/task_group_utils/question_answering.py
@@ -58,10 +58,10 @@ class QuestionAnsweringTrainer(Trainer):
             **kwargs,
         )
 
-        # Get the CLS token id for the tokeniser
-        if self.tokenizer is not None:
-            assert isinstance(self.tokenizer, PreTrainedTokenizerBase)
-            special_token_metadata = get_special_token_metadata(self.tokenizer)
+        # Get the CLS token id for the processing_class
+        if self.processing_class is not None:
+            assert isinstance(self.processing_class, PreTrainedTokenizerBase)
+            special_token_metadata = get_special_token_metadata(self.processing_class)
             self.cls_token_id = special_token_metadata["cls_token_id"]
 
         # Set the label names


### PR DESCRIPTION
This PR fixes two errors from transformers v5.2+:

1. Replace deprecated `warmup_ratio` with `warmup_steps` in TrainingArguments
2. Use `self.processing_class` instead of `self.tokenizer` in QuestionAnsweringTrainer

Both changes align with the transformers v5.2 API where `warmup_ratio` is deprecated and the Trainer base class renamed `tokenizer` to `processing_class`.