### PR TITLE
Fix: handle empty model choices in AngryTweets evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fixed a bug where evaluating on AngryTweets sentiment classification raised
+  `Sequences and scores must have the same length` when the model returned no choices for
+  some samples. The `_create_model_output` method now appends an empty score list
+  alongside the empty sequence to keep both lists in sync.
 - Fixed deprecation warnings from `transformers` v5.2+:
   - Replaced deprecated `warmup_ratio` with dynamic `warmup_steps` calculation (1% of
     `max_steps`, minimum 1 step).

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -930,11 +930,11 @@ class LiteLLMModel(BenchmarkModule):
                 If the model response is invalid.
         """
         sequences = []
-        scores = []
+        scores: list[c.Sequence[c.Sequence[tuple[str, float]]] | None] = []
         for model_response in model_responses:
             if not model_response.choices:
                 sequences.append("")
-                scores.append([])
+                scores.append(None)
                 log(
                     f"The model {model_id!r} did not end up "
                     "generating any text. This is likely because the model ran "
@@ -979,6 +979,7 @@ class LiteLLMModel(BenchmarkModule):
 
             # Structure the model output as a GenerativeModelOutput object
             sequences.append(generation_output)
+            sample_scores: c.Sequence[c.Sequence[tuple[str, float]]] | None = None
             if (
                 hasattr(model_response_choices, "logprobs")
                 and model_response_choices.logprobs is not None
@@ -1052,7 +1053,8 @@ class LiteLLMModel(BenchmarkModule):
                         )
                     ]
 
-                scores.append(logprobs_list)
+                sample_scores = logprobs_list
+            scores.append(sample_scores)
 
         if not sequences:
             log(
@@ -1069,8 +1071,10 @@ class LiteLLMModel(BenchmarkModule):
                 f"Got {len(sequences)} sequences and {len(scores)} scores."
             )
 
+        # Only return scores if at least one sample has logprobs
+        has_logprobs = any(s is not None for s in scores)
         return GenerativeModelOutput(
-            sequences=sequences, scores=scores if scores else None
+            sequences=sequences, scores=scores if has_logprobs else None
         )
 
     @cached_property

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -1073,9 +1073,13 @@ class LiteLLMModel(BenchmarkModule):
 
         # Only return scores if at least one sample has logprobs
         has_logprobs = any(s is not None for s in scores)
-        return GenerativeModelOutput(
-            sequences=sequences, scores=scores if has_logprobs else None
-        )
+        # Convert None placeholders to empty lists for type compatibility
+        scores_out: c.Sequence[c.Sequence[c.Sequence[tuple[str, float]]]] | None
+        if has_logprobs:
+            scores_out = [s if s is not None else [] for s in scores]
+        else:
+            scores_out = None
+        return GenerativeModelOutput(sequences=sequences, scores=scores_out)
 
     @cached_property
     def num_params(self) -> int:

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -934,6 +934,7 @@ class LiteLLMModel(BenchmarkModule):
         for model_response in model_responses:
             if not model_response.choices:
                 sequences.append("")
+                scores.append([])
                 log(
                     f"The model {model_id!r} did not end up "
                     "generating any text. This is likely because the model ran "

--- a/tests/test_benchmark_modules/test_litellm.py
+++ b/tests/test_benchmark_modules/test_litellm.py
@@ -71,9 +71,14 @@ class TestCreateModelOutput:
             model_id="test-model",
         )
 
-        # Verify the output is valid
+        # Verify the output is valid - sequences and scores are aligned
         assert len(output.sequences) == 2
         assert output.sequences[0] == "positive"
         assert output.sequences[1] == ""
+        # Scores should be non-None since at least one sample has logprobs
         assert output.scores is not None
         assert len(output.scores) == 2
+        # First sample has logprobs, second sample (empty choices) has None
+        assert output.scores[0] is not None
+        assert len(output.scores[0]) == 1
+        assert output.scores[1] is None

--- a/tests/test_benchmark_modules/test_litellm.py
+++ b/tests/test_benchmark_modules/test_litellm.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import MagicMock
 
-import pytest
 from litellm.types.utils import Choices
 
 from euroeval.benchmark_modules.litellm import LiteLLMModel
@@ -63,9 +62,10 @@ class TestCreateModelOutput:
             log_metadata=False,
         )
 
-        # This should NOT raise InvalidBenchmark about length mismatch
+        # This should NOT raise InvalidBenchmark about length mismatch.
         # Without the fix, this raises:
-        # "Sequences and scores must have the same length. Got 2 sequences and 1 scores."
+        # "Sequences and scores must have the same length. Got 2 sequences and 1
+        # scores."
         output = model._create_model_output(
             model_responses=[mock_valid_response, mock_empty_response],
             model_id="test-model",
@@ -78,7 +78,7 @@ class TestCreateModelOutput:
         # Scores should be non-None since at least one sample has logprobs
         assert output.scores is not None
         assert len(output.scores) == 2
-        # First sample has logprobs, second sample (empty choices) has None
+        # First sample has logprobs, second sample (empty choices) has empty list
         assert output.scores[0] is not None
         assert len(output.scores[0]) == 1
-        assert output.scores[1] is None
+        assert output.scores[1] == []

--- a/tests/test_benchmark_modules/test_litellm.py
+++ b/tests/test_benchmark_modules/test_litellm.py
@@ -1,0 +1,79 @@
+"""Unit tests for the `litellm` module."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from litellm.types.utils import Choices
+
+from euroeval.benchmark_modules.litellm import LiteLLMModel
+from euroeval.data_models import BenchmarkConfig, DatasetConfig, ModelConfig
+
+
+class TestCreateModelOutput:
+    """Tests for the _create_model_output method in LiteLLMModel."""
+
+    def test_empty_choices_appends_empty_scores(
+        self,
+        model_config: ModelConfig,
+        dataset_config: DatasetConfig,
+        benchmark_config: BenchmarkConfig,
+    ) -> None:
+        """Test that responses with no choices get empty score lists.
+
+        This is a regression test for a bug where evaluating on AngryTweets raised
+        "Sequences and scores must have the same length. Got 1320 sequences and 1319
+        scores" when the model returned no choices for some samples. The bug was in
+        _create_model_output which appended an empty string to sequences but skipped
+        appending to scores when choices were empty.
+
+        The test mocks logprobs as a list of dicts matching ChoiceLogprobs schema
+        to trigger the scores append for the valid response.
+        """
+        # Create a mock response with valid choices and logprobs (as list fallback)
+        mock_valid_response = MagicMock()
+        mock_choice = MagicMock(spec=Choices)
+        mock_message = MagicMock()
+        mock_message.content = "positive"
+        mock_choice.message = mock_message
+        # Mock logprobs as list of dicts matching ChoiceLogprobs schema
+        # Each dict needs a 'content' field with list of token logprobs
+        mock_choice.logprobs = [
+            {
+                "content": [
+                    {
+                        "token": "positive",
+                        "logprob": -0.5,
+                        "bytes": [112, 111, 115, 105, 116, 105, 118, 101],
+                        "top_logprobs": [],
+                    }
+                ]
+            }
+        ]
+        mock_valid_response.choices = [mock_choice]
+
+        # Create a mock response with empty choices (model ran out of tokens)
+        mock_empty_response = MagicMock()
+        mock_empty_response.choices = []
+
+        # Create the LiteLLMModel instance
+        model = LiteLLMModel(
+            model_config=model_config,
+            dataset_config=dataset_config,
+            benchmark_config=benchmark_config,
+            log_metadata=False,
+        )
+
+        # This should NOT raise InvalidBenchmark about length mismatch
+        # Without the fix, this raises:
+        # "Sequences and scores must have the same length. Got 2 sequences and 1 scores."
+        output = model._create_model_output(
+            model_responses=[mock_valid_response, mock_empty_response],
+            model_id="test-model",
+        )
+
+        # Verify the output is valid
+        assert len(output.sequences) == 2
+        assert output.sequences[0] == "positive"
+        assert output.sequences[1] == ""
+        assert output.scores is not None
+        assert len(output.scores) == 2


### PR DESCRIPTION
## Summary

Fixes a bug where evaluating on AngryTweets sentiment classification raised `Sequences and scores must have the same length` when the model returned no choices for some samples.

## Changes

- In `_create_model_output`, append an empty score list (`scores.append([])`) alongside the empty sequence when a model response has no choices
- This keeps both lists in sync, preventing the length mismatch error

## Testing

The error occurred when evaluating on AngryTweets with 1320 sequences but only 1319 scores. This fix ensures that every iteration of the loop appends to both `sequences` and `scores`.

Closes #<issue-number-if-applicable>