### PR TITLE
fix: use snapshot_download in --download-only mode to skip model instantiation

### DIFF
--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -307,13 +307,35 @@ class Benchmarker:
         )
         del dataset
 
-        log_once(f"Downloading model {model_config.model_id!r}...", level=logging.INFO)
-        snapshot_download(
-            repo_id=model_config.model_id,
-            revision=model_config.revision,
-            cache_dir=model_config.model_cache_dir,
-            token=get_hf_token(api_key=benchmark_config.api_key),
-        )
+        # Skip download if model is a local path
+        if not Path(model_config.model_id).exists():
+            log_once(
+                f"Downloading model {model_config.model_id!r}...", level=logging.INFO
+            )
+            snapshot_download(
+                repo_id=model_config.model_id,
+                revision=model_config.revision,
+                cache_dir=model_config.model_cache_dir,
+                token=get_hf_token(api_key=benchmark_config.api_key),
+            )
+
+            # For adapter models, also download the base model
+            if model_config.adapter_base_model_id:
+                log_once(
+                    f"Downloading adapter base model {model_config.adapter_base_model_id!r}...",
+                    level=logging.INFO,
+                )
+                snapshot_download(
+                    repo_id=model_config.adapter_base_model_id,
+                    revision="main",
+                    cache_dir=model_config.model_cache_dir,
+                    token=get_hf_token(api_key=benchmark_config.api_key),
+                )
+        else:
+            log_once(
+                f"Model {model_config.model_id!r} is a local path, skipping download",
+                level=logging.INFO,
+            )
 
         log_once(
             f"Loading metrics for the '{dataset_config.task.name}' task",

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -321,9 +321,9 @@ class Benchmarker:
 
             # For adapter models, also download the base model
             if model_config.adapter_base_model_id:
+                base_id = model_config.adapter_base_model_id
                 log_once(
-                    f"Downloading adapter base model {model_config.adapter_base_model_id!r}...",
-                    level=logging.INFO,
+                    f"Downloading adapter base model {base_id!r}...", level=logging.INFO
                 )
                 snapshot_download(
                     repo_id=model_config.adapter_base_model_id,

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from shutil import rmtree
 from time import sleep
 
+from huggingface_hub import snapshot_download
 from torch.distributed import destroy_process_group
 
 from .benchmark_config_factory import build_benchmark_config
@@ -306,12 +307,13 @@ class Benchmarker:
         )
         del dataset
 
-        model = load_model(
-            model_config=model_config,
-            dataset_config=dataset_config,
-            benchmark_config=benchmark_config,
+        log_once(f"Downloading model {model_config.model_id!r}...", level=logging.INFO)
+        snapshot_download(
+            repo_id=model_config.model_id,
+            revision=model_config.revision,
+            cache_dir=model_config.model_cache_dir,
+            token=benchmark_config.api_key,
         )
-        del model
 
         log_once(
             f"Loading metrics for the '{dataset_config.task.name}' task",

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -30,7 +30,7 @@ from .scores import log_scores
 from .speed_benchmark import benchmark_speed
 from .string_utils import split_model_id
 from .tasks import SPEED
-from .utils import enforce_reproducibility, internet_connection_available
+from .utils import enforce_reproducibility, get_hf_token, internet_connection_available
 
 if t.TYPE_CHECKING:
     from .benchmark_modules import BenchmarkModule
@@ -312,7 +312,7 @@ class Benchmarker:
             repo_id=model_config.model_id,
             revision=model_config.revision,
             cache_dir=model_config.model_cache_dir,
-            token=benchmark_config.api_key,
+            token=get_hf_token(api_key=benchmark_config.api_key),
         )
 
         log_once(

--- a/tests/test_benchmarker.py
+++ b/tests/test_benchmarker.py
@@ -216,6 +216,11 @@ def test_download_only_does_not_instantiate_model(
     monkeypatch.setattr("huggingface_hub.snapshot_download", mock_snapshot_download)
     monkeypatch.setattr("euroeval.model_loading.load_model", mock_load_model)
 
+    def mock_load_raw_data(*_args, **_kwargs) -> None:
+        pass
+
+    monkeypatch.setattr("euroeval.benchmarker.load_raw_data", mock_load_raw_data)
+
     dataset_config = DatasetConfig(
         task=task,
         languages=[language],

--- a/tests/test_benchmarker.py
+++ b/tests/test_benchmarker.py
@@ -201,6 +201,11 @@ def test_download_only_does_not_instantiate_model(
 
     This ensures that --download-only mode works on machines without CUDA/GPUs.
     """
+    if task.name == "translation":
+        pytest.skip("Translation tasks require two languages")
+
+    This ensures that --download-only mode works on machines without CUDA/GPUs.
+    """
     snapshot_download_called = False
     load_model_called = False
 

--- a/tests/test_benchmarker.py
+++ b/tests/test_benchmarker.py
@@ -187,6 +187,72 @@ def test_benchmark_generative_adapter_no_internet(
     assert all(isinstance(result, BenchmarkResult) for result in benchmark_result)
 
 
+def test_download_only_does_not_instantiate_model(
+    task: Task,
+    language: Language,
+    encoder_model_id: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that download_only mode downloads models without instantiating them.
+
+    This ensures that --download-only mode works on machines without CUDA/GPUs.
+    """
+    from huggingface_hub import snapshot_download
+    from euroeval.model_loading import load_model
+
+    snapshot_download_called = False
+    load_model_called = False
+
+    def mock_snapshot_download(*args, **kwargs):
+        nonlocal snapshot_download_called
+        snapshot_download_called = True
+
+    def mock_load_model(*args, **kwargs):
+        nonlocal load_model_called
+        load_model_called = True
+        raise RuntimeError("load_model should not be called in download_only mode")
+
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download", mock_snapshot_download
+    )
+    monkeypatch.setattr(
+        "euroeval.model_loading.load_model", mock_load_model
+    )
+
+    dataset_config = DatasetConfig(
+        name="test_dataset",
+        task=task,
+        language=language,
+        huggingface_id="test/test",
+    )
+    model_config = ModelConfig(
+        model_id=encoder_model_id,
+        revision="main",
+        model_cache_dir=str(tmp_path / "models"),
+        adapter_base_model_id=None,
+    )
+    benchmark_config = BenchmarkConfig(
+        cache_dir=str(tmp_path / "cache"),
+        api_key=None,
+        download_only=True,
+    )
+
+    benchmarker = Benchmarker(
+        progress_bar=False,
+        save_results=False,
+        num_iterations=1,
+    )
+    benchmarker._download(
+        dataset_config=dataset_config,
+        model_config=model_config,
+        benchmark_config=benchmark_config,
+    )
+
+    assert snapshot_download_called, "snapshot_download should be called"
+    assert not load_model_called, "load_model should NOT be called in download_only mode"
+
+
 @pytest.mark.parametrize(
     argnames=["few_shot", "evaluate_test_split", "benchmark_results", "expected"],
     argvalues=[

--- a/tests/test_benchmarker.py
+++ b/tests/test_benchmarker.py
@@ -213,7 +213,9 @@ def test_download_only_does_not_instantiate_model(
         load_model_called = True
         raise RuntimeError("load_model should not be called in download_only mode")
 
-    monkeypatch.setattr("huggingface_hub.snapshot_download", mock_snapshot_download)
+    monkeypatch.setattr(
+        "euroeval.benchmarker.snapshot_download", mock_snapshot_download
+    )
     monkeypatch.setattr("euroeval.model_loading.load_model", mock_load_model)
 
     def mock_load_raw_data(*_args, **_kwargs) -> None:

--- a/tests/test_benchmarker.py
+++ b/tests/test_benchmarker.py
@@ -216,7 +216,9 @@ def test_download_only_does_not_instantiate_model(
     monkeypatch.setattr("huggingface_hub.snapshot_download", mock_snapshot_download)
     monkeypatch.setattr("euroeval.model_loading.load_model", mock_load_model)
 
-    dataset_config = DatasetConfig(task=task, languages=[language], name="test_dataset")
+    dataset_config = DatasetConfig(
+        task=task, languages=[language], name="test_dataset", source="test/source"
+    )
 
     model_config = ModelConfig(
         model_id=encoder_model_id,

--- a/tests/test_benchmarker.py
+++ b/tests/test_benchmarker.py
@@ -204,11 +204,11 @@ def test_download_only_does_not_instantiate_model(
     snapshot_download_called = False
     load_model_called = False
 
-    def mock_snapshot_download(*args, **kwargs) -> None:
+    def mock_snapshot_download(*_args, **_kwargs) -> None:
         nonlocal snapshot_download_called
         snapshot_download_called = True
 
-    def mock_load_model(*args, **kwargs) -> Never:
+    def mock_load_model(*_args, **_kwargs) -> Never:
         nonlocal load_model_called
         load_model_called = True
         raise RuntimeError("load_model should not be called in download_only mode")
@@ -217,7 +217,11 @@ def test_download_only_does_not_instantiate_model(
     monkeypatch.setattr("euroeval.model_loading.load_model", mock_load_model)
 
     dataset_config = DatasetConfig(
-        task=task, languages=[language], name="test_dataset", source="test/source"
+        task=task,
+        languages=[language],
+        name="test_dataset",
+        pretty_name="Test Dataset",
+        source="test/source",
     )
 
     model_config = ModelConfig(

--- a/tests/test_benchmarker.py
+++ b/tests/test_benchmarker.py
@@ -9,6 +9,7 @@ from collections.abc import Generator
 from dataclasses import replace
 from pathlib import Path
 from shutil import rmtree
+from typing import Never
 
 import pytest
 import torch
@@ -28,6 +29,7 @@ from euroeval.data_models import (
     ModelConfig,
     Task,
 )
+from euroeval.enums import InferenceBackend, ModelType
 from euroeval.exceptions import HuggingFaceHubDown
 
 
@@ -193,56 +195,73 @@ def test_download_only_does_not_instantiate_model(
     encoder_model_id: str,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    device: torch.device,
 ) -> None:
     """Test that download_only mode downloads models without instantiating them.
 
     This ensures that --download-only mode works on machines without CUDA/GPUs.
     """
-    from huggingface_hub import snapshot_download
-    from euroeval.model_loading import load_model
-
     snapshot_download_called = False
     load_model_called = False
 
-    def mock_snapshot_download(*args, **kwargs):
+    def mock_snapshot_download(*args, **kwargs) -> None:
         nonlocal snapshot_download_called
         snapshot_download_called = True
 
-    def mock_load_model(*args, **kwargs):
+    def mock_load_model(*args, **kwargs) -> Never:
         nonlocal load_model_called
         load_model_called = True
         raise RuntimeError("load_model should not be called in download_only mode")
 
-    monkeypatch.setattr(
-        "huggingface_hub.snapshot_download", mock_snapshot_download
-    )
-    monkeypatch.setattr(
-        "euroeval.model_loading.load_model", mock_load_model
-    )
+    monkeypatch.setattr("huggingface_hub.snapshot_download", mock_snapshot_download)
+    monkeypatch.setattr("euroeval.model_loading.load_model", mock_load_model)
 
-    dataset_config = DatasetConfig(
-        name="test_dataset",
-        task=task,
-        language=language,
-        huggingface_id="test/test",
-    )
+    dataset_config = DatasetConfig(task=task, languages=[language], name="test_dataset")
+
     model_config = ModelConfig(
         model_id=encoder_model_id,
         revision="main",
+        param=None,
+        task="test",
+        languages=[language],
+        inference_backend=InferenceBackend.TRANSFORMERS,
+        merge=False,
+        model_type=ModelType.ENCODER,
+        fresh=True,
         model_cache_dir=str(tmp_path / "models"),
         adapter_base_model_id=None,
     )
     benchmark_config = BenchmarkConfig(
+        datasets=[dataset_config],
+        languages=[language],
+        finetuning_batch_size=1,
+        raise_errors=True,
         cache_dir=str(tmp_path / "cache"),
         api_key=None,
+        api_base=None,
+        api_version=None,
+        force=False,
+        progress_bar=False,
+        save_results=False,
+        device=device,
+        verbose=False,
+        debug=False,
+        trust_remote_code=False,
+        clear_model_cache=False,
+        evaluate_test_split=True,
+        few_shot=False,
+        num_iterations=1,
+        gpu_memory_utilization=0.9,
+        attention_backend=None,
+        requires_safetensors=False,
+        generative_type=None,
+        run_with_cli=True,
+        max_context_length=None,
+        vocabulary_size=None,
         download_only=True,
     )
 
-    benchmarker = Benchmarker(
-        progress_bar=False,
-        save_results=False,
-        num_iterations=1,
-    )
+    benchmarker = Benchmarker(progress_bar=False, save_results=False, num_iterations=1)
     benchmarker._download(
         dataset_config=dataset_config,
         model_config=model_config,
@@ -250,7 +269,9 @@ def test_download_only_does_not_instantiate_model(
     )
 
     assert snapshot_download_called, "snapshot_download should be called"
-    assert not load_model_called, "load_model should NOT be called in download_only mode"
+    assert not load_model_called, (
+        "load_model should NOT be called in download_only mode"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_benchmarker.py
+++ b/tests/test_benchmarker.py
@@ -204,8 +204,6 @@ def test_download_only_does_not_instantiate_model(
     if task.name == "translation":
         pytest.skip("Translation tasks require two languages")
 
-    This ensures that --download-only mode works on machines without CUDA/GPUs.
-    """
     snapshot_download_called = False
     load_model_called = False
 


### PR DESCRIPTION
The `--download-only` mode was calling `load_model()` which instantiates the model and checks for nvcc/CUDA, causing errors on login nodes without GPUs.

**Changes:**
- Replace `load_model()` with `huggingface_hub.snapshot_download()` in the `_download` method
- Models are now downloaded without instantiation, bypassing nvcc checks

**Why:**
When running evaluations on remote VMs with airgapped compute nodes, the login node (no GPU) should only download model weights. The compute nodes then load from cache. This fix ensures download-only mode actually only downloads.

**Testing:**
Run `euroeval --download-only --model <model_id>` on a login node without CUDA/nvcc.