### PR TITLE
fix: Shrink generation budget for small-context models instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fixed vLLM benchmarking crashing on models whose context window is too small to
+  fit both the prompt and the dataset's full generation budget (e.g. a 2,048-token
+  model on IFEval, which reserves 2,048 generation tokens). Previously the prompt
+  budget collapsed to a single token and truncation raised "Truncation of prompts
+  failed". The generation budget is now shrunk (down to half the context) so the
+  prompt retains room, and zero-shot instruction-tuned prompts that still don't fit
+  are hard-truncated as a last resort instead of failing the benchmark.
 - Fixed `BenchmarkResult.append_to_results` writing records with a leading
   newline and no trailing newline, which left results files without a final
   newline and could glue two records onto a single line. Records are now written

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -871,8 +871,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                         text=prompts,
                         truncation=True,
                         max_length=max(
-                            max_context_length - max_tokens - extra_truncation,
-                            0,
+                            max_context_length - max_tokens - extra_truncation, 0
                         ),
                     )
                     prompts = self._tokeniser.batch_decode(

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -155,6 +155,45 @@ def _skip_image_processor_context() -> c.Generator[None, None, None]:
         AutoImageProcessor.from_pretrained = classmethod(original_func)  # ty: ignore[invalid-assignment]
 
 
+def compute_token_budget(
+    model_max_length: int, max_generated_tokens: int
+) -> tuple[int, int]:
+    """Compute the generation and per-prompt token budgets for a model.
+
+    The generation budget cannot exceed the model's context length, and we
+    additionally need to reserve room for the prompt. For models whose context is
+    too small to fit both the prompt and the dataset's full generation budget, we
+    shrink the generation budget (down to half the context) so that the prompt
+    retains room, rather than truncating the prompt down to nothing.
+
+    Args:
+        model_max_length:
+            The maximum context length of the model's tokeniser.
+        max_generated_tokens:
+            The dataset's configured number of tokens to generate.
+
+    Returns:
+        A pair ``(generation_budget, max_tokens_per_prompt)``, being the number of
+        tokens reserved for generation and the resulting maximum number of tokens
+        allowed in a prompt, respectively.
+
+    Raises:
+        InvalidBenchmark:
+            If the model's context length is too small to fit any prompt alongside
+            the generation budget.
+    """
+    max_context_length = min(model_max_length, MAX_CONTEXT_LENGTH)
+    generation_budget = min(max_generated_tokens, max(max_context_length // 2, 1))
+    max_tokens_per_prompt = max_context_length - generation_budget
+    if max_tokens_per_prompt <= 0:
+        raise InvalidBenchmark(
+            f"The model's context length of {max_context_length:,} tokens is too "
+            "small to fit any prompt alongside its generation budget, so it cannot "
+            "be benchmarked on this dataset."
+        )
+    return generation_budget, max_tokens_per_prompt
+
+
 class VLLMModel(HuggingFaceEncoderModel):
     """A generative model using the vLLM inference framework."""
 
@@ -671,22 +710,24 @@ class VLLMModel(HuggingFaceEncoderModel):
                     level=logging.DEBUG,
                 )
 
-        # The generation budget cannot exceed the model's context length, and we
-        # additionally reserve room for the prompt. For models whose context is too
-        # small to fit both the prompt and the dataset's full generation budget, we
-        # shrink the generation budget (down to half the context) rather than
-        # truncating the prompt down to nothing.
+        # Compute how many tokens to reserve for generation and, correspondingly,
+        # how long prompts may be. For models whose context is too small to fit both
+        # the prompt and the dataset's full generation budget, the reserved
+        # generation budget is shrunk so the prompt retains room (see
+        # `compute_token_budget`).
         max_context_length = min(self._tokeniser.model_max_length, MAX_CONTEXT_LENGTH)
-        generation_budget = min(
-            self.dataset_config.max_generated_tokens, max(max_context_length // 2, 1)
+        generation_budget, max_tokens_per_prompt = compute_token_budget(
+            model_max_length=self._tokeniser.model_max_length,
+            max_generated_tokens=self.dataset_config.max_generated_tokens,
         )
         if generation_budget < self.dataset_config.max_generated_tokens:
             log_once(
                 f"The model {self.model_config.model_id!r} has a context length of "
                 f"{max_context_length:,} tokens, which is too small to fit both the "
-                "prompt and the dataset's generation budget of "
-                f"{self.dataset_config.max_generated_tokens:,} tokens. Shrinking the "
-                f"generation budget to {generation_budget:,} tokens.",
+                "prompt and the dataset's full generation budget of "
+                f"{self.dataset_config.max_generated_tokens:,} tokens. Reserving "
+                f"{generation_budget:,} tokens for generation when budgeting prompt "
+                "lengths instead.",
                 level=logging.WARNING,
             )
 
@@ -733,9 +774,8 @@ class VLLMModel(HuggingFaceEncoderModel):
             )
             prompts = [prompt.strip() for prompt in prompts]
 
-        # Truncate the prompts if needed, reserving room for the (possibly shrunk)
-        # generation budget computed above.
-        max_tokens_per_prompt = max_context_length - generation_budget
+        # Truncate the prompts if needed, using the per-prompt token budget computed
+        # above.
         tokenized_prompts = self._tokeniser(
             text=prompts, max_length=max_tokens_per_prompt
         )
@@ -795,6 +835,17 @@ class VLLMModel(HuggingFaceEncoderModel):
                         # Removing few-shot examples was not enough (or there were
                         # none to remove, as in zero-shot tasks), so hard-truncate the
                         # prompts as a last resort rather than failing the benchmark.
+                        # We truncate the prompts with *all* few-shot examples removed,
+                        # to avoid keeping partial few-shot context while cutting away
+                        # the actual query.
+                        prompts_without_few_shots = [
+                            end_of_chat_token.join(
+                                prompt_segment[
+                                    2 * self.dataset_config.num_few_shot_examples :
+                                ]
+                            )
+                            for prompt_segment in prompt_segments
+                        ]
                         log_once(
                             "Could not fit the prompts for the model "
                             f"{self.model_config.model_id!r} within "
@@ -803,7 +854,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                             level=logging.WARNING,
                         )
                         truncated_tokenized_prompts = self._tokeniser(
-                            text=prompts,
+                            text=prompts_without_few_shots,
                             max_length=max_tokens_per_prompt,
                             truncation=True,
                         )

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -671,10 +671,29 @@ class VLLMModel(HuggingFaceEncoderModel):
                     level=logging.DEBUG,
                 )
 
+        # The generation budget cannot exceed the model's context length, and we
+        # additionally reserve room for the prompt. For models whose context is too
+        # small to fit both the prompt and the dataset's full generation budget, we
+        # shrink the generation budget (down to half the context) rather than
+        # truncating the prompt down to nothing.
+        max_context_length = min(self._tokeniser.model_max_length, MAX_CONTEXT_LENGTH)
+        generation_budget = min(
+            self.dataset_config.max_generated_tokens, max(max_context_length // 2, 1)
+        )
+        if generation_budget < self.dataset_config.max_generated_tokens:
+            log_once(
+                f"The model {self.model_config.model_id!r} has a context length of "
+                f"{max_context_length:,} tokens, which is too small to fit both the "
+                "prompt and the dataset's generation budget of "
+                f"{self.dataset_config.max_generated_tokens:,} tokens. Shrinking the "
+                f"generation budget to {generation_budget:,} tokens.",
+                level=logging.WARNING,
+            )
+
         max_tokens: int = (
             REASONING_MAX_TOKENS
             if self.generative_type == GenerativeType.REASONING
-            else self.dataset_config.max_generated_tokens
+            else generation_budget
         )
         sampling_params = SamplingParams(
             max_tokens=max_tokens,
@@ -714,13 +733,9 @@ class VLLMModel(HuggingFaceEncoderModel):
             )
             prompts = [prompt.strip() for prompt in prompts]
 
-        # Truncate the prompts if needed
-        max_tokens_per_prompt = min(
-            self._tokeniser.model_max_length, MAX_CONTEXT_LENGTH
-        )
-        max_tokens_per_prompt -= min(
-            self.dataset_config.max_generated_tokens, max_tokens_per_prompt - 1
-        )
+        # Truncate the prompts if needed, reserving room for the (possibly shrunk)
+        # generation budget computed above.
+        max_tokens_per_prompt = max_context_length - generation_budget
         tokenized_prompts = self._tokeniser(
             text=prompts, max_length=max_tokens_per_prompt
         )
@@ -777,9 +792,24 @@ class VLLMModel(HuggingFaceEncoderModel):
                             prompts = new_prompts
                             break
                     else:
-                        raise InvalidBenchmark(
-                            "Truncation of prompts failed, some prompts are still too "
-                            "long."
+                        # Removing few-shot examples was not enough (or there were
+                        # none to remove, as in zero-shot tasks), so hard-truncate the
+                        # prompts as a last resort rather than failing the benchmark.
+                        log_once(
+                            "Could not fit the prompts for the model "
+                            f"{self.model_config.model_id!r} within "
+                            f"{max_tokens_per_prompt:,} tokens by removing few-shot "
+                            "examples, so hard-truncating them instead.",
+                            level=logging.WARNING,
+                        )
+                        truncated_tokenized_prompts = self._tokeniser(
+                            text=prompts,
+                            max_length=max_tokens_per_prompt,
+                            truncation=True,
+                        )
+                        prompts = self._tokeniser.batch_decode(
+                            sequences=truncated_tokenized_prompts.input_ids,
+                            skip_special_tokens=True,
                         )
                 case _:
                     raise InvalidBenchmark("The model type is not set!")
@@ -841,9 +871,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                         text=prompts,
                         truncation=True,
                         max_length=max(
-                            min(self._tokeniser.model_max_length, MAX_CONTEXT_LENGTH)
-                            - max_tokens
-                            - extra_truncation,
+                            max_context_length - max_tokens - extra_truncation,
                             0,
                         ),
                     )

--- a/src/leaderboards/leaderboard_generation.py
+++ b/src/leaderboards/leaderboard_generation.py
@@ -433,8 +433,7 @@ def generate_dataframe(
             language_ranks_scores = {
                 lang: _format_rank_score(entry)
                 if all(
-                    ds in results
-                    for ds in language_to_required_datasets.get(lang, [])
+                    ds in results for ds in language_to_required_datasets.get(lang, [])
                 )
                 else "-"
                 for lang, entry in language_ranks.items()

--- a/tests/test_benchmark_modules/test_vllm.py
+++ b/tests/test_benchmark_modules/test_vllm.py
@@ -12,12 +12,13 @@ from transformers.models.auto.image_processing_auto import AutoImageProcessor
 from euroeval.benchmark_modules.vllm import (
     VLLMModel,
     _skip_image_processor_context,
+    compute_token_budget,
     load_model,
 )
 from euroeval.constants import MAX_CONTEXT_LENGTH, REASONING_MAX_TOKENS
 from euroeval.data_models import BenchmarkConfig, DatasetConfig, ModelConfig
 from euroeval.enums import GenerativeType
-from euroeval.exceptions import InvalidModel, NeedsSystemDependency
+from euroeval.exceptions import InvalidBenchmark, InvalidModel, NeedsSystemDependency
 
 
 class TestNvccCheck:
@@ -225,6 +226,49 @@ class TestVLLMPromptTruncation:
 
         assert len(result.sequences) == 1
         assert result.sequences[0] == "generated text"
+
+
+class TestComputeTokenBudget:
+    """Tests for `compute_token_budget`.
+
+    Regression tests for the bug where a model whose context window could not fit
+    both the prompt and the dataset's full generation budget (e.g. a 2,048-token
+    model on IFEval, which reserves 2,048 generation tokens) had its prompt budget
+    collapse to a single token, causing truncation to fail.
+    """
+
+    def test_large_context_keeps_full_generation_budget(self) -> None:
+        """A model with ample context reserves the full generation budget."""
+        generation_budget, max_tokens_per_prompt = compute_token_budget(
+            model_max_length=MAX_CONTEXT_LENGTH, max_generated_tokens=2048
+        )
+        assert generation_budget == 2048
+        assert max_tokens_per_prompt == MAX_CONTEXT_LENGTH - 2048
+
+    def test_small_context_shrinks_generation_budget(self) -> None:
+        """A model whose context equals the generation budget keeps prompt room.
+
+        The generation budget is shrunk to half the context so the prompt is not
+        truncated down to (nearly) nothing.
+        """
+        generation_budget, max_tokens_per_prompt = compute_token_budget(
+            model_max_length=2048, max_generated_tokens=2048
+        )
+        assert generation_budget == 1024
+        assert max_tokens_per_prompt == 1024
+
+    def test_model_max_length_capped_at_max_context_length(self) -> None:
+        """The context length is capped at MAX_CONTEXT_LENGTH."""
+        generation_budget, max_tokens_per_prompt = compute_token_budget(
+            model_max_length=10 * MAX_CONTEXT_LENGTH, max_generated_tokens=2048
+        )
+        assert generation_budget == 2048
+        assert max_tokens_per_prompt == MAX_CONTEXT_LENGTH - 2048
+
+    def test_too_small_context_raises(self) -> None:
+        """A context too small to fit any prompt raises a clear benchmark error."""
+        with pytest.raises(InvalidBenchmark):
+            compute_token_budget(model_max_length=1, max_generated_tokens=2048)
 
 
 class TestLoadModelMaxModelLen:


### PR DESCRIPTION
## What

Fixes a crash when benchmarking models whose context window is too small to fit both the prompt and the dataset's full generation budget. The clearest example: a 2,048-token model (e.g. `AI-Sweden-Models/gpt-sw3-1.3b-instruct`) on IFEval, which reserves `max_generated_tokens=2048`.

## The bug

Two compounding issues in `src/euroeval/benchmark_modules/vllm.py`:

1. **Prompt budget collapsed to 1 token.** The budget was `min(model_max_length, MAX_CONTEXT_LENGTH) - min(max_generated_tokens, budget - 1)` = `2048 - 2047 = 1`. The generation reservation consumed the entire context, producing the log line "Truncating prompts ... to a maximum of **1** tokens."
2. **Zero-shot truncation always raised.** For instruction-tuned models, truncation only removes few-shot examples via `range(1, num_few_shot_examples + 1)`. IFEval is zero-shot (`num_few_shot_examples=0`), so the loop is empty and falls straight through to `raise InvalidBenchmark("Truncation of prompts failed...")`.

## The fix

- **Shrink the generation budget** (down to half the context length) when the full budget wouldn't leave room for the prompt, instead of squeezing the prompt to nothing. A warning is logged when this happens. Large-context models are unaffected (`8192 // 2 = 4096 ≥ 2048`), and the reasoning path is untouched.
- The shrunk budget now feeds both the sampling `max_tokens` and the prompt-truncation budget, and the downstream retry-truncation reuses the same `max_context_length`.
- **Hard-truncate as a last resort** for zero-shot instruction-tuned prompts that still don't fit, rather than failing the whole benchmark.

For a 2,048-ctx model on IFEval this means ~1,024 tokens for the prompt and ~1,024 for generation; short IFEval instructions now fit and the benchmark runs (responses may be cut at 1,024 instead of 2,048).

## Notes

- Behavior chosen with the maintainer: shrink generation rather than fail the benchmark.
- The split is static (half/half). If a smaller prompt reservation is preferred (giving generation more room), that's a one-line change to the cap.
- Lint (`ruff`) and type-check (`ty`) pass; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
