### PR TITLE
fix(queue): surface the real error in evaluation-failed comments

### DIFF
--- a/src/leaderboards/queue_parsing.py
+++ b/src/leaderboards/queue_parsing.py
@@ -8,6 +8,7 @@ side-effect-free except :func:`read_jsonl_lines`, which reads from disk.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 from euroeval.data_models import BenchmarkResult
@@ -19,6 +20,39 @@ from .constants import (
     SKIPPED_BENCHMARKS_RE,
 )
 from .evaluation_common import missing_official_dataset_language_pairs
+
+# Strips ANSI colour/style escape codes that euroeval emits when logging. Matches
+# both the real escape byte (``\x1b[..m``, as captured live from the pty) and the
+# caret-notation form (``^[[..m``) that some log/transport layers substitute.
+_ANSI_ESCAPE_RE = re.compile(r"(?:\x1b|\^\[)\[[0-9;]*m")
+
+# Lines that ``FULL_LOG=1`` floods the output with and which bury the real
+# error: serialised result records and transformers training-progress dicts.
+_NOISE_SUBSTRINGS = (
+    '"schema_version"',
+    '"evaluation_id"',
+    '"raw_results"',
+    '"evaluation_results"',
+    "samples_per_second",
+    "steps_per_second",
+)
+_TRAINING_PROGRESS_RE = re.compile(
+    r"^\{'(loss|eval_loss|train_runtime|train_loss)'|^\{\"(loss|eval_loss)\""
+)
+
+# Markers of the actually-useful error text, in priority order of specificity.
+_LOAD_ERROR_RE = re.compile(
+    r"could not be loaded|Unrecognized configuration class|is a gated repository|"
+    r"PYTORCH_ENABLE_MPS_FALLBACK|does not support the .* task",
+    re.IGNORECASE,
+)
+_TRACEBACK_START = "Traceback (most recent call last):"
+_EXCEPTION_LINE_RE = re.compile(r"^[\w.]*(Error|Exception|Timeout|Interrupt)\b.*")
+_SUMMARY_LINE_RE = re.compile(r"errored\s+\d+\s+benchmarks?", re.IGNORECASE)
+
+# Individual lines longer than this are truncated so a single giant JSON/param
+# dump line can't swamp the summary; the informative head is kept.
+_MAX_LINE_CHARS = 600
 
 
 def extract_model_id(title: str, body: str | None = None) -> str | None:
@@ -88,6 +122,107 @@ def num_skipped_benchmarks(output: str) -> int:
     for m in SKIPPED_BENCHMARKS_RE.finditer(output):
         last = int(m.group(1))
     return last
+
+
+def _is_noise_line(line: str) -> bool:
+    """Return True if a line is verbose ``FULL_LOG`` output rather than an error.
+
+    Args:
+        line:
+            A single (already ANSI-stripped) line of euroeval output.
+
+    Returns:
+        True if the line is a serialised result record or a training-progress
+        dict that should be dropped from an error summary.
+    """
+    stripped = line.strip()
+    if any(sub in stripped for sub in _NOISE_SUBSTRINGS):
+        return True
+    return bool(_TRAINING_PROGRESS_RE.match(stripped))
+
+
+def _last_traceback(lines: list[str]) -> str | None:
+    """Return the last Python traceback in ``lines``, or None if there is none.
+
+    Args:
+        lines:
+            The cleaned, noise-filtered output lines.
+
+    Returns:
+        The traceback text, from its ``Traceback (most recent call last):``
+        header through the terminating exception line, or None.
+    """
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip().startswith(_TRACEBACK_START):
+            start = i
+    if start is None:
+        return None
+    # Extend to the exception line that closes the traceback (the first line at
+    # the end that is not an indented frame), keeping the block compact.
+    end = start
+    for i in range(start + 1, len(lines)):
+        end = i
+        if _EXCEPTION_LINE_RE.match(lines[i].strip()):
+            break
+    return "\n".join(lines[start : end + 1]).strip()
+
+
+def summarise_evaluation_error(output: str, max_chars: int = 4000) -> str:
+    """Extract the meaningful error from a euroeval subprocess's output.
+
+    The queue runs euroeval with ``FULL_LOG=1``, so the raw output is dominated
+    by serialised result records, training-progress dicts and giant parameter
+    lists. A blind tail of that output almost never shows the real error (and is
+    frequently identical across unrelated models), so this scans the whole
+    output for the informative error text: a Python traceback, a model-load or
+    gating error, and the ``errored N benchmarks`` summary line.
+
+    Args:
+        output:
+            The full captured combined-output of the euroeval subprocess.
+        max_chars:
+            The maximum length of the returned summary. Defaults to 4000.
+
+    Returns:
+        A compact human-readable error summary, or ``"(no output captured)"``
+        when nothing usable is found.
+    """
+    text = _ANSI_ESCAPE_RE.sub("", output)
+    lines: list[str] = []
+    for raw_line in text.splitlines():
+        if not raw_line.strip() or _is_noise_line(raw_line):
+            continue
+        line = raw_line.rstrip()
+        if len(line) > _MAX_LINE_CHARS:
+            line = line[:_MAX_LINE_CHARS] + " …(truncated)"
+        lines.append(line)
+
+    if not lines:
+        return "(no output captured)"
+
+    parts: list[str] = []
+    traceback = _last_traceback(lines=lines)
+    if traceback:
+        parts.append(traceback)
+    for line in reversed(lines):
+        if _LOAD_ERROR_RE.search(line):
+            parts.append(line.strip())
+            break
+    for line in reversed(lines):
+        if _SUMMARY_LINE_RE.search(line):
+            parts.append(line.strip())
+            break
+
+    # Fall back to the tail of the cleaned output when no marker was found.
+    if not parts:
+        parts = [line.strip() for line in lines[-20:]]
+
+    # De-duplicate while preserving order (a traceback may repeat the summary).
+    summary = "\n".join(dict.fromkeys(part for part in parts if part)).strip()
+    if len(summary) > max_chars:
+        summary = summary[-max_chars:].strip()
+    return summary or "(no output captured)"
 
 
 def format_dataset_language_pairs(dataset_language_pairs: set[tuple[str, str]]) -> str:

--- a/src/scripts/process_evaluation_queue.py
+++ b/src/scripts/process_evaluation_queue.py
@@ -96,6 +96,7 @@ from leaderboards.queue_parsing import (
     num_skipped_benchmarks,
     read_jsonl_lines,
     result_lines_for_model,
+    summarise_evaluation_error,
 )
 from leaderboards.queue_runtime import (
     ThermalConfig,
@@ -813,19 +814,19 @@ def _run_claimed_issue(issue: dict, model_id: str, languages: list[str]) -> None
         # Handle gating.
         if gated_in_lang:
             gated_detected = True
-            failure_output_tail = output[-6000:].strip() or "(no output captured)"
+            failure_output_tail = summarise_evaluation_error(output=output)
             failed.append(lang)
             break
 
         # Handle errors.
         if returncode != 0:
             failure_reason = f"euroeval exited with code {returncode}"
-            failure_output_tail = output[-6000:].strip() or "(no output captured)"
+            failure_output_tail = summarise_evaluation_error(output=output)
             failed.append(lang)
             break
         elif num_errored > 0:
             failure_reason = f"euroeval reported {num_errored} errored benchmark(s)"
-            failure_output_tail = output[-6000:].strip() or "(no output captured)"
+            failure_output_tail = summarise_evaluation_error(output=output)
             failed.append(lang)
             break
 
@@ -852,7 +853,7 @@ def _run_claimed_issue(issue: dict, model_id: str, languages: list[str]) -> None
                 f"missing official dataset-language pair(s): "
                 f"{format_dataset_language_pairs(dataset_language_pairs=missing)}"
             )
-            failure_output_tail = last_output[-6000:].strip() or "(no output captured)"
+            failure_output_tail = summarise_evaluation_error(output=last_output)
             failed.extend([lang for lang in pending if lang not in done])
         elif missing:
             logger.info(

--- a/tests/leaderboards/test_queue_parsing.py
+++ b/tests/leaderboards/test_queue_parsing.py
@@ -1,0 +1,84 @@
+"""Tests for the `leaderboards.queue_parsing` module."""
+
+from leaderboards.queue_parsing import summarise_evaluation_error
+
+
+class TestSummariseEvaluationError:
+    """Tests for `summarise_evaluation_error`."""
+
+    def test_empty_output(self) -> None:
+        """An empty or whitespace-only output yields the placeholder."""
+        assert summarise_evaluation_error(output="") == "(no output captured)"
+        assert summarise_evaluation_error(output="   \n  \n") == "(no output captured)"
+
+    def test_strips_ansi_codes(self) -> None:
+        """ANSI colour codes are removed from the summary."""
+        output = "\x1b[93mThe model 'x' could not be loaded.\x1b[0m"
+        summary = summarise_evaluation_error(output=output)
+        assert "\x1b[" not in summary
+        assert "could not be loaded" in summary
+
+    def test_surfaces_model_load_error_over_result_noise(self) -> None:
+        """The real load error is surfaced despite a FULL_LOG results dump."""
+        noise = "\n".join(
+            '{"schema_version": "0.2.1", "evaluation_id": "besls/x/1", '
+            '"raw_results": "[...]", "evaluation_results": []}'
+            for _ in range(50)
+        )
+        output = (
+            "Loading the model 'jinaai/jina-embeddings-v5-text-nano'...\n"
+            "The model 'jinaai/jina-embeddings-v5-text-nano' could not be loaded. "
+            'The error was ValueError("Unrecognized configuration class '
+            "JinaEmbeddingsV5Config for this kind of AutoModel: "
+            'AutoModelForSequenceClassification.").\n' + noise
+        )
+        summary = summarise_evaluation_error(output=output)
+        assert "could not be loaded" in summary
+        assert "Unrecognized configuration class" in summary
+        assert '"schema_version"' not in summary
+        assert '"raw_results"' not in summary
+
+    def test_extracts_traceback(self) -> None:
+        """A Python traceback is extracted through its exception line."""
+        output = (
+            "Benchmarking model on Turku NER-fi...\n"
+            "Traceback (most recent call last):\n"
+            '  File "/x/euroeval", line 10, in <module>\n'
+            "    sys.exit(benchmark())\n"
+            "httpx.ReadTimeout: The read operation timed out\n"
+        )
+        summary = summarise_evaluation_error(output=output)
+        assert "Traceback (most recent call last):" in summary
+        assert "httpx.ReadTimeout: The read operation timed out" in summary
+
+    def test_includes_errored_summary_line(self) -> None:
+        """The euroeval `errored N benchmarks` summary line is included."""
+        output = (
+            "The model 'm' could not be loaded. The error was ValueError('x').\n"
+            "Completed 2 benchmarks, and errored 2 benchmarks\n"
+        )
+        summary = summarise_evaluation_error(output=output)
+        assert "could not be loaded" in summary
+        assert "errored 2 benchmarks" in summary
+
+    def test_falls_back_to_tail_without_markers(self) -> None:
+        """Without error markers, the tail of the cleaned output is returned."""
+        output = "\n".join(f"some log line {i}" for i in range(40))
+        summary = summarise_evaluation_error(output=output)
+        assert "some log line 39" in summary
+        assert "some log line 0" not in summary
+
+    def test_truncates_giant_single_line(self) -> None:
+        """A single enormous line is truncated so it can't swamp the summary."""
+        giant = "could not be loaded. The error was " + ("x" * 5000)
+        summary = summarise_evaluation_error(output=giant)
+        assert "…(truncated)" in summary
+        assert len(summary) < 1000
+
+    def test_respects_max_chars(self) -> None:
+        """The summary never exceeds the requested maximum length."""
+        output = "\n".join(
+            f"Traceback (most recent call last): frame {i}" for i in range(500)
+        )
+        summary = summarise_evaluation_error(output=output, max_chars=200)
+        assert len(summary) <= 200


### PR DESCRIPTION
## Summary

The evaluation queue posts an error comment on each `evaluation-failed` issue. Because the queue runs euroeval with `FULL_LOG=1`, the captured output is dominated by serialised result records, training-progress dicts and giant parameter lists. The old code took a blind `output[-6000:]` tail, which:

- almost never contained the actual error, and
- was frequently **byte-identical across completely unrelated models** — e.g. issues #1944, #1943, #1942, #1941, #1937, #1934, #1932, #1930, #1927 and #1923 all got the *exact same* comment, which was just the tail of the shared `euroeval_benchmark_results.jsonl` (records for `google-bert/bert-base-multilingual-cased`).

This made the failures impossible to diagnose from the issues.

## Changes

- New `summarise_evaluation_error()` in `leaderboards/queue_parsing.py`, which:
  - strips ANSI codes (both real `\x1b[..m` and caret-notation `^[[..m`);
  - drops FULL_LOG noise (result records, `{'loss': ...}`/`{'eval_loss': ...}` dicts, `samples_per_second` lines);
  - scans the **whole** output for the informative error: a Python traceback, a model-load/gating error line, and the `errored N benchmarks` summary line;
  - truncates individual giant lines and caps the total length;
  - falls back to a cleaned tail when no marker is found.
- Wire it into every failure-comment site in `process_evaluation_queue.py`.

## Effect

Validated against the real failed-issue outputs. For example, #1929 (harrier) now yields:

```
The model 'microsoft/harrier-oss-v1-270m' could not be loaded. The error was ValueError("Unrecognized configuration class ... Gemma3TextConfig ... for this kind of AutoModel: AutoModelForTokenClassification. ...") …(truncated)
Completed 2 benchmarks, and errored 2 benchmarks
```

instead of an anonymous dump of another model's result JSON.

## Test plan

- `make check` passes.
- New `tests/leaderboards/test_queue_parsing.py` (8 tests) covers ANSI stripping, noise filtering, traceback extraction, the summary line, giant-line truncation, `max_chars`, and the no-marker fallback.

## Notes

- No CHANGELOG entry: this only touches `src/leaderboards` and `src/scripts`, not `src/euroeval`.
- These models legitimately fail (they cannot be evaluated until the relevant config class is implemented in `transformers`); this PR just makes the failure reason clear in the issue comment instead of an anonymous result dump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
