### PR TITLE
fix: skip image processor loading for multimodal models without preprocessor config

### DIFF
--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -18,6 +18,7 @@ from huggingface_hub import snapshot_download
 from pydantic import conlist, create_model
 from transformers import PythonBackend, SentencePieceBackend, TokenizersBackend
 from transformers.generation.configuration_utils import GenerationConfig
+from transformers.models.auto.image_processing_auto import AutoImageProcessor
 from transformers.models.auto.tokenization_auto import AutoTokenizer
 from urllib3.exceptions import RequestError
 
@@ -121,6 +122,38 @@ if t.TYPE_CHECKING:
 # class (Gemma4ForConditionalGeneration) and a text-only class
 # (Gemma4TextForCausalLM).  vLLM only registers the former, so we remap here.
 _ARCHITECTURE_ALIASES: dict[str, str] = {"Gemma4TextForCausalLM": "Gemma4ForCausalLM"}
+
+
+@contextlib.contextmanager
+def _skip_image_processor_context() -> c.Generator[None, None, None]:
+    """Suppress missing image processor errors during model loading.
+
+    Some models have multimodal architectures (e.g. Mistral3ForConditionalGeneration)
+    but are released without the preprocessor_config.json that transformers needs to
+    load the image processor.  Since EuroEval only does text inference, we can safely
+    return None for the image processor and let vLLM load the text backbone normally.
+    """
+    original_func = AutoImageProcessor.from_pretrained.__func__
+
+    @classmethod  # type: ignore[misc]
+    def patched(
+        cls: type,
+        pretrained_model_name_or_path: str,
+        *args: object,
+        **kwargs: object,
+    ) -> object:
+        try:
+            return original_func(cls, pretrained_model_name_or_path, *args, **kwargs)
+        except OSError as e:
+            if "Can't load image processor" in str(e):
+                return None
+            raise
+
+    AutoImageProcessor.from_pretrained = patched  # type: ignore[method-assign]
+    try:
+        yield
+    finally:
+        AutoImageProcessor.from_pretrained = classmethod(original_func)  # type: ignore[method-assign]
 
 
 class VLLMModel(HuggingFaceEncoderModel):
@@ -1217,46 +1250,63 @@ def load_model(
         select_backend_and_parallelism()
     )
 
-    try:
-        model_location = (
-            model_id
-            if internet_connection_available() or Path(model_id).is_dir()
-            else resolve_model_path(download_dir=download_dir)
-        )
+    model_location = (
+        model_id
+        if internet_connection_available() or Path(model_id).is_dir()
+        else resolve_model_path(download_dir=download_dir)
+    )
 
-        max_model_len = min(
-            true_max_model_len,
-            MAX_CONTEXT_LENGTH + REASONING_MAX_TOKENS
-            if generative_type == GenerativeType.REASONING
-            else MAX_CONTEXT_LENGTH,
-        )
-        model = LLM(
-            model=model_location,
-            tokenizer=model_location,
-            gpu_memory_utilization=benchmark_config.gpu_memory_utilization,
-            max_model_len=max_model_len,
-            max_num_batched_tokens=max_model_len,
-            download_dir=download_dir,
-            trust_remote_code=benchmark_config.trust_remote_code,
-            revision=revision,
-            seed=4242,
-            distributed_executor_backend=distributed_executor_backend,
-            tensor_parallel_size=tensor_parallel_size,
-            pipeline_parallel_size=pipeline_parallel_size,
-            disable_custom_all_reduce=True,
-            quantization=quantization,
-            dtype=dtype,  # ty: ignore[invalid-argument-type]
-            enforce_eager=True,
-            # TEMP: Prefix caching isn't supported with sliding window in vLLM yet,
-            # so we disable it for now
-            enable_prefix_caching=False,
-            enable_lora=model_config.adapter_base_model_id is not None,
-            max_lora_rank=256,
-            **({"hf_overrides": hf_overrides} if hf_overrides else {}),  # ty: ignore[invalid-argument-type]
-            **vllm_params,
-        )
+    max_model_len = min(
+        true_max_model_len,
+        MAX_CONTEXT_LENGTH + REASONING_MAX_TOKENS
+        if generative_type == GenerativeType.REASONING
+        else MAX_CONTEXT_LENGTH,
+    )
+    llm_kwargs: dict[str, object] = dict(
+        model=model_location,
+        tokenizer=model_location,
+        gpu_memory_utilization=benchmark_config.gpu_memory_utilization,
+        max_model_len=max_model_len,
+        max_num_batched_tokens=max_model_len,
+        download_dir=download_dir,
+        trust_remote_code=benchmark_config.trust_remote_code,
+        revision=revision,
+        seed=4242,
+        distributed_executor_backend=distributed_executor_backend,
+        tensor_parallel_size=tensor_parallel_size,
+        pipeline_parallel_size=pipeline_parallel_size,
+        disable_custom_all_reduce=True,
+        quantization=quantization,
+        dtype=dtype,
+        enforce_eager=True,
+        # TEMP: Prefix caching isn't supported with sliding window in vLLM yet,
+        # so we disable it for now
+        enable_prefix_caching=False,
+        enable_lora=model_config.adapter_base_model_id is not None,
+        max_lora_rank=256,
+    )
+    if hf_overrides:
+        llm_kwargs["hf_overrides"] = hf_overrides
+    llm_kwargs.update(vllm_params)
+
+    try:
+        model = LLM(**llm_kwargs)  # ty: ignore[invalid-argument-type]
     except (RuntimeError, ValueError, OSError) as e:
-        if "awaiting a review from the repo authors" in str(e):
+        if "Can't load image processor" in str(e):
+            log(
+                f"Model {model_id!r} is missing an image processor config. Retrying "
+                "without image processing since EuroEval only does text inference.",
+                level=logging.DEBUG,
+            )
+            try:
+                with _skip_image_processor_context():
+                    model = LLM(**llm_kwargs)  # ty: ignore[invalid-argument-type]
+            except (RuntimeError, ValueError, OSError) as retry_e:
+                raise InvalidModel(
+                    f"The model {model_id!r} could not be loaded. The error was "
+                    f"{retry_e!r}."
+                ) from retry_e
+        elif "awaiting a review from the repo authors" in str(e):
             raise InvalidModel(
                 f"The model {model_id!r} is awaiting a review from the repository "
                 "authors. Please try again later."
@@ -1293,9 +1343,10 @@ def load_model(
                 f"`FULL_LOG=1 euroeval --model {model_id}`."
             )
             raise InvalidModel(msg) from e
-        raise InvalidModel(
-            f"The model {model_id!r} could not be loaded. The error was {e!r}."
-        ) from e
+        else:
+            raise InvalidModel(
+                f"The model {model_id!r} could not be loaded. The error was {e!r}."
+            ) from e
 
     model.config = hf_model_config
 

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -1261,35 +1261,36 @@ def load_model(
         if generative_type == GenerativeType.REASONING
         else MAX_CONTEXT_LENGTH,
     )
-    llm_kwargs: dict[str, object] = dict(
-        model=model_location,
-        tokenizer=model_location,
-        gpu_memory_utilization=benchmark_config.gpu_memory_utilization,
-        max_model_len=max_model_len,
-        max_num_batched_tokens=max_model_len,
-        download_dir=download_dir,
-        trust_remote_code=benchmark_config.trust_remote_code,
-        revision=revision,
-        seed=4242,
-        distributed_executor_backend=distributed_executor_backend,
-        tensor_parallel_size=tensor_parallel_size,
-        pipeline_parallel_size=pipeline_parallel_size,
-        disable_custom_all_reduce=True,
-        quantization=quantization,
-        dtype=dtype,
-        enforce_eager=True,
-        # TEMP: Prefix caching isn't supported with sliding window in vLLM yet,
-        # so we disable it for now
-        enable_prefix_caching=False,
-        enable_lora=model_config.adapter_base_model_id is not None,
-        max_lora_rank=256,
-    )
-    if hf_overrides:
-        llm_kwargs["hf_overrides"] = hf_overrides
-    llm_kwargs.update(vllm_params)
+
+    def _create_llm() -> "LLM":
+        return LLM(
+            model=model_location,
+            tokenizer=model_location,
+            gpu_memory_utilization=benchmark_config.gpu_memory_utilization,
+            max_model_len=max_model_len,
+            max_num_batched_tokens=max_model_len,
+            download_dir=download_dir,
+            trust_remote_code=benchmark_config.trust_remote_code,
+            revision=revision,
+            seed=4242,
+            distributed_executor_backend=distributed_executor_backend,
+            tensor_parallel_size=tensor_parallel_size,
+            pipeline_parallel_size=pipeline_parallel_size,
+            disable_custom_all_reduce=True,
+            quantization=quantization,
+            dtype=dtype,  # ty: ignore[invalid-argument-type]
+            enforce_eager=True,
+            # TEMP: Prefix caching isn't supported with sliding window in vLLM yet,
+            # so we disable it for now
+            enable_prefix_caching=False,
+            enable_lora=model_config.adapter_base_model_id is not None,
+            max_lora_rank=256,
+            **({"hf_overrides": hf_overrides} if hf_overrides else {}),  # ty: ignore[invalid-argument-type]
+            **vllm_params,
+        )
 
     try:
-        model = LLM(**llm_kwargs)  # ty: ignore[invalid-argument-type]
+        model = _create_llm()
     except (RuntimeError, ValueError, OSError) as e:
         if "Can't load image processor" in str(e) and "preprocessor_config.json" in str(
             e
@@ -1301,7 +1302,7 @@ def load_model(
             )
             try:
                 with _skip_image_processor_context():
-                    model = LLM(**llm_kwargs)  # ty: ignore[invalid-argument-type]
+                    model = _create_llm()
             except (RuntimeError, ValueError, OSError) as retry_e:
                 raise InvalidModel(
                     f"The model {model_id!r} could not be loaded. The error was "

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -137,23 +137,22 @@ def _skip_image_processor_context() -> c.Generator[None, None, None]:
 
     @classmethod  # type: ignore[misc]
     def patched(
-        cls: type,
-        pretrained_model_name_or_path: str,
-        *args: object,
-        **kwargs: object,
+        cls: type, pretrained_model_name_or_path: str, *args: object, **kwargs: object
     ) -> object:
         try:
-            return original_func(cls, pretrained_model_name_or_path, *args, **kwargs)
+            return original_func(cls, pretrained_model_name_or_path, *args, **kwargs)  # ty: ignore[invalid-argument-type]
         except OSError as e:
-            if "Can't load image processor" in str(e):
+            if "Can't load image processor" in str(
+                e
+            ) and "preprocessor_config.json" in str(e):
                 return None
             raise
 
-    AutoImageProcessor.from_pretrained = patched  # type: ignore[method-assign]
+    AutoImageProcessor.from_pretrained = patched  # ty: ignore[invalid-assignment]
     try:
         yield
     finally:
-        AutoImageProcessor.from_pretrained = classmethod(original_func)  # type: ignore[method-assign]
+        AutoImageProcessor.from_pretrained = classmethod(original_func)  # ty: ignore[invalid-assignment]
 
 
 class VLLMModel(HuggingFaceEncoderModel):
@@ -1292,7 +1291,9 @@ def load_model(
     try:
         model = LLM(**llm_kwargs)  # ty: ignore[invalid-argument-type]
     except (RuntimeError, ValueError, OSError) as e:
-        if "Can't load image processor" in str(e):
+        if "Can't load image processor" in str(e) and "preprocessor_config.json" in str(
+            e
+        ):
             log(
                 f"Model {model_id!r} is missing an image processor config. Retrying "
                 "without image processing since EuroEval only does text inference.",

--- a/tests/test_benchmark_modules/test_vllm.py
+++ b/tests/test_benchmark_modules/test_vllm.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 import torch.version
-
 from transformers.models.auto.image_processing_auto import AutoImageProcessor
 
 from euroeval.benchmark_modules.vllm import (
@@ -336,17 +335,23 @@ class TestSkipImageProcessorContext:
 
     def test_suppresses_missing_image_processor_error(self) -> None:
         """Inside the context, from_pretrained returns None instead of raising."""
+
         def _raise_missing(
-            cls: type, pretrained_model_name_or_path: str, *args: object, **kwargs: object
+            cls: type,
+            pretrained_model_name_or_path: str,
+            *args: object,
+            **kwargs: object,
         ) -> object:
             raise OSError(
                 f"Can't load image processor for '{pretrained_model_name_or_path}'. "
                 "If you were trying to load it from 'https://huggingface.co/models', "
-                "make sure you don't have a local directory with the same name."
+                "make sure you don't have a local directory with the same name. "
+                "Otherwise, make sure the path contains a preprocessor_config.json"
+                " file."
             )
 
         real_func = AutoImageProcessor.from_pretrained.__func__
-        AutoImageProcessor.from_pretrained = classmethod(_raise_missing)  # type: ignore[method-assign]
+        AutoImageProcessor.from_pretrained = classmethod(_raise_missing)  # ty: ignore[invalid-assignment]
         try:
             with pytest.raises(OSError, match="Can't load image processor"):
                 AutoImageProcessor.from_pretrained("missing-model")
@@ -359,23 +364,27 @@ class TestSkipImageProcessorContext:
             with pytest.raises(OSError, match="Can't load image processor"):
                 AutoImageProcessor.from_pretrained("missing-model")
         finally:
-            AutoImageProcessor.from_pretrained = classmethod(real_func)  # type: ignore[method-assign]
+            AutoImageProcessor.from_pretrained = classmethod(real_func)  # ty: ignore[invalid-assignment]
 
     def test_unrelated_oserrors_are_not_suppressed(self) -> None:
         """OSErrors unrelated to image processor loading propagate unchanged."""
+
         def _raise_other(
-            cls: type, pretrained_model_name_or_path: str, *args: object, **kwargs: object
+            cls: type,
+            pretrained_model_name_or_path: str,
+            *args: object,
+            **kwargs: object,
         ) -> object:
             raise OSError("Some other file-system error")
 
         real_func = AutoImageProcessor.from_pretrained.__func__
-        AutoImageProcessor.from_pretrained = classmethod(_raise_other)  # type: ignore[method-assign]
+        AutoImageProcessor.from_pretrained = classmethod(_raise_other)  # ty: ignore[invalid-assignment]
         try:
             with _skip_image_processor_context():
                 with pytest.raises(OSError, match="Some other file-system error"):
                     AutoImageProcessor.from_pretrained("any-model")
         finally:
-            AutoImageProcessor.from_pretrained = classmethod(real_func)  # type: ignore[method-assign]
+            AutoImageProcessor.from_pretrained = classmethod(real_func)  # ty: ignore[invalid-assignment]
 
 
 class TestLoadModelImageProcessorRetry:
@@ -389,9 +398,7 @@ class TestLoadModelImageProcessorRetry:
     """
 
     def test_load_model_retries_on_missing_image_processor(
-        self,
-        model_config: ModelConfig,
-        benchmark_config: BenchmarkConfig,
+        self, model_config: ModelConfig, benchmark_config: BenchmarkConfig
     ) -> None:
         """load_model succeeds when LLM() raises the image-processor OSError once."""
         mock_llm_instance = MagicMock()
@@ -410,7 +417,9 @@ class TestLoadModelImageProcessorRetry:
                 raise OSError(
                     "Can't load image processor for 'test-model/4bit'. "
                     "If you were trying to load it from 'https://huggingface.co/models',"
-                    " make sure you don't have a local directory with the same name."
+                    " make sure you don't have a local directory with the same name. "
+                    "Otherwise, make sure the path contains a preprocessor_config.json"
+                    " file."
                 )
             return mock_llm_instance
 
@@ -420,7 +429,11 @@ class TestLoadModelImageProcessorRetry:
                 side_effect=_llm_constructor,
                 create=True,
             ),
-            patch("euroeval.benchmark_modules.vllm.vllm", new=mock_vllm_module, create=True),
+            patch(
+                "euroeval.benchmark_modules.vllm.vllm",
+                new=mock_vllm_module,
+                create=True,
+            ),
             patch("euroeval.benchmark_modules.vllm.clear_vllm"),
             patch(
                 "euroeval.benchmark_modules.vllm.select_backend_and_parallelism",
@@ -449,9 +462,7 @@ class TestLoadModelImageProcessorRetry:
         assert result is mock_llm_instance
 
     def test_load_model_raises_invalid_model_when_retry_also_fails(
-        self,
-        model_config: ModelConfig,
-        benchmark_config: BenchmarkConfig,
+        self, model_config: ModelConfig, benchmark_config: BenchmarkConfig
     ) -> None:
         """load_model raises InvalidModel when both attempts fail."""
         mock_hf_model_config = MagicMock(spec=["dtype", "architectures"])
@@ -474,7 +485,11 @@ class TestLoadModelImageProcessorRetry:
                 side_effect=_always_fail,
                 create=True,
             ),
-            patch("euroeval.benchmark_modules.vllm.vllm", new=mock_vllm_module, create=True),
+            patch(
+                "euroeval.benchmark_modules.vllm.vllm",
+                new=mock_vllm_module,
+                create=True,
+            ),
             patch("euroeval.benchmark_modules.vllm.clear_vllm"),
             patch(
                 "euroeval.benchmark_modules.vllm.select_backend_and_parallelism",

--- a/tests/test_benchmark_modules/test_vllm.py
+++ b/tests/test_benchmark_modules/test_vllm.py
@@ -8,11 +8,17 @@ import pytest
 import torch
 import torch.version
 
-from euroeval.benchmark_modules.vllm import VLLMModel, load_model
+from transformers.models.auto.image_processing_auto import AutoImageProcessor
+
+from euroeval.benchmark_modules.vllm import (
+    VLLMModel,
+    _skip_image_processor_context,
+    load_model,
+)
 from euroeval.constants import MAX_CONTEXT_LENGTH, REASONING_MAX_TOKENS
 from euroeval.data_models import BenchmarkConfig, DatasetConfig, ModelConfig
 from euroeval.enums import GenerativeType
-from euroeval.exceptions import NeedsSystemDependency
+from euroeval.exceptions import InvalidModel, NeedsSystemDependency
 
 
 class TestNvccCheck:
@@ -317,3 +323,179 @@ class TestLoadModelMaxModelLen:
         mock_llm_cls.assert_called_once()
         call_kwargs = mock_llm_cls.call_args.kwargs
         assert call_kwargs["max_model_len"] == expected_max_model_len
+
+
+class TestSkipImageProcessorContext:
+    """Tests for _skip_image_processor_context.
+
+    Regression for: models such as IMISLab/Maistros-8B-Instruct-4bit that carry a
+    multimodal architecture (Mistral3ForConditionalGeneration) but are released without
+    a preprocessor_config.json.  vLLM calls AutoImageProcessor.from_pretrained() for
+    such models, which previously raised an unhandled OSError and prevented loading.
+    """
+
+    def test_suppresses_missing_image_processor_error(self) -> None:
+        """Inside the context, from_pretrained returns None instead of raising."""
+        def _raise_missing(
+            cls: type, pretrained_model_name_or_path: str, *args: object, **kwargs: object
+        ) -> object:
+            raise OSError(
+                f"Can't load image processor for '{pretrained_model_name_or_path}'. "
+                "If you were trying to load it from 'https://huggingface.co/models', "
+                "make sure you don't have a local directory with the same name."
+            )
+
+        real_func = AutoImageProcessor.from_pretrained.__func__
+        AutoImageProcessor.from_pretrained = classmethod(_raise_missing)  # type: ignore[method-assign]
+        try:
+            with pytest.raises(OSError, match="Can't load image processor"):
+                AutoImageProcessor.from_pretrained("missing-model")
+
+            with _skip_image_processor_context():
+                result = AutoImageProcessor.from_pretrained("missing-model")
+            assert result is None
+
+            # context exited: original behaviour restored
+            with pytest.raises(OSError, match="Can't load image processor"):
+                AutoImageProcessor.from_pretrained("missing-model")
+        finally:
+            AutoImageProcessor.from_pretrained = classmethod(real_func)  # type: ignore[method-assign]
+
+    def test_unrelated_oserrors_are_not_suppressed(self) -> None:
+        """OSErrors unrelated to image processor loading propagate unchanged."""
+        def _raise_other(
+            cls: type, pretrained_model_name_or_path: str, *args: object, **kwargs: object
+        ) -> object:
+            raise OSError("Some other file-system error")
+
+        real_func = AutoImageProcessor.from_pretrained.__func__
+        AutoImageProcessor.from_pretrained = classmethod(_raise_other)  # type: ignore[method-assign]
+        try:
+            with _skip_image_processor_context():
+                with pytest.raises(OSError, match="Some other file-system error"):
+                    AutoImageProcessor.from_pretrained("any-model")
+        finally:
+            AutoImageProcessor.from_pretrained = classmethod(real_func)  # type: ignore[method-assign]
+
+
+class TestLoadModelImageProcessorRetry:
+    """Tests that load_model retries with _skip_image_processor_context on OSError.
+
+    Regression for: IMISLab/Maistros-8B-Instruct-4bit and similar models where
+    LLM() raises OSError("Can't load image processor ...") because the model repo
+    has no preprocessor_config.json.  Before the fix this propagated as InvalidModel;
+    after the fix load_model retries once inside _skip_image_processor_context and
+    succeeds for text-only inference.
+    """
+
+    def test_load_model_retries_on_missing_image_processor(
+        self,
+        model_config: ModelConfig,
+        benchmark_config: BenchmarkConfig,
+    ) -> None:
+        """load_model succeeds when LLM() raises the image-processor OSError once."""
+        mock_llm_instance = MagicMock()
+        mock_hf_model_config = MagicMock(spec=["dtype", "architectures"])
+        mock_hf_model_config.dtype = torch.float16
+        mock_hf_model_config.architectures = None
+        mock_tokeniser = MagicMock()
+        mock_vllm_module = MagicMock()
+        mock_vllm_module.config = MagicMock(spec=[])
+
+        call_count = [0]
+
+        def _llm_constructor(**kwargs: object) -> object:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise OSError(
+                    "Can't load image processor for 'test-model/4bit'. "
+                    "If you were trying to load it from 'https://huggingface.co/models',"
+                    " make sure you don't have a local directory with the same name."
+                )
+            return mock_llm_instance
+
+        with (
+            patch(
+                "euroeval.benchmark_modules.vllm.LLM",
+                side_effect=_llm_constructor,
+                create=True,
+            ),
+            patch("euroeval.benchmark_modules.vllm.vllm", new=mock_vllm_module, create=True),
+            patch("euroeval.benchmark_modules.vllm.clear_vllm"),
+            patch(
+                "euroeval.benchmark_modules.vllm.select_backend_and_parallelism",
+                return_value=("mp", 1, 1),
+            ),
+            patch(
+                "euroeval.benchmark_modules.vllm.internet_connection_available",
+                return_value=True,
+            ),
+            patch(
+                "euroeval.benchmark_modules.vllm.get_vllm_tokenisation_params",
+                return_value={},
+            ),
+        ):
+            result = load_model(
+                model_config=model_config,
+                benchmark_config=benchmark_config,
+                attention_backend=None,
+                generative_type=GenerativeType.INSTRUCTION_TUNED,
+                true_max_model_len=4096,
+                tokeniser=mock_tokeniser,
+                hf_model_config=mock_hf_model_config,
+            )
+
+        assert call_count[0] == 2, "LLM should be called twice: first attempt + retry"
+        assert result is mock_llm_instance
+
+    def test_load_model_raises_invalid_model_when_retry_also_fails(
+        self,
+        model_config: ModelConfig,
+        benchmark_config: BenchmarkConfig,
+    ) -> None:
+        """load_model raises InvalidModel when both attempts fail."""
+        mock_hf_model_config = MagicMock(spec=["dtype", "architectures"])
+        mock_hf_model_config.dtype = torch.float16
+        mock_hf_model_config.architectures = None
+        mock_tokeniser = MagicMock()
+        mock_vllm_module = MagicMock()
+        mock_vllm_module.config = MagicMock(spec=[])
+
+        def _always_fail(**kwargs: object) -> object:
+            raise OSError(
+                "Can't load image processor for 'test-model/4bit'. "
+                "If you were trying to load it from 'https://huggingface.co/models',"
+                " make sure you don't have a local directory with the same name."
+            )
+
+        with (
+            patch(
+                "euroeval.benchmark_modules.vllm.LLM",
+                side_effect=_always_fail,
+                create=True,
+            ),
+            patch("euroeval.benchmark_modules.vllm.vllm", new=mock_vllm_module, create=True),
+            patch("euroeval.benchmark_modules.vllm.clear_vllm"),
+            patch(
+                "euroeval.benchmark_modules.vllm.select_backend_and_parallelism",
+                return_value=("mp", 1, 1),
+            ),
+            patch(
+                "euroeval.benchmark_modules.vllm.internet_connection_available",
+                return_value=True,
+            ),
+            patch(
+                "euroeval.benchmark_modules.vllm.get_vllm_tokenisation_params",
+                return_value={},
+            ),
+        ):
+            with pytest.raises(InvalidModel):
+                load_model(
+                    model_config=model_config,
+                    benchmark_config=benchmark_config,
+                    attention_backend=None,
+                    generative_type=GenerativeType.INSTRUCTION_TUNED,
+                    true_max_model_len=4096,
+                    tokeniser=mock_tokeniser,
+                    hf_model_config=mock_hf_model_config,
+                )


### PR DESCRIPTION
## What

Some models carry a multimodal architecture (`Mistral3ForConditionalGeneration`, etc.) but are released without the `preprocessor_config.json` that transformers needs to instantiate the image processor. When vLLM initialises one of these models it calls `AutoProcessor.from_pretrained()` → `AutoImageProcessor.from_pretrained()`, which raises an `OSError` and causes the whole model load to fail with a confusing error message.

## Why it matters

A real example: `IMISLab/Maistros-8B-Instruct-4bit` (a Greek-language quantised model). It has a Mistral 3 architecture but no image processor config, so it was completely unloadable even though EuroEval never uses images.

## How it works

Two changes in `src/euroeval/benchmark_modules/vllm.py`:

- **`_skip_image_processor_context()`** — a context manager that temporarily patches `AutoImageProcessor.from_pretrained` to return `None` instead of raising `OSError` when the config file is missing. For text-only inference (all we do) a `None` image processor is safe because vLLM never calls `.preprocess()` on it.
- **`load_model()` retry** — when the initial `LLM()` call raises with `"Can't load image processor"`, we log a debug message and retry once inside `_skip_image_processor_context()`. If the retry also fails, we surface a normal `InvalidModel` error.

The `LLM()` kwargs are also refactored into a `dict` so the parameter list doesn't have to be duplicated between the first attempt and the retry.