### PR TITLE
fix: actually reload weights in fp32 on finetuning NaN-retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fixed the finetuning NaN-retry not actually switching to fp32. When NaN values were
+  detected under mixed precision, the retry disabled autocast but reloaded the model
+  via `get_dtype`, which is hardware-driven and kept returning bf16/fp16 on CUDA — so
+  the weights stayed in the same NaN-producing dtype and the retry was a no-op (notably
+  for embedding-finetuned encoders like `intfloat/multilingual-e5-large-instruct`,
+  whose CUDA fused-attention backward NaNs in bf16). The retry now threads a
+  `dtype_override` down to model loading so the weights are genuinely reloaded in fp32.
 - Added `download()` method to `PipelineMetric` class
   - Enables offline mode for metrics that use scikit-learn pipelines (e.g., European
     Values metric)

--- a/src/euroeval/benchmark_modules/hf.py
+++ b/src/euroeval/benchmark_modules/hf.py
@@ -49,6 +49,7 @@ from ..constants import (
 from ..data_models import HashableDict, HFModelInfo, ModelConfig
 from ..enums import (
     BatchingPreference,
+    DataType,
     GenerativeType,
     InferenceBackend,
     ModelType,
@@ -107,6 +108,7 @@ class HuggingFaceEncoderModel(BenchmarkModule):
         dataset_config: "DatasetConfig",
         benchmark_config: "BenchmarkConfig",
         log_metadata: bool = True,
+        dtype_override: "DataType | None" = None,
     ) -> None:
         """Initialise the model.
 
@@ -119,6 +121,10 @@ class HuggingFaceEncoderModel(BenchmarkModule):
                 The benchmark configuration.
             log_metadata:
                 Whether to log the model metadata.
+            dtype_override:
+                An explicit data type to load the model weights in, taking precedence
+                over the hardware-derived default. Used by the finetuning NaN-retry to
+                force a full fp32 reload.
         """
         raise_if_wrong_params(
             model_config=model_config, allowed_params=self.allowed_params
@@ -132,6 +138,7 @@ class HuggingFaceEncoderModel(BenchmarkModule):
             model_config=model_config,
             dataset_config=dataset_config,
             benchmark_config=benchmark_config,
+            dtype_override=dtype_override,
         )
         self._model: "PreTrainedModel" = model
         self._tokeniser: "PreTrainedTokenizer | MistralCommonTokenizer" = tokeniser
@@ -565,6 +572,7 @@ def load_model_and_tokeniser(
     model_config: "ModelConfig",
     dataset_config: "DatasetConfig",
     benchmark_config: "BenchmarkConfig",
+    dtype_override: "DataType | None" = None,
 ) -> tuple["PreTrainedModel", Tokeniser]:
     """Load the model and tokeniser.
 
@@ -575,6 +583,10 @@ def load_model_and_tokeniser(
             The dataset configuration.
         benchmark_config:
             The benchmark configuration
+        dtype_override:
+            An explicit data type to load the model weights in, taking precedence
+            over the hardware-derived default. Used by the finetuning NaN-retry to
+            force a full fp32 reload.
 
     Returns:
         A pair (model, tokeniser), with the loaded model and tokeniser
@@ -624,6 +636,7 @@ def load_model_and_tokeniser(
             bf16_available=(
                 torch.cuda.is_available() and torch.cuda.is_bf16_supported()
             ),
+            dtype_override=dtype_override,
         ),
     )
 
@@ -1033,7 +1046,10 @@ def load_tokeniser(
 
 @cache_arguments()
 def get_dtype(
-    device: torch.device, dtype_is_set: bool, bf16_available: bool
+    device: torch.device,
+    dtype_is_set: bool,
+    bf16_available: bool,
+    dtype_override: "DataType | None" = None,
 ) -> str | torch.dtype:
     """Get the torch dtype, used for loading the model.
 
@@ -1044,10 +1060,23 @@ def get_dtype(
             Whether the data type is set in the model configuration.
         bf16_available:
             Whether bfloat16 is available.
+        dtype_override:
+            An explicit data type to load the model weights in, taking precedence
+            over both the model configuration and the hardware-derived default. Used
+            by the finetuning NaN-retry, which reloads the model in full fp32 after
+            detecting NaN values under mixed precision; without honouring the
+            override the model would be reloaded in the same (NaN-producing) dtype.
 
     Returns:
         The dtype.
     """
+    if dtype_override is not None:
+        return {
+            DataType.FP32: torch.float32,
+            DataType.FP16: torch.float16,
+            DataType.BF16: torch.bfloat16,
+        }[dtype_override]
+
     using_cuda = device == torch.device("cuda")
     if using_cuda and dtype_is_set:
         return "auto"

--- a/src/euroeval/finetuning.py
+++ b/src/euroeval/finetuning.py
@@ -69,6 +69,10 @@ def finetune(
     bs: int = benchmark_config.finetuning_batch_size
     scores: list[dict[str, float]] = list()
     model_already_initialized = False
+    # None means "load in the hardware-derived default dtype"; set to FP32 by the
+    # NaN-retry below so the model is actually *reloaded* in fp32 rather than just
+    # having mixed-precision autocast disabled while the weights stay in bf16/fp16.
+    dtype_override: DataType | None = None
     for idx in get_pbar(
         iterable=range(benchmark_config.num_iterations),
         desc="Benchmarking",
@@ -108,6 +112,7 @@ def finetune(
                     model_config=model_config,
                     dataset_config=dataset_config,
                     benchmark_config=benchmark_config,
+                    dtype_override=dtype_override,
                 )
 
                 scores.append(itr_scores)
@@ -124,6 +129,7 @@ def finetune(
             except NaNValueInModelOutput as e:
                 if dtype != DataType.FP32:
                     dtype = DataType.FP32
+                    dtype_override = DataType.FP32
                     model_already_initialized = False
                     log(
                         "NaN value detected in model outputs while using mixed "
@@ -171,6 +177,7 @@ def finetune_single_iteration(
     model_config: "ModelConfig",
     dataset_config: "DatasetConfig",
     benchmark_config: "BenchmarkConfig",
+    dtype_override: "DataType | None" = None,
 ) -> dict[str, float]:
     """Run a single iteration of a benchmark.
 
@@ -187,6 +194,10 @@ def finetune_single_iteration(
             The dataset configuration.
         benchmark_config:
             The benchmark configuration.
+        dtype_override:
+            An explicit data type to load the model weights in, taking precedence over
+            the hardware-derived default. Only used when a new model is loaded (i.e.
+            ``model`` is None), to force a full fp32 reload on the NaN-retry.
 
     Returns:
         The scores for the test dataset.
@@ -205,6 +216,7 @@ def finetune_single_iteration(
             model_config=model_config,
             dataset_config=dataset_config,
             benchmark_config=benchmark_config,
+            dtype_override=dtype_override,
         )
 
     trainer = model.trainer_class(

--- a/src/euroeval/model_loading.py
+++ b/src/euroeval/model_loading.py
@@ -9,7 +9,7 @@ from .benchmark_modules import (
     LiteLLMModel,
     VLLMModel,
 )
-from .enums import GenerativeType, InferenceBackend, ModelType
+from .enums import DataType, GenerativeType, InferenceBackend, ModelType
 from .exceptions import InvalidModel
 from .logging_utils import log_once
 
@@ -86,6 +86,7 @@ def load_model(
     model_config: "ModelConfig",
     dataset_config: "DatasetConfig",
     benchmark_config: "BenchmarkConfig",
+    dtype_override: "DataType | None" = None,
 ) -> "BenchmarkModule":
     """Load a model.
 
@@ -96,6 +97,10 @@ def load_model(
             The dataset configuration.
         benchmark_config:
             The benchmark configuration.
+        dtype_override:
+            An explicit data type to load the model weights in, taking precedence
+            over the hardware-derived default. Only applies to encoder models loaded
+            for finetuning; used by the NaN-retry to force a full fp32 reload.
 
     Returns:
         The model.
@@ -135,11 +140,23 @@ def load_model(
         model_config=model_config, benchmark_config=benchmark_config
     )
 
-    model = model_class(
-        model_config=model_config,
-        dataset_config=dataset_config,
-        benchmark_config=benchmark_config,
-    )
+    # The dtype override is only plumbed through the plain encoder loading path (the
+    # only one that derives its dtype from the hardware via `get_dtype`), so restrict
+    # it to exactly that class -- subclasses such as `VLLMModel` and `FreshEncoderModel`
+    # neither finetune from a pretrained checkpoint nor accept this argument.
+    if dtype_override is not None and model_class is HuggingFaceEncoderModel:
+        model = HuggingFaceEncoderModel(
+            model_config=model_config,
+            dataset_config=dataset_config,
+            benchmark_config=benchmark_config,
+            dtype_override=dtype_override,
+        )
+    else:
+        model = model_class(
+            model_config=model_config,
+            dataset_config=dataset_config,
+            benchmark_config=benchmark_config,
+        )
 
     # The generative type is only known once the model's tokeniser is loaded, so this
     # check must run after instantiation.


### PR DESCRIPTION
## Problem

When a finetuning iteration hits NaN values under mixed precision, `finetune()` catches `NaNValueInModelOutput` and "retries in fp32". But the retry only flipped the **autocast** off in the `TrainingArguments` (`bf16=False`); the model itself was reloaded by `load_model` → `get_dtype`, which is **hardware-driven** and keeps returning `torch.bfloat16` on CUDA regardless of the retry. So the weights stayed in the same NaN-producing dtype and the "fp32 retry" was effectively a no-op — the run continued to train on NaN gradients and recorded a near-random score.

This was surfaced by `intfloat/multilingual-e5-large-instruct` on the evaluation queue: every language gets `grad_norm: nan` from the first step, even after the fp32 "switch".

## Root cause

The NaN originates in the **CUDA fused/memory-efficient attention backward in bf16** (verified locally: the same model trains cleanly in *both* fp32 and bf16 on MPS, which uses a different attention kernel — so it's not a generic bf16-weights problem). A genuine fp32 reload dodges it, but `get_dtype` never received the fp32 decision: `finetune_single_iteration` called `load_model(...)` with no dtype, and `get_dtype` only looks at hardware capability.

## Fix

Thread an optional `dtype_override` from `finetune()` (set to `FP32` on the NaN-retry) down through `finetune_single_iteration` → `load_model` → `HuggingFaceEncoderModel` → `load_model_and_tokeniser` → `get_dtype`. When set, it takes precedence over the hardware default so the weights are genuinely reloaded in fp32.

- The override is scoped to exactly `HuggingFaceEncoderModel` (the only path that derives its dtype from hardware via `get_dtype`); `VLLMModel`/`LiteLLMModel`/`FreshEncoderModel` are untouched.
- The default loading path (no override) is byte-for-byte unchanged.

## Testing

- Unit-checked `get_dtype`: the FP32 override returns `torch.float32` on a simulated CUDA+bf16 host, while the no-override path still returns `torch.bfloat16` (and `torch.float32` on CPU) — i.e. no behaviour change when not retrying.
- `make check` passes (ruff, ruff-format, ty, markdownlint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)