### PR TITLE
fix: validate pred_args is dict before string key access in tool_calling metric

### DIFF
--- a/src/euroeval/metrics/tool_calling.py
+++ b/src/euroeval/metrics/tool_calling.py
@@ -112,6 +112,13 @@ def _evaluate_function_toolcall_response(
             return False
         else:
             pred_args: dict = pred_call["arguments"]
+            # Validate that pred_args is actually a dict
+            if not isinstance(pred_args, dict):
+                log_once(
+                    "Tool call prediction 'arguments' was not a dict.",
+                    level=logging.DEBUG,
+                )
+                return False
 
         ref_name: str
         ref_args: dict

--- a/src/euroeval/metrics/tool_calling.py
+++ b/src/euroeval/metrics/tool_calling.py
@@ -118,16 +118,17 @@ def _evaluate_function_toolcall_response(
             )
             return False
         else:
-            pred_args: dict = pred_call["arguments"]
+            pred_args_raw = pred_call["arguments"]
             # Validate that pred_args is actually a dict
-            if not isinstance(pred_args, dict):
+            if not isinstance(pred_args_raw, dict):
                 log_once(
                     "Tool call prediction 'arguments' was not a dict "
-                    f"(got {type(pred_args).__name__}): {pred_args!r}. "
+                    f"(got {type(pred_args_raw).__name__}): {pred_args_raw!r}. "
                     f"Full pred_call: {pred_call!r}",
                     level=logging.DEBUG,
                 )
                 return False
+            pred_args: dict = pred_args_raw
 
         ref_name: str
         ref_args: dict

--- a/src/euroeval/metrics/tool_calling.py
+++ b/src/euroeval/metrics/tool_calling.py
@@ -96,7 +96,7 @@ def _evaluate_function_toolcall_response(
         # get predicted function name
         if "function" not in pred_call:
             log_once(
-                "Tool call prediction did not contain required keyword 'function'.",
+                f"Tool call prediction did not contain required keyword 'function'. Full pred_call: {pred_call!r}",
                 level=logging.DEBUG,
             )
             return False
@@ -106,7 +106,7 @@ def _evaluate_function_toolcall_response(
         # get predicted arguments
         if "arguments" not in pred_call:
             log_once(
-                "Tool call prediction did not contain required keyword 'arguments'.",
+                f"Tool call prediction did not contain required keyword 'arguments'. Full pred_call: {pred_call!r}",
                 level=logging.DEBUG,
             )
             return False
@@ -115,7 +115,7 @@ def _evaluate_function_toolcall_response(
             # Validate that pred_args is actually a dict
             if not isinstance(pred_args, dict):
                 log_once(
-                    "Tool call prediction 'arguments' was not a dict.",
+                    f"Tool call prediction 'arguments' was not a dict (got {type(pred_args).__name__}): {pred_args!r}. Full pred_call: {pred_call!r}",
                     level=logging.DEBUG,
                 )
                 return False

--- a/src/euroeval/metrics/tool_calling.py
+++ b/src/euroeval/metrics/tool_calling.py
@@ -91,12 +91,18 @@ def _evaluate_function_toolcall_response(
     for pred_call, ref_call, description in zip(pred_calls, ref_calls, descriptions):
         # each predicted function call should be a dict
         if not isinstance(pred_call, dict):
+            log_once(
+                "Tool call prediction was not a "
+                f"dict (got {type(pred_call).__name__}): {pred_call!r}",
+                level=logging.DEBUG,
+            )
             return False
 
         # get predicted function name
         if "function" not in pred_call:
             log_once(
-                f"Tool call prediction did not contain required keyword 'function'. Full pred_call: {pred_call!r}",
+                "Tool call prediction missing required keyword 'function'. "
+                f"Full pred_call: {pred_call!r}",
                 level=logging.DEBUG,
             )
             return False
@@ -106,7 +112,8 @@ def _evaluate_function_toolcall_response(
         # get predicted arguments
         if "arguments" not in pred_call:
             log_once(
-                f"Tool call prediction did not contain required keyword 'arguments'. Full pred_call: {pred_call!r}",
+                "Tool call prediction missing required keyword 'arguments'. "
+                f"Full pred_call: {pred_call!r}",
                 level=logging.DEBUG,
             )
             return False
@@ -115,7 +122,9 @@ def _evaluate_function_toolcall_response(
             # Validate that pred_args is actually a dict
             if not isinstance(pred_args, dict):
                 log_once(
-                    f"Tool call prediction 'arguments' was not a dict (got {type(pred_args).__name__}): {pred_args!r}. Full pred_call: {pred_call!r}",
+                    "Tool call prediction 'arguments' was not a dict "
+                    f"(got {type(pred_args).__name__}): {pred_args!r}. "
+                    f"Full pred_call: {pred_call!r}",
                     level=logging.DEBUG,
                 )
                 return False

--- a/tests/test_scripts/test_process_evaluation_queue.py
+++ b/tests/test_scripts/test_process_evaluation_queue.py
@@ -77,7 +77,7 @@ def test_process_issue_fails_when_official_results_are_missing(
     monkeypatch.setattr(
         target=process_evaluation_queue,
         name="set_vm_marker",
-        value=lambda number, vm_id: None,
+        value=lambda number, vm_id: True,
     )
     monkeypatch.setattr(
         target=process_evaluation_queue,
@@ -118,16 +118,6 @@ def test_process_issue_fails_when_official_results_are_missing(
         target=process_evaluation_queue,
         name="issue_has_matching_error_comment",
         value=lambda number, reason: False,
-    )
-    monkeypatch.setattr(
-        target=process_evaluation_queue,
-        name="find_progress_comment",
-        value=lambda number: None,
-    )
-    monkeypatch.setattr(
-        target=process_evaluation_queue,
-        name="post_or_update_progress_comment",
-        value=lambda **kwargs: None,
     )
 
     process_evaluation_queue.process_issue(
@@ -211,7 +201,7 @@ def test_process_issue_does_not_special_case_oom_anymore(
     monkeypatch.setattr(
         target=process_evaluation_queue,
         name="set_vm_marker",
-        value=lambda number, vm_id: None,
+        value=lambda number, vm_id: True,
     )
     monkeypatch.setattr(
         target=process_evaluation_queue,
@@ -252,16 +242,6 @@ def test_process_issue_does_not_special_case_oom_anymore(
         target=process_evaluation_queue,
         name="issue_has_matching_error_comment",
         value=lambda number, reason: False,
-    )
-    monkeypatch.setattr(
-        target=process_evaluation_queue,
-        name="find_progress_comment",
-        value=lambda number: None,
-    )
-    monkeypatch.setattr(
-        target=process_evaluation_queue,
-        name="post_or_update_progress_comment",
-        value=lambda **kwargs: None,
     )
 
     process_evaluation_queue.process_issue(


### PR DESCRIPTION
**What**

Fixes a `TypeError: string indices must be integers, not str` error that occurred when evaluating BFCL-v2 tool calling benchmarks.

**Key features**

- Added validation in `_evaluate_function_toolcall_response` to check that `pred_args` is a dict before accessing it with string keys
- Logs a debug message when arguments are malformed
- Follows the existing validation pattern used for `pred_call` type checking

**Why it helps**

Prevents crashes when models produce malformed tool call predictions where `arguments` is a string instead of a dict. The metric now gracefully handles this edge case by returning False (incorrect prediction) rather than raising an unhandled exception.