### PR TITLE
refactor: remove deprecated use_legacy_prediction_loop handling

### DIFF
--- a/src/euroeval/finetuning.py
+++ b/src/euroeval/finetuning.py
@@ -306,40 +306,32 @@ def get_training_args(
     max_steps = 1 if hasattr(sys, "_called_from_test") else 10_000
     warmup_steps = max(1, max_steps // 100)
 
-    # Build kwargs for TrainingArguments to handle version compatibility
-    training_args_kwargs = {
-        "output_dir": model_config.model_cache_dir,
-        "eval_strategy": IntervalStrategy.STEPS,
-        "logging_strategy": logging_strategy,
-        "save_strategy": IntervalStrategy.STEPS,
-        "eval_steps": 30,
-        "logging_steps": 30,
-        "save_steps": 30,
-        "max_steps": max_steps,
-        "use_cpu": benchmark_config.device == torch.device("cpu"),
-        "report_to": [],
-        "save_total_limit": 1,
-        "per_device_train_batch_size": batch_size,
-        "per_device_eval_batch_size": batch_size,
-        "eval_accumulation_steps": 32,
-        "optim": OptimizerNames.ADAMW_TORCH,
-        "learning_rate": 2e-5,
-        "warmup_steps": warmup_steps,
-        "gradient_accumulation_steps": 32 // batch_size,
-        "load_best_model_at_end": True,
-        "seed": 4242 + iteration_idx,
-        "fp16": dtype == DataType.FP16,
-        "bf16": dtype == DataType.BF16,
-        "disable_tqdm": not benchmark_config.progress_bar,
-        "ddp_find_unused_parameters": False,
-    }
-
-    # Add use_legacy_prediction_loop only if the TrainingArguments class supports it
-    # This attribute was deprecated in transformers 4.30 and removed in later versions
-    if hasattr(TrainingArguments, "use_legacy_prediction_loop"):
-        training_args_kwargs["use_legacy_prediction_loop"] = False
-
-    training_args = TrainingArguments(**training_args_kwargs)  # type: ignore
+    training_args = TrainingArguments(
+        output_dir=model_config.model_cache_dir,
+        eval_strategy=IntervalStrategy.STEPS,
+        logging_strategy=logging_strategy,
+        save_strategy=IntervalStrategy.STEPS,
+        eval_steps=30,
+        logging_steps=30,
+        save_steps=30,
+        max_steps=max_steps,
+        use_cpu=benchmark_config.device == torch.device("cpu"),
+        report_to=[],
+        save_total_limit=1,
+        per_device_train_batch_size=batch_size,
+        per_device_eval_batch_size=batch_size,
+        eval_accumulation_steps=32,
+        optim=OptimizerNames.ADAMW_TORCH,
+        learning_rate=2e-5,
+        warmup_steps=warmup_steps,
+        gradient_accumulation_steps=32 // batch_size,
+        load_best_model_at_end=True,
+        seed=4242 + iteration_idx,
+        fp16=dtype == DataType.FP16,
+        bf16=dtype == DataType.BF16,
+        disable_tqdm=not benchmark_config.progress_bar,
+        ddp_find_unused_parameters=False,
+    )
 
     # TEMP: Use only 1 GPU for now for finetuning
     if benchmark_config.device == torch.device("cuda"):

--- a/src/euroeval/finetuning.py
+++ b/src/euroeval/finetuning.py
@@ -306,32 +306,40 @@ def get_training_args(
     max_steps = 1 if hasattr(sys, "_called_from_test") else 10_000
     warmup_steps = max(1, max_steps // 100)
 
-    training_args = TrainingArguments(
-        output_dir=model_config.model_cache_dir,
-        eval_strategy=IntervalStrategy.STEPS,
-        logging_strategy=logging_strategy,
-        save_strategy=IntervalStrategy.STEPS,
-        eval_steps=30,
-        logging_steps=30,
-        save_steps=30,
-        max_steps=max_steps,
-        use_cpu=benchmark_config.device == torch.device("cpu"),
-        report_to=[],
-        save_total_limit=1,
-        per_device_train_batch_size=batch_size,
-        per_device_eval_batch_size=batch_size,
-        eval_accumulation_steps=32,
-        optim=OptimizerNames.ADAMW_TORCH,
-        learning_rate=2e-5,
-        warmup_steps=warmup_steps,
-        gradient_accumulation_steps=32 // batch_size,
-        load_best_model_at_end=True,
-        seed=4242 + iteration_idx,
-        fp16=dtype == DataType.FP16,
-        bf16=dtype == DataType.BF16,
-        disable_tqdm=not benchmark_config.progress_bar,
-        ddp_find_unused_parameters=False,
-    )
+    # Build kwargs for TrainingArguments to handle version compatibility
+    training_args_kwargs = {
+        "output_dir": model_config.model_cache_dir,
+        "eval_strategy": IntervalStrategy.STEPS,
+        "logging_strategy": logging_strategy,
+        "save_strategy": IntervalStrategy.STEPS,
+        "eval_steps": 30,
+        "logging_steps": 30,
+        "save_steps": 30,
+        "max_steps": max_steps,
+        "use_cpu": benchmark_config.device == torch.device("cpu"),
+        "report_to": [],
+        "save_total_limit": 1,
+        "per_device_train_batch_size": batch_size,
+        "per_device_eval_batch_size": batch_size,
+        "eval_accumulation_steps": 32,
+        "optim": OptimizerNames.ADAMW_TORCH,
+        "learning_rate": 2e-5,
+        "warmup_steps": warmup_steps,
+        "gradient_accumulation_steps": 32 // batch_size,
+        "load_best_model_at_end": True,
+        "seed": 4242 + iteration_idx,
+        "fp16": dtype == DataType.FP16,
+        "bf16": dtype == DataType.BF16,
+        "disable_tqdm": not benchmark_config.progress_bar,
+        "ddp_find_unused_parameters": False,
+    }
+
+    # Add use_legacy_prediction_loop only if the TrainingArguments class supports it
+    # This attribute was deprecated in transformers 4.30 and removed in later versions
+    if hasattr(TrainingArguments, "use_legacy_prediction_loop"):
+        training_args_kwargs["use_legacy_prediction_loop"] = False
+
+    training_args = TrainingArguments(**training_args_kwargs)  # type: ignore
 
     # TEMP: Use only 1 GPU for now for finetuning
     if benchmark_config.device == torch.device("cuda"):

--- a/src/euroeval/task_group_utils/multiple_choice_classification.py
+++ b/src/euroeval/task_group_utils/multiple_choice_classification.py
@@ -43,8 +43,7 @@ class MultipleChoiceClassificationTrainer(Trainer):
         """
         eval_dataloader = self.get_eval_dataloader(eval_dataset)  # ty: ignore[invalid-argument-type]
 
-        eval_loop = self.evaluation_loop
-        output = eval_loop(
+        output = self.evaluation_loop(
             eval_dataloader,
             description="Evaluation",
             prediction_loss_only=None,

--- a/src/euroeval/task_group_utils/multiple_choice_classification.py
+++ b/src/euroeval/task_group_utils/multiple_choice_classification.py
@@ -43,11 +43,7 @@ class MultipleChoiceClassificationTrainer(Trainer):
         """
         eval_dataloader = self.get_eval_dataloader(eval_dataset)  # ty: ignore[invalid-argument-type]
 
-        eval_loop = (
-            self.prediction_loop
-            if self.args.use_legacy_prediction_loop
-            else self.evaluation_loop
-        )
+        eval_loop = self.evaluation_loop
         output = eval_loop(
             eval_dataloader,
             description="Evaluation",

--- a/src/euroeval/task_group_utils/question_answering.py
+++ b/src/euroeval/task_group_utils/question_answering.py
@@ -98,11 +98,7 @@ class QuestionAnsweringTrainer(Trainer):
         # Temporarily disable metric computation, we will do it in the loop here.
         compute_metrics = self.compute_metrics
         self.compute_metrics = None
-        eval_loop = (
-            self.prediction_loop
-            if self.args.use_legacy_prediction_loop
-            else self.evaluation_loop
-        )
+        eval_loop = self.evaluation_loop
         try:
             output = eval_loop(
                 eval_dataloader,

--- a/src/euroeval/task_group_utils/question_answering.py
+++ b/src/euroeval/task_group_utils/question_answering.py
@@ -98,9 +98,8 @@ class QuestionAnsweringTrainer(Trainer):
         # Temporarily disable metric computation, we will do it in the loop here.
         compute_metrics = self.compute_metrics
         self.compute_metrics = None
-        eval_loop = self.evaluation_loop
         try:
-            output = eval_loop(
+            output = self.evaluation_loop(
                 eval_dataloader,
                 description="Evaluation",
                 prediction_loss_only=True if compute_metrics is None else None,

--- a/src/euroeval/utils.py
+++ b/src/euroeval/utils.py
@@ -9,8 +9,8 @@ import sys
 import typing as t
 from pathlib import Path
 
-import huggingface_hub as hf_hub
 import httpx
+import huggingface_hub as hf_hub
 import numpy as np
 import torch
 from huggingface_hub.errors import LocalTokenNotFoundError


### PR DESCRIPTION
**What**

Removed all handling of the deprecated `use_legacy_prediction_loop` attribute from the transformers library. This attribute was deprecated in transformers 4.30 and removed in 4.31+.

**Key features**

- Removed `use_legacy_prediction_loop` from `TrainingArguments` instantiation in `finetuning.py`
- Removed conditional checks in `MultipleChoiceClassificationTrainer.evaluate()` and `QuestionAnsweringTrainer.evaluate()` — now call `self.evaluation_loop` directly without intermediate variables

**Examples**

No API changes — the fix is transparent to end users. The code now assumes modern transformers (4.31+) where `evaluation_loop` is always used.

**Why it helps**

Simplifies the codebase by removing backwards-compatibility shims for deprecated transformers features. Reduces code complexity and improves readability by calling `self.evaluation_loop` directly instead of through intermediate variables.