### PR TITLE
feat(queue): evaluate encoder models after generative models

### DIFF
--- a/src/leaderboards/queue_hf_cache.py
+++ b/src/leaderboards/queue_hf_cache.py
@@ -17,13 +17,41 @@ import time
 from huggingface_hub import HfApi, ModelInfo
 from huggingface_hub.errors import GatedRepoError, RepositoryNotFoundError
 
+from euroeval.constants import GENERATIVE_PIPELINE_TAGS
+
 from .constants import HF_CACHE_PATH, HF_CACHE_TTL_SECONDS
 
 logger = logging.getLogger(__name__)
 
 
+def is_generative_model(info: ModelInfo) -> bool:
+    """Return whether a model_info result describes a generative model.
+
+    Mirrors euroeval's own classification (see ``get_model_repo_info`` in
+    ``euroeval.benchmark_modules.hf``): a model is generative when its pipeline
+    tag is one of :data:`GENERATIVE_PIPELINE_TAGS`, or -- when no pipeline tag is
+    set -- when its architecture is a causal or sequence-to-sequence LM. Anything
+    else (fill-mask, feature-extraction, sentence-similarity, ...) is an encoder.
+
+    Args:
+        info:
+            The model info returned by ``HfApi.model_info``.
+
+    Returns:
+        Whether the repo is a generative model.
+    """
+    pipeline_tag = getattr(info, "pipeline_tag", None)
+    if pipeline_tag is not None:
+        return pipeline_tag in GENERATIVE_PIPELINE_TAGS
+    architectures = (getattr(info, "config", None) or {}).get("architectures") or []
+    return any(
+        "ForCausalLM" in arch or "ForConditionalGeneration" in arch
+        for arch in architectures
+    )
+
+
 def cached_model_summary(model_id: str) -> dict | None:
-    """Return a ``{param_count, gated, gguf}`` summary for a model id.
+    """Return a ``{param_count, gated, gguf, generative}`` summary for a model id.
 
     Looks up :data:`HF_CACHE_PATH` first and falls back to
     ``HfApi.model_info`` only on cache miss or stale entry. Negative
@@ -43,6 +71,9 @@ def cached_model_summary(model_id: str) -> dict | None:
           ``GatedRepoError``).
         - ``gguf`` (bool, True when the repo is a GGUF model, which the
           evaluation queue cannot run).
+        - ``generative`` (bool, True for generative models and False for
+          encoder models; see :func:`is_generative_model`). Defaults to True
+          for gated repos and legacy cache entries whose type is unknown.
 
         Returns None when the model is not on the Hub.
     """
@@ -53,6 +84,7 @@ def cached_model_summary(model_id: str) -> dict | None:
             "param_count": int(entry["param_count"]),
             "gated": False,
             "gguf": bool(entry.get("gguf", False)),
+            "generative": bool(entry.get("generative", True)),
         }
 
     try:
@@ -60,7 +92,12 @@ def cached_model_summary(model_id: str) -> dict | None:
     except GatedRepoError:
         # Don't cache: access can be granted at any time, and we want to
         # pick that up on the next run.
-        return {"param_count": sys.maxsize, "gated": True, "gguf": False}
+        return {
+            "param_count": sys.maxsize,
+            "gated": True,
+            "gguf": False,
+            "generative": True,
+        }
     except RepositoryNotFoundError:
         # Expected for typo-d / since-deleted repos; just drop the candidate.
         return None
@@ -75,14 +112,21 @@ def cached_model_summary(model_id: str) -> dict | None:
     param_count = total if isinstance(total, int) and total > 0 else sys.maxsize
 
     gguf = is_gguf_model(info=info)
+    generative = is_generative_model(info=info)
 
     cache[model_id] = {
         "timestamp": time.time(),
         "param_count": param_count,
         "gguf": gguf,
+        "generative": generative,
     }
     _write_hf_cache(cache=cache)
-    return {"param_count": param_count, "gated": False, "gguf": gguf}
+    return {
+        "param_count": param_count,
+        "gated": False,
+        "gguf": gguf,
+        "generative": generative,
+    }
 
 
 def is_gguf_model(info: ModelInfo) -> bool:

--- a/src/scripts/process_evaluation_queue.py
+++ b/src/scripts/process_evaluation_queue.py
@@ -403,12 +403,16 @@ def age_sort_value(issue: dict) -> float:
 def process_queue_once() -> None:
     """Process every unassigned model-evaluation-request issue once.
 
-    Issues are sorted by (slow priority asc, status priority asc,
-    parameter bucket asc, age asc). Parameter buckets match the
+    Issues are sorted by (slow priority asc, type priority asc, status
+    priority asc, parameter bucket asc, age asc). Parameter buckets match the
     leaderboards: tiny (<2B), small (2-10B), medium (10-40B),
     large (40-80B), xlarge (>=80B).
     Slow priority is 0 for normal issues and 1 for issues with the 'slow'
     label, pushing slow evaluations to the end of the queue.
+    Type priority is 0 for generative models and 1 for encoder models, so the
+    vLLM-based generative workload is drained before the slower encoder
+    finetuning (gated repos and legacy cache entries whose type is unknown are
+    treated as generative).
     Status priority is 0 for gated repos (cheap marker refresh),
     1 for retries of previously errored evaluations (issues with the
     ``evaluation-failed`` label), and 2 for fresh issues, so that gated repos
@@ -423,7 +427,7 @@ def process_queue_once() -> None:
         logger.error(f"Failed to list issues: {e}")
         return
 
-    candidates: list[tuple[int, int, int, float, dict, str, list[str]]] = []
+    candidates: list[tuple[int, int, int, int, float, dict, str, list[str]]] = []
     for issue in issues:
         number = issue["number"]
         title = issue.get("title", "")
@@ -462,11 +466,16 @@ def process_queue_once() -> None:
             if any(label["name"] == "slow" for label in issue.get("labels", []))
             else 0
         )
+        # Generative models (0) are drained before encoder models (1), so the
+        # vLLM-based leaderboard workload runs ahead of the slower encoder
+        # finetuning. Ranked below the 'slow' label but above status/size/age.
+        type_priority = 0 if summary.get("generative", True) else 1
 
         param_bucket_idx = _param_bucket(param_count)
         candidates.append(
             (
                 slow_priority,
+                type_priority,
                 status_priority,
                 param_bucket_idx,
                 age_sort_value(issue=issue),
@@ -476,7 +485,7 @@ def process_queue_once() -> None:
             )
         )
 
-    candidates.sort(key=lambda c: (c[0], c[1], c[2], c[3]))
+    candidates.sort(key=lambda c: (c[0], c[1], c[2], c[3], c[4]))
     logger.info(f"Found {len(candidates)} processable issue(s).")
 
     gpu_bytes = gpu_total_memory_bytes()
@@ -489,6 +498,7 @@ def process_queue_once() -> None:
 
     for (
         slow_priority,
+        type_priority,
         status_priority,
         param_count,
         _age,
@@ -497,10 +507,11 @@ def process_queue_once() -> None:
         groups,
     ) in candidates:
         status = {0: "gated", 1: "retry of errored eval", 2: "fresh"}[status_priority]
+        model_type = "generative" if type_priority == 0 else "encoder"
         slow_tag = ", slow" if slow_priority else ""
         logger.info(
             f"#{issue['number']}: queueing {model_id!r} ({param_count} params, "
-            f"{status}{slow_tag})."
+            f"{model_type}, {status}{slow_tag})."
         )
         if gpu_bytes is not None:
             needed = estimated_model_bytes(model_id=model_id)

--- a/tests/leaderboards/test_queue_hf_cache.py
+++ b/tests/leaderboards/test_queue_hf_cache.py
@@ -3,7 +3,7 @@
 import pytest
 from huggingface_hub import ModelInfo
 
-from leaderboards.queue_hf_cache import is_gguf_model
+from leaderboards.queue_hf_cache import is_generative_model, is_gguf_model
 
 
 @pytest.mark.parametrize(
@@ -39,3 +39,32 @@ from leaderboards.queue_hf_cache import is_gguf_model
 def test_is_gguf_model(info: ModelInfo, expected: bool) -> None:
     """GGUF repos are detected via tag, library_name, or any .gguf sibling."""
     assert is_gguf_model(info=info) is expected
+
+
+@pytest.mark.parametrize(
+    argnames=["info", "expected"],
+    argvalues=[
+        # Generative pipeline tags.
+        (ModelInfo(id="org/m", pipeline_tag="text-generation"), True),
+        (ModelInfo(id="org/m", pipeline_tag="text2text-generation"), True),
+        (ModelInfo(id="org/m", pipeline_tag="image-text-to-text"), True),
+        # Encoder pipeline tags.
+        (ModelInfo(id="org/m", pipeline_tag="fill-mask"), False),
+        (ModelInfo(id="org/m", pipeline_tag="feature-extraction"), False),
+        (ModelInfo(id="org/m", pipeline_tag="sentence-similarity"), False),
+        # No pipeline tag: fall back to the architecture.
+        (ModelInfo(id="org/m", config={"architectures": ["LlamaForCausalLM"]}), True),
+        (
+            ModelInfo(
+                id="org/m", config={"architectures": ["T5ForConditionalGeneration"]}
+            ),
+            True,
+        ),
+        (ModelInfo(id="org/m", config={"architectures": ["BertForMaskedLM"]}), False),
+        # No pipeline tag and no config: treated as encoder.
+        (ModelInfo(id="org/m"), False),
+    ],
+)
+def test_is_generative_model(info: ModelInfo, expected: bool) -> None:
+    """Generative models are detected via pipeline tag or LM architecture."""
+    assert is_generative_model(info=info) is expected


### PR DESCRIPTION
## Summary

The evaluation queue now drains **all generative (vLLM) evaluations before any encoder (transformers finetuning) evaluations**, so the primary generative-leaderboard workload isn't held up behind the slower encoder finetuning.

## Changes

- `cached_model_summary` gains a `generative` field, classified by the new `is_generative_model()` helper. It mirrors euroeval's own classification (`get_model_repo_info`): generative when the pipeline tag is one of `GENERATIVE_PIPELINE_TAGS` (imported from `euroeval.constants` as the source of truth), or — when no pipeline tag is set — when the architecture is a causal / seq2seq LM (`*ForCausalLM` / `*ForConditionalGeneration`). Everything else (fill-mask, feature-extraction, sentence-similarity, …) is an encoder.
- The queue sort key changes from `(slow, status, size, age)` to `(slow, type, status, size, age)` — `type` is `0` for generative and `1` for encoder. Per the chosen placement: **below the `slow` label, above status/size/age**, so `slow`-labelled models stay deferred to the very end but otherwise generatives fully precede encoders.
- Gated repos and legacy cache entries whose type is unknown default to `generative` (so cheap gated refreshes aren't deprioritized behind the encoder tail). The 6h cache TTL re-populates the new field for existing entries.
- The queueing log line now shows the model type.

## Test plan

- `make check` passes.
- New parametrized `test_is_generative_model` in `tests/leaderboards/test_queue_hf_cache.py` covers generative/encoder pipeline tags, architecture fallback, and the no-metadata case.

## Notes

- No CHANGELOG entry: this only touches `src/leaderboards` and `src/scripts`, not `src/euroeval`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)