### PR TITLE
fix: mark non-Danish RAGTruth datasets as unofficial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,10 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   European languages (Danish, Albanian, Belarusian, Bosnian, Bulgarian, Catalan,
   Croatian, Czech, Dutch, Estonian, Faroese, Finnish, French, German, Greek, Hungarian,
   Icelandic, Italian, Latvian, Lithuanian, Norwegian, Polish, Portuguese, Romanian,
-  Serbian, Slovak, Slovene, Spanish, Swedish, Ukrainian). This was contributed by
+  Serbian, Slovak, Slovene, Spanish, Swedish, Ukrainian). All non-Danish datasets
+  are marked `unofficial` as the published Hugging Face versions are placeholder
+  test-split-only snapshots awaiting full regeneration. This was contributed by
   @FrejaThoresen ✨
-
-### Changed
-
-- The RAGTruth hallucination datasets for all non-Danish European languages are
-  now marked as `unofficial` for now, as the published Hugging Face versions are
-  placeholder test-split-only snapshots awaiting full regeneration. The Danish
-  RAGTruth dataset remains `official`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   Serbian, Slovak, Slovene, Spanish, Swedish, Ukrainian). This was contributed by
   @FrejaThoresen ✨
 
+### Changed
+
+- The RAGTruth hallucination datasets for all non-Danish European languages are
+  now marked as `unofficial` for now, as the published Hugging Face versions are
+  placeholder test-split-only snapshots awaiting full regeneration. The Danish
+  RAGTruth dataset remains `official`.
+
 ### Fixed
 
 - vLLM's own caches (compiled graphs and the model-info registry) are now stored under

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   European languages (Danish, Albanian, Belarusian, Bosnian, Bulgarian, Catalan,
   Croatian, Czech, Dutch, Estonian, Faroese, Finnish, French, German, Greek, Hungarian,
   Icelandic, Italian, Latvian, Lithuanian, Norwegian, Polish, Portuguese, Romanian,
-  Serbian, Slovak, Slovene, Spanish, Swedish, Ukrainian). All non-Danish datasets
-  are marked `unofficial` as the published Hugging Face versions are placeholder
+  Serbian, Slovak, Slovene, Spanish, Swedish, Ukrainian). All are marked
+  `unofficial` as the published Hugging Face versions are placeholder
   test-split-only snapshots awaiting full regeneration. This was contributed by
   @FrejaThoresen ✨
 

--- a/src/euroeval/dataset_configs/albanian.py
+++ b/src/euroeval/dataset_configs/albanian.py
@@ -82,4 +82,5 @@ RAGTRUTH_SQ_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[ALBANIAN],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/belarusian.py
+++ b/src/euroeval/dataset_configs/belarusian.py
@@ -53,4 +53,5 @@ RAGTRUTH_BE_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[BELARUSIAN],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/bosnian.py
+++ b/src/euroeval/dataset_configs/bosnian.py
@@ -45,4 +45,5 @@ RAGTRUTH_BS_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[BOSNIAN],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/bulgarian.py
+++ b/src/euroeval/dataset_configs/bulgarian.py
@@ -74,4 +74,5 @@ RAGTRUTH_BG_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[BULGARIAN],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/catalan.py
+++ b/src/euroeval/dataset_configs/catalan.py
@@ -90,4 +90,5 @@ RAGTRUTH_CA_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[CATALAN],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/croatian.py
+++ b/src/euroeval/dataset_configs/croatian.py
@@ -74,4 +74,5 @@ RAGTRUTH_HR_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[CROATIAN],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/czech.py
+++ b/src/euroeval/dataset_configs/czech.py
@@ -81,4 +81,5 @@ RAGTRUTH_CS_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[CZECH],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/danish.py
+++ b/src/euroeval/dataset_configs/danish.py
@@ -114,6 +114,7 @@ RAGTRUTH_DA_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[DANISH],
     train_split=None,
+    unofficial=True,
 )
 
 # Unofficial datasets ###

--- a/src/euroeval/dataset_configs/dutch.py
+++ b/src/euroeval/dataset_configs/dutch.py
@@ -258,4 +258,5 @@ RAGTRUTH_NL_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[DUTCH],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/estonian.py
+++ b/src/euroeval/dataset_configs/estonian.py
@@ -148,4 +148,5 @@ RAGTRUTH_ET_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[ESTONIAN],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/faroese.py
+++ b/src/euroeval/dataset_configs/faroese.py
@@ -94,4 +94,5 @@ RAGTRUTH_FO_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[FAROESE],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/finnish.py
+++ b/src/euroeval/dataset_configs/finnish.py
@@ -145,4 +145,5 @@ RAGTRUTH_FI_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[FINNISH],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/french.py
+++ b/src/euroeval/dataset_configs/french.py
@@ -173,4 +173,5 @@ RAGTRUTH_FR_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[FRENCH],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/german.py
+++ b/src/euroeval/dataset_configs/german.py
@@ -209,4 +209,5 @@ RAGTRUTH_DE_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[GERMAN],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/greek.py
+++ b/src/euroeval/dataset_configs/greek.py
@@ -111,4 +111,5 @@ RAGTRUTH_EL_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[GREEK],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/hungarian.py
+++ b/src/euroeval/dataset_configs/hungarian.py
@@ -82,4 +82,5 @@ RAGTRUTH_HU_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[HUNGARIAN],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/icelandic.py
+++ b/src/euroeval/dataset_configs/icelandic.py
@@ -226,4 +226,5 @@ RAGTRUTH_IS_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[ICELANDIC],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/italian.py
+++ b/src/euroeval/dataset_configs/italian.py
@@ -181,4 +181,5 @@ RAGTRUTH_IT_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[ITALIAN],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/latvian.py
+++ b/src/euroeval/dataset_configs/latvian.py
@@ -93,4 +93,5 @@ RAGTRUTH_LV_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[LATVIAN],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/lithuanian.py
+++ b/src/euroeval/dataset_configs/lithuanian.py
@@ -90,4 +90,5 @@ RAGTRUTH_LT_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[LITHUANIAN],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/norwegian.py
+++ b/src/euroeval/dataset_configs/norwegian.py
@@ -340,4 +340,5 @@ RAGTRUTH_NO_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[NORWEGIAN],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/polish.py
+++ b/src/euroeval/dataset_configs/polish.py
@@ -112,4 +112,5 @@ RAGTRUTH_PL_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[POLISH],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/portuguese.py
+++ b/src/euroeval/dataset_configs/portuguese.py
@@ -145,4 +145,5 @@ RAGTRUTH_PT_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[PORTUGUESE],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/romanian.py
+++ b/src/euroeval/dataset_configs/romanian.py
@@ -71,4 +71,5 @@ RAGTRUTH_RO_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[ROMANIAN],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/serbian.py
+++ b/src/euroeval/dataset_configs/serbian.py
@@ -82,4 +82,5 @@ RAGTRUTH_SR_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[SERBIAN],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/slovak.py
+++ b/src/euroeval/dataset_configs/slovak.py
@@ -61,4 +61,5 @@ RAGTRUTH_SK_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[SLOVAK],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/slovene.py
+++ b/src/euroeval/dataset_configs/slovene.py
@@ -62,4 +62,5 @@ RAGTRUTH_SL_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[SLOVENE],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/spanish.py
+++ b/src/euroeval/dataset_configs/spanish.py
@@ -189,4 +189,5 @@ RAGTRUTH_ES_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[SPANISH],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/swedish.py
+++ b/src/euroeval/dataset_configs/swedish.py
@@ -233,4 +233,5 @@ RAGTRUTH_SV_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[SWEDISH],
     train_split=None,
+    unofficial=True,
 )

--- a/src/euroeval/dataset_configs/ukrainian.py
+++ b/src/euroeval/dataset_configs/ukrainian.py
@@ -102,4 +102,5 @@ RAGTRUTH_UK_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[UKRAINIAN],
     train_split=None,
+    unofficial=True,
 )


### PR DESCRIPTION
Marks the `RAGTRUTH_*_CONFIG` block as `unofficial=True` in every non-Danish dataset config under `src/euroeval/dataset_configs/` (29 configs across 29 files). The Danish `RAGTRUTH_DA_CONFIG` stays `official` pending its full regeneration. `CHANGELOG.md` gets a new `### Changed` bullet under `[Unreleased]`.

## Key changes
- Adds `unofficial=True,` immediately after `train_split=None,` in the single RAGTRUTH block of each of the 29 non-Danish language config files.
- Danish ragtruth config untouched (stays `official`); the 16 pre-existing `unofficial=True` configs in `danish.py` and elsewhere were not duplicated or moved.
- New CHANGELOG bullet under `[## [Unreleased]`'s `### Changed` subsection (inserted between `### Added` and `### Fixed`).

## Why
The published non-Danish RAGTruth hallucination datasets on Hugging Face are currently test-split-only placeholders awaiting full regeneration. With `unofficial=False`, the queue's default dataset enumeration in `prepare_dataset_configs` (see `src/euroeval/benchmark_config_factory.py`, line 191) tries to load them, hitting `KeyError: 'val'` in `load_raw_data` (because `val_split` defaults to `'val'` but the test versions have no `val` split). This fails every queue-issued benchmark run — see issues #1946 and #1847 (Albanian `ragtruth-sq` is the one full version that does have `val`, so it remains untouched).

After this change, those datasets are excluded both from the CLI's default dataset list and from the queue's `official_dataset_language_pairs` completion check, so queue runs won't fail on them until the full versions are uploaded. The Danish ragtruth config remains `official` so that, once the full Danish dataset is uploaded, it is picked up automatically without further code changes.

The corresponding test-only Hugging Face repositories for the 18 affected languages have been deleted (separate operation) so they don't linger as stale test-split-only snapshots.