### PR TITLE
fix: sum safetensors parameter counts across dtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fixed the parameter count derived from safetensors metadata when a model has multiple
+  dtype entries. The `parameter_count` dict maps each dtype to the number of parameters
+  stored in that dtype, so the total is the sum across entries — previously only the
+  largest entry was used, undercounting models with weights split across multiple dtypes.
 - Fixed the finetuning NaN-retry not actually switching to fp32. When NaN values were
   detected under mixed precision, the retry disabled autocast but reloaded the model
   via `get_dtype`, which is hardware-driven and kept returning bf16/fp16 on CUDA — so

--- a/src/euroeval/safetensors_utils.py
+++ b/src/euroeval/safetensors_utils.py
@@ -94,11 +94,12 @@ def get_num_params_from_safetensors_metadata(
             )
             return None
         case 1:
-            return max(parameter_count_dict.values())
+            return sum(parameter_count_dict.values())
         case _:
             log_once(
                 f"The model {model_id} has multiple parameter count entries in its "
-                f"safetensors metadata: {parameter_count_dict}. Using the largest one.",
+                f"safetensors metadata: {parameter_count_dict}. Using the sum of all "
+                "entries, since each entry is the parameter count for a given dtype.",
                 level=logging.DEBUG,
             )
-            return max(parameter_count_dict.values())
+            return sum(parameter_count_dict.values())

--- a/tests/test_safetensors_utils.py
+++ b/tests/test_safetensors_utils.py
@@ -56,8 +56,9 @@ class TestGetNumParamsFromSafetensorsMetadata:
             model_id="test/large-model", revision="main", api_key=None
         )
 
-        # Should return the maximum value
-        assert result == 1500000
+        # Should return the sum across all dtype entries, since each entry is the
+        # parameter count for a given dtype
+        assert result == 3000000
 
     @patch("euroeval.safetensors_utils.get_hf_token")
     @patch("euroeval.safetensors_utils.get_safetensors_metadata")


### PR DESCRIPTION
## Summary

When a model's safetensors metadata reports parameter counts split across
multiple dtypes, EuroEval was using the **largest** entry as the parameter
count. But `metadata.parameter_count` maps each dtype to the number of
parameters stored in that dtype, so the total is the **sum** across entries,
not the max.

For example, the debug log below shows `intfloat/multilingual-e5-base` with an
`I64` buffer and the bulk of its weights in `F32`:

```
[DEBUG] The model intfloat/multilingual-e5-base has multiple parameter count
entries in its safetensors metadata: {'I64': 514, 'F32': 278043648}. Using the
largest one.
```

This PR switches to summing the entries (the single-entry case is unchanged,
since `max == sum` there) and updates the debug message accordingly.

## Changes

- `src/euroeval/safetensors_utils.py`: use `sum(...)` instead of `max(...)` for
  the parameter count, and update the debug message wording.
- Updated the corresponding unit test to assert the summed total.
- Added a CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)