### PR TITLE
fix(vllm): store vLLM caches under the euroeval cache dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- vLLM's own caches (compiled graphs and the model-info registry) are now stored under
+  the euroeval cache directory (`<cache_dir>/vllm`) alongside the downloaded weights,
+  instead of the shared `~/.cache/vllm`. This avoids `PermissionError`s on shared
+  machines where the default location can be owned by another user. Set an explicit
+  `VLLM_CACHE_ROOT` to override.
 - Fixed race condition in cache cleanup where `rmtree` would fail with
   `FileNotFoundError` when checkpoint directories were removed concurrently during model
   benchmarking. Now uses `ignore_errors=True` to handle concurrent deletions gracefully.

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -1459,6 +1459,17 @@ def load_model(
     else:
         download_dir = str(model_config.model_cache_dir)
 
+    # Keep vLLM's own caches (compiled graphs, model-info registry) under the
+    # euroeval cache directory alongside the downloaded weights, rather than the
+    # shared ``~/.cache/vllm`` default. On shared machines the latter can end up
+    # owned by another user (e.g. from a past ``sudo`` run), which makes vLLM fail
+    # with a ``PermissionError`` when it tries to write there. ``setdefault`` so an
+    # explicit ``VLLM_CACHE_ROOT`` from the environment still wins. vLLM reads this
+    # variable lazily, so setting it before the engine is created is sufficient.
+    os.environ.setdefault(
+        "VLLM_CACHE_ROOT", str((Path(benchmark_config.cache_dir) / "vllm").resolve())
+    )
+
     vllm_params = get_vllm_tokenisation_params(
         tokeniser=tokeniser, model_config=model_config
     )


### PR DESCRIPTION
## Summary

vLLM writes its compiled-graph cache and model-info registry under `VLLM_CACHE_ROOT`, which euroeval never set — so they went to the shared `~/.cache/vllm`, even though model weights already download into `.euroeval_cache/model_cache/…`.

On shared machines that default location can end up owned by another user (e.g. `~/.cache/vllm/modelinfos` created root-owned by a past `sudo`/root run), which makes vLLM fail while loading a model:

```
Error saving model info cache.
...
PermissionError: [Errno 13] Permission denied: '/home/<user>/.cache/vllm/modelinfos/tmp…'
```

## Change

In `load_model` (vLLM module), set `VLLM_CACHE_ROOT` to `<cache_dir>/vllm` (default `.euroeval_cache/vllm`) before the engine is created, via `os.environ.setdefault` so an explicit `VLLM_CACHE_ROOT` from the environment still wins. vLLM reads the variable lazily, so setting it before engine construction is sufficient, and child worker processes inherit it.

This keeps *all* vLLM caches alongside the downloaded weights under the euroeval cache directory, consistent with the model cache.

## Test plan

- `make check` passes.
- `VLLM_CACHE_ROOT` now resolves to an absolute path under the project cache dir; the shared `~/.cache/vllm` is no longer touched, so the permission failure can't recur from a poisoned shared cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)