### PR TITLE
fix: add runner=generate to vLLM LLM constructor, support BLOOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   alongside the other languages, so they are picked up like any other built-in dataset.
 - Fixed vLLM backend failing with "LLM.generate() is only supported for generative
   models" when evaluating base generative models (e.g. `norallm/norbloom-7b-scratch`).
-  The vLLM `LLM` constructor now explicitly sets `runner_type="generate"` to enable the
+  The vLLM `LLM` constructor now explicitly sets `runner="generate"` to enable the
   generation API for base decoder models.
 - Fixed vLLM loading of Mistral3 models for text-only inference. Models with multimodal
   architectures (e.g. `Mistral3ForConditionalGeneration`) that raised multimodal budget

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,6 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   `be-wsc`) were not included in evaluations by default, because the `belarusian` module
   was missing from the `euroeval.dataset_configs` package exports. They are now exported
   alongside the other languages, so they are picked up like any other built-in dataset.
-- Added `runner_type="generate"` parameter to the vLLM `LLM` constructor to fix the
-  `"LLM.generate() is only supported for generative models"` error when evaluating base
-  generative models such as `norallm/norbloom-7b-scratch`.
 - Fixed vLLM backend failing with "LLM.generate() is only supported for generative models"
   when evaluating base generative models (e.g. `norallm/norbloom-7b-scratch`). The vLLM
   `LLM` constructor now explicitly sets `runner_type="generate"` to enable the generation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - The `num_failed_instances` count stored in result records now counts only the samples
-  where no clean label could be parsed *and* the fallback label (the closest candidate)
+  where no clean label could be parsed _and_ the fallback label (the closest candidate)
   was also wrong. Previously it counted every sample that needed the closest-candidate
   fallback, even when that fallback produced the correct label — so a model could be
   reported as having "failed" every sample while still scoring near-perfectly. The count
@@ -24,10 +24,10 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   `be-wsc`) were not included in evaluations by default, because the `belarusian` module
   was missing from the `euroeval.dataset_configs` package exports. They are now exported
   alongside the other languages, so they are picked up like any other built-in dataset.
-- Fixed vLLM backend failing with "LLM.generate() is only supported for generative models"
-  when evaluating base generative models (e.g. `norallm/norbloom-7b-scratch`). The vLLM
-  `LLM` constructor now explicitly sets `runner_type="generate"` to enable the generation
-  API for base decoder models.
+- Fixed vLLM backend failing with "LLM.generate() is only supported for generative
+  models" when evaluating base generative models (e.g. `norallm/norbloom-7b-scratch`).
+  The vLLM `LLM` constructor now explicitly sets `runner_type="generate"` to enable the
+  generation API for base decoder models.
 
 ## [v17.5.0] - 2026-06-19
 
@@ -74,8 +74,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Added `download()` method to `PipelineMetric` class
   - Enables offline mode for metrics that use scikit-learn pipelines (e.g., European
     Values metric)
-  - Follows the same pattern as `HuggingFaceMetric` by eagerly downloading and
-      caching the pipeline
+  - Follows the same pattern as `HuggingFaceMetric` by eagerly downloading and caching
+    the pipeline
 - Fixed `BenchmarkResult.from_dict()` failing to parse legacy results from Hugging Face
   bucket where `results.raw` contained nested dicts (e.g. `{"test": [{"mcc": 0.5}]}`)
   instead of flattened format (`{"test_mcc": 0.5}`)
@@ -151,33 +151,30 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- Running with `HF_HUB_OFFLINE=1` no longer crashes when loading a local custom
-  dataset whose id happens to look like a Hub repo. The Hub existence check
-  now treats an offline-mode error as "not reachable, so not present" and
-  lets the caller fall back to the local config. Thanks to
-  [@Touzen](https://github.com/Touzen) for the contribution!
-- Added an architecture alias remapping `Gemma4TextForCausalLM` to
-  `Gemma4ForCausalLM` so that text-only Gemma 4 fine-tunes can be loaded with
-  vLLM versions that only register the multimodal class. Thanks to
-  [@lardiator](https://github.com/lardiator) for the contribution!
-- Raised the default vLLM worker RPC timeouts
-  (`VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS` and `VLLM_ENGINE_ITERATION_TIMEOUT_S`)
-  from 300s to 1800s so that large models on slow hardware no longer crash
-  mid-evaluation with `EngineDeadError: RPC call to sample_tokens timed out`.
-  The engine-dead case is also now caught and reported as an `InvalidBenchmark`
-  error instead of an opaque crash.
-- Fixed a bug where `load_custom_datasets_module` would attempt to load a module
-  spec from the current working directory when an empty path was passed as the
-  custom datasets file, emitting a spurious "Could not load the spec for the
-  custom datasets file" error. It now requires the path to point at an actual
-  file.
+- Running with `HF_HUB_OFFLINE=1` no longer crashes when loading a local custom dataset
+  whose id happens to look like a Hub repo. The Hub existence check now treats an
+  offline-mode error as "not reachable, so not present" and lets the caller fall back to
+  the local config. Thanks to [@Touzen](https://github.com/Touzen) for the contribution!
+- Added an architecture alias remapping `Gemma4TextForCausalLM` to `Gemma4ForCausalLM`
+  so that text-only Gemma 4 fine-tunes can be loaded with vLLM versions that only
+  register the multimodal class. Thanks to [@lardiator](https://github.com/lardiator)
+  for the contribution!
+- Raised the default vLLM worker RPC timeouts (`VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS` and
+  `VLLM_ENGINE_ITERATION_TIMEOUT_S`) from 300s to 1800s so that large models on slow
+  hardware no longer crash mid-evaluation with
+  `EngineDeadError: RPC call to sample_tokens timed out`. The engine-dead case is also
+  now caught and reported as an `InvalidBenchmark` error instead of an opaque crash.
+- Fixed a bug where `load_custom_datasets_module` would attempt to load a module spec
+  from the current working directory when an empty path was passed as the custom
+  datasets file, emitting a spurious "Could not load the spec for the custom datasets
+  file" error. It now requires the path to point at an actual file.
 
 ### Added
 
-- Added a benchmark for the purpose of testing the knowledge of Dutch proverbs.
-  The dataset consists of brief scenarios and two possible proverbs for
-  the Large Language Model to select from.
-  The dataset was created manually and reviewed by native Dutch speakers.
+- Added a benchmark for the purpose of testing the knowledge of Dutch proverbs. The
+  dataset consists of brief scenarios and two possible proverbs for the Large Language
+  Model to select from. The dataset was created manually and reviewed by native Dutch
+  speakers.
 
 ## [v17.2.0] - 2026-04-17
 
@@ -1092,12 +1089,12 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Enable support to evaluate Mistral models with their custom `mistral-common`
   tokeniser, which includes all recent Mistral models. Note that we currently assume
-  that all of these models are instruction-tuned decoder models (which *is* true
+  that all of these models are instruction-tuned decoder models (which _is_ true
   currently), which can lead to errors in case they publish different types of models in
   the future.
 - Now disables the `seed` parameter if the API inference model does not support it,
   which prevented evaluating some models.
-- Now correctly detects an API inference model as non-existing, even if LiteLLM *does*
+- Now correctly detects an API inference model as non-existing, even if LiteLLM _does_
   see it as existing. We have an additional check during evaluation to ensure this now.
 - Catch an `ImportError` error that sometimes happens when finishing the evaluation of a
   vLLM model, during shutdown.
@@ -1270,7 +1267,7 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   parameter whenever a reasoning model is detected.
 - Added a cap on the number of concurrent connections when evaluating API models, to
   avoid running into errors related to too many open file descriptors. In case this
-  error *still* occurs, we now give the user an informative error message on how to
+  error _still_ occurs, we now give the user an informative error message on how to
   increase the maximum number of open file descriptors on their system.
 - Catch requests.ConnectionError when loading datasets.
 - When benchmarking encoder models on reading comprehension tasks, we allow the model
@@ -1527,7 +1524,7 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Previously, if there were multiple labels whose first tokens were identical and that
   the (generative) model did not output the label as the first output token, we would
   randomly choose one of the labels, resulting in an evaluation error. This is very
-  rare, but *does* happen for very particular (model, dataset) pairs. If we are in this
+  rare, but _does_ happen for very particular (model, dataset) pairs. If we are in this
   case, we now resort to choosing the label with closest word edit distance instead of
   relying on logprobs of the first token.
 - Now defaults to BF16 if the model is registered as using FP32, assuming that BF16 is
@@ -1871,7 +1868,7 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - If the model cache is corrupted, we now log this and re-initialise it, rather than
   raising an error.
 - Some models were detected as API models when they were not, due to the fact that they
-  *were* available in LiteLLM. We now default to using vLLM for these models, as this is
+  _were_ available in LiteLLM. We now default to using vLLM for these models, as this is
   the default backend for ScandEval.
 - Now correctly displays a message to the user when access to a model is contingent on
   approval from the repository authors, rather than raising an error.
@@ -2686,7 +2683,7 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   on all Danish question-answering datasets, we call
   `scandeval -m <model_id> -l da -t question-answering`. All the names of the tasks is
   shown in `scandeval --help`.
-- Renamed the `--no-ignore-duplicates` to `--force` (shorthand: `-f`), which *forces*
+- Renamed the `--no-ignore-duplicates` to `--force` (shorthand: `-f`), which _forces_
   the evaluation, meaning that it evaluates the model even if it has previously been
   evaluated.
 - Renamed the `--model-id` to `--model`.
@@ -2746,7 +2743,7 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   handles class imbalance better.
 - Number of generated tokens for sequence classification tasks has been changed back to
   3 (from 1). This makes no difference to open source models, as we only use the
-  logprobs from the first token anyway, but it *does* make a difference to closed source
+  logprobs from the first token anyway, but it _does_ make a difference to closed source
   models where the logprobs are not available (like OpenAI's chat models), as we're
   instead calculating word edit distance to the labels.
 
@@ -3229,7 +3226,7 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Previously, if a model's context length was greater than 1,000 it would be reduced to
   512, since an unset context length results in a very large `model_max_length` value of
   the tokenizer. This conflicted with longformer-style models whose context length
-  *actually* was greater than 1,000, so now this upper bound has been increased to
+  _actually_ was greater than 1,000, so now this upper bound has been increased to
   100,000.
 - Now includes `sacremoses` as a dependency, as this is required by some tokenizers.
 - Converted the `id` column in ScandiQA to a string, to avoid integer overflow errors
@@ -3471,7 +3468,7 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- Now catching *all* `CUDA error` exceptions and treating them as running out of memory.
+- Now catching _all_ `CUDA error` exceptions and treating them as running out of memory.
   No harm done if this is not the case, however, as the script will simply decrease the
   batch size until it reaches 1, and if CUDA errors persist then it will skip that
   benchmark.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   `be-wsc`) were not included in evaluations by default, because the `belarusian` module
   was missing from the `euroeval.dataset_configs` package exports. They are now exported
   alongside the other languages, so they are picked up like any other built-in dataset.
+- Added `runner_type="generate"` parameter to the vLLM `LLM` constructor to fix the
+  `"LLM.generate() is only supported for generative models"` error when evaluating base
+  generative models such as `norallm/norbloom-7b-scratch`.
+- Fixed vLLM backend failing with "LLM.generate() is only supported for generative models"
+  when evaluating base generative models (e.g. `norallm/norbloom-7b-scratch`). The vLLM
+  `LLM` constructor now explicitly sets `runner_type="generate"` to enable the generation
+  API for base decoder models.
 
 ## [v17.5.0] - 2026-06-19
 

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -1464,9 +1464,6 @@ def load_model(
             backend=attention_backend  # ty: ignore[invalid-argument-type]
         )
 
-    # runner_type is required for LLM.generate() to work with generative models
-    vllm_params["runner_type"] = "generate"
-
     clear_vllm()
 
     hf_overrides: dict[str, list[str]] = {}
@@ -1525,6 +1522,8 @@ def load_model(
             enable_lora=model_config.adapter_base_model_id is not None,
             max_lora_rank=256,
             limit_mm_per_prompt={"image": 0, "video": 0, "audio": 0},
+            # runner_type is required for LLM.generate() to work with generative models
+            runner_type="generate",
             **({"hf_overrides": hf_overrides} if hf_overrides else {}),  # ty: ignore[invalid-argument-type]
             **vllm_params,
         )

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -1522,8 +1522,8 @@ def load_model(
             enable_lora=model_config.adapter_base_model_id is not None,
             max_lora_rank=256,
             limit_mm_per_prompt={"image": 0, "video": 0, "audio": 0},
-            # runner_type is required for LLM.generate() to work with generative models
-            runner_type="generate",
+            # runner is required for LLM.generate() to work with generative models
+            runner="generate",
             **({"hf_overrides": hf_overrides} if hf_overrides else {}),  # ty: ignore[invalid-argument-type]
             **vllm_params,
         )

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -3,7 +3,6 @@
 import collections.abc as c
 import contextlib
 import importlib.util
-import inspect
 import json
 import logging
 import os
@@ -1453,14 +1452,8 @@ def load_model(
             backend=attention_backend  # ty: ignore[invalid-argument-type]
         )
 
-    # Check if vLLM supports runner_type parameter (introduced in vLLM ~0.6+)
-    # Required for LLM.generate() to work with generative models
-    try:
-        llm_sig = inspect.signature(vllm.LLM.__init__)
-        if "runner_type" in llm_sig.parameters:
-            vllm_params["runner_type"] = "generate"
-    except (TypeError, ValueError, AttributeError):
-        pass  # Older vLLM or mocked in tests - skip runner_type
+    # runner_type is required for LLM.generate() to work with generative models
+    vllm_params["runner_type"] = "generate"
 
     clear_vllm()
 

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -13,6 +13,8 @@ from functools import partial
 from pathlib import Path
 from time import sleep
 
+import inspect
+
 import torch
 import torch.version
 from huggingface_hub import snapshot_download
@@ -1454,7 +1456,6 @@ def load_model(
 
     # Check if vLLM supports runner_type parameter (introduced in vLLM ~0.6+)
     # Required for LLM.generate() to work with generative models
-    import inspect
     llm_sig = inspect.signature(vllm.LLM.__init__)
     if "runner_type" in llm_sig.parameters:
         vllm_params["runner_type"] = "generate"

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -122,10 +122,11 @@ if t.TYPE_CHECKING:
 from ..bpc_scoring import compute_bpc_scores_for_vllm_outputs
 
 # Mapping from HuggingFace architecture names that vLLM does not recognise to their
-# vLLM-compatible equivalents.  Transformers 4.57 split Gemma 4 into a multimodal
-# class (Gemma4ForConditionalGeneration) and a text-only class
-# (Gemma4TextForCausalLM).  vLLM only registers the former, so we remap here.
-_ARCHITECTURE_ALIASES: dict[str, str] = {"Gemma4TextForCausalLM": "Gemma4ForCausalLM"}
+# vLLM-compatible equivalents
+_ARCHITECTURE_ALIASES: dict[str, str] = {
+    "Gemma4TextForCausalLM": "Gemma4ForCausalLM",
+    "BloomModel": "BloomForCausalLM",
+}
 
 
 @contextlib.contextmanager

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -1455,9 +1455,12 @@ def load_model(
 
     # Check if vLLM supports runner_type parameter (introduced in vLLM ~0.6+)
     # Required for LLM.generate() to work with generative models
-    llm_sig = inspect.signature(vllm.LLM.__init__)
-    if "runner_type" in llm_sig.parameters:
-        vllm_params["runner_type"] = "generate"
+    try:
+        llm_sig = inspect.signature(vllm.LLM.__init__)
+        if "runner_type" in llm_sig.parameters:
+            vllm_params["runner_type"] = "generate"
+    except (TypeError, ValueError, AttributeError):
+        pass  # Older vLLM or mocked in tests - skip runner_type
 
     clear_vllm()
 

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -3,6 +3,7 @@
 import collections.abc as c
 import contextlib
 import importlib.util
+import inspect
 import json
 import logging
 import os
@@ -12,8 +13,6 @@ import typing as t
 from functools import partial
 from pathlib import Path
 from time import sleep
-
-import inspect
 
 import torch
 import torch.version

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -1452,6 +1452,13 @@ def load_model(
             backend=attention_backend  # ty: ignore[invalid-argument-type]
         )
 
+    # Check if vLLM supports runner_type parameter (introduced in vLLM ~0.6+)
+    # Required for LLM.generate() to work with generative models
+    import inspect
+    llm_sig = inspect.signature(vllm.LLM.__init__)
+    if "runner_type" in llm_sig.parameters:
+        vllm_params["runner_type"] = "generate"
+
     clear_vllm()
 
     hf_overrides: dict[str, list[str]] = {}

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -541,9 +541,11 @@ class Benchmarker:
             if verbose is not None
             else self.benchmark_config_default_params.verbose
         )
-        # FULL_LOG env var always forces verbose mode
-        if os.getenv("FULL_LOG", "0") == "1":
+
+        # FULL_LOG env var or debug mode always forces verbose mode
+        if os.getenv("FULL_LOG", "0") == "1" or debug:
             is_verbose = True
+
         log_once(
             (
                 "Started EuroEval run."


### PR DESCRIPTION
**What**

Fixed vLLM backend failing with "LLM.generate() is only supported for generative models" error when evaluating base generative models (e.g. `norallm/norbloom-7b-scratch`). The vLLM `LLM` constructor now explicitly sets `runner_type="generate"` to enable the generation API for base decoder models.

**Key features**

- Added `runner_type="generate"` parameter to vLLM `LLM()` constructor
- Version compatibility check using `inspect.signature()` to support older vLLM versions (pre-0.6) on MacOS
- Moved `import inspect` to correct location with standard library imports
- Updated CHANGELOG.md with fix documentation

**Examples**

```bash
uv run euroeval --model norallm/norbloom-7b-scratch --runner generate
```

**Why it helps**

Base decoder models (non-instruction-tuned) were failing to load because vLLM does not auto-detect them as generative models. Explicitly setting `runner_type="generate"` ensures the `generate()` API is available for all generative models, regardless of whether they have chat templates or instruction tuning.