### PR TITLE
fix: handle InvalidModel exception for quantized models

### DIFF
--- a/src/euroeval/benchmark_modules/hf.py
+++ b/src/euroeval/benchmark_modules/hf.py
@@ -488,15 +488,18 @@ class HuggingFaceEncoderModel(BenchmarkModule):
             whether the model exists.
         """
         model_id_components = split_model_id(model_id=model_id)
-        model_info = get_model_repo_info(
-            model_id=model_id_components.model_id,
-            revision=model_id_components.revision,
-            api_key=benchmark_config.api_key,
-            cache_dir=benchmark_config.cache_dir,
-            trust_remote_code=benchmark_config.trust_remote_code,
-            requires_safetensors=benchmark_config.requires_safetensors,
-            run_with_cli=benchmark_config.run_with_cli,
-        )
+        try:
+            model_info = get_model_repo_info(
+                model_id=model_id_components.model_id,
+                revision=model_id_components.revision,
+                api_key=benchmark_config.api_key,
+                cache_dir=benchmark_config.cache_dir,
+                trust_remote_code=benchmark_config.trust_remote_code,
+                requires_safetensors=benchmark_config.requires_safetensors,
+                run_with_cli=benchmark_config.run_with_cli,
+            )
+        except InvalidModel:
+            return False
         return (
             model_info is not None
             and model_info.pipeline_tag not in GENERATIVE_PIPELINE_TAGS

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -970,15 +970,18 @@ class VLLMModel(HuggingFaceEncoderModel):
         model_id = model_id_components.model_id
         revision = model_id_components.revision
 
-        model_info = get_model_repo_info(
-            model_id=model_id,
-            revision=revision,
-            api_key=benchmark_config.api_key,
-            cache_dir=benchmark_config.cache_dir,
-            trust_remote_code=benchmark_config.trust_remote_code,
-            requires_safetensors=benchmark_config.requires_safetensors,
-            run_with_cli=benchmark_config.run_with_cli,
-        )
+        try:
+            model_info = get_model_repo_info(
+                model_id=model_id,
+                revision=revision,
+                api_key=benchmark_config.api_key,
+                cache_dir=benchmark_config.cache_dir,
+                trust_remote_code=benchmark_config.trust_remote_code,
+                requires_safetensors=benchmark_config.requires_safetensors,
+                run_with_cli=benchmark_config.run_with_cli,
+            )
+        except InvalidModel:
+            return False
         return (
             model_info is not None
             and model_info.pipeline_tag in GENERATIVE_PIPELINE_TAGS


### PR DESCRIPTION
## What

Fixes model loading failures for quantized models (e.g., NVFP4 variants) that lack a `model_type` key in their `config.json`.

## Problem

When evaluating models like `mistralai/Mistral-Small-4-119B-2603-NVFP4`, the config loading would fail with:

```
ValueError: Unrecognized model in mistralai/Mistral-Small-4-119B-2603-NVFP4. Should have a `model_type` key in its config.json.
```

This prevented the model lookup from falling through to the appropriate backend (LiteLLM/VLLM).

## Solution

Catches `InvalidModel` exceptions in `model_exists()` methods for both `HuggingFaceEncoderModel` and `VLLMModel`, returning `False` when the config can't be loaded. This allows graceful fallback to other backends.

## Files changed

- `src/euroeval/benchmark_modules/hf.py`
- `src/euroeval/benchmark_modules/vllm.py`

## Testing

The fix allows models with non-standard configs (quantized formats) to be properly routed to their correct backends without raising exceptions.