### PR TITLE
feat: Add RAGTruth hallucination detection configs for 29 European languages

### DIFF
--- a/src/euroeval/dataset_configs/albanian.py
+++ b/src/euroeval/dataset_configs/albanian.py
@@ -2,7 +2,7 @@
 
 from ..data_models import DatasetConfig
 from ..languages import ALBANIAN
-from ..tasks import COMMON_SENSE, KNOW, LA, NER, RC, SENT, SUMM
+from ..tasks import COMMON_SENSE, HALLU, KNOW, LA, NER, RC, SENT, SUMM
 
 # Official datasets ###
 
@@ -73,4 +73,13 @@ INCLUDE_SQ_CONFIG = DatasetConfig(
     task=KNOW,
     languages=[ALBANIAN],
     unofficial=True,
+)
+
+RAGTRUTH_AL_CONFIG = DatasetConfig(
+    name="ragtruth-al",
+    pretty_name="RAGTruth-al",
+    source="EuroEval/ragtruth-translated-hallucinations-al-mini",
+    task=HALLU,
+    languages=[ALBANIAN],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/belarusian.py
+++ b/src/euroeval/dataset_configs/belarusian.py
@@ -2,7 +2,7 @@
 
 from ..data_models import DatasetConfig
 from ..languages import BELARUSIAN
-from ..tasks import COMMON_SENSE, LA, NER, RC, SENT
+from ..tasks import COMMON_SENSE, HALLU, LA, NER, RC, SENT
 
 # Official datasets ###
 
@@ -44,4 +44,13 @@ BE_WSC_CONFIG = DatasetConfig(
     source="EuroEval/be-wsc",
     task=COMMON_SENSE,
     languages=[BELARUSIAN],
+)
+
+RAGTRUTH_BE_CONFIG = DatasetConfig(
+    name="ragtruth-be",
+    pretty_name="RAGTruth-be",
+    source="EuroEval/ragtruth-translated-hallucinations-be-mini",
+    task=HALLU,
+    languages=[BELARUSIAN],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/bosnian.py
+++ b/src/euroeval/dataset_configs/bosnian.py
@@ -2,7 +2,7 @@
 
 from ..data_models import DatasetConfig
 from ..languages import BOSNIAN
-from ..tasks import NER, RC, SENT, SUMM
+from ..tasks import HALLU, NER, RC, SENT, SUMM
 
 # Official datasets ###
 
@@ -36,4 +36,13 @@ LR_SUM_BS_CONFIG = DatasetConfig(
     source="EuroEval/lr-sum-bs-mini",
     task=SUMM,
     languages=[BOSNIAN],
+)
+
+RAGTRUTH_BS_CONFIG = DatasetConfig(
+    name="ragtruth-bs",
+    pretty_name="RAGTruth-bs",
+    source="EuroEval/ragtruth-translated-hallucinations-bs-mini",
+    task=HALLU,
+    languages=[BOSNIAN],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/bulgarian.py
+++ b/src/euroeval/dataset_configs/bulgarian.py
@@ -2,7 +2,7 @@
 
 from ..data_models import DatasetConfig
 from ..languages import BULGARIAN
-from ..tasks import COMMON_SENSE, KNOW, LA, NER, RC, SENT
+from ..tasks import COMMON_SENSE, HALLU, KNOW, LA, NER, RC, SENT
 
 # Official datasets ###
 
@@ -65,4 +65,13 @@ INCLUDE_BG_CONFIG = DatasetConfig(
     task=KNOW,
     languages=[BULGARIAN],
     unofficial=True,
+)
+
+RAGTRUTH_BG_CONFIG = DatasetConfig(
+    name="ragtruth-bg",
+    pretty_name="RAGTruth-bg",
+    source="EuroEval/ragtruth-translated-hallucinations-bg-mini",
+    task=HALLU,
+    languages=[BULGARIAN],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/catalan.py
+++ b/src/euroeval/dataset_configs/catalan.py
@@ -2,7 +2,17 @@
 
 from ..data_models import DatasetConfig
 from ..languages import CATALAN
-from ..tasks import COMMON_SENSE, INSTRUCTION_FOLLOWING, KNOW, LA, NER, RC, SENT, SUMM
+from ..tasks import (
+    COMMON_SENSE,
+    HALLU,
+    INSTRUCTION_FOLLOWING,
+    KNOW,
+    LA,
+    NER,
+    RC,
+    SENT,
+    SUMM,
+)
 
 # Official datasets ###
 
@@ -71,4 +81,13 @@ IFEVAL_CA_CONFIG = DatasetConfig(
     languages=[CATALAN],
     train_split=None,
     val_split=None,
+)
+
+RAGTRUTH_CA_CONFIG = DatasetConfig(
+    name="ragtruth-ca",
+    pretty_name="RAGTruth-ca",
+    source="EuroEval/ragtruth-translated-hallucinations-ca-mini",
+    task=HALLU,
+    languages=[CATALAN],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/croatian.py
+++ b/src/euroeval/dataset_configs/croatian.py
@@ -2,7 +2,7 @@
 
 from ..data_models import DatasetConfig
 from ..languages import CROATIAN
-from ..tasks import COMMON_SENSE, KNOW, LA, NER, RC, SENT
+from ..tasks import COMMON_SENSE, HALLU, KNOW, LA, NER, RC, SENT
 
 # Official datasets ###
 
@@ -65,4 +65,13 @@ INCLUDE_HR_CONFIG = DatasetConfig(
     task=KNOW,
     languages=[CROATIAN],
     unofficial=True,
+)
+
+RAGTRUTH_HR_CONFIG = DatasetConfig(
+    name="ragtruth-hr",
+    pretty_name="RAGTruth-hr",
+    source="EuroEval/ragtruth-translated-hallucinations-hr-mini",
+    task=HALLU,
+    languages=[CROATIAN],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/czech.py
+++ b/src/euroeval/dataset_configs/czech.py
@@ -2,7 +2,7 @@
 
 from ..data_models import DatasetConfig
 from ..languages import CZECH
-from ..tasks import COMMON_SENSE, KNOW, LA, NER, RC, SENT, SUMM
+from ..tasks import COMMON_SENSE, HALLU, KNOW, LA, NER, RC, SENT, SUMM
 
 # Official datasets ###
 
@@ -72,4 +72,13 @@ SCALA_CS_CONFIG = DatasetConfig(
     task=LA,
     languages=[CZECH],
     unofficial=True,
+)
+
+RAGTRUTH_CS_CONFIG = DatasetConfig(
+    name="ragtruth-cs",
+    pretty_name="RAGTruth-cs",
+    source="EuroEval/ragtruth-translated-hallucinations-cs-mini",
+    task=HALLU,
+    languages=[CZECH],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/dutch.py
+++ b/src/euroeval/dataset_configs/dutch.py
@@ -6,6 +6,7 @@ from ..tasks import (
     COMMON_SENSE,
     EUROPEAN_VALUES,
     GED,
+    HALLU,
     KNOW,
     LA,
     LOGIC,
@@ -248,4 +249,13 @@ ZEBRA_PUZZLE_HARD_NL_CONFIG = DatasetConfig(
     task=LOGIC,
     languages=[DUTCH],
     unofficial=True,
+)
+
+RAGTRUTH_NL_CONFIG = DatasetConfig(
+    name="ragtruth-nl",
+    pretty_name="RAGTruth-nl",
+    source="EuroEval/ragtruth-translated-hallucinations-nl-mini",
+    task=HALLU,
+    languages=[DUTCH],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/estonian.py
+++ b/src/euroeval/dataset_configs/estonian.py
@@ -5,6 +5,7 @@ from ..languages import ESTONIAN
 from ..tasks import (
     COMMON_SENSE,
     EUROPEAN_VALUES,
+    HALLU,
     INSTRUCTION_FOLLOWING,
     KNOW,
     LA,
@@ -138,4 +139,13 @@ INCLUDE_ET_CONFIG = DatasetConfig(
     task=KNOW,
     languages=[ESTONIAN],
     unofficial=True,
+)
+
+RAGTRUTH_ET_CONFIG = DatasetConfig(
+    name="ragtruth-et",
+    pretty_name="RAGTruth-et",
+    source="EuroEval/ragtruth-translated-hallucinations-et-mini",
+    task=HALLU,
+    languages=[ESTONIAN],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/faroese.py
+++ b/src/euroeval/dataset_configs/faroese.py
@@ -2,7 +2,7 @@
 
 from ..data_models import DatasetConfig
 from ..languages import FAROESE
-from ..tasks import GED, LA, LOGIC, NER, RC, SENT
+from ..tasks import GED, HALLU, LA, LOGIC, NER, RC, SENT
 
 # Official datasets ###
 
@@ -85,4 +85,13 @@ ZEBRA_PUZZLE_HARD_FO_CONFIG = DatasetConfig(
     task=LOGIC,
     languages=[FAROESE],
     unofficial=True,
+)
+
+RAGTRUTH_FO_CONFIG = DatasetConfig(
+    name="ragtruth-fo",
+    pretty_name="RAGTruth-fo",
+    source="EuroEval/ragtruth-translated-hallucinations-fo-mini",
+    task=HALLU,
+    languages=[FAROESE],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/finnish.py
+++ b/src/euroeval/dataset_configs/finnish.py
@@ -5,6 +5,7 @@ from ..languages import FINNISH
 from ..tasks import (
     COMMON_SENSE,
     EUROPEAN_VALUES,
+    HALLU,
     INSTRUCTION_FOLLOWING,
     KNOW,
     LA,
@@ -135,4 +136,13 @@ INCLUDE_FI_CONFIG = DatasetConfig(
     task=KNOW,
     languages=[FINNISH],
     unofficial=True,
+)
+
+RAGTRUTH_FI_CONFIG = DatasetConfig(
+    name="ragtruth-fi",
+    pretty_name="RAGTruth-fi",
+    source="EuroEval/ragtruth-translated-hallucinations-fi-mini",
+    task=HALLU,
+    languages=[FINNISH],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/french.py
+++ b/src/euroeval/dataset_configs/french.py
@@ -5,6 +5,7 @@ from ..languages import FRENCH
 from ..tasks import (
     COMMON_SENSE,
     EUROPEAN_VALUES,
+    HALLU,
     INSTRUCTION_FOLLOWING,
     KNOW,
     LA,
@@ -163,4 +164,13 @@ MULTINRC_FR_CONFIG = DatasetConfig(
     task=KNOW,
     languages=[FRENCH],
     unofficial=True,
+)
+
+RAGTRUTH_FR_CONFIG = DatasetConfig(
+    name="ragtruth-fr",
+    pretty_name="RAGTruth-fr",
+    source="EuroEval/ragtruth-translated-hallucinations-fr-mini",
+    task=HALLU,
+    languages=[FRENCH],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/german.py
+++ b/src/euroeval/dataset_configs/german.py
@@ -6,6 +6,7 @@ from ..tasks import (
     COMMON_SENSE,
     EUROPEAN_VALUES,
     GED,
+    HALLU,
     INSTRUCTION_FOLLOWING,
     KNOW,
     LA,
@@ -199,4 +200,13 @@ ZEBRA_PUZZLE_HARD_DE_CONFIG = DatasetConfig(
     task=LOGIC,
     languages=[GERMAN],
     unofficial=True,
+)
+
+RAGTRUTH_DE_CONFIG = DatasetConfig(
+    name="ragtruth-de",
+    pretty_name="RAGTruth-de",
+    source="EuroEval/ragtruth-translated-hallucinations-de-mini",
+    task=HALLU,
+    languages=[GERMAN],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/greek.py
+++ b/src/euroeval/dataset_configs/greek.py
@@ -2,7 +2,17 @@
 
 from ..data_models import DatasetConfig
 from ..languages import GREEK
-from ..tasks import COMMON_SENSE, INSTRUCTION_FOLLOWING, KNOW, LA, NER, RC, SENT, SUMM
+from ..tasks import (
+    COMMON_SENSE,
+    HALLU,
+    INSTRUCTION_FOLLOWING,
+    KNOW,
+    LA,
+    NER,
+    RC,
+    SENT,
+    SUMM,
+)
 
 # Official datasets ###
 
@@ -92,4 +102,13 @@ GREEK_MMLU_CONFIG = DatasetConfig(
     task=KNOW,
     languages=[GREEK],
     unofficial=True,
+)
+
+RAGTRUTH_EL_CONFIG = DatasetConfig(
+    name="ragtruth-el",
+    pretty_name="RAGTruth-el",
+    source="EuroEval/ragtruth-translated-hallucinations-el-mini",
+    task=HALLU,
+    languages=[GREEK],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/hungarian.py
+++ b/src/euroeval/dataset_configs/hungarian.py
@@ -2,7 +2,7 @@
 
 from ..data_models import DatasetConfig
 from ..languages import HUNGARIAN
-from ..tasks import COMMON_SENSE, KNOW, LA, NER, RC, SENT, SUMM
+from ..tasks import COMMON_SENSE, HALLU, KNOW, LA, NER, RC, SENT, SUMM
 
 # Official datasets ###
 
@@ -73,4 +73,13 @@ INCLUDE_HU_CONFIG = DatasetConfig(
     task=KNOW,
     languages=[HUNGARIAN],
     unofficial=True,
+)
+
+RAGTRUTH_HU_CONFIG = DatasetConfig(
+    name="ragtruth-hu",
+    pretty_name="RAGTruth-hu",
+    source="EuroEval/ragtruth-translated-hallucinations-hu-mini",
+    task=HALLU,
+    languages=[HUNGARIAN],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/icelandic.py
+++ b/src/euroeval/dataset_configs/icelandic.py
@@ -6,6 +6,7 @@ from ..tasks import (
     COMMON_SENSE,
     EUROPEAN_VALUES,
     GED,
+    HALLU,
     KNOW,
     LA,
     LOGIC,
@@ -216,4 +217,13 @@ ZEBRA_PUZZLE_HARD_IS_CONFIG = DatasetConfig(
     task=LOGIC,
     languages=[ICELANDIC],
     unofficial=True,
+)
+
+RAGTRUTH_IS_CONFIG = DatasetConfig(
+    name="ragtruth-is",
+    pretty_name="RAGTruth-is",
+    source="EuroEval/ragtruth-translated-hallucinations-is-mini",
+    task=HALLU,
+    languages=[ICELANDIC],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/italian.py
+++ b/src/euroeval/dataset_configs/italian.py
@@ -5,6 +5,7 @@ from ..languages import ITALIAN
 from ..tasks import (
     COMMON_SENSE,
     EUROPEAN_VALUES,
+    HALLU,
     INSTRUCTION_FOLLOWING,
     KNOW,
     LA,
@@ -171,4 +172,13 @@ WIC_ITA_CONFIG = DatasetConfig(
     task=WIC,
     languages=[ITALIAN],
     unofficial=True,
+)
+
+RAGTRUTH_IT_CONFIG = DatasetConfig(
+    name="ragtruth-it",
+    pretty_name="RAGTruth-it",
+    source="EuroEval/ragtruth-translated-hallucinations-it-mini",
+    task=HALLU,
+    languages=[ITALIAN],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/latvian.py
+++ b/src/euroeval/dataset_configs/latvian.py
@@ -2,7 +2,7 @@
 
 from ..data_models import DatasetConfig
 from ..languages import LATVIAN
-from ..tasks import COMMON_SENSE, KNOW, LA, NER, RC, SENT, SUMM
+from ..tasks import COMMON_SENSE, HALLU, KNOW, LA, NER, RC, SENT, SUMM
 
 # Official datasets ###
 
@@ -84,4 +84,13 @@ WINOGRANDE_LV_CONFIG = DatasetConfig(
     languages=[LATVIAN],
     labels=["a", "b"],
     unofficial=True,
+)
+
+RAGTRUTH_LV_CONFIG = DatasetConfig(
+    name="ragtruth-lv",
+    pretty_name="RAGTruth-lv",
+    source="EuroEval/ragtruth-translated-hallucinations-lv-mini",
+    task=HALLU,
+    languages=[LATVIAN],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/lithuanian.py
+++ b/src/euroeval/dataset_configs/lithuanian.py
@@ -2,7 +2,7 @@
 
 from ..data_models import DatasetConfig
 from ..languages import LITHUANIAN
-from ..tasks import COMMON_SENSE, KNOW, LA, NER, RC, SENT, SUMM
+from ..tasks import COMMON_SENSE, HALLU, KNOW, LA, NER, RC, SENT, SUMM
 
 # Official datasets ###
 
@@ -81,4 +81,13 @@ INCLUDE_LT_CONFIG = DatasetConfig(
     task=KNOW,
     languages=[LITHUANIAN],
     unofficial=True,
+)
+
+RAGTRUTH_LT_CONFIG = DatasetConfig(
+    name="ragtruth-lt",
+    pretty_name="RAGTruth-lt",
+    source="EuroEval/ragtruth-translated-hallucinations-lt-mini",
+    task=HALLU,
+    languages=[LITHUANIAN],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/norwegian.py
+++ b/src/euroeval/dataset_configs/norwegian.py
@@ -340,5 +340,4 @@ RAGTRUTH_NO_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[NORWEGIAN],
     train_split=None,
-    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/norwegian.py
+++ b/src/euroeval/dataset_configs/norwegian.py
@@ -6,6 +6,7 @@ from ..tasks import (
     COMMON_SENSE,
     EUROPEAN_VALUES,
     GED,
+    HALLU,
     KNOW,
     LA,
     LOGIC,
@@ -329,5 +330,15 @@ ZEBRA_PUZZLE_HARD_NN_CONFIG = DatasetConfig(
     source="EuroEval/zebra-puzzles-hard-nn",
     task=LOGIC,
     languages=[NORWEGIAN_NYNORSK, NORWEGIAN],
+    unofficial=True,
+)
+
+RAGTRUTH_NO_CONFIG = DatasetConfig(
+    name="ragtruth-no",
+    pretty_name="RAGTruth-no",
+    source="EuroEval/ragtruth-translated-hallucinations-no-mini",
+    task=HALLU,
+    languages=[NORWEGIAN],
+    train_split=None,
     unofficial=True,
 )

--- a/src/euroeval/dataset_configs/polish.py
+++ b/src/euroeval/dataset_configs/polish.py
@@ -2,7 +2,7 @@
 
 from ..data_models import DatasetConfig
 from ..languages import POLISH
-from ..tasks import COMMON_SENSE, EUROPEAN_VALUES, KNOW, LA, NER, RC, SENT, SUMM
+from ..tasks import COMMON_SENSE, EUROPEAN_VALUES, HALLU, KNOW, LA, NER, RC, SENT, SUMM
 
 # Official datasets ###
 
@@ -103,4 +103,13 @@ INCLUDE_PL_CONFIG = DatasetConfig(
     task=KNOW,
     languages=[POLISH],
     unofficial=True,
+)
+
+RAGTRUTH_PL_CONFIG = DatasetConfig(
+    name="ragtruth-pl",
+    pretty_name="RAGTruth-pl",
+    source="EuroEval/ragtruth-translated-hallucinations-pl-mini",
+    task=HALLU,
+    languages=[POLISH],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/portuguese.py
+++ b/src/euroeval/dataset_configs/portuguese.py
@@ -5,6 +5,7 @@ from ..languages import EUROPEAN_PORTUGUESE, PORTUGUESE
 from ..tasks import (
     COMMON_SENSE,
     EUROPEAN_VALUES,
+    HALLU,
     INSTRUCTION_FOLLOWING,
     KNOW,
     LA,
@@ -135,4 +136,13 @@ MULTILOKO_PT_CONFIG = DatasetConfig(
     languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
     val_split=None,
     unofficial=True,
+)
+
+RAGTRUTH_PT_CONFIG = DatasetConfig(
+    name="ragtruth-pt",
+    pretty_name="RAGTruth-pt",
+    source="EuroEval/ragtruth-translated-hallucinations-pt-mini",
+    task=HALLU,
+    languages=[PORTUGUESE],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/romanian.py
+++ b/src/euroeval/dataset_configs/romanian.py
@@ -2,7 +2,7 @@
 
 from ..data_models import DatasetConfig
 from ..languages import ROMANIAN
-from ..tasks import COMMON_SENSE, KNOW, LA, NER, RC, SENT, SUMM
+from ..tasks import COMMON_SENSE, HALLU, KNOW, LA, NER, RC, SENT, SUMM
 
 # Official datasets ###
 
@@ -62,4 +62,13 @@ WINOGRANDE_RO_CONFIG = DatasetConfig(
     task=COMMON_SENSE,
     languages=[ROMANIAN],
     labels=["a", "b"],
+)
+
+RAGTRUTH_RO_CONFIG = DatasetConfig(
+    name="ragtruth-ro",
+    pretty_name="RAGTruth-ro",
+    source="EuroEval/ragtruth-translated-hallucinations-ro-mini",
+    task=HALLU,
+    languages=[ROMANIAN],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/serbian.py
+++ b/src/euroeval/dataset_configs/serbian.py
@@ -2,7 +2,7 @@
 
 from ..data_models import DatasetConfig
 from ..languages import SERBIAN
-from ..tasks import COMMON_SENSE, KNOW, LA, NER, RC, SENT, SUMM
+from ..tasks import COMMON_SENSE, HALLU, KNOW, LA, NER, RC, SENT, SUMM
 
 # Official datasets ###
 
@@ -73,4 +73,13 @@ INCLUDE_SR_CONFIG = DatasetConfig(
     task=KNOW,
     languages=[SERBIAN],
     unofficial=True,
+)
+
+RAGTRUTH_SR_CONFIG = DatasetConfig(
+    name="ragtruth-sr",
+    pretty_name="RAGTruth-sr",
+    source="EuroEval/ragtruth-translated-hallucinations-sr-mini",
+    task=HALLU,
+    languages=[SERBIAN],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/slovak.py
+++ b/src/euroeval/dataset_configs/slovak.py
@@ -2,7 +2,7 @@
 
 from ..data_models import DatasetConfig
 from ..languages import SLOVAK
-from ..tasks import COMMON_SENSE, KNOW, LA, NER, RC, SENT
+from ..tasks import COMMON_SENSE, HALLU, KNOW, LA, NER, RC, SENT
 
 # Official datasets ###
 
@@ -52,4 +52,13 @@ WINOGRANDE_SK_CONFIG = DatasetConfig(
     source="EuroEval/winogrande-sk",
     task=COMMON_SENSE,
     languages=[SLOVAK],
+)
+
+RAGTRUTH_SK_CONFIG = DatasetConfig(
+    name="ragtruth-sk",
+    pretty_name="RAGTruth-sk",
+    source="EuroEval/ragtruth-translated-hallucinations-sk-mini",
+    task=HALLU,
+    languages=[SLOVAK],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/slovene.py
+++ b/src/euroeval/dataset_configs/slovene.py
@@ -2,7 +2,7 @@
 
 from ..data_models import DatasetConfig
 from ..languages import SLOVENE
-from ..tasks import COMMON_SENSE, KNOW, LA, NER, RC, SENT
+from ..tasks import COMMON_SENSE, HALLU, KNOW, LA, NER, RC, SENT
 
 # Official datasets ###
 
@@ -53,4 +53,13 @@ WINOGRANDE_SL_CONFIG = DatasetConfig(
     task=COMMON_SENSE,
     languages=[SLOVENE],
     labels=["a", "b"],
+)
+
+RAGTRUTH_SL_CONFIG = DatasetConfig(
+    name="ragtruth-sl",
+    pretty_name="RAGTruth-sl",
+    source="EuroEval/ragtruth-translated-hallucinations-sl-mini",
+    task=HALLU,
+    languages=[SLOVENE],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/spanish.py
+++ b/src/euroeval/dataset_configs/spanish.py
@@ -5,6 +5,7 @@ from ..languages import SPANISH
 from ..tasks import (
     COMMON_SENSE,
     EUROPEAN_VALUES,
+    HALLU,
     INSTRUCTION_FOLLOWING,
     KNOW,
     LA,
@@ -179,4 +180,13 @@ MULTINRC_ES_CONFIG = DatasetConfig(
     task=KNOW,
     languages=[SPANISH],
     unofficial=True,
+)
+
+RAGTRUTH_ES_CONFIG = DatasetConfig(
+    name="ragtruth-es",
+    pretty_name="RAGTruth-es",
+    source="EuroEval/ragtruth-translated-hallucinations-es-mini",
+    task=HALLU,
+    languages=[SPANISH],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/swedish.py
+++ b/src/euroeval/dataset_configs/swedish.py
@@ -6,6 +6,7 @@ from ..tasks import (
     COMMON_SENSE,
     EUROPEAN_VALUES,
     GED,
+    HALLU,
     INSTRUCTION_FOLLOWING,
     KNOW,
     LA,
@@ -223,4 +224,13 @@ ZEBRA_PUZZLE_HARD_SV_CONFIG = DatasetConfig(
     task=LOGIC,
     languages=[SWEDISH],
     unofficial=True,
+)
+
+RAGTRUTH_SV_CONFIG = DatasetConfig(
+    name="ragtruth-sv",
+    pretty_name="RAGTruth-sv",
+    source="EuroEval/ragtruth-translated-hallucinations-sv-mini",
+    task=HALLU,
+    languages=[SWEDISH],
+    train_split=None,
 )

--- a/src/euroeval/dataset_configs/ukrainian.py
+++ b/src/euroeval/dataset_configs/ukrainian.py
@@ -2,7 +2,17 @@
 
 from ..data_models import DatasetConfig
 from ..languages import UKRAINIAN
-from ..tasks import COMMON_SENSE, INSTRUCTION_FOLLOWING, KNOW, LA, NER, RC, SENT, SUMM
+from ..tasks import (
+    COMMON_SENSE,
+    HALLU,
+    INSTRUCTION_FOLLOWING,
+    KNOW,
+    LA,
+    NER,
+    RC,
+    SENT,
+    SUMM,
+)
 
 # Official datasets ###
 
@@ -83,4 +93,13 @@ INCLUDE_UK_CONFIG = DatasetConfig(
     task=KNOW,
     languages=[UKRAINIAN],
     unofficial=True,
+)
+
+RAGTRUTH_UK_CONFIG = DatasetConfig(
+    name="ragtruth-uk",
+    pretty_name="RAGTruth-uk",
+    source="EuroEval/ragtruth-translated-hallucinations-uk-mini",
+    task=HALLU,
+    languages=[UKRAINIAN],
+    train_split=None,
 )


### PR DESCRIPTION
## What

Add RAGTruth hallucination detection dataset configurations for all 29 European languages from the RAGTruth translation pipeline, following the same pattern as the existing Danish config.

## Key features

- Adds dataset configs for 29 languages: Albanian, Belarusian, Bosnian, Bulgarian, Catalan, Croatian, Czech, Dutch, Estonian, Faroese, Finnish, French, German, Greek, Hungarian, Icelandic, Italian, Latvian, Lithuanian, Norwegian, Polish, Portuguese, Romanian, Serbian, Slovak, Slovene, Spanish, Swedish, and Ukrainian
- Each config uses the HALLU task with empty templates (matching Danish pattern)
- Points to the corresponding mini datasets on Hugging Face Hub

## How to use

The configs enable evaluation of hallucination detection for models across all 29 European languages using the RAGTruth dataset.

## Why it helps

Expands EuroEval's multilingual hallucination detection capabilities beyond just Danish, enabling robust evaluation across the full set of European languages supported by the RAGTruth translation pipeline.