### PR TITLE
fix: move EvalPrediction import outside TYPE_CHECKING block

### DIFF
--- a/src/euroeval/task_group_utils/question_answering.py
+++ b/src/euroeval/task_group_utils/question_answering.py
@@ -10,6 +10,7 @@ from transformers.tokenization_utils_base import (
     TruncationStrategy,
 )
 from transformers.trainer import Trainer
+from transformers.trainer_utils import EvalPrediction
 
 from ..exceptions import InvalidBenchmark
 from ..tokenisation_utils import get_special_token_metadata
@@ -23,7 +24,6 @@ if t.TYPE_CHECKING:
     from transformers.tokenization_utils import PreTrainedTokenizer
     from transformers.tokenization_utils_base import BatchEncoding
     from transformers.trainer_callback import TrainerCallback
-    from transformers.trainer_utils import EvalPrediction
     from transformers.training_args import TrainingArguments
 
     from ..data_models import BenchmarkConfig, DatasetConfig, GenerativeModelOutput

--- a/src/euroeval/task_group_utils/sequence_classification.py
+++ b/src/euroeval/task_group_utils/sequence_classification.py
@@ -6,6 +6,7 @@ import re
 import typing as t
 
 import numpy as np
+from transformers.trainer_utils import EvalPrediction
 
 from ..closest_match import get_closest_match
 from ..enums import TaskGroup
@@ -16,7 +17,6 @@ from ..utils import log_once, raise_if_model_output_contains_nan_values
 
 if t.TYPE_CHECKING:
     from datasets.arrow_dataset import Dataset
-    from transformers.trainer_utils import EvalPrediction
 
     from ..data_models import (
         BenchmarkConfig,

--- a/src/euroeval/task_group_utils/token_classification.py
+++ b/src/euroeval/task_group_utils/token_classification.py
@@ -6,6 +6,7 @@ import typing as t
 from copy import deepcopy
 
 import numpy as np
+from transformers.trainer_utils import EvalPrediction
 
 from ..exceptions import InvalidBenchmark
 from ..logging_utils import log
@@ -16,7 +17,6 @@ if t.TYPE_CHECKING:
     from datasets.arrow_dataset import Dataset
     from transformers.tokenization_utils import PreTrainedTokenizer
     from transformers.tokenization_utils_base import BatchEncoding
-    from transformers.trainer_utils import EvalPrediction
 
     from ..data_models import BenchmarkConfig, DatasetConfig, GenerativeModelOutput
     from ..types import Labels, Predictions


### PR DESCRIPTION
**What**
Fixes `name 'EvalPrediction' is not defined` runtime error that occurred when evaluating models (e.g., `permitt/galton-modernbertic-base`) on MultiWikiQA-bg and other question answering tasks.

**Key features**
- Moves `from transformers.trainer_utils import EvalPrediction` from `TYPE_CHECKING` blocks to runtime imports
- Applies to three task group utilities: `question_answering.py`, `sequence_classification.py`, and `token_classification.py`
- Ensures `EvalPrediction` is available at runtime for `compute_metrics()` function signatures

**Why it helps**
`TYPE_CHECKING` imports are stripped at runtime and only available during static analysis. Since `EvalPrediction` is used in function signatures (e.g., `def compute_metrics(eval_pred: EvalPrediction)`), Python needs the symbol available when the function is *defined*, not just during type checking.
