### PR TITLE
fix(benchmarker): skip tasks a model architecture cannot support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Encoder models whose architecture supports some tasks but not others (e.g.
+  Gemma3-based models such as `google/embeddinggemma-300m`, which support sequence
+  classification but have no token-classification head registered in `transformers`)
+  now skip the unsupported benchmarks instead of erroring the entire evaluation. The
+  model is still benchmarked on every task it does support. Models whose architecture
+  has no supported head at all (e.g. `jinaai/jina-embeddings-v5-*`) now skip all
+  benchmarks cleanly rather than reporting them as errors.
 - Fixed race condition in cache cleanup where `rmtree` would fail with
   `FileNotFoundError` when checkpoint directories were removed concurrently during model
   benchmarking. Now uses `ignore_errors=True` to handle concurrent deletions gracefully.

--- a/src/euroeval/benchmark_modules/hf.py
+++ b/src/euroeval/benchmark_modules/hf.py
@@ -61,6 +61,7 @@ from ..exceptions import (
     NeedsAdditionalArgument,
     NeedsEnvironmentVariable,
     NeedsExtraInstalled,
+    UnsupportedModelTask,
 )
 from ..generation_utils import raise_if_wrong_params
 from ..languages import get_all_languages
@@ -596,6 +597,9 @@ def load_model_and_tokeniser(
             If the model could not be loaded.
         InvalidBenchmark:
             If the model could not be loaded for this particular dataset.
+        UnsupportedModelTask:
+            If the model's architecture has no head registered for the task's
+            ``AutoModel`` class, so the benchmark should be skipped.
     """
     config: "PretrainedConfig"
     block_terminal_output()
@@ -695,6 +699,19 @@ def load_model_and_tokeniser(
             if "checkpoint seems to be incorrect" in str(e):
                 raise InvalidModel(
                     f"The model {model_id!r} has an incorrect checkpoint."
+                ) from e
+            # The model loads fine for other tasks, but its architecture has no head
+            # registered for this task's `AutoModel` class (e.g. a Gemma3-based encoder
+            # that supports sequence classification but not token classification). This
+            # is a per-task limitation, so the benchmark is skipped rather than counted
+            # as a hard error that fails the whole model.
+            if "Unrecognized configuration class" in str(e) and (
+                "for this kind of AutoModel" in str(e)
+            ):
+                raise UnsupportedModelTask(
+                    model_id=model_id,
+                    task_name=dataset_config.task.name,
+                    auto_model_class=task_group_to_class_name(task_group=task_group),
                 ) from e
             if "trust_remote_code" in str(e):
                 raise InvalidModel(

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -19,7 +19,12 @@ from .constants import ATTENTION_BACKENDS, GENERATIVE_PIPELINE_TAGS, ORTHOGONAL_
 from .data_loading import load_data, load_raw_data
 from .data_models import BenchmarkConfigParams, BenchmarkResult, get_package_version
 from .enums import Device, GenerativeType, InferenceBackend, ModelType
-from .exceptions import HuggingFaceHubDown, InvalidBenchmark, InvalidModel
+from .exceptions import (
+    HuggingFaceHubDown,
+    InvalidBenchmark,
+    InvalidModel,
+    UnsupportedModelTask,
+)
 from .finetuning import finetune
 from .generation import generate
 from .logging_utils import adjust_logging_level, get_pbar, log, log_once
@@ -901,8 +906,13 @@ class Benchmarker:
 
                 elif isinstance(benchmark_output_or_err, InvalidBenchmark):
                     log(benchmark_output_or_err.message, level=logging.WARNING)
-                    # Orthogonal task failures count as skipped, not errored
-                    if dataset_config.task.name in ORTHOGONAL_TASKS:
+                    # Task-incompatibility (the model architecture has no head for this
+                    # task) and orthogonal task failures count as skipped, not errored:
+                    # the model can still be evaluated on the tasks it does support.
+                    if (
+                        isinstance(benchmark_output_or_err, UnsupportedModelTask)
+                        or dataset_config.task.name in ORTHOGONAL_TASKS
+                    ):
                         num_skipped_benchmarks += 1
                     else:
                         num_errored_benchmarks += 1

--- a/src/euroeval/exceptions.py
+++ b/src/euroeval/exceptions.py
@@ -17,6 +17,39 @@ class InvalidBenchmark(Exception):
         super().__init__(self.message)
 
 
+class UnsupportedModelTask(InvalidBenchmark):
+    """The model's architecture does not support the task's required head.
+
+    Raised when a model can be loaded for some tasks but not the specific task
+    being benchmarked, because the model architecture has no head registered
+    for the corresponding ``AutoModel`` class (e.g. a Gemma3-based encoder that
+    supports sequence classification but not token classification). This is a
+    per-task limitation rather than a fatal model error, so the affected
+    benchmark is skipped rather than errored.
+    """
+
+    def __init__(self, model_id: str, task_name: str, auto_model_class: str) -> None:
+        """Initialise the exception.
+
+        Args:
+            model_id:
+                The model that could not be loaded for the task.
+            task_name:
+                The name of the task whose head is unsupported.
+            auto_model_class:
+                The ``AutoModel`` class the model could not be loaded as.
+        """
+        self.model_id = model_id
+        self.task_name = task_name
+        self.auto_model_class = auto_model_class
+        self.message = (
+            f"The model {model_id!r} does not support the {task_name!r} task, as its "
+            f"architecture has no head registered for `{auto_model_class}`. Skipping "
+            "this benchmark."
+        )
+        super().__init__(self.message)
+
+
 class InvalidModel(Exception):
     """The model cannot be benchmarked on any datasets."""
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -105,6 +105,33 @@ class TestNeedsEnvironmentVariable:
         assert exc.env_var == env_var
 
 
+class TestUnsupportedModelTask:
+    """Tests for the UnsupportedModelTask exception."""
+
+    def test_message_contains_details(self) -> None:
+        """Test that the message contains the model, task and AutoModel class."""
+        exc = exceptions.UnsupportedModelTask(
+            model_id="some/model",
+            task_name="named-entity-recognition",
+            auto_model_class="AutoModelForTokenClassification",
+        )
+        assert "some/model" in exc.message
+        assert "named-entity-recognition" in exc.message
+        assert "AutoModelForTokenClassification" in exc.message
+        assert exc.model_id == "some/model"
+        assert exc.task_name == "named-entity-recognition"
+        assert exc.auto_model_class == "AutoModelForTokenClassification"
+
+    def test_is_invalid_benchmark_subclass(self) -> None:
+        """Test that it is a subclass of InvalidBenchmark so it is skippable."""
+        exc = exceptions.UnsupportedModelTask(
+            model_id="some/model",
+            task_name="named-entity-recognition",
+            auto_model_class="AutoModelForTokenClassification",
+        )
+        assert isinstance(exc, exceptions.InvalidBenchmark)
+
+
 class TestBaseExceptions:
     """Tests for base exception classes."""
 


### PR DESCRIPTION
## Summary

Several `evaluation-failed` queue issues fail because a model's architecture supports *some* tasks but not the specific task being benchmarked. Previously this errored the **whole** evaluation; now the unsupported benchmark is **skipped** and the model is still evaluated on every task it does support.

Root cause, found while triaging the `evaluation-failed` issues on the queue server:

- **`google/embeddinggemma-300m` (#1933), `microsoft/harrier-oss-v1-*` (#1929):** Gemma3-based encoders. `transformers` 5.12.1 registers `Gemma3(Text)ForSequenceClassification` (so ScaLA completes) but has **no** `Gemma3ForTokenClassification`, so NER benchmarks raise `ValueError: Unrecognized configuration class ... for this kind of AutoModel: AutoModelForTokenClassification`.
- **`jinaai/jina-embeddings-v5-*` (#1931, #1928):** custom `JinaEmbeddingsV5Config` registers no task heads at all, so every benchmark raised the same error.

`load_model` raised `InvalidModel` for these, which the benchmarker treats as fatal (errors all remaining benchmarks and breaks). But this is a **per-task** limitation, analogous to the existing generative-type-mismatch skip.

## Changes

- New `UnsupportedModelTask(InvalidBenchmark)` exception (`exceptions.py`).
- `load_model` (`benchmark_modules/hf.py`) raises it when `from_pretrained` fails with `Unrecognized configuration class ... for this kind of AutoModel`.
- `benchmarker.py` counts `UnsupportedModelTask` as **skipped**, not errored.
- Tests + CHANGELOG.

## Effect

- Gemma3-based encoders get scored on the tasks they support (seq. classification, QA, etc.) with NER skipped.
- Models with no supported head skip all benchmarks cleanly instead of erroring — so the evaluation queue no longer marks them `evaluation-failed` and retries them forever.

## Test plan

- `make check` passes.
- New unit tests in `tests/test_exceptions.py` cover the exception.
- Existing `tests/test_exceptions.py` suite green (16 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)