### PR TITLE
Add Norwegian instruction-following (ifeval-nb + ifeval-nn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   multi-class), named entity recognition, textual entailment, sentiment analysis, and
   topic classification. The MultiWikiQA-lb reading comprehension dataset is also
   included.
+- Added Norwegian instruction-following datasets `ifeval-nb` (Bokmål) and `ifeval-nn`
+  (Nynorsk), integrating the Norwegian splits of
+  [MultiIFEval](https://huggingface.co/datasets/danish-foundation-models/multi-ifeval)
+  (524 examples each, unofficial, test-only). Added a
+  `length_constraints:number_sentences_with_language` constraint that takes a `language`
+  keyword argument (an NLTK language name such as `"norwegian"`) and counts sentences
+  with the matching NLTK Punkt tokenizer, so abbreviations such as `f.eks.` and `bl.a.`
+  are not miscounted as sentence boundaries; the existing
+  `length_constraints:number_sentences` constraint is unchanged. Following MultiIFEval,
+  the `language:response_language` constraint is left out for Norwegian, as language
+  detection cannot reliably separate Bokmål from Nynorsk.
 
 ### Fixed
 

--- a/src/euroeval/dataset_configs/norwegian.py
+++ b/src/euroeval/dataset_configs/norwegian.py
@@ -7,6 +7,7 @@ from ..tasks import (
     EUROPEAN_VALUES,
     GED,
     HALLU,
+    INSTRUCTION_FOLLOWING,
     KNOW,
     LA,
     LOGIC,
@@ -116,6 +117,28 @@ VALEU_NO_CONFIG = DatasetConfig(
 
 
 # Unofficial datasets ###
+
+IFEVAL_NB_CONFIG = DatasetConfig(
+    name="ifeval-nb",
+    pretty_name="IFEval-nb",
+    source="EuroEval/ifeval-nb",
+    task=INSTRUCTION_FOLLOWING,
+    languages=[NORWEGIAN_BOKMÅL, NORWEGIAN],
+    train_split=None,
+    val_split=None,
+    unofficial=True,
+)
+
+IFEVAL_NN_CONFIG = DatasetConfig(
+    name="ifeval-nn",
+    pretty_name="IFEval-nn",
+    source="EuroEval/ifeval-nn",
+    task=INSTRUCTION_FOLLOWING,
+    languages=[NORWEGIAN_NYNORSK, NORWEGIAN],
+    train_split=None,
+    val_split=None,
+    unofficial=True,
+)
 
 NO_COLA_CONFIG = DatasetConfig(
     name="no-cola",

--- a/src/euroeval/metrics/ifeval/constraints.py
+++ b/src/euroeval/metrics/ifeval/constraints.py
@@ -320,6 +320,42 @@ def check_number_sentences(response: str, **constraint_kwargs) -> bool:
     return actual >= num_sentences
 
 
+@register(
+    "no:length_constraints:number_sentences",
+    num_sentences=int,
+    relation=t.Literal["less than", "at least"],
+)
+def check_number_sentences_norwegian(response: str, **constraint_kwargs) -> bool:
+    """Check number of sentences using the Norwegian sentence tokenizer.
+
+    The default (English) ``sent_tokenize`` over-counts Norwegian sentences that
+    contain common abbreviations such as ``f.eks.`` and ``bl.a.``, treating them
+    as sentence boundaries. NLTK ships a Norwegian Punkt model; passing
+    ``language="norwegian"`` fixes the count. Falls back to the default model if
+    the Norwegian one is unavailable, so a missing resource degrades gracefully
+    rather than raising ``LookupError`` and aborting the eval.
+
+    Args:
+        response:
+            The response string to check.
+        **constraint_kwargs:
+            Keyword arguments containing ``num_sentences`` and ``relation``.
+
+    Returns:
+        True if the sentence count satisfies the relation, False otherwise.
+    """
+    num_sentences: int = constraint_kwargs["num_sentences"]
+    relation: str = constraint_kwargs["relation"]
+
+    try:
+        actual = len(nltk.tokenize.sent_tokenize(text=response, language="norwegian"))
+    except LookupError:
+        actual = len(nltk.tokenize.sent_tokenize(text=response))
+    if relation == "less than":
+        return actual < num_sentences
+    return actual >= num_sentences
+
+
 @register("length_constraints:number_paragraphs", num_paragraphs=int)
 @register("fr:length_constraints:number_paragraphs", num_paragraphs=int)
 @register("es:length_constraints:number_paragraphs", num_paragraphs=int)

--- a/src/euroeval/metrics/ifeval/constraints.py
+++ b/src/euroeval/metrics/ifeval/constraints.py
@@ -279,40 +279,102 @@ def check_letter_frequency(response: str, **constraint_kwargs) -> bool:
     return counts[letter.lower()] >= let_frequency
 
 
+def _check_number_sentences(
+    response: str,
+    *,
+    num_sentences: int,
+    relation: str,
+    language: "t.Optional[str]" = None,
+) -> bool:
+    """Shared sentence-count check for the number_sentences constraints.
+
+    When ``language`` is given (an NLTK language name such as ``"english"`` or
+    ``"norwegian"``) the sentence count uses the matching Punkt model. This
+    matters because the default English tokenizer over-counts sentences in
+    languages whose abbreviations it does not know — e.g. Norwegian ``f.eks.``
+    and ``bl.a.`` are treated as sentence boundaries. Falls back to the default
+    model if the requested one is unavailable, so a missing resource degrades
+    gracefully rather than raising ``LookupError`` and aborting the eval.
+
+    Args:
+        response:
+            The response string to check.
+        num_sentences:
+            The threshold number of sentences.
+        relation:
+            The comparison relation (a less-than or at-least variant).
+        language:
+            Optional NLTK language name for the sentence tokenizer. If None, the
+            default tokenizer is used.
+
+    Returns:
+        True if the sentence count satisfies the relation, False otherwise.
+    """
+    if language is None:
+        actual = len(nltk.tokenize.sent_tokenize(text=response))
+    else:
+        try:
+            actual = len(nltk.tokenize.sent_tokenize(text=response, language=language))
+        except LookupError:
+            actual = len(nltk.tokenize.sent_tokenize(text=response))
+    if relation in {"less than", "moins de", "færre enn"}:
+        return actual < num_sentences
+    return actual >= num_sentences
+
+
 @register(
     "length_constraints:number_sentences",
     num_sentences=int,
     relation=t.Literal["less than", "at least"],
-    language=str,
 )
 @register(
     "fr:length_constraints:number_sentences",
     num_sentences=int,
     relation=t.Literal["moins de", "au moins"],
-    language=str,
 )
 @register(
     "es:length_constraints:number_sentences",
     num_sentences=int,
     relation=t.Literal["less than", "at least"],
-    language=str,
 )
 @register(
     "ca:length_constraints:number_sentences",
     num_sentences=int,
     relation=t.Literal["less than", "at least"],
-    language=str,
 )
 def check_number_sentences(response: str, **constraint_kwargs) -> bool:
-    """Check number of sentences.
+    """Check number of sentences (default sentence tokenizer).
 
-    The sentence count uses the NLTK Punkt model for ``language`` (an NLTK
-    language name such as ``"english"`` or ``"norwegian"``). This matters because
-    the default English tokenizer over-counts sentences in languages whose
-    abbreviations it does not know — e.g. Norwegian ``f.eks.`` and ``bl.a.`` are
-    treated as sentence boundaries. Falls back to the default model if the
-    requested one is unavailable, so a missing resource degrades gracefully
-    rather than raising ``LookupError`` and aborting the eval.
+    Args:
+        response:
+            The response string to check.
+        **constraint_kwargs:
+            Keyword arguments containing ``num_sentences`` and ``relation``.
+
+    Returns:
+        True if the sentence count satisfies the relation, False otherwise.
+    """
+    return _check_number_sentences(
+        response,
+        num_sentences=constraint_kwargs["num_sentences"],
+        relation=constraint_kwargs["relation"],
+    )
+
+
+@register(
+    "length_constraints:number_sentences_with_language",
+    num_sentences=int,
+    relation=t.Literal["less than", "at least", "færre enn"],
+    language=str,
+)
+def check_number_sentences_with_language(response: str, **constraint_kwargs) -> bool:
+    """Check number of sentences, selecting the sentence tokenizer by language.
+
+    Identical to :func:`check_number_sentences` but takes a required ``language``
+    NLTK name (e.g. ``"norwegian"``) so the count uses the matching Punkt model
+    instead of the default English one. Used by datasets whose language needs a
+    non-default tokenizer; older datasets keep using
+    ``length_constraints:number_sentences`` unchanged.
 
     Args:
         response:
@@ -324,17 +386,12 @@ def check_number_sentences(response: str, **constraint_kwargs) -> bool:
     Returns:
         True if the sentence count satisfies the relation, False otherwise.
     """
-    num_sentences: int = constraint_kwargs["num_sentences"]
-    relation: str = constraint_kwargs["relation"]
-    language: str = constraint_kwargs["language"]
-
-    try:
-        actual = len(nltk.tokenize.sent_tokenize(text=response, language=language))
-    except LookupError:
-        actual = len(nltk.tokenize.sent_tokenize(text=response))
-    if relation in {"less than", "moins de"}:
-        return actual < num_sentences
-    return actual >= num_sentences
+    return _check_number_sentences(
+        response,
+        num_sentences=constraint_kwargs["num_sentences"],
+        relation=constraint_kwargs["relation"],
+        language=constraint_kwargs["language"],
+    )
 
 
 @register("length_constraints:number_paragraphs", num_paragraphs=int)

--- a/src/euroeval/metrics/ifeval/constraints.py
+++ b/src/euroeval/metrics/ifeval/constraints.py
@@ -283,75 +283,56 @@ def check_letter_frequency(response: str, **constraint_kwargs) -> bool:
     "length_constraints:number_sentences",
     num_sentences=int,
     relation=t.Literal["less than", "at least"],
+    language=str,
 )
 @register(
     "fr:length_constraints:number_sentences",
     num_sentences=int,
     relation=t.Literal["moins de", "au moins"],
+    language=str,
 )
 @register(
     "es:length_constraints:number_sentences",
     num_sentences=int,
     relation=t.Literal["less than", "at least"],
+    language=str,
 )
 @register(
     "ca:length_constraints:number_sentences",
     num_sentences=int,
     relation=t.Literal["less than", "at least"],
+    language=str,
 )
 def check_number_sentences(response: str, **constraint_kwargs) -> bool:
     """Check number of sentences.
 
-    Args:
-        response:
-            The response string to check.
-        **constraint_kwargs:
-            Keyword arguments containing ``num_sentences`` and ``relation``.
-
-    Returns:
-        True if the sentence count satisfies the relation, False otherwise.
-    """
-    num_sentences: int = constraint_kwargs["num_sentences"]
-    relation: str = constraint_kwargs["relation"]
-
-    actual = len(nltk.tokenize.sent_tokenize(text=response))
-    if relation in {"less than", "moins de"}:
-        return actual < num_sentences
-    return actual >= num_sentences
-
-
-@register(
-    "no:length_constraints:number_sentences",
-    num_sentences=int,
-    relation=t.Literal["less than", "at least"],
-)
-def check_number_sentences_norwegian(response: str, **constraint_kwargs) -> bool:
-    """Check number of sentences using the Norwegian sentence tokenizer.
-
-    The default (English) ``sent_tokenize`` over-counts Norwegian sentences that
-    contain common abbreviations such as ``f.eks.`` and ``bl.a.``, treating them
-    as sentence boundaries. NLTK ships a Norwegian Punkt model; passing
-    ``language="norwegian"`` fixes the count. Falls back to the default model if
-    the Norwegian one is unavailable, so a missing resource degrades gracefully
+    The sentence count uses the NLTK Punkt model for ``language`` (an NLTK
+    language name such as ``"english"`` or ``"norwegian"``). This matters because
+    the default English tokenizer over-counts sentences in languages whose
+    abbreviations it does not know — e.g. Norwegian ``f.eks.`` and ``bl.a.`` are
+    treated as sentence boundaries. Falls back to the default model if the
+    requested one is unavailable, so a missing resource degrades gracefully
     rather than raising ``LookupError`` and aborting the eval.
 
     Args:
         response:
             The response string to check.
         **constraint_kwargs:
-            Keyword arguments containing ``num_sentences`` and ``relation``.
+            Keyword arguments containing ``num_sentences``, ``relation`` and
+            ``language``.
 
     Returns:
         True if the sentence count satisfies the relation, False otherwise.
     """
     num_sentences: int = constraint_kwargs["num_sentences"]
     relation: str = constraint_kwargs["relation"]
+    language: str = constraint_kwargs["language"]
 
     try:
-        actual = len(nltk.tokenize.sent_tokenize(text=response, language="norwegian"))
+        actual = len(nltk.tokenize.sent_tokenize(text=response, language=language))
     except LookupError:
         actual = len(nltk.tokenize.sent_tokenize(text=response))
-    if relation == "less than":
+    if relation in {"less than", "moins de"}:
         return actual < num_sentences
     return actual >= num_sentences
 

--- a/src/frontend/md/datasets/norwegian.md
+++ b/src/frontend/md/datasets/norwegian.md
@@ -2637,7 +2637,7 @@ Here are a few examples from the test split:
     "target_text": {
         "instruction_id_list": [
             "keywords:letter_frequency",
-            "length_constraints:number_sentences",
+            "length_constraints:number_sentences_with_language",
             "detectable_format:number_highlighted_sections"
         ],
         "kwargs": [
@@ -2718,7 +2718,7 @@ Here are a few examples from the test split:
     "target_text": {
         "instruction_id_list": [
             "keywords:letter_frequency",
-            "length_constraints:number_sentences",
+            "length_constraints:number_sentences_with_language",
             "detectable_format:number_highlighted_sections"
         ],
         "kwargs": [

--- a/src/frontend/md/datasets/norwegian.md
+++ b/src/frontend/md/datasets/norwegian.md
@@ -2577,3 +2577,171 @@ You can evaluate this dataset directly as follows:
 ```bash
 euroeval --model <model-id> --dataset zebra-puzzles-hard-nn
 ```
+
+## Instruction Following
+
+### Unofficial: IFEval-nb
+
+This dataset is the Bokmål split of
+[MultiIFEval](https://huggingface.co/datasets/danish-foundation-models/multi-ifeval),
+an automatically translated version of the English IFEval dataset, which was published
+in [this paper](https://doi.org/10.48550/arXiv.2311.07911) and contains prompts each
+with a combination of one or more of 25 different constraints, verified
+programmatically rather than with a judge.
+
+We use the dataset as the test split, and do not include other splits, as we only
+evaluate models zero-shot and the size is too small to warrant a validation set.
+
+The `number_sentences` constraint carries a `language` keyword argument set to
+`"norwegian"`, so it counts sentences with the Norwegian sentence tokenizer; the
+default English tokenizer over-counts Norwegian abbreviations such as `f.eks.` and
+`bl.a.`. Following MultiIFEval, the `language:response_language` constraint is left
+out for Norwegian, as language detection cannot reliably separate Bokmål from
+Nynorsk.
+
+Here are a few examples from the test split:
+
+```json
+{
+    "text": "Jeg planlegger en reise til Japan og jeg vil at du skal skrive en reiseplan for turen min i en stil som minner om William Shakespeare. Du har ikke lov til å bruke komma i svaret ditt.",
+    "target_text": {
+        "instruction_id_list": [
+            "punctuation:no_comma"
+        ],
+        "kwargs": [
+            {}
+        ]
+    }
+}
+```
+
+```json
+{
+    "text": "Skriv en CV for en som nettopp er ferdig med videregående skole og som søker sin første jobb. Sørg for å inkludere minst 12 plassholdere representert med firkantparenteser, slik som [adresse], [navn].",
+    "target_text": {
+        "instruction_id_list": [
+            "detectable_content:number_placeholders"
+        ],
+        "kwargs": [
+            {
+                "num_placeholders": 12
+            }
+        ]
+    }
+}
+```
+
+```json
+{
+    "text": "Skriv en mal for en chatbot som tar brukerens posisjon og gir dem værmeldingen. Bruk bokstaven o som et nøkkelord i syntaksen til malen. Bokstaven o må forekomme minst 6 ganger. Svaret ditt skal inneholde færre enn 6 setninger. Uthev minst 2 tekstseksjoner, f.eks. *uthevet seksjon*.",
+    "target_text": {
+        "instruction_id_list": [
+            "keywords:letter_frequency",
+            "length_constraints:number_sentences",
+            "detectable_format:number_highlighted_sections"
+        ],
+        "kwargs": [
+            {
+                "let_relation": "at least",
+                "letter": "o",
+                "let_frequency": 6
+            },
+            {
+                "relation": "less than",
+                "num_sentences": 6,
+                "language": "norwegian"
+            },
+            {
+                "num_highlights": 2
+            }
+        ]
+    }
+}
+```
+
+You can evaluate a model on this dataset as follows:
+
+```bash
+euroeval --model <model-id> --dataset ifeval-nb
+```
+
+### Unofficial: IFEval-nn
+
+This dataset is the Nynorsk split of
+[MultiIFEval](https://huggingface.co/datasets/danish-foundation-models/multi-ifeval),
+an automatically translated version of the English IFEval dataset, which was published
+in [this paper](https://doi.org/10.48550/arXiv.2311.07911) and contains prompts each
+with a combination of one or more of 25 different constraints, verified
+programmatically rather than with a judge.
+
+We use the dataset as the test split, and do not include other splits, as we only
+evaluate models zero-shot and the size is too small to warrant a validation set.
+
+As for IFEval-nb, `number_sentences` carries `language: "norwegian"` (Norwegian
+sentence tokenizer), and `language:response_language` is left out.
+
+Here are a few examples from the test split:
+
+```json
+{
+    "text": "Eg planlegg ei reise til Japan og eg vil at du skal skrive ein reiseplan for ferda mi i ein stil som minner om Shakespeare. Du har ikkje lov til å bruke komma i svaret ditt.",
+    "target_text": {
+        "instruction_id_list": [
+            "punctuation:no_comma"
+        ],
+        "kwargs": [
+            {}
+        ]
+    }
+}
+```
+
+```json
+{
+    "text": "Skriv ein CV for ein som nettopp er ferdig på vidaregåande skule og som søkjer si første stelle. Pass på å inkludere minst 12 plasshaldarar representert ved firkantparentesar, slik som [adresse], [namn].",
+    "target_text": {
+        "instruction_id_list": [
+            "detectable_content:number_placeholders"
+        ],
+        "kwargs": [
+            {
+                "num_placeholders": 12
+            }
+        ]
+    }
+}
+```
+
+```json
+{
+    "text": "Skriv ein mal for ein pratebot som tek imot lokasjonen til ein brukar og gjev dei vêrvarsel. Bruk bokstaven o som eit nøkkelord i syntaksen til malen. Bokstaven o må førekome minst 6 gonger. Svaret ditt skal innehalde færre enn 6 setningar. Uthev minst 2 tekstseksjonar, til dømes *utheva seksjon*.",
+    "target_text": {
+        "instruction_id_list": [
+            "keywords:letter_frequency",
+            "length_constraints:number_sentences",
+            "detectable_format:number_highlighted_sections"
+        ],
+        "kwargs": [
+            {
+                "let_relation": "at least",
+                "letter": "o",
+                "let_frequency": 6
+            },
+            {
+                "relation": "less than",
+                "num_sentences": 6,
+                "language": "norwegian"
+            },
+            {
+                "num_highlights": 2
+            }
+        ]
+    }
+}
+```
+
+You can evaluate a model on this dataset as follows:
+
+```bash
+euroeval --model <model-id> --dataset ifeval-nn
+```

--- a/src/scripts/dataset_creation/create_ifeval.py
+++ b/src/scripts/dataset_creation/create_ifeval.py
@@ -31,25 +31,16 @@ LANGUAGES = {
 }
 TARGET_REPO = "EuroEval/ifeval-{language}"
 
-# Constraints that need a language-specific verifier variant in EuroEval. The
-# instruction_id is remapped to the variant in the data, mirroring how the fr:
-# sets carry prefixed ids. Norwegian: the default English sentence tokenizer
-# miscounts Norwegian abbreviations (f.eks., bl.a.), so number_sentences uses the
-# no: variant (Norwegian Punkt model). language:response_language is intentionally
-# left as-is — MultiIFEval drops it for Norwegian since langdetect can't separate
-# nb/nn.
-LANGUAGE_INSTRUCTION_ID_REMAP = {
-    "nb": {
-        "length_constraints:number_sentences": (
-            "no:length_constraints:number_sentences"
-        )
-    },
-    "nn": {
-        "length_constraints:number_sentences": (
-            "no:length_constraints:number_sentences"
-        )
-    },
-}
+# The `length_constraints:number_sentences` constraint counts sentences with an
+# NLTK Punkt model, taking the NLTK language name from a `language` kwarg. The
+# default English tokenizer over-counts languages whose abbreviations it does not
+# know (e.g. Norwegian `f.eks.`, `bl.a.`), so we record the NLTK language name per
+# dataset language. Languages without a dedicated entry fall back to English,
+# preserving existing behaviour; languages without an NLTK Punkt model degrade
+# gracefully in the constraint itself.
+NUMBER_SENTENCES_CONSTRAINT = "length_constraints:number_sentences"
+SENTENCE_TOKENIZER_LANGUAGE = {"nb": "norwegian", "nn": "norwegian"}
+DEFAULT_SENTENCE_TOKENIZER_LANGUAGE = "english"
 
 PROMPT_COLUMN_CANDIDATES = ["prompt", "promptly", "turn_1_prompt"]
 INSTRUCTION_ID_LIST_COLUMN_CANDIDATES = [
@@ -159,14 +150,6 @@ def main() -> None:
             if isinstance(instruction_id_list, str):
                 instruction_id_list = json.loads(instruction_id_list)
 
-            # Remap instruction_ids to language-specific verifier variants, if any
-            id_remap = LANGUAGE_INSTRUCTION_ID_REMAP.get(language, {})
-            if id_remap:
-                instruction_id_list = [
-                    id_remap.get(instruction_id, instruction_id)
-                    for instruction_id in instruction_id_list
-                ]
-
             # Ensure that kwargs is a list of dicts
             kwargs = row[kwargs_column]
             if isinstance(kwargs, str):
@@ -175,6 +158,18 @@ def main() -> None:
                 kwargs = [json.loads(kwarg) for kwarg in kwargs]
             if isinstance(kwargs, dict):
                 kwargs = [kwargs] * len(instruction_id_list)
+
+            # Record the NLTK sentence-tokenizer language for number_sentences, so
+            # the constraint counts sentences with the right Punkt model.
+            sentence_language = SENTENCE_TOKENIZER_LANGUAGE.get(
+                language, DEFAULT_SENTENCE_TOKENIZER_LANGUAGE
+            )
+            kwargs = [
+                {**kwarg, "language": sentence_language}
+                if instruction_id == NUMBER_SENTENCES_CONSTRAINT
+                else kwarg
+                for instruction_id, kwarg in zip(instruction_id_list, kwargs)
+            ]
 
             return dict(
                 text=prompt,

--- a/src/scripts/dataset_creation/create_ifeval.py
+++ b/src/scripts/dataset_creation/create_ifeval.py
@@ -23,11 +23,33 @@ LANGUAGES = {
     "et": "tartuNLP/ifeval_et",
     "fi": "LumiOpen/ifeval_mt::fi",
     "fr": "json:https://raw.githubusercontent.com/lightblue-tech/M-IFEval/refs/heads/main/data/fr_input_data.jsonl",
+    "nb": "danish-foundation-models/multi-ifeval::no",
+    "nn": "danish-foundation-models/multi-ifeval::nn",
     "pt": "facebook/Multi-IF?language=Portuguese",
     "sv": "LumiOpen/ifeval_mt::sv",
     "uk": "INSAIT-Institute/ifeval_ukr",
 }
 TARGET_REPO = "EuroEval/ifeval-{language}"
+
+# Constraints that need a language-specific verifier variant in EuroEval. The
+# instruction_id is remapped to the variant in the data, mirroring how the fr:
+# sets carry prefixed ids. Norwegian: the default English sentence tokenizer
+# miscounts Norwegian abbreviations (f.eks., bl.a.), so number_sentences uses the
+# no: variant (Norwegian Punkt model). language:response_language is intentionally
+# left as-is — MultiIFEval drops it for Norwegian since langdetect can't separate
+# nb/nn.
+LANGUAGE_INSTRUCTION_ID_REMAP = {
+    "nb": {
+        "length_constraints:number_sentences": (
+            "no:length_constraints:number_sentences"
+        )
+    },
+    "nn": {
+        "length_constraints:number_sentences": (
+            "no:length_constraints:number_sentences"
+        )
+    },
+}
 
 PROMPT_COLUMN_CANDIDATES = ["prompt", "promptly", "turn_1_prompt"]
 INSTRUCTION_ID_LIST_COLUMN_CANDIDATES = [
@@ -136,6 +158,14 @@ def main() -> None:
             # Ensure that the instruction_id_list is a list of strings
             if isinstance(instruction_id_list, str):
                 instruction_id_list = json.loads(instruction_id_list)
+
+            # Remap instruction_ids to language-specific verifier variants, if any
+            id_remap = LANGUAGE_INSTRUCTION_ID_REMAP.get(language, {})
+            if id_remap:
+                instruction_id_list = [
+                    id_remap.get(instruction_id, instruction_id)
+                    for instruction_id in instruction_id_list
+                ]
 
             # Ensure that kwargs is a list of dicts
             kwargs = row[kwargs_column]

--- a/src/scripts/dataset_creation/create_ifeval.py
+++ b/src/scripts/dataset_creation/create_ifeval.py
@@ -31,16 +31,17 @@ LANGUAGES = {
 }
 TARGET_REPO = "EuroEval/ifeval-{language}"
 
-# The `length_constraints:number_sentences` constraint counts sentences with an
-# NLTK Punkt model, taking the NLTK language name from a `language` kwarg. The
-# default English tokenizer over-counts languages whose abbreviations it does not
-# know (e.g. Norwegian `f.eks.`, `bl.a.`), so we record the NLTK language name per
-# dataset language. Languages without a dedicated entry fall back to English,
-# preserving existing behaviour; languages without an NLTK Punkt model degrade
-# gracefully in the constraint itself.
+# Datasets whose language needs a non-default NLTK Punkt sentence tokenizer remap
+# their `length_constraints:number_sentences` constraint to
+# `length_constraints:number_sentences_with_language`, carrying the NLTK language
+# name in a `language` kwarg. The default English tokenizer over-counts languages
+# whose abbreviations it does not know (e.g. Norwegian `f.eks.`, `bl.a.`).
+# Languages without an entry here keep the original constraint and data unchanged.
 NUMBER_SENTENCES_CONSTRAINT = "length_constraints:number_sentences"
+NUMBER_SENTENCES_WITH_LANGUAGE_CONSTRAINT = (
+    "length_constraints:number_sentences_with_language"
+)
 SENTENCE_TOKENIZER_LANGUAGE = {"nb": "norwegian", "nn": "norwegian"}
-DEFAULT_SENTENCE_TOKENIZER_LANGUAGE = "english"
 
 PROMPT_COLUMN_CANDIDATES = ["prompt", "promptly", "turn_1_prompt"]
 INSTRUCTION_ID_LIST_COLUMN_CANDIDATES = [
@@ -159,17 +160,22 @@ def main() -> None:
             if isinstance(kwargs, dict):
                 kwargs = [kwargs] * len(instruction_id_list)
 
-            # Record the NLTK sentence-tokenizer language for number_sentences, so
-            # the constraint counts sentences with the right Punkt model.
-            sentence_language = SENTENCE_TOKENIZER_LANGUAGE.get(
-                language, DEFAULT_SENTENCE_TOKENIZER_LANGUAGE
-            )
-            kwargs = [
-                {**kwarg, "language": sentence_language}
-                if instruction_id == NUMBER_SENTENCES_CONSTRAINT
-                else kwarg
-                for instruction_id, kwarg in zip(instruction_id_list, kwargs)
-            ]
+            # For languages that need a non-default sentence tokenizer, remap the
+            # number_sentences constraint to its language-aware variant and carry
+            # the NLTK language name. Other languages keep the original id and
+            # data unchanged, so existing datasets need no regeneration.
+            sentence_language = SENTENCE_TOKENIZER_LANGUAGE.get(language)
+            if sentence_language is not None:
+                remapped_ids = []
+                remapped_kwargs = []
+                for instruction_id, kwarg in zip(instruction_id_list, kwargs):
+                    if instruction_id == NUMBER_SENTENCES_CONSTRAINT:
+                        remapped_ids.append(NUMBER_SENTENCES_WITH_LANGUAGE_CONSTRAINT)
+                        remapped_kwargs.append({**kwarg, "language": sentence_language})
+                    else:
+                        remapped_ids.append(instruction_id)
+                        remapped_kwargs.append(kwarg)
+                instruction_id_list, kwargs = remapped_ids, remapped_kwargs
 
             return dict(
                 text=prompt,

--- a/tests/test_metrics/test_ifeval_constraints.py
+++ b/tests/test_metrics/test_ifeval_constraints.py
@@ -1,0 +1,49 @@
+"""Tests for IFEval instruction-following constraints."""
+
+import nltk
+import pytest
+
+from euroeval.metrics.ifeval.constraints import ALL_CONSTRAINTS
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _punkt() -> None:
+    """Ensure the NLTK Punkt models are available (incl. Norwegian)."""
+    nltk.download("punkt_tab", quiet=True)
+
+
+class TestNorwegianNumberSentences:
+    """Tests for the `no:length_constraints:number_sentences` variant.
+
+    The default English sentence tokenizer over-counts Norwegian sentences that
+    contain common abbreviations (e.g. ``f.eks.``, ``bl.a.``), treating them as
+    sentence boundaries. The Norwegian variant uses the Norwegian Punkt model.
+    """
+
+    constraint = "no:length_constraints:number_sentences"
+    # Two real sentences, each containing a Norwegian abbreviation that the
+    # English tokenizer splits on (counting three sentences instead of two).
+    two_sentences = "Vi bruker mange forkortelser, f.eks. denne. Det er to setninger."
+
+    def test_is_registered(self) -> None:
+        """The Norwegian variant is registered."""
+        assert self.constraint in ALL_CONSTRAINTS
+
+    def test_abbreviation_not_overcounted(self) -> None:
+        """A two-sentence answer satisfies 'less than 3' (English tokenizer fails).
+
+        The English tokenizer counts three sentences here, so the base constraint
+        would wrongly reject this answer; the Norwegian variant counts two.
+        """
+        verifier = ALL_CONSTRAINTS[self.constraint]
+        assert verifier(self.two_sentences, num_sentences=3, relation="less than")
+
+    def test_base_constraint_overcounts(self) -> None:
+        """Contrast: the base English constraint over-counts the same answer."""
+        base = ALL_CONSTRAINTS["length_constraints:number_sentences"]
+        assert not base(self.two_sentences, num_sentences=3, relation="less than")
+
+    def test_genuine_violation_still_fails(self) -> None:
+        """A one-sentence answer does not satisfy 'at least 3'."""
+        verifier = ALL_CONSTRAINTS[self.constraint]
+        assert not verifier("Bare én setning.", num_sentences=3, relation="at least")

--- a/tests/test_metrics/test_ifeval_constraints.py
+++ b/tests/test_metrics/test_ifeval_constraints.py
@@ -12,38 +12,57 @@ def _punkt() -> None:
     nltk.download("punkt_tab", quiet=True)
 
 
-class TestNorwegianNumberSentences:
-    """Tests for the `no:length_constraints:number_sentences` variant.
+class TestNumberSentencesLanguage:
+    """Tests for the ``language`` argument of ``check_number_sentences``.
 
-    The default English sentence tokenizer over-counts Norwegian sentences that
-    contain common abbreviations (e.g. ``f.eks.``, ``bl.a.``), treating them as
-    sentence boundaries. The Norwegian variant uses the Norwegian Punkt model.
+    The default English sentence tokenizer over-counts sentences in languages
+    whose abbreviations it does not know — e.g. Norwegian ``f.eks.`` and
+    ``bl.a.`` are treated as sentence boundaries. The ``language`` argument
+    selects the right Punkt model.
     """
 
-    constraint = "no:length_constraints:number_sentences"
-    # Two real sentences, each containing a Norwegian abbreviation that the
-    # English tokenizer splits on (counting three sentences instead of two).
+    constraint = "length_constraints:number_sentences"
+    # Two real Norwegian sentences, each containing an abbreviation the English
+    # tokenizer splits on (counting three sentences instead of two).
     two_sentences = "Vi bruker mange forkortelser, f.eks. denne. Det er to setninger."
 
-    def test_is_registered(self) -> None:
-        """The Norwegian variant is registered."""
-        assert self.constraint in ALL_CONSTRAINTS
-
-    def test_abbreviation_not_overcounted(self) -> None:
-        """A two-sentence answer satisfies 'less than 3' (English tokenizer fails).
-
-        The English tokenizer counts three sentences here, so the base constraint
-        would wrongly reject this answer; the Norwegian variant counts two.
-        """
+    def test_norwegian_not_overcounted(self) -> None:
+        """With language='norwegian', a two-sentence answer satisfies 'less than 3'."""
         verifier = ALL_CONSTRAINTS[self.constraint]
-        assert verifier(self.two_sentences, num_sentences=3, relation="less than")
+        assert verifier(
+            self.two_sentences,
+            num_sentences=3,
+            relation="less than",
+            language="norwegian",
+        )
 
-    def test_base_constraint_overcounts(self) -> None:
-        """Contrast: the base English constraint over-counts the same answer."""
-        base = ALL_CONSTRAINTS["length_constraints:number_sentences"]
-        assert not base(self.two_sentences, num_sentences=3, relation="less than")
+    def test_english_overcounts(self) -> None:
+        """Contrast: with language='english' the same answer is over-counted."""
+        verifier = ALL_CONSTRAINTS[self.constraint]
+        assert not verifier(
+            self.two_sentences,
+            num_sentences=3,
+            relation="less than",
+            language="english",
+        )
 
     def test_genuine_violation_still_fails(self) -> None:
         """A one-sentence answer does not satisfy 'at least 3'."""
         verifier = ALL_CONSTRAINTS[self.constraint]
-        assert not verifier("Bare én setning.", num_sentences=3, relation="at least")
+        assert not verifier(
+            "Bare én setning.",
+            num_sentences=3,
+            relation="at least",
+            language="norwegian",
+        )
+
+    def test_unknown_language_falls_back(self) -> None:
+        """An unavailable Punkt language falls back to the default tokenizer."""
+        verifier = ALL_CONSTRAINTS[self.constraint]
+        # Should not raise LookupError; counts with the default model instead.
+        assert verifier(
+            "Én setning her.",
+            num_sentences=2,
+            relation="less than",
+            language="some-nonexistent-language",
+        )

--- a/tests/test_metrics/test_ifeval_constraints.py
+++ b/tests/test_metrics/test_ifeval_constraints.py
@@ -13,7 +13,7 @@ def _punkt() -> None:
 
 
 class TestNumberSentencesLanguage:
-    """Tests for the ``language`` argument of ``check_number_sentences``.
+    """Tests for ``check_number_sentences_with_language``.
 
     The default English sentence tokenizer over-counts sentences in languages
     whose abbreviations it does not know — e.g. Norwegian ``f.eks.`` and
@@ -21,7 +21,7 @@ class TestNumberSentencesLanguage:
     selects the right Punkt model.
     """
 
-    constraint = "length_constraints:number_sentences"
+    constraint = "length_constraints:number_sentences_with_language"
     # Two real Norwegian sentences, each containing an abbreviation the English
     # tokenizer splits on (counting three sentences instead of two).
     two_sentences = "Vi bruker mange forkortelser, f.eks. denne. Det er to setninger."
@@ -65,4 +65,31 @@ class TestNumberSentencesLanguage:
             num_sentences=2,
             relation="less than",
             language="some-nonexistent-language",
+        )
+
+    def test_norwegian_relation_literal(self) -> None:
+        """The Norwegian 'færre enn' relation maps to a less-than check.
+
+        The multi-ifeval Norwegian splits carry one ``'færre enn'`` relation
+        among otherwise English literals, so the constraint must accept it.
+        """
+        verifier = ALL_CONSTRAINTS[self.constraint]
+        assert verifier(
+            self.two_sentences,
+            num_sentences=3,
+            relation="færre enn",
+            language="norwegian",
+        )
+
+
+class TestNumberSentencesBackwardsCompatible:
+    """The original constraint stays usable without a ``language`` argument."""
+
+    constraint = "length_constraints:number_sentences"
+
+    def test_no_language_argument_required(self) -> None:
+        """Older datasets call number_sentences with only num_sentences/relation."""
+        verifier = ALL_CONSTRAINTS[self.constraint]
+        assert verifier(
+            "First sentence. Second sentence.", num_sentences=3, relation="less than"
         )


### PR DESCRIPTION
Adds Norwegian (Bokmål + Nynorsk) instruction-following to EuroEval, integrating
the Norwegian splits of danish-foundation-models/multi-ifeval as requested in #1913.

Datasets: added the `no` and `nn` splits to create_ifeval.py as ifeval-nb and
ifeval-nn (524 examples each), unofficial, test-only, following the create_ifeval
re-hosting pattern used for the other languages. The source is the public
danish-foundation-models/multi-ifeval, so the script can materialise
EuroEval/ifeval-nb and EuroEval/ifeval-nn on your side.

Verification: I checked both splits before integrating. Keyword/prompt
consistency is clean (0% desync), and the nn split is genuine Nynorsk, not
relabelled Bokmål (542 Nynorsk-marker hits vs 33 Bokmål-only across 524 samples).
All instruction_ids resolve to registered verifiers — no silent skips.

One verifier fix included: number_sentences uses NLTK's default English sentence
tokenizer, which miscounts Norwegian abbreviations (f.eks., bl.a.) — about 7% of
affected examples in the `no` split scored incorrectly. This PR adds a
no:length_constraints:number_sentences variant using the Norwegian Punkt model,
with a LookupError fallback so it can't break CI if the model isn't downloaded.
The affected ids are remapped to the no: form in the data, matching how the fr:
sets carry prefixed ids.

I followed MultiIFEval in leaving out language:response_language for Norwegian,
since langdetect can't separate nb/nn and the constraint can't score reliably
there.

(Generating these splits relied on a fix I sent to multi_ifeval —
alexandrainst/multi_ifeval#15 — which resolved a crash that was dropping most
examples during translation.)



Closes #1913
