### PR TITLE
feat: add download() method to PipelineMetric for offline mode support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
 - Added `download()` method to `PipelineMetric` class
-    - Enables offline mode for metrics that use scikit-learn pipelines (e.g.,
+  - Enables offline mode for metrics that use scikit-learn pipelines (e.g.,
       European Values metric)
-    - Follows the same pattern as `HuggingFaceMetric` by eagerly downloading and
+  - Follows the same pattern as `HuggingFaceMetric` by eagerly downloading and
       caching the pipeline
+
+### Fixed
 
 - Fixed offline benchmarking on air-gapped systems (e.g. supercomputers):
   - `get_hf_token` now catches `httpx.ConnectError` to gracefully degrade when token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,6 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
     instead of raising `InvalidModel`
   - `snapshot_download` now checks for existing cached weights before downloading,
     avoiding redundant downloads in `--download-only` mode
-  - Added `download()` method to `PipelineMetric` class to enable offline mode for
-    metrics that use scikit-learn pipelines (e.g. European Values):
-    - The method eagerly downloads and caches the pipeline, following the same pattern
-      as `HuggingFaceMetric`
 - Fixed `resolve_model_path` to prefer actual commit snapshots over stale `model_files`
   symlink directories, preventing broken symlink errors when cache has multiple snapshots
 - Fixed orthogonal benchmark failures (e.g. `european-values`) being counted as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Added `download()` method to `PipelineMetric` class
+    - Enables offline mode for metrics that use scikit-learn pipelines (e.g.,
+      European Values metric)
+    - Follows the same pattern as `HuggingFaceMetric` by eagerly downloading and
+      caching the pipeline
+
 - Fixed offline benchmarking on air-gapped systems (e.g. supercomputers):
   - `get_hf_token` now catches `httpx.ConnectError` to gracefully degrade when token
     validation fails offline
@@ -16,6 +22,10 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
     instead of raising `InvalidModel`
   - `snapshot_download` now checks for existing cached weights before downloading,
     avoiding redundant downloads in `--download-only` mode
+  - Added `download()` method to `PipelineMetric` class to enable offline mode for
+    metrics that use scikit-learn pipelines (e.g. European Values):
+    - The method eagerly downloads and caches the pipeline, following the same pattern
+      as `HuggingFaceMetric`
 - Fixed `resolve_model_path` to prefer actual commit snapshots over stale `model_files`
   symlink directories, preventing broken symlink errors when cache has multiple snapshots
 - Fixed orthogonal benchmark failures (e.g. `european-values`) being counted as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Added `download()` method to `PipelineMetric` class
-  - Enables offline mode for metrics that use scikit-learn pipelines (e.g.,
-      European Values metric)
-  - Follows the same pattern as `HuggingFaceMetric` by eagerly downloading and
-      caching the pipeline
+  - Enables offline mode for metrics that use scikit-learn pipelines (e.g., European
+    Values metric)
+  - Follows the same pattern as `HuggingFaceMetric` by eagerly downloading and caching
+    the pipeline
 
 ### Fixed
 
@@ -25,7 +25,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   - `snapshot_download` now checks for existing cached weights before downloading,
     avoiding redundant downloads in `--download-only` mode
 - Fixed `resolve_model_path` to prefer actual commit snapshots over stale `model_files`
-  symlink directories, preventing broken symlink errors when cache has multiple snapshots
+  symlink directories, preventing broken symlink errors when cache has multiple
+  snapshots
 - Fixed orthogonal benchmark failures (e.g. `european-values`) being counted as
   "errored" instead of "skipped" in the summary
 
@@ -39,8 +40,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fixed a bug where evaluating on AngryTweets sentiment classification raised
-  `Sequences and scores must have the same length` when the model returned no choices for
-  some samples. The `_create_model_output` method now appends an empty score list
+  `Sequences and scores must have the same length` when the model returned no choices
+  for some samples. The `_create_model_output` method now appends an empty score list
   alongside the empty sequence to keep both lists in sync.
 - Fixed deprecation warnings from `transformers` v5.2+:
   - Replaced deprecated `warmup_ratio` with dynamic `warmup_steps` calculation (1% of
@@ -54,12 +55,13 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   a JSON-encoded string (e.g. `'"bg"'` instead of `["bg"]`). This occurred when mixing
   EEE format results with legacy format results.
 - Fixed model loading failures (e.g., shape mismatches, CUDA errors) incorrectly being
-  counted as "skipped" benchmarks instead of "errored". The queue processor now correctly
-  detects these as failures and applies the `evaluation-failed` label to GitHub issues.
+  counted as "skipped" benchmarks instead of "errored". The queue processor now
+  correctly detects these as failures and applies the `evaluation-failed` label to
+  GitHub issues.
 - Fixed tokenizer loading failures for XLM-RoBERTa variant models (e.g.
-  `EMBEDDIA/litlat-bert`) that raised `TypeError: argument 'vocab': 'dict' object cannot
-  be converted to 'Sequence'`. The tokenizer loader now falls back to `use_fast=False`
-  when this error occurs.
+  `EMBEDDIA/litlat-bert`) that raised
+  `TypeError: argument 'vocab': 'dict' object cannot be converted to 'Sequence'`. The
+  tokenizer loader now falls back to `use_fast=False` when this error occurs.
 
 ## [v17.3.0] - 2026-05-31
 

--- a/src/euroeval/metrics/pipeline.py
+++ b/src/euroeval/metrics/pipeline.py
@@ -102,6 +102,8 @@ class PipelineMetric(Metric):
         Returns:
             The metric object itself.
         """
+        if self.pipeline is not None:
+            return self
         pipeline_cache_dir = Path(cache_dir) / "pipelines"
         pipeline_cache_dir.mkdir(parents=True, exist_ok=True)
         self.pipeline = self._download_pipeline(cache_dir=pipeline_cache_dir.as_posix())

--- a/src/euroeval/metrics/pipeline.py
+++ b/src/euroeval/metrics/pipeline.py
@@ -135,6 +135,9 @@ class PipelineMetric(Metric):
         """
         if self.pipeline is None:
             self.download(cache_dir=benchmark_config.cache_dir)
+        assert self.pipeline is not None, (
+            "Pipeline should be initialized after download"
+        )
         if self.preprocessing_fn is not None:
             predictions = self.preprocessing_fn(
                 predictions=predictions, dataset=dataset

--- a/src/euroeval/metrics/pipeline.py
+++ b/src/euroeval/metrics/pipeline.py
@@ -92,6 +92,21 @@ class PipelineMetric(Metric):
         self.pipeline: "Pipeline | None" = None
         self.preprocessing_fn = preprocessing_fn
 
+    def download(self, cache_dir: str) -> "PipelineMetric":
+        """Initiates the download of the pipeline if needed.
+
+        Args:
+            cache_dir:
+                The directory where the pipeline will be downloaded to.
+
+        Returns:
+            The PipelineMetric object itself.
+        """
+        pipeline_cache_dir = Path(cache_dir) / "pipelines"
+        pipeline_cache_dir.mkdir(parents=True, exist_ok=True)
+        self.pipeline = self._download_pipeline(cache_dir=pipeline_cache_dir.as_posix())
+        return self
+
     def __call__(
         self,
         predictions: c.Sequence,
@@ -119,9 +134,7 @@ class PipelineMetric(Metric):
             The calculated metric score, or None if the score should be ignored.
         """
         if self.pipeline is None:
-            self.pipeline = self._download_pipeline(
-                cache_dir=benchmark_config.cache_dir
-            )
+            self.download(cache_dir=benchmark_config.cache_dir)
         if self.preprocessing_fn is not None:
             predictions = self.preprocessing_fn(
                 predictions=predictions, dataset=dataset

--- a/src/euroeval/metrics/pipeline.py
+++ b/src/euroeval/metrics/pipeline.py
@@ -100,7 +100,7 @@ class PipelineMetric(Metric):
                 The directory where the pipeline will be downloaded to.
 
         Returns:
-            The PipelineMetric object itself.
+            The metric object itself.
         """
         pipeline_cache_dir = Path(cache_dir) / "pipelines"
         pipeline_cache_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## What

Adds a download() method to the PipelineMetric class to enable offline mode for metrics that use scikit-learn pipelines, such as the European Values metric.

## Key features

- **Eager pipeline loading**: The download() method eagerly downloads and caches the scikit-learn pipeline, following the same pattern as HuggingFaceMetric
- **Offline mode support**: Allows pre-downloading pipelines before running evaluations in air-gapped environments
- **Consistent API**: The __call__ method now uses download() internally, ensuring the public API is consistently used

## How to use

Pre-download pipelines before going offline:

```python
metric = PipelineMetric(...)
metric.download(cache_dir=/path/to/cache)
# Now metric can be used offline
score = metric(predictions, references, dataset, dataset_config, benchmark_config)
```

## Why this helps

Previously, PipelineMetric didn't override the download() method from the base Metric class, which meant pipelines were only downloaded lazily during __call__. This broke offline mode since there was no way to pre-fetch the pipeline before losing network access.