### PR TITLE
Fix race condition in cache cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed race condition in cache cleanup where `rmtree` would fail with `FileNotFoundError`
+  when checkpoint directories were removed concurrently during model benchmarking. Now
+  uses `ignore_errors=True` to handle concurrent deletions gracefully.
+
 ## [v17.6.0] - 2026-06-30
 
 ### Added
@@ -26,8 +32,6 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- Fixed race condition in cache cleanup where `rmtree` would fail if checkpoint
-  directories were removed concurrently.
 - The (unofficial) MultiLoko datasets had an error in their dataset configs, as they do
   not have a validation split. The configs have now been fixed.
 - Fixed the parameter count derived from safetensors metadata when a model has multiple

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fixed race condition in cache cleanup where `rmtree` would fail if checkpoint
+  directories were removed concurrently.
 - The (unofficial) MultiLoko datasets had an error in their dataset configs, as they do
   not have a validation split. The configs have now been fixed.
 - Fixed the parameter count derived from safetensors metadata when a model has multiple

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -1273,10 +1273,7 @@ def clear_model_cache_fn(cache_dir: str) -> None:
         if model_dir.is_dir():
             for sub_model_dir in model_dir.iterdir():
                 if sub_model_dir.is_dir():
-                    try:
-                        rmtree(sub_model_dir)
-                    except FileNotFoundError:
-                        pass  # Directory already removed concurrently
+                    rmtree(sub_model_dir, ignore_errors=True)
 
 
 def initial_logging(

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -1273,7 +1273,10 @@ def clear_model_cache_fn(cache_dir: str) -> None:
         if model_dir.is_dir():
             for sub_model_dir in model_dir.iterdir():
                 if sub_model_dir.is_dir():
-                    rmtree(sub_model_dir)
+                    try:
+                        rmtree(sub_model_dir)
+                    except FileNotFoundError:
+                        pass  # Directory already removed concurrently
 
 
 def initial_logging(


### PR DESCRIPTION
Fixed race condition in cache cleanup where `rmtree` would fail with `FileNotFoundError` when checkpoint directories were removed concurrently during model benchmarking.

**Key features**

- Uses `ignore_errors=True` parameter in `rmtree` to handle concurrent deletions gracefully
- Minimal change that matches existing cleanup patterns in the codebase
- Prevents benchmarking failures when cleaning up model cache

**Examples**

The fix applies to the `clear_model_cache_fn` function called after benchmarking completes:

```python
# Before:
try:
    rmtree(sub_model_dir)
except FileNotFoundError:
    pass

# After:
rmtree(sub_model_dir, ignore_errors=True)
```

**Why it helps**

This prevents the benchmarking CLI from crashing during cache cleanup when checkpoint directories are removed concurrently, which can happen due to Transformer's internal checkpoint management.