### PR TITLE
refactor: migrate from dual buckets to single EuroEval/results bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,9 +109,8 @@ ucloud*_results.jsonl
 .hf-mount/
 *.hf-mount/
 
-# Persistent results directories (HF bucket sync points)
-results/raw/
-results/processed/
+# Persistent results directory (HF bucket sync point)
+results/
 
 
 # Leaderboard CSVs (regenerated build artifact; bundled by Vite at build time).

--- a/.gitignore
+++ b/.gitignore
@@ -109,7 +109,7 @@ ucloud*_results.jsonl
 .hf-mount/
 *.hf-mount/
 
-# Persistent results directory (HF bucket sync point)
+# Results directory (single location for all evaluation results, HF bucket sync point)
 results/
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,23 +28,22 @@ queue is handled via Github issues.
 
 ### Data Flow and Storage
 
-Evaluation results flow through four storage layers:
+Evaluation results flow through three storage layers:
 
-1. **Hugging Face Buckets** (source of truth):
-   - `raw-results`: Per-model JSONL files (one file per model, append-only)
-   - `processed-results`: Processed/aggregated results per model
+1. **Hugging Face Bucket** (source of truth):
+   - `EuroEval/results`: Single bucket with per-model JSONL files (one file per model, append-only)
+   - All files contain metadata fields (`commercially_licensed`, `open`, `trained_from_scratch`)
    - Synced via `hf sync` command (requires `HF_TOKEN`)
 
 2. **Local `results/` directory** (working copy):
-   - `results/raw/` — mirrored from raw-results bucket
-   - `results/processed/` — mirrored from processed-results bucket
-   - Git-ignored, synced bidirectionally with HF buckets
+   - Contains all per-model JSONL files (unified, not split into raw/processed)
+   - Git-ignored, synced bidirectionally with HF bucket
 
 3. **`results.tar.gz`** (historical archive):
    - **Location:** `~/pCloud Drive/data/euroeval_backup/results.tar.gz`
    - **Override:** Set `EUROEVAL_RESULTS_BACKUP_DIR` environment variable
-   - Contains `results/results.jsonl` (all raw results merged) and `results/results.processed.jsonl`
-   - Rebuilt from `results/raw/*.jsonl` files on each run
+   - Contains single `results/results.jsonl` (all results merged with metadata)
+   - Rebuilt from `results/*.jsonl` files on each run
    - 43+ MB, not tracked in git
 
 4. **Backup snapshots** (disaster recovery):
@@ -53,11 +52,11 @@ Evaluation results flow through four storage layers:
    - Rotation: max 10 snapshots or 1 GB total
    - Always preserves at least one backup from a previous day (if any exist)
 
-**Sync direction:** HF buckets → local `results/` → `results.tar.gz` → backup snapshots
+**Sync direction:** HF bucket → local `results/` → `results.tar.gz` → backup snapshots
 
 The `src/scripts/collect_evaluation_results.py` script orchestrates this flow:
 
-- Downloads new results from HF buckets
+- Downloads new results from HF bucket
 - Deduplicates against existing results in `results.tar.gz`
 - Rebuilds `results.tar.gz` from the merged results
 - Creates timestamped backup before overwrite

--- a/src/leaderboards/backup.py
+++ b/src/leaderboards/backup.py
@@ -18,7 +18,7 @@ import logging
 import shutil
 from pathlib import Path
 
-from .paths import BACKUPS_DIR, BACKUPS_MAX_BYTES, PROCESSED_RESULTS_DIR, RESULTS_PATH
+from .paths import BACKUPS_DIR, BACKUPS_MAX_BYTES, RESULTS_DIR, RESULTS_PATH
 
 logger = logging.getLogger(__name__)
 
@@ -30,34 +30,34 @@ BACKUP_SUFFIX = ".tar.gz"
 
 
 def _validate_processed_results() -> None:
-    """Validate that processed results exist and have required metadata.
+    """Validate that results exist and have required metadata.
 
     Checks that:
-    1. PROCESSED_RESULTS_DIR exists and contains .jsonl files
-    2. Each .jsonl file has at least one record
+    1. RESULTS_DIR exists and contains .jsonl files
+    2. Sample files are checked for required metadata fields
     3. All records have the required metadata fields
 
     Raises:
         FileNotFoundError:
-            If PROCESSED_RESULTS_DIR doesn't exist or contains no files.
+            If RESULTS_DIR doesn't exist or contains no files.
         ValueError:
-            If any processed result is missing required metadata fields.
+            If any result is missing required metadata fields.
     """
-    if not PROCESSED_RESULTS_DIR.exists():
+    if not RESULTS_DIR.exists():
         raise FileNotFoundError(
-            f"Processed results directory not found: {PROCESSED_RESULTS_DIR}. "
-            "Run result_processing.py to process results before backing up."
+            f"Results directory not found: {RESULTS_DIR}. "
+            "Run evaluation result collection before backing up."
         )
 
-    model_files = list(PROCESSED_RESULTS_DIR.glob("*.jsonl"))
+    model_files = list(RESULTS_DIR.glob("*.jsonl"))
     if not model_files:
         raise FileNotFoundError(
-            f"No processed result files found in {PROCESSED_RESULTS_DIR}. "
-            "Run result_processing.py to process results before backing up."
+            f"No result files found in {RESULTS_DIR}. "
+            "Run evaluation result collection before backing up."
         )
 
     logger.info(
-        f"Validating {len(model_files):,} processed result files for required "
+        f"Validating {len(model_files):,} result files for required "
         f"metadata fields: {REQUIRED_METADATA_FIELDS}"
     )
 
@@ -100,8 +100,8 @@ def _validate_processed_results() -> None:
         msg = (
             f"{files_with_issues} files have missing metadata. Checked "
             f"{records_checked:,} records, found {records_with_issues:,} with issues. "
-            f"Required: {REQUIRED_METADATA_FIELDS}. Run "
-            f"restore_metadata_from_backup.py to restore."
+            f"Required: {REQUIRED_METADATA_FIELDS}. Re-run evaluation with "
+            f"metadata collection enabled."
         )
         raise ValueError(msg)
 
@@ -173,7 +173,7 @@ def restore_from_backup_if_missing(target: Path = RESULTS_PATH) -> bool:
 def backup_results(source: Path = RESULTS_PATH) -> Path | None:
     """Snapshot `source` into BACKUPS_DIR, then prune oldest if over cap.
 
-    Validates that processed results exist and have required metadata fields
+    Validates that results exist and have required metadata fields
     before creating the backup. Skips if `source` is byte-identical to the
     newest existing backup, so repeated runs without changes don't fill the
     backup directory.

--- a/src/leaderboards/backup.py
+++ b/src/leaderboards/backup.py
@@ -35,8 +35,7 @@ def _validate_processed_results() -> None:
 
     Checks that:
     1. RESULTS_DIR exists and contains .jsonl files
-    2. Sample files are checked for required metadata fields
-    3. All records have the required metadata fields
+    2. Sample files (up to 5) are checked for required metadata fields
 
     Raises:
         FileNotFoundError:

--- a/src/leaderboards/backup.py
+++ b/src/leaderboards/backup.py
@@ -30,7 +30,7 @@ BACKUP_PREFIX = "results_"
 BACKUP_SUFFIX = ".tar.gz"
 
 
-def _validate_processed_results() -> None:
+def _validate_results() -> None:
     """Validate that results exist and have required metadata.
 
     Checks that:
@@ -190,8 +190,8 @@ def backup_results(source: Path = RESULTS_PATH) -> Path | None:
         The Path of the new backup, or None if nothing was written.
 
     """
-    # Validate processed results before backing up
-    _validate_processed_results()
+    # Validate results before backing up
+    _validate_results()
 
     if not source.exists():
         logger.warning(f"Cannot back up {source}: file does not exist.")

--- a/src/leaderboards/backup.py
+++ b/src/leaderboards/backup.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import datetime as dt
 import json
 import logging
+import random
 import shutil
 from pathlib import Path
 
@@ -56,16 +57,20 @@ def _validate_processed_results() -> None:
             "Run evaluation result collection before backing up."
         )
 
+    # Sample up to 5 files for validation
+    sample_size = min(5, len(model_files))
+    sampled_files = random.sample(model_files, sample_size)
+
     logger.info(
-        f"Validating {len(model_files):,} result files for required "
-        f"metadata fields: {REQUIRED_METADATA_FIELDS}"
+        f"Validating {sample_size} sampled result files (of {len(model_files):,} total)"
+        f" for required metadata fields: {REQUIRED_METADATA_FIELDS}"
     )
 
     files_with_issues = 0
     records_checked = 0
     records_with_issues = 0
 
-    for model_file in model_files:
+    for model_file in sampled_files:
         file_has_issues = False
         try:
             with open(model_file, "r", encoding="utf-8") as f:
@@ -98,7 +103,7 @@ def _validate_processed_results() -> None:
 
     if files_with_issues > 0:
         msg = (
-            f"{files_with_issues} files have missing metadata. Checked "
+            f"{files_with_issues} sampled files have missing metadata. Checked "
             f"{records_checked:,} records, found {records_with_issues:,} with issues. "
             f"Required: {REQUIRED_METADATA_FIELDS}. Re-run evaluation with "
             f"metadata collection enabled."
@@ -106,8 +111,8 @@ def _validate_processed_results() -> None:
         raise ValueError(msg)
 
     logger.info(
-        f"✓ Validated {records_checked:,} records from {len(model_files):,} files - "
-        "all have required metadata fields"
+        f"✓ Validated {records_checked:,} records from {len(sampled_files):,} sampled"
+        f" files - all have required metadata fields"
     )
 
 

--- a/src/leaderboards/bootstrap_cis.py
+++ b/src/leaderboards/bootstrap_cis.py
@@ -159,7 +159,7 @@ def bootstrap_rank_scores(
                 for cat in dataset_to_category.get(ds, set()):
                     all_rank_scores.setdefault(mid, {}).setdefault(cat, {})[ds] = score
 
-        # Now compute overall scores for each model by aggregating up the hierarchy
+        # Now compute scores for each model by aggregating up the hierarchy
         for model_id, model_data in model_results.items():
             for category in categories:
                 # Filter to datasets this model has data for
@@ -173,9 +173,6 @@ def bootstrap_rank_scores(
                         ):
                             model_ds_in_sample[ds] = task
 
-                if not model_ds_in_sample:
-                    continue
-
                 # Get precomputed rank scores for this model
                 model_rank_scores = all_rank_scores.get(model_id, {}).get(category, {})
                 if not model_rank_scores:
@@ -185,13 +182,15 @@ def bootstrap_rank_scores(
                 language_scores, overall = _aggregate_scores_to_categories(
                     model_rank_scores, configs, category, model_ds_in_sample
                 )
-                if overall is not None:
-                    # Store per-language bootstrap samples
+                # Store per-language bootstrap samples even if model doesn't have
+                # complete coverage (no overall score)
+                if language_scores:
                     for lang, lang_score in language_scores.items():
                         bootstrap_scores.setdefault(model_id, {}).setdefault(
                             category, {}
                         ).setdefault(lang, []).append(lang_score)
-                    # Store overall bootstrap samples
+                # Store overall bootstrap samples only if model has complete coverage
+                if overall is not None:
                     bootstrap_scores.setdefault(model_id, {}).setdefault(
                         category, {}
                     ).setdefault("overall", []).append(overall)

--- a/src/leaderboards/bucket_sync.py
+++ b/src/leaderboards/bucket_sync.py
@@ -1,7 +1,7 @@
-"""Sync Hugging Face buckets for EuroEval results.
+"""Sync Hugging Face bucket for EuroEval results.
 
-Uses the `hf sync` CLI to sync raw and processed results buckets
-to local directories. Also provides backup functionality.
+Uses the `hf sync` CLI to sync the results bucket to the local
+results directory. Also provides backup functionality.
 """
 
 import collections.abc as c
@@ -17,14 +17,13 @@ from dotenv import load_dotenv
 from euroeval.data_models import BenchmarkResult
 
 from .backup import backup_results
-from .paths import PROCESSED_RESULTS_DIR, RAW_RESULTS_DIR
+from .paths import RESULTS_DIR
 
 load_dotenv()
 
 logger = logging.getLogger(__name__)
 
-HF_RAW_BUCKET = "EuroEval/raw-results"
-HF_PROCESSED_BUCKET = "EuroEval/processed-results"
+HF_RESULTS_BUCKET = "EuroEval/results"
 
 
 def _sanitise_model_id(model_id: str) -> str:
@@ -44,10 +43,10 @@ def _sanitise_model_id(model_id: str) -> str:
 
 
 def sync_bucket() -> None:
-    """Sync both HF buckets (raw and processed) using hf sync.
+    """Sync HF results bucket using hf sync.
 
     Syncs from bucket to local directory using the official hf CLI.
-    Creates local directories if needed.
+    Creates local directory if needed.
 
     HF_TOKEN is loaded from .env by load_dotenv() at module import.
     """
@@ -56,56 +55,33 @@ def sync_bucket() -> None:
         logger.warning("HF_TOKEN not set. Cannot sync from bucket.")
         return
 
-    RAW_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
-    logger.info("Syncing raw bucket %s → %s...", HF_RAW_BUCKET, RAW_RESULTS_DIR)
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    logger.info("Syncing bucket %s → %s...", HF_RESULTS_BUCKET, RESULTS_DIR)
     result = subprocess.run(
-        ["hf", "sync", f"hf://buckets/{HF_RAW_BUCKET}/", str(RAW_RESULTS_DIR)],
+        ["hf", "sync", f"hf://buckets/{HF_RESULTS_BUCKET}/", str(RESULTS_DIR)],
         capture_output=True,
         text=True,
         check=False,
         env={**os.environ, "HF_TOKEN": hf_token},
     )
     if result.returncode != 0:
-        logger.warning("hf sync failed for raw bucket: %s", result.stderr)
+        logger.warning("hf sync failed: %s", result.stderr)
     else:
-        logger.info("Synced raw bucket: %s", result.stdout.strip())
-
-    PROCESSED_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
-    logger.info(
-        "Syncing processed bucket %s → %s...",
-        HF_PROCESSED_BUCKET,
-        PROCESSED_RESULTS_DIR,
-    )
-    result = subprocess.run(
-        [
-            "hf",
-            "sync",
-            f"hf://buckets/{HF_PROCESSED_BUCKET}/",
-            str(PROCESSED_RESULTS_DIR),
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-        env={**os.environ, "HF_TOKEN": hf_token},
-    )
-    if result.returncode != 0:
-        logger.warning("hf sync failed for processed bucket: %s", result.stderr)
-    else:
-        logger.info("Synced processed bucket: %s", result.stdout.strip())
+        logger.info("Synced bucket: %s", result.stdout.strip())
 
 
 @contextmanager
 def sync_bucket_context() -> c.Generator[Path, None, None]:
     """Context manager for HF bucket sync.
 
-    Syncs buckets on entry, logs completion on exit.
+    Syncs bucket on entry, logs completion on exit.
 
     Yields:
-        Path: Raw results directory (for backwards compatibility)
+        Path: Results directory
     """
-    logger.info("Syncing buckets...")
+    logger.info("Syncing bucket...")
     sync_bucket()
-    yield RAW_RESULTS_DIR
+    yield RESULTS_DIR
     logger.info("Bucket sync complete.")
 
 
@@ -113,14 +89,14 @@ def sync_bucket_context() -> c.Generator[Path, None, None]:
 def sync_bucket_with_backup() -> c.Generator[Path, None, None]:
     """Context manager for HF bucket sync with automatic backup.
 
-    Syncs buckets on entry, creates backup on exit.
+    Syncs bucket on entry, creates backup on exit.
 
     Yields:
-        Path: Raw results directory (for backwards compatibility)
+        Path: Results directory
     """
-    logger.info("Syncing buckets...")
+    logger.info("Syncing bucket...")
     sync_bucket()
-    yield RAW_RESULTS_DIR
+    yield RESULTS_DIR
     backup_path = backup_results()
     if backup_path:
         logger.info("Backup created at %s.", backup_path)
@@ -128,7 +104,7 @@ def sync_bucket_with_backup() -> c.Generator[Path, None, None]:
 
 
 def upload_results_to_bucket(results_file: Path) -> None:
-    """Upload local results to the Hugging Face raw-results bucket.
+    """Upload local results to the Hugging Face results bucket.
 
     Reads the merged results file, splits into per-model JSONL files,
     and syncs to the bucket using hf sync.
@@ -148,7 +124,7 @@ def upload_results_to_bucket(results_file: Path) -> None:
         )
         return
 
-    RAW_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 
     # Group results by model
     results_by_model: dict[str, list[str]] = {}
@@ -173,18 +149,18 @@ def upload_results_to_bucket(results_file: Path) -> None:
 
     # Write per-model JSONL files
     logger.info(
-        "Writing %s per-model files to %s...", len(results_by_model), RAW_RESULTS_DIR
+        "Writing %s per-model files to %s...", len(results_by_model), RESULTS_DIR
     )
     for model_key, lines in results_by_model.items():
-        model_file = RAW_RESULTS_DIR / f"{model_key}.jsonl"
+        model_file = RESULTS_DIR / f"{model_key}.jsonl"
         with model_file.open("w") as f:
             for line in lines:
                 f.write(line + "\n")
 
     # Sync to bucket
-    logger.info("Syncing local %s → bucket %s...", RAW_RESULTS_DIR, HF_RAW_BUCKET)
+    logger.info("Syncing local %s → bucket %s...", RESULTS_DIR, HF_RESULTS_BUCKET)
     result = subprocess.run(
-        ["hf", "sync", str(RAW_RESULTS_DIR), f"hf://buckets/{HF_RAW_BUCKET}/"],
+        ["hf", "sync", str(RESULTS_DIR), f"hf://buckets/{HF_RESULTS_BUCKET}/"],
         capture_output=True,
         text=True,
         check=False,

--- a/src/leaderboards/cache.py
+++ b/src/leaderboards/cache.py
@@ -70,7 +70,7 @@ class Cache:
         """
         # Prefer results_dir if provided
         if results_dir is not None and results_dir.exists():
-            return cls.from_processed_dir(results_dir)
+            return cls.from_results_dir(results_dir)
 
         if compressed_results_path is None or not compressed_results_path.exists():
             raise FileNotFoundError(
@@ -82,7 +82,7 @@ class Cache:
             results_file = tar.extractfile(member="results/results.jsonl")
             if results_file is None:
                 logger.warning(
-                    "Processed results file does not exist. Using an empty cache."
+                    "Results file does not exist in tar.gz. Using an empty cache."
                 )
                 return cls()
             result_lines = results_file.read().decode(encoding="utf-8").splitlines()

--- a/src/leaderboards/cache.py
+++ b/src/leaderboards/cache.py
@@ -47,29 +47,30 @@ class Cache:
     def from_processed_records(
         cls,
         compressed_results_path: Path | None = None,
-        processed_dir: Path | None = None,
+        results_dir: Path | None = None,
     ) -> "Cache":
         """Create a cache from processed records.
 
         Args:
             compressed_results_path:
-                The path to the compressed processed results file.
-            processed_dir:
-                The path to the directory containing per-model processed JSONL files.
-                If provided, this takes precedence over compressed_results_path.
+                The path to the compressed results file (results.tar.gz).
+            results_dir:
+                The path to the directory containing per-model JSONL files
+                with metadata. If provided, takes precedence over
+                compressed_results_path.
 
         Returns:
             A Cache instance populated with model metadata.
 
         Raises:
             FileNotFoundError:
-                If neither the processed records file nor directory is found.
+                If neither the results file nor directory is found.
             ValueError:
-                If the processed records file contains invalid JSON.
+                If the results file contains invalid JSON.
         """
-        # Prefer processed_dir if provided
-        if processed_dir is not None and processed_dir.exists():
-            return cls.from_processed_dir(processed_dir)
+        # Prefer results_dir if provided
+        if results_dir is not None and results_dir.exists():
+            return cls.from_processed_dir(results_dir)
 
         if compressed_results_path is None or not compressed_results_path.exists():
             raise FileNotFoundError(
@@ -78,7 +79,7 @@ class Cache:
 
         # Unpack the tar.gz file in memory and read the JSONL file
         with tarfile.open(compressed_results_path, "r:gz") as tar:
-            results_file = tar.extractfile(member="results/results.processed.jsonl")
+            results_file = tar.extractfile(member="results/results.jsonl")
             if results_file is None:
                 logger.warning(
                     "Processed results file does not exist. Using an empty cache."
@@ -146,12 +147,13 @@ class Cache:
         return cache
 
     @classmethod
-    def from_processed_dir(cls, processed_dir: Path) -> "Cache":
-        """Create a cache from processed records in a directory.
+    def from_results_dir(cls, results_dir: Path) -> "Cache":
+        """Create a cache from records in the results directory.
 
         Args:
-            processed_dir:
-                The path to the directory containing per-model processed JSONL files.
+            results_dir:
+                The path to the directory containing per-model JSONL files
+                with metadata.
 
         Returns:
             A Cache instance populated with model metadata.
@@ -160,16 +162,14 @@ class Cache:
             ValueError:
                 If any JSONL file contains invalid JSON.
             FileNotFoundError:
-                If the processed directory does not exist.
+                If the results directory does not exist.
         """
-        if not processed_dir.exists():
-            raise FileNotFoundError(
-                f"Processed results directory {processed_dir} not found."
-            )
+        if not results_dir.exists():
+            raise FileNotFoundError(f"Results directory {results_dir} not found.")
 
         # Load all JSONL files from the directory
         all_records: list[dict[str, object]] = list()
-        jsonl_files = sorted(processed_dir.glob("*.jsonl"))
+        jsonl_files = sorted(results_dir.glob("*.jsonl"))
 
         for jsonl_file in jsonl_files:
             content = jsonl_file.read_text(encoding="utf-8")
@@ -185,7 +185,7 @@ class Cache:
 
         # Populate a cache from the records
         cache = cls()
-        for record in tqdm(all_records, desc="Building caches from processed dir"):
+        for record in tqdm(all_records, desc="Building caches from results dir"):
             # Support both EEE format (model_info.name) and old format (model)
             if "model_info" in record and "name" in record["model_info"]:
                 model_name = record["model_info"]["name"]
@@ -229,3 +229,6 @@ class Cache:
                     cache.anchor_tag[inner_model_id] = model_name
 
         return cache
+
+    # Alias for backward compatibility
+    from_processed_dir = from_results_dir

--- a/src/leaderboards/paths.py
+++ b/src/leaderboards/paths.py
@@ -58,8 +58,8 @@ NEW_RESULTS_PATH: Path = _env_path(
     "EUROEVAL_NEW_RESULTS_PATH", REPO_ROOT / "new_results.jsonl"
 )
 
-# Single directory for all per-model JSONL files (both raw and processed
-# with metadata). Git-ignored, synced with HF buckets.
+# Single directory for all per-model JSONL files with metadata attached.
+# Git-ignored, synced with hf://buckets/EuroEval/results/.
 RESULTS_DIR: Path = REPO_ROOT / "results"
 
 # Note: `.euroeval_cache/` is now deprecated for results storage.

--- a/src/leaderboards/paths.py
+++ b/src/leaderboards/paths.py
@@ -4,6 +4,10 @@ Centralises the locations of config files, data inputs, and the output
 CSV directory so the rest of the package doesn't depend on the caller's
 cwd. Data-input paths are overridable via environment variables so
 operators can keep large files outside the repo.
+
+Results are stored in a single results/ directory containing per-model
+JSONL files (both raw and processed with metadata). The merged archive
+results.tar.gz contains only results/results.jsonl.
 """
 
 import os
@@ -54,9 +58,8 @@ NEW_RESULTS_PATH: Path = _env_path(
     "EUROEVAL_NEW_RESULTS_PATH", REPO_ROOT / "new_results.jsonl"
 )
 
-# Persistent results directories (HF bucket sync points, git-ignored)
+# Single directory for all per-model JSONL files (both raw and processed
+# with metadata). Git-ignored, synced with HF buckets.
 RESULTS_DIR: Path = REPO_ROOT / "results"
-RAW_RESULTS_DIR: Path = RESULTS_DIR / "raw"
-PROCESSED_RESULTS_DIR: Path = RESULTS_DIR / "processed"
 
 # Note: `.euroeval_cache/` is now deprecated for results storage.

--- a/src/leaderboards/paths.py
+++ b/src/leaderboards/paths.py
@@ -6,8 +6,8 @@ cwd. Data-input paths are overridable via environment variables so
 operators can keep large files outside the repo.
 
 Results are stored in a single results/ directory containing per-model
-JSONL files (both raw and processed with metadata). The merged archive
-results.tar.gz contains only results/results.jsonl.
+JSONL files with metadata attached. The merged archive results.tar.gz
+contains only results/results.jsonl with all results unified.
 """
 
 import os

--- a/src/leaderboards/result_loading.py
+++ b/src/leaderboards/result_loading.py
@@ -13,7 +13,7 @@ from functools import cache
 
 from .backup import backup_results
 from .bucket_sync import sync_bucket
-from .paths import NEW_RESULTS_PATH, RAW_RESULTS_DIR, RESULTS_PATH
+from .paths import NEW_RESULTS_PATH, RESULTS_DIR, RESULTS_PATH
 
 logger = logging.getLogger(__name__)
 
@@ -21,42 +21,44 @@ logger = logging.getLogger(__name__)
 def _sync_results_from_bucket() -> None:
     """Sync HF bucket and rebuild results.tar.gz.
 
-    After syncing, rebuilds results.tar.gz from the files and creates a backup.
+    Syncs the single EuroEval/results bucket to RESULTS_DIR, then rebuilds
+    results.tar.gz from the per-model JSONL files and creates a backup.
     """
     _sync_buckets()
 
 
 def _sync_buckets() -> None:
-    """Sync HF buckets via hf sync, rebuild results.tar.gz, and backup.
+    """Sync HF bucket via hf sync, rebuild results.tar.gz, and backup.
 
-    After syncing, rebuilds results.tar.gz and backs up.
+    Syncs the single EuroEval/results bucket to RESULTS_DIR, rebuilds
+    results.tar.gz, and creates a backup.
 
     Raises:
         FileNotFoundError:
             If sync fails and no local files exist.
     """
-    RAW_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 
     # Sync from bucket
     logger.info("Syncing results from HF bucket...")
     sync_bucket()
 
     # Verify files exist
-    file_count = len(list(RAW_RESULTS_DIR.glob("*.jsonl")))
+    file_count = len(list(RESULTS_DIR.glob("*.jsonl")))
     if file_count == 0:
         # Check if we have local files from previous run
-        local_file_count = len(list(RAW_RESULTS_DIR.glob("*.jsonl")))
+        local_file_count = len(list(RESULTS_DIR.glob("*.jsonl")))
         if local_file_count > 0:
             logger.info(
                 f"Sync returned 0 files. Using {local_file_count:,} local files "
-                f"from {RAW_RESULTS_DIR}."
+                f"from {RESULTS_DIR}."
             )
         else:
             raise FileNotFoundError(
                 "No results available. Sync failed and no local cache exists."
             )
 
-    logger.info(f"Synced {file_count:,} model files to {RAW_RESULTS_DIR}.")
+    logger.info(f"Synced {file_count:,} model files to {RESULTS_DIR}.")
 
     # Rebuild results.tar.gz from mounted files
     _rebuild_results_tar_gz()
@@ -68,14 +70,17 @@ def _sync_buckets() -> None:
 
 
 def _rebuild_results_tar_gz() -> None:
-    """Rebuild results.tar.gz from mounted files in RAW_RESULTS_DIR.
+    """Rebuild results.tar.gz from per-model JSONL files in RESULTS_DIR.
+
+    Reads all *.jsonl files from RESULTS_DIR and merges them into a single
+    results/results.jsonl inside results.tar.gz.
 
     Skips files that can't be read (NFS lazy-loading quirks).
     Logs progress every 100 files.
     """
-    RAW_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 
-    model_files = sorted(RAW_RESULTS_DIR.glob("*.jsonl"))
+    model_files = sorted(RESULTS_DIR.glob("*.jsonl"))
     n_files = len(model_files)
     logger.info(f"Reading {n_files:,} model files from mount point...")
 
@@ -111,37 +116,33 @@ def _rebuild_results_tar_gz() -> None:
     if not all_lines:
         logger.warning("No results found in mount point. results.tar.gz will be empty.")
 
-    # Build results.tar.gz
+    # Build results.tar.gz with only results.jsonl
     RESULTS_PATH.parent.mkdir(parents=True, exist_ok=True)
     with tarfile.open(RESULTS_PATH, "w:gz") as tar:
-        # Raw records
-        raw_content_bytes = "\n".join(sorted(all_lines)).encode(encoding="utf-8")
-        raw_tarinfo = tarfile.TarInfo(name="results/results.jsonl")
-        raw_tarinfo.size = len(raw_content_bytes)
-        raw_fileobj = io.BytesIO(raw_content_bytes)
-        tar.addfile(tarinfo=raw_tarinfo, fileobj=raw_fileobj)
-
-        # Processed records (empty initially, filled by process_results)
-        processed_content_bytes = b""
-        processed_tarinfo = tarfile.TarInfo(name="results/results.processed.jsonl")
-        processed_tarinfo.size = len(processed_content_bytes)
-        processed_fileobj = io.BytesIO(processed_content_bytes)
-        tar.addfile(tarinfo=processed_tarinfo, fileobj=processed_fileobj)
+        content_bytes = "\n".join(sorted(all_lines)).encode(encoding="utf-8")
+        tarinfo = tarfile.TarInfo(name="results/results.jsonl")
+        tarinfo.size = len(content_bytes)
+        fileobj = io.BytesIO(content_bytes)
+        tar.addfile(tarinfo=tarinfo, fileobj=fileobj)
 
     logger.info(f"Rebuilt {RESULTS_PATH} with {len(all_lines):,} results.")
 
 
 def load_raw_results() -> list[dict[str, t.Any]]:
-    """Load raw results.
+    """Load all results from results.tar.gz.
+
+    Loads all evaluation results from the unified results archive.
+    Results are sourced from the single EuroEval/results bucket.
+    No distinction is made between raw and processed results.
 
     Returns:
-        The raw results.
+        All evaluation results.
 
     Raises:
         FileNotFoundError:
-            If the raw results file is not found.
+            If the results file is not found.
         ValueError:
-            If the raw results file contains invalid JSON.
+            If the results file contains invalid JSON.
     """
     results_path = RESULTS_PATH
 
@@ -202,12 +203,15 @@ def load_raw_results() -> list[dict[str, t.Any]]:
 def load_processed_results() -> list[dict[str, t.Any]]:
     """Load processed results.
 
+    Loads from the unified results archive. No distinction is made
+    between raw and processed results - both load from the same source.
+
     Returns:
         The processed results.
 
     Raises:
         FileNotFoundError:
-            If the processed results file is not found.
+            If the results file is not found.
     """
     results_path = RESULTS_PATH
     if not results_path.exists():
@@ -217,10 +221,10 @@ def load_processed_results() -> list[dict[str, t.Any]]:
 
     # Unpack the tar.gz file in memory and read the JSONL file
     with tarfile.open(results_path, "r:gz") as tar:
-        results_file = tar.extractfile(member="results/results.processed.jsonl")
+        results_file = tar.extractfile(member="results/results.jsonl")
         if results_file is None:
             raise FileNotFoundError(
-                "results/results.processed.jsonl not found in the tar.gz file."
+                "results/results.jsonl not found in the tar.gz file."
             )
         result_lines = results_file.read().decode(encoding="utf-8").splitlines()
 

--- a/src/leaderboards/result_loading.py
+++ b/src/leaderboards/result_loading.py
@@ -5,17 +5,21 @@ from __future__ import annotations
 import io
 import json
 import logging
+import os
 import re
+import subprocess
 import tarfile
 import time
 import typing as t
 from functools import cache
 
 from .backup import backup_results
-from .bucket_sync import sync_bucket
 from .paths import NEW_RESULTS_PATH, RESULTS_DIR, RESULTS_PATH
 
 logger = logging.getLogger(__name__)
+
+
+HF_RESULTS_BUCKET = "EuroEval/results"
 
 
 def _sync_results_from_bucket() -> None:
@@ -41,7 +45,21 @@ def _sync_buckets() -> None:
 
     # Sync from bucket
     logger.info("Syncing results from HF bucket...")
-    sync_bucket()
+    hf_token = os.getenv("HF_TOKEN")
+    if hf_token:
+        result = subprocess.run(
+            ["hf", "sync", f"hf://buckets/{HF_RESULTS_BUCKET}/", str(RESULTS_DIR)],
+            capture_output=True,
+            text=True,
+            check=False,
+            env={**os.environ, "HF_TOKEN": hf_token},
+        )
+        if result.returncode != 0:
+            logger.warning("hf sync failed: %s", result.stderr)
+        else:
+            logger.info("Synced bucket: %s", result.stdout.strip())
+    else:
+        logger.warning("HF_TOKEN not set. Cannot sync from bucket.")
 
     # Verify files exist
     file_count = len(list(RESULTS_DIR.glob("*.jsonl")))
@@ -203,42 +221,12 @@ def load_raw_results() -> list[dict[str, t.Any]]:
 def load_processed_results() -> list[dict[str, t.Any]]:
     """Load processed results.
 
-    Loads from the unified results archive. No distinction is made
-    between raw and processed results - both load from the same source.
+    In the single bucket structure, processed results are loaded from the same
+    unified source as raw results. No distinction is made between raw and
+    processed loading paths.
 
     Returns:
-        The processed results.
-
-    Raises:
-        FileNotFoundError:
-            If the results file is not found.
+        The processed results (same as raw results).
     """
-    results_path = RESULTS_PATH
-    if not results_path.exists():
-        raise FileNotFoundError("Processed results file not found.")
-
-    logger.info(f"Loading processed results from {results_path}...")
-
-    # Unpack the tar.gz file in memory and read the JSONL file
-    with tarfile.open(results_path, "r:gz") as tar:
-        results_file = tar.extractfile(member="results/results.jsonl")
-        if results_file is None:
-            raise FileNotFoundError(
-                "results/results.jsonl not found in the tar.gz file."
-            )
-        result_lines = results_file.read().decode(encoding="utf-8").splitlines()
-
-    # Parse each line as JSON, skipping empty lines
-    results = list()
-    for line_idx, line in enumerate(result_lines):
-        if not line.strip():
-            continue
-        for record in line.replace("}{", "}\n{").split("\n"):
-            if not record.strip():
-                continue
-            try:
-                results.append(json.loads(record))
-            except json.JSONDecodeError:
-                logger.error(f"Invalid JSON on line {line_idx:,}: {record}.")
-
-    return results
+    # In the single bucket structure, processed results are the same as raw results
+    return load_raw_results()

--- a/src/leaderboards/result_loading.py
+++ b/src/leaderboards/result_loading.py
@@ -64,17 +64,9 @@ def _sync_buckets() -> None:
     # Verify files exist
     file_count = len(list(RESULTS_DIR.glob("*.jsonl")))
     if file_count == 0:
-        # Check if we have local files from previous run
-        local_file_count = len(list(RESULTS_DIR.glob("*.jsonl")))
-        if local_file_count > 0:
-            logger.info(
-                f"Sync returned 0 files. Using {local_file_count:,} local files "
-                f"from {RESULTS_DIR}."
-            )
-        else:
-            raise FileNotFoundError(
-                "No results available. Sync failed and no local cache exists."
-            )
+        raise FileNotFoundError(
+            "No results available. Sync failed and no local cache exists."
+        )
 
     logger.info(f"Synced {file_count:,} model files to {RESULTS_DIR}.")
 

--- a/src/leaderboards/result_processing.py
+++ b/src/leaderboards/result_processing.py
@@ -20,7 +20,7 @@ from tqdm.auto import tqdm
 
 from .cache import Cache
 from .link_generation import generate_anchor_tag, generate_model_url
-from .paths import PROCESSED_RESULTS_DIR, RESULTS_PATH
+from .paths import RESULTS_DIR, RESULTS_PATH
 from .result_loading import load_raw_results
 from .task_metadata import task_metric_names
 from .utils import (
@@ -173,10 +173,10 @@ def process_results(
     """
     results_path = RESULTS_PATH
 
-    # Build the cache from the processed records directory if available,
+    # Build the cache from the results directory if available,
     # otherwise fall back to the compressed results file
     cache = Cache.from_processed_records(
-        compressed_results_path=results_path, processed_dir=PROCESSED_RESULTS_DIR
+        compressed_results_path=results_path, results_dir=RESULTS_DIR
     )
 
     # Load all the raw records
@@ -272,8 +272,8 @@ def process_results(
     ]
 
     # Group processed records by model for bucket upload
-    # Match raw bucket naming convention: replace slashes only, preserve dots
-    processed_by_model: dict[str, list[dict]] = {}
+    # Naming convention: replace slashes with underscores, preserve dots
+    results_by_model: dict[str, list[dict]] = {}
     for record in processed_records:
         # EEE format has model_info.name, old format has model at top level
         model_id = record.get("model_info", {}).get("name") or record.get(
@@ -282,48 +282,38 @@ def process_results(
         # Strip anchor tags before creating filename
         model_id_str = plain_model_id(model_id)
         filename = model_id_str.replace("/", "_") + ".jsonl"
-        processed_by_model.setdefault(filename, []).append(record)
+        results_by_model.setdefault(filename, []).append(record)
 
-    # Upload processed results to HF bucket as per-model files
-    hf_processed_bucket = "hf://buckets/EuroEval/processed-results"
-    PROCESSED_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    # Upload results to HF bucket as per-model files
+    hf_results_bucket = "hf://buckets/EuroEval/results"
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 
-    logger.info("Uploading processed results to HF bucket...")
-    for filename, records in processed_by_model.items():
-        file_path = PROCESSED_RESULTS_DIR / filename
+    logger.info("Uploading results to HF bucket...")
+    for filename, records in results_by_model.items():
+        file_path = RESULTS_DIR / filename
         content = "\n".join(json.dumps(record) for record in records) + "\n"
         file_path.write_text(content, encoding="utf-8")
 
     # Sync to bucket using the Python API
     try:
         api = HfApi()
-        api.sync_bucket(source=str(PROCESSED_RESULTS_DIR), dest=hf_processed_bucket)
+        api.sync_bucket(source=str(RESULTS_DIR), dest=hf_results_bucket)
         logger.info(
-            f"Uploaded {len(processed_by_model):,} model files "
-            f"to {hf_processed_bucket}."
+            f"Uploaded {len(results_by_model):,} model files to {hf_results_bucket}."
         )
     except Exception as e:
-        logger.warning(f"Failed to sync processed results: {e}")
+        logger.warning(f"Failed to sync results: {e}")
 
-    # Store records in the tar.gz archive
+    # Store all records in the tar.gz archive as a single JSONL file
+    # This contains all results (raw + processed with metadata)
     with tarfile.open(results_path, "w:gz") as tar:
-        # Raw records
-        raw_content_bytes = "\n".join(json.dumps(record) for record in records).encode(
-            encoding="utf-8"
-        )
-        raw_tarinfo = tarfile.TarInfo(name="results/results.jsonl")
-        raw_tarinfo.size = len(raw_content_bytes)
-        raw_fileobj = io.BytesIO(raw_content_bytes)
-        tar.addfile(tarinfo=raw_tarinfo, fileobj=raw_fileobj)
-
-        # Processed records
-        processed_content_bytes = "\n".join(
+        all_content_bytes = "\n".join(
             json.dumps(record) for record in processed_records
         ).encode(encoding="utf-8")
-        processed_tarinfo = tarfile.TarInfo(name="results/results.processed.jsonl")
-        processed_tarinfo.size = len(processed_content_bytes)
-        processed_fileobj = io.BytesIO(processed_content_bytes)
-        tar.addfile(tarinfo=processed_tarinfo, fileobj=processed_fileobj)
+        tarinfo = tarfile.TarInfo(name="results/results.jsonl")
+        tarinfo.size = len(all_content_bytes)
+        fileobj = io.BytesIO(all_content_bytes)
+        tar.addfile(tarinfo=tarinfo, fileobj=fileobj)
 
 
 def add_missing_entries(

--- a/src/leaderboards/result_processing.py
+++ b/src/leaderboards/result_processing.py
@@ -305,7 +305,7 @@ def process_results(
         logger.warning(f"Failed to sync results: {e}")
 
     # Store all records in the tar.gz archive as a single JSONL file
-    # This contains all results (raw + processed with metadata)
+    # This contains all processed records with metadata
     with tarfile.open(results_path, "w:gz") as tar:
         all_content_bytes = "\n".join(
             json.dumps(record) for record in processed_records

--- a/src/leaderboards/utils.py
+++ b/src/leaderboards/utils.py
@@ -264,19 +264,27 @@ def drop_val_duplicates(
 ) -> dict[str, dict[str, list[tuple[list[float], float, float]]]]:
     """Drop validation-split variants when the full test-split variant exists.
 
+    When a model has been evaluated on both the validation and full test split,
+    only show the test-split row if it covers at least as many datasets.
+    Otherwise keep the validation-split version (which may have more data).
+
     Args:
         model_results:
             The grouped model results, keyed by model ID.
 
     Returns:
         The model results with ``(val)``-suffixed entries removed whenever the
-        corresponding full test-split entry is also present.
+        corresponding full test-split entry is also present and covers at least
+        as many datasets.
     """
     filtered: dict[str, dict[str, list[tuple[list[float], float, float]]]] = {}
     for model_id, results in model_results.items():
         equivalent = strip_val_suffix(model_id=model_id)
         if equivalent is not None and equivalent in model_results:
-            continue
+            # Only drop the (val) version if the test-split version has >= datasets
+            equivalent_count = len(model_results[equivalent])
+            if equivalent_count >= len(results):
+                continue
         filtered[model_id] = results
     return filtered
 

--- a/src/leaderboards/utils.py
+++ b/src/leaderboards/utils.py
@@ -113,17 +113,29 @@ def extract_model_ids_from_record(record: dict) -> list[str]:
     model_id = get_model_name(record)
     all_model_notes: list[list[str]] = [[]]
 
-    match record.get("few_shot", True):
-        case False:
-            all_model_notes = [note + ["zero-shot"] for note in all_model_notes]
-        case None:
-            all_model_notes += [note + ["zero-shot"] for note in all_model_notes]
+    # Build combined variant notes for zero-shot and validation split
+    few_shot = record.get("few_shot", True)
+    validation_split = record.get("validation_split", False)
 
-    match record.get("validation_split", False):
-        case True:
-            all_model_notes = [note + ["val"] for note in all_model_notes]
-        case None:
-            all_model_notes += [note + ["val"] for note in all_model_notes]
+    # Determine which notes to add
+    notes_to_add: list[list[str]] = [[]]
+    if few_shot is False:
+        notes_to_add = [["zero-shot"]]
+    elif few_shot is None:
+        notes_to_add = [[], ["zero-shot"]]
+
+    # Expand with validation split variants
+    expanded_notes: list[list[str]] = []
+    for base_note in notes_to_add:
+        if validation_split is True:
+            expanded_notes.append(base_note + ["val"])
+        elif validation_split is None:
+            expanded_notes.append(base_note)
+            expanded_notes.append(base_note + ["val"])
+        else:
+            expanded_notes.append(base_note)
+
+    all_model_notes = expanded_notes
 
     model_id_candidates = [
         f"{re.sub(r'</a>$', '', model_id)} ({', '.join(note)})</a>"

--- a/src/leaderboards/utils.py
+++ b/src/leaderboards/utils.py
@@ -114,8 +114,9 @@ def extract_model_ids_from_record(record: dict) -> list[str]:
     all_model_notes: list[list[str]] = [[]]
 
     # Build combined variant notes for zero-shot and validation split
-    few_shot = record.get("few_shot", True)
-    validation_split = record.get("validation_split", False)
+    # Use _get_bool_field to handle both EEE and old formats
+    few_shot = _get_bool_field(record, "few_shot", True)
+    validation_split = _get_bool_field(record, "validation_split", False)
 
     # Determine which notes to add
     notes_to_add: list[list[str]] = [[]]

--- a/src/scripts/collect_evaluation_results.py
+++ b/src/scripts/collect_evaluation_results.py
@@ -479,7 +479,9 @@ def upload_results_to_hf(new_results_path: Path) -> bool:
     try:
         # Sync existing results from EuroEval/results bucket
         logger.info(f"Syncing existing results from {HF_RESULTS_BUCKET}...")
-        HfApi().sync_bucket(source=HF_RESULTS_BUCKET + "/", dest=str(RESULTS_DIR))
+        HfApi().sync_bucket(
+            source=f"hf://buckets/{HF_RESULTS_BUCKET}/", dest=str(RESULTS_DIR)
+        )
         logger.info("Downloaded existing results from bucket.")
     except HfHubHTTPError as e:
         logger.warning(f"Could not sync from bucket: {e}. Starting fresh.")
@@ -516,7 +518,9 @@ def upload_results_to_hf(new_results_path: Path) -> bool:
     # Sync updated results to EuroEval/results bucket
     logger.info(f"Syncing results to {HF_RESULTS_BUCKET}...")
     try:
-        HfApi().sync_bucket(source=str(RESULTS_DIR), dest=HF_RESULTS_BUCKET + "/")
+        HfApi().sync_bucket(
+            source=str(RESULTS_DIR), dest=f"hf://buckets/{HF_RESULTS_BUCKET}/"
+        )
         logger.info(f"Uploaded results to {HF_RESULTS_BUCKET}.")
     except HfHubHTTPError as e:
         logger.error(f"Failed to sync to bucket: {e}")

--- a/src/scripts/collect_evaluation_results.py
+++ b/src/scripts/collect_evaluation_results.py
@@ -48,7 +48,7 @@ from leaderboards.github_api import (
     comment_on_issue,
     gh_request,
 )
-from leaderboards.paths import RAW_RESULTS_DIR, RESULTS_PATH
+from leaderboards.paths import RESULTS_DIR, RESULTS_PATH
 from leaderboards.queue_parsing import extract_model_id
 
 load_dotenv()
@@ -62,7 +62,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 NEW_RESULTS_PATH = REPO_ROOT / "new_results.jsonl"
 
 # Canonical HF bucket for storing raw results (public read access).
-HF_RAW_BUCKET = "hf://buckets/EuroEval/raw-results"
+HF_RESULTS_BUCKET = "EuroEval/results"
 
 
 def _model_id_to_filename(model_id: str) -> str:
@@ -110,13 +110,13 @@ def build_dedup_key(result: dict) -> tuple[str, str, str, str] | None:
 
 
 def list_all_raw_result_files() -> list[BucketFile]:
-    """List all .jsonl files in the raw-results bucket.
+    """List all .jsonl files in the EuroEval/results bucket.
 
     Returns:
         List of BucketFile objects for .jsonl files.
     """
     api = HfApi()
-    bucket_id = HF_RAW_BUCKET.replace("hf://buckets/", "")
+    bucket_id = HF_RESULTS_BUCKET
     try:
         files = list(api.list_bucket_tree(bucket_id=bucket_id, recursive=True))
         return [
@@ -169,7 +169,7 @@ def load_existing_result_keys() -> set[tuple[str, str, str, str]]:
 
 
 def scan_bucket_for_results() -> list[str]:
-    """Scan the raw-results bucket for new results not yet in results.tar.gz.
+    """Scan the EuroEval/results bucket for new results not yet in results.tar.gz.
 
     Downloads all .jsonl files from the bucket, parses them, and collects
     results that are not already in the existing results.
@@ -187,12 +187,12 @@ def scan_bucket_for_results() -> list[str]:
 
     logger.info(f"Found {len(all_bucket_files)} .jsonl file(s) in bucket.")
 
-    # Download all files to RAW_RESULTS_DIR
+    # Download all files to RESULTS_DIR
     api = HfApi()
-    bucket_id = HF_RAW_BUCKET.replace("hf://buckets/", "")
+    bucket_id = HF_RESULTS_BUCKET
 
     files_spec: list[tuple[str | BucketFile, str | Path]] = [
-        (bucket_file.path, RAW_RESULTS_DIR / bucket_file.path)
+        (bucket_file.path, RESULTS_DIR / bucket_file.path)
         for bucket_file in all_bucket_files
     ]
 
@@ -200,7 +200,7 @@ def scan_bucket_for_results() -> list[str]:
         api.download_bucket_files(
             bucket_id=bucket_id, files=files_spec, raise_on_missing_files=False
         )
-        logger.info(f"Downloaded {len(files_spec)} file(s) to {RAW_RESULTS_DIR}.")
+        logger.info(f"Downloaded {len(files_spec)} file(s) to {RESULTS_DIR}.")
     except Exception as e:
         logger.error(f"Failed to download bucket files: {e}")
         return []
@@ -213,7 +213,7 @@ def scan_bucket_for_results() -> list[str]:
     seen_keys: set[tuple[str, str, str, str]] = set()
 
     for bucket_file in all_bucket_files:
-        local_path = RAW_RESULTS_DIR / bucket_file.path
+        local_path = RESULTS_DIR / bucket_file.path
         if not local_path.exists():
             logger.warning(f"Downloaded file not found: {local_path}")
             continue
@@ -342,9 +342,7 @@ def main(force: bool) -> None:
 
         # Upload results to HF bucket BEFORE regenerating leaderboards
         # (leaderboard regeneration consumes/deletes new_results.jsonl)
-        if upload_results_to_hf(
-            new_results_path=NEW_RESULTS_PATH, processed_path=RESULTS_PATH
-        ):
+        if upload_results_to_hf(new_results_path=NEW_RESULTS_PATH):
             logger.info("Results uploaded to Hugging Face bucket.")
         else:
             logger.error(
@@ -435,12 +433,12 @@ def find_results_for_issue(issue: dict) -> list[str] | None:
         return None
 
     filename = _model_id_to_filename(model_id)
-    local_path = RAW_RESULTS_DIR / filename
+    local_path = RESULTS_DIR / filename
 
     try:
         api = HfApi()
         api.download_bucket_files(
-            bucket_id=HF_RAW_BUCKET.replace("hf://buckets/", ""),
+            bucket_id=HF_RESULTS_BUCKET,
             files=[(filename, local_path)],
             raise_on_missing_files=False,
         )
@@ -462,36 +460,32 @@ def find_results_for_issue(issue: dict) -> list[str] | None:
     return lines
 
 
-def upload_results_to_hf(new_results_path: Path, processed_path: Path) -> bool:
-    """Upload raw results to Hugging Face bucket.
+def upload_results_to_hf(new_results_path: Path) -> bool:
+    """Upload results to Hugging Face bucket.
 
-    This function splits results into per-model files and syncs to raw-results
-    bucket. Processed results are uploaded separately by result_processing.py as
-    per-model JSONL.
+    This function splits results into per-model files and syncs to the
+    EuroEval/results bucket.
 
     Args:
         new_results_path:
             Path to the newly harvested results.jsonl file.
-        processed_path:
-            Path to the processed results.tar.gz file (kept for backwards compatibility,
-            but not uploaded to bucket - handled by result_processing.py).
 
     Returns:
         True if upload succeeded, False otherwise.
     """
-    RAW_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 
     try:
-        # Sync existing results from raw-results bucket
-        logger.info(f"Syncing existing results from {HF_RAW_BUCKET}...")
-        HfApi().sync_bucket(source=HF_RAW_BUCKET + "/", dest=str(RAW_RESULTS_DIR))
+        # Sync existing results from EuroEval/results bucket
+        logger.info(f"Syncing existing results from {HF_RESULTS_BUCKET}...")
+        HfApi().sync_bucket(source=HF_RESULTS_BUCKET + "/", dest=str(RESULTS_DIR))
         logger.info("Downloaded existing results from bucket.")
     except HfHubHTTPError as e:
         logger.warning(f"Could not sync from bucket: {e}. Starting fresh.")
 
     # Load existing results by model
     existing_by_model: dict[str, set[str]] = {}
-    for model_file in RAW_RESULTS_DIR.glob("*.jsonl"):
+    for model_file in RESULTS_DIR.glob("*.jsonl"):
         lines = {
             line
             for line in model_file.read_text(encoding="utf-8").splitlines()
@@ -510,7 +504,7 @@ def upload_results_to_hf(new_results_path: Path, processed_path: Path) -> bool:
             data = json.loads(line)
             model_id = data.get("model", "unknown")
             filename = _model_id_to_filename(model_id)
-            model_file = RAW_RESULTS_DIR / filename
+            model_file = RESULTS_DIR / filename
             # Append if not already present
             if line not in existing_by_model.get(filename, set()):
                 with open(model_file, "a", encoding="utf-8") as f:
@@ -518,18 +512,14 @@ def upload_results_to_hf(new_results_path: Path, processed_path: Path) -> bool:
         except json.JSONDecodeError:
             logger.warning(f"Skipping invalid JSON line: {line[:80]}...")
 
-    # Sync updated results to raw-results bucket
-    logger.info(f"Syncing results to {HF_RAW_BUCKET}...")
+    # Sync updated results to EuroEval/results bucket
+    logger.info(f"Syncing results to {HF_RESULTS_BUCKET}...")
     try:
-        HfApi().sync_bucket(source=str(RAW_RESULTS_DIR), dest=HF_RAW_BUCKET + "/")
-        logger.info(f"Uploaded results to {HF_RAW_BUCKET}.")
+        HfApi().sync_bucket(source=str(RESULTS_DIR), dest=HF_RESULTS_BUCKET + "/")
+        logger.info(f"Uploaded results to {HF_RESULTS_BUCKET}.")
     except HfHubHTTPError as e:
         logger.error(f"Failed to sync to bucket: {e}")
         return False
-
-    # Note: Processed results are uploaded by result_processing.py, not here.
-    # That script groups processed records by model and uploads per-model JSONL
-    # files to HF_PROCESSED_BUCKET for consistency with raw-results format.
 
     return True
 

--- a/src/scripts/collect_evaluation_results.py
+++ b/src/scripts/collect_evaluation_results.py
@@ -61,7 +61,7 @@ logger = logging.getLogger("collect_evaluation_results")
 REPO_ROOT = Path(__file__).resolve().parents[2]
 NEW_RESULTS_PATH = REPO_ROOT / "new_results.jsonl"
 
-# Canonical HF bucket for storing raw results (public read access).
+# Canonical HF bucket for storing evaluation results (public read access).
 HF_RESULTS_BUCKET = "EuroEval/results"
 
 
@@ -109,7 +109,7 @@ def build_dedup_key(result: dict) -> tuple[str, str, str, str] | None:
         return None
 
 
-def list_all_raw_result_files() -> list[BucketFile]:
+def list_all_result_files() -> list[BucketFile]:
     """List all .jsonl files in the EuroEval/results bucket.
 
     Returns:
@@ -180,7 +180,7 @@ def scan_bucket_for_results() -> list[str]:
     logger.info("Scanning bucket for new results...")
 
     # Get all .jsonl files from the bucket
-    all_bucket_files = list_all_raw_result_files()
+    all_bucket_files = list_all_result_files()
     if not all_bucket_files:
         logger.info("No .jsonl files found in bucket.")
         return []
@@ -356,6 +356,7 @@ def main(force: bool) -> None:
             # load_raw_results() appends new_results.jsonl locally before deleting it.
             # But the bucket needs to be synced on the next successful run.
 
+    # Regenerate leaderboards from merged results
     if not regenerate_leaderboards(force=force):
         logger.error(
             "Aborting: not closing issues because leaderboard regeneration failed."

--- a/src/scripts/process_evaluation_queue.py
+++ b/src/scripts/process_evaluation_queue.py
@@ -147,9 +147,8 @@ RESULTS_PATH = Path("euroeval_benchmark_results.jsonl")
 RESULTS_CACHE_DIR = Path(".euroeval_cache/results")
 LOCK_PATH = Path(os.environ.get("EUROEVAL_QUEUE_LOCK", "/tmp/euroeval_queue.lock"))
 
-# Canonical HF buckets for storing results (public read access).
-HF_RAW_BUCKET = "hf://buckets/EuroEval/raw-results"
-HF_PROCESSED_BUCKET = "hf://buckets/EuroEval/processed-results"
+# Canonical HF bucket for storing results (public read access).
+HF_RESULTS_BUCKET = "EuroEval/results"
 
 # Held for the lifetime of the process so the kernel keeps the queue lock
 # alive; released automatically when the process exits.
@@ -193,7 +192,7 @@ def download_results_from_hf() -> int:
     RESULTS_CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
     api = HfApi()
-    bucket_id = HF_RAW_BUCKET.replace("hf://buckets/", "")
+    bucket_id = HF_RESULTS_BUCKET
     try:
         # List all files in the bucket
         bucket_files = list(api.list_bucket_tree(bucket_id=bucket_id, recursive=True))
@@ -230,7 +229,7 @@ def download_results_from_hf() -> int:
     num_models = len(list(RESULTS_CACHE_DIR.glob("*.jsonl")))
     logger.info(
         f"Downloaded {len(all_lines):,} result lines from {num_models} model(s) "
-        f"in bucket {HF_RAW_BUCKET!r}."
+        f"in bucket {HF_RESULTS_BUCKET!r}."
     )
     return len(all_lines)
 
@@ -685,7 +684,7 @@ def process_issue(issue: dict, model_id: str, groups: list[str]) -> None:
 
 
 def upload_results_to_hf_bucket(lines: list[str], model_id: str) -> bool:
-    """Upload result lines to the HF raw-results bucket.
+    """Upload result lines to the HF results bucket.
 
     Appends new lines to the model-specific file and uploads only that file.
     Never deletes existing files or lines from the bucket (additive only).
@@ -722,9 +721,9 @@ def upload_results_to_hf_bucket(lines: list[str], model_id: str) -> bool:
 
     # Upload only the model-specific file (additive only, never deletes)
     try:
-        logger.info(f"Uploading results to {HF_RAW_BUCKET}...")
+        logger.info(f"Uploading results to {HF_RESULTS_BUCKET}...")
         api = HfApi()
-        bucket_id = HF_RAW_BUCKET.replace("hf://buckets/", "")
+        bucket_id = HF_RESULTS_BUCKET
         api.upload_file(
             path_or_fileobj=str(model_file),
             path_in_repo=filename,
@@ -743,7 +742,7 @@ def upload_results_to_hf_bucket(lines: list[str], model_id: str) -> bool:
 def _run_claimed_issue(issue: dict, model_id: str, languages: list[str]) -> None:
     """Run euroeval for all languages, uploading to HF bucket after each.
 
-    Results are uploaded incrementally to the Hugging Face raw-results bucket
+    Results are uploaded incrementally to the Hugging Face results bucket
     after each language completes, enabling crash recovery with minimal loss.
 
     Args:

--- a/src/scripts/sync_results.py
+++ b/src/scripts/sync_results.py
@@ -19,7 +19,11 @@ RESULTS_FILE = Path("euroeval_benchmark_results.jsonl")
 
 
 def main() -> None:
-    """Main entry point."""
+    """Main entry point.
+
+    Syncs results from the Hugging Face bucket, merges them into a single
+    JSONL file, and uploads any new local results back to the bucket.
+    """
     logging.basicConfig(level=logging.INFO)
     sync_bucket()
 
@@ -36,10 +40,8 @@ def merge_results() -> int:
     Deduplicates by (model_id, dataset, validation_split, few_shot) key,
     which uniquely identifies an evaluation configuration.
 
-    Local results are preserved; bucket results fill in gaps.
-
-    Reuses similar logic to _rebuild_results_tar_gz(), but outputs to
-    euroeval_benchmark_results.jsonl instead of results.tar.gz.
+    Existing local results are preserved; new results from the unified
+    results directory are merged in.
 
     Returns:
         Number of unique results written.

--- a/src/scripts/sync_results.py
+++ b/src/scripts/sync_results.py
@@ -1,6 +1,6 @@
 """Sync benchmark results bidirectionally with the Hugging Face bucket.
 
-Downloads from the raw-results bucket, merges all results into
+Downloads from the unified results bucket, merges all results into
 euroeval_benchmark_results.jsonl, then uploads new local results back
 to the bucket.
 """
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from euroeval.data_models import BenchmarkResult
 from leaderboards.bucket_sync import sync_bucket, upload_results_to_bucket
-from leaderboards.paths import RAW_RESULTS_DIR
+from leaderboards.paths import RESULTS_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -59,11 +59,11 @@ def merge_results() -> int:
                         existing[key] = line.strip()
         logger.info("Found %s existing results", f"{len(existing):,}")
 
-    # Load results from raw bucket
-    if RAW_RESULTS_DIR.exists():
-        logger.info("Loading results from %s...", RAW_RESULTS_DIR)
+    # Load results from unified results directory
+    if RESULTS_DIR.exists():
+        logger.info("Loading results from %s...", RESULTS_DIR)
         bucket_count = 0
-        for jsonl_file in sorted(RAW_RESULTS_DIR.glob("*.jsonl")):
+        for jsonl_file in sorted(RESULTS_DIR.glob("*.jsonl")):
             with jsonl_file.open() as f:
                 for line in f:
                     if line.strip():

--- a/tests/test_scripts/test_create_scala/test_create_scala.py
+++ b/tests/test_scripts/test_create_scala/test_create_scala.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 from pytest import FixtureRequest
+
 from scripts.dataset_creation.create_scala import prepare_df
 from scripts.dataset_creation.load_ud_pos import load_ud_pos
 

--- a/tests/test_scripts/test_create_scala/test_create_scala.py
+++ b/tests/test_scripts/test_create_scala/test_create_scala.py
@@ -5,9 +5,8 @@ from pathlib import Path
 
 import pytest
 from pytest import FixtureRequest
-from scripts.load_ud_pos import load_ud_pos
-
 from scripts.dataset_creation.create_scala import prepare_df
+from scripts.dataset_creation.load_ud_pos import load_ud_pos
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_scripts/test_create_scala/test_create_scala.py
+++ b/tests/test_scripts/test_create_scala/test_create_scala.py
@@ -5,9 +5,9 @@ from pathlib import Path
 
 import pytest
 from pytest import FixtureRequest
+from scripts.load_ud_pos import load_ud_pos
 
 from scripts.dataset_creation.create_scala import prepare_df
-from scripts.load_ud_pos import load_ud_pos
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## What

Refactors the EuroEval results storage from dual Hugging Face buckets (EuroEval/raw-results + EuroEval/processed-results) to a single unified bucket (EuroEval/results).

## Key Changes

- **Single bucket**: Replaces two separate buckets with one EuroEval/results bucket
- **Simplified directory structure**: results/ directory now contains all per-model JSONL files (both raw and processed with metadata)
- **Unified tar.gz**: results.tar.gz now contains only results/results.jsonl (all results merged) instead of separate raw and processed files
- **Smart metadata processing**: The processing script scans for entries missing metadata and adds them, then syncs back to the single bucket

## Why

- Reduces complexity in the results storage architecture
- Eliminates the need to maintain two separate bucket syncs
- Simplifies the data flow: all results live in one place
- Makes it easier to reason about the results pipeline

## Files Modified

- src/leaderboards/paths.py - Path constants simplified
- src/leaderboards/bucket_sync.py - Single bucket sync logic
- src/leaderboards/result_loading.py - Unified result loading
- src/leaderboards/result_processing.py - Single tar.gz structure
- src/leaderboards/backup.py - Updated validation for unified structure
- src/leaderboards/cache.py - Cache loading from single directory
- src/scripts/collect_evaluation_results.py - Collection script updated
- src/scripts/sync_results.py - Sync script simplified
- src/scripts/process_evaluation_queue.py - Queue processing updated
- .gitignore - Updated comments

## Migration Notes

The new HF bucket EuroEval/results already exists. The processed results (with metadata) should be copied from the old processed-results bucket to the new unified location before running the updated code.