### PR TITLE
fix: Report successful iterations when some iterations fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fixed a single failing iteration aborting an entire evaluation. When a model
+  refuses to answer in a way that produces no valid label (e.g. on the European
+  Values task, which doesn't allow invalid model outputs), that iteration is now
+  skipped and the scores of the remaining successful iterations are reported. The
+  evaluation only fails if every iteration fails.
 - Fixed `BenchmarkResult.append_to_results` writing records with a leading
   newline and no trailing newline, which left results files without a final
   newline and could glue two records onto a single line. Records are now written

--- a/src/euroeval/generation.py
+++ b/src/euroeval/generation.py
@@ -81,21 +81,47 @@ def generate(
     )
 
     scores: list["IterationScores"] = list()
+    iteration_errors: list["InvalidBenchmark"] = list()
     for idx in get_pbar(
         iterable=range(len(datasets)),
         desc="Benchmarking",
         disable=not benchmark_config.progress_bar,
     ):
-        test_scores = generate_single_iteration(
-            model=model,
-            dataset=datasets[idx]["test"],
-            cache=cache,
-            dataset_config=dataset_config,
-            benchmark_config=benchmark_config,
-        )
+        # We tolerate individual iterations failing (e.g. the model refusing to answer
+        # in a way that produces no valid label), as long as at least one iteration
+        # succeeds. This way we can still report the scores of the successful
+        # iterations rather than discarding the entire evaluation.
+        try:
+            test_scores = generate_single_iteration(
+                model=model,
+                dataset=datasets[idx]["test"],
+                cache=cache,
+                dataset_config=dataset_config,
+                benchmark_config=benchmark_config,
+            )
+        except InvalidBenchmark as e:
+            log(
+                f"Iteration {idx} failed and will be skipped: {e}",
+                level=logging.WARNING,
+            )
+            iteration_errors.append(e)
+            clear_memory()
+            continue
         log(f"Test scores for iteration {idx}: {test_scores}", level=logging.DEBUG)
         scores.append(test_scores)
         clear_memory()
+
+    # If every iteration failed then there is nothing to report, so we raise the first
+    # encountered error to abort the evaluation
+    if not scores:
+        raise iteration_errors[0]
+    if iteration_errors:
+        log(
+            f"{len(iteration_errors):,} of {len(datasets):,} iterations failed and "
+            f"were skipped; reporting the scores of the {len(scores):,} successful "
+            "iterations.",
+            level=logging.WARNING,
+        )
 
     if not benchmark_config.debug:
         cache.remove()

--- a/src/euroeval/generation.py
+++ b/src/euroeval/generation.py
@@ -111,9 +111,11 @@ def generate(
         scores.append(test_scores)
         clear_memory()
 
-    # If every iteration failed then there is nothing to report, so we raise the first
-    # encountered error to abort the evaluation
-    if not scores:
+    # If every iteration that actually ran failed then there is nothing to report, so
+    # we raise the first encountered error to abort the evaluation. If no iterations
+    # ran at all (e.g. `num_iterations` is zero) there are no errors to raise, and we
+    # simply return the empty list of scores, as before.
+    if not scores and iteration_errors:
         raise iteration_errors[0]
     if iteration_errors:
         log(


### PR DESCRIPTION
## What

When running the per-iteration loop in `generate()`, a single failing iteration used to abort the *entire* evaluation. If a model refused to answer in a way that produced no valid label — which most visibly happens on the **European Values** task, where `allow_invalid_model_outputs=False` forces an `InvalidBenchmark` to be raised — every other iteration's work was discarded and the whole eval was recorded as failed.

This PR makes the iteration loop tolerant of individual failures: a failing iteration is logged and skipped, and the scores of the successful iterations are reported. The evaluation only fails if **every** iteration fails (in which case the first error is re-raised).

## Key changes

- `generate()` wraps each `generate_single_iteration()` call in a `try/except InvalidBenchmark`, accumulating successes and collecting errors.
- If no iteration succeeds, the first error is re-raised so the eval still fails loudly.
- If some succeed and some fail, a WARNING summarises how many were skipped.
- No change to `aggregate_scores()` — it already averages over whatever iterations are present and widens the confidence interval accordingly (falling back to `NaN` when only one survives).

## Why it helps

European Values runs 10 non-bootstrapped iterations to measure variance. Previously, one stochastic refusal in any iteration threw away all 10. Now the successful runs are still reported as long as at least one succeeds.

## Caveat

Because European Values sets `bootstrap_samples=False`, all 10 iterations use the *identical* dataset. This salvages results only when refusals are stochastic (sampling variance). A model that *deterministically* refuses a given question will still fail all iterations — which is the correct outcome, since there'd be no valid data to report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)