### PR TITLE
fix: surface real vLLM errors instead of generic 'did not mention' boilerplate

### DIFF
--- a/src/leaderboards/queue_parsing.py
+++ b/src/leaderboards/queue_parsing.py
@@ -207,6 +207,12 @@ def summarise_evaluation_error(output: str, max_chars: int = 4000) -> str:
         parts.append(traceback)
     for line in reversed(lines):
         if _LOAD_ERROR_RE.search(line):
+            # When a real traceback was already surfaced, the vLLM generic
+            # "could not be loaded, but vLLM did not mention exactly what
+            # happened" excuse line only buries the actual exception, so skip
+            # it rather than appending it on top of the traceback.
+            if traceback and "did not mention exactly what" in line:
+                break
             parts.append(line.strip())
             break
     for line in reversed(lines):

--- a/tests/leaderboards/test_queue_parsing.py
+++ b/tests/leaderboards/test_queue_parsing.py
@@ -73,6 +73,7 @@ class TestSummariseEvaluationError:
         summary = summarise_evaluation_error(output=output)
         assert "configured KV-cache size is too small" in summary
         assert "did not mention exactly what" not in summary
+        assert "could not be loaded, but vLLM did" not in summary
         assert "errored 6 benchmarks" in summary
 
     def test_includes_errored_summary_line(self) -> None:

--- a/tests/leaderboards/test_queue_parsing.py
+++ b/tests/leaderboards/test_queue_parsing.py
@@ -51,6 +51,30 @@ class TestSummariseEvaluationError:
         assert "Traceback (most recent call last):" in summary
         assert "httpx.ReadTimeout: The read operation timed out" in summary
 
+    def test_suppresses_vllm_boilerplate_when_traceback_present(self) -> None:
+        """The vLLM 'did not mention' boilerplate is dropped when a traceback exists."""
+        output = (
+            "Benchmarking model on CoNLL-en...\n"
+            "Traceback (most recent call last):\n"
+            '  File "/euroeval/src/euroeval/benchmark_modules/vllm.py", '
+            "line 1547, in load_model\n"
+            "    model = _create_llm()\n"
+            '  File "/vllm/engine/llm.py", line 102, in LLM.__init__\n'
+            "    self._verify_kv_cache()\n"
+            "ValueError: the configured KV-cache size is too small for "
+            "sliding-window attention, increase gpu_memory_utilization\n"
+            "The model 'CohereLabs/aya-23-35B' could not be loaded, but vLLM did "
+            "not mention exactly what happened. Since you're running in verbose "
+            "mode, you might see a descriptive error above already. \n"
+            "re-running the benchmark with the environment variable `FULL_LOG` "
+            "set to `1` to see the full stack trace.\n"
+            "Completed 4 benchmarks, and errored 6 benchmarks\n"
+        )
+        summary = summarise_evaluation_error(output=output)
+        assert "configured KV-cache size is too small" in summary
+        assert "did not mention exactly what" not in summary
+        assert "errored 6 benchmarks" in summary
+
     def test_includes_errored_summary_line(self) -> None:
         """The euroeval `errored N benchmarks` summary line is included."""
         output = (


### PR DESCRIPTION
`summarise_evaluation_error` now skips the vLLM generic "could not be loaded, but vLLM did not mention exactly what happened" excuse when a real Python traceback is already visible in the captured subprocess output. Adds a regression test.

## Key changes
- `src/leaderboards/queue_parsing.py` — in `summarise_evaluation_error`, `traceback` is computed up front via `_last_traceback(lines=lines)` and appended to `parts` if truthy. In the reverse search that appends the first line matching `_LOAD_ERROR_RE`, the matched line is now SKIPPED (just `break`) when `traceback` is truthy AND the matched line contains the verbatim substring `"did not mention exactly what"`. All other helper logic, constants, de-duplication and `max_chars` truncation are untouched.
- `tests/leaderboards/test_queue_parsing.py` — new `test_suppresses_vllm_boilerplate_when_traceback_present` exercising the suppression: builds an output with a Python traceback ending in a `ValueError` about KV-cache size, then the multi-line vLLM boilerplate, then the `Errored 6 benchmarks` summary line. Asserts the underlying `ValueError` text survives, "did not mention exactly what" disappears, and "errored 6 benchmarks" is present.

## Why
When vLLM swallows the underlying exception and re-raises it as `Exception: WorkerProc initialization failed ... See stack trace for root cause.`, `src/euroeval/benchmark_modules/vllm.py` wraps it in an `InvalidModel` message starting `The model {model_id!r} could not be loaded, but vLLM did not mention exactly what happened. ... FULL_LOG=1 ...`. The actual underlying error (e.g. a `ValueError: To serve at least one request with the model's max seq len (8192) ...` for `CohereLabs/aya-23-35B`, issue #1748) IS present in the captured subprocess output (FULL_LOG=1) and IS extracted by `_last_traceback`, but `summarise_evaluation_error` was appending the vLLM wrapper boilerplate on top, burying the real cause in the GitHub failure comment.

No CHANGELOG entry because the changed files are under `src/leaderboards/` and `tests/leaderboards/`, not the published `euroeval` package.

## Examples

Before (issue #1748 comment shape):

    Traceback (most recent call last):
      ...
    ValueError: To serve at least one request with the model's max seq len (8192), ...
    The model 'CohereLabs/aya-23-35B' could not be loaded, but vLLM did not mention
    exactly what happened. ...
    Errored 6 benchmarks

After: the `ValueError` line and the `Errored 6 benchmarks` line only — the wrapper boilerplate is dropped.