### PR TITLE
fix: drop verbose=False and narrow mistral tokeniser fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,13 +29,11 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Fixed race condition in cache cleanup where `rmtree` would fail with
   `FileNotFoundError` when checkpoint directories were removed concurrently during model
   benchmarking. Now uses `ignore_errors=True` to handle concurrent deletions gracefully.
-- The tokeniser loader no longer passes `verbose=False` to
+- The HF, vLLM and fresh model tokeniser loaders no longer pass `verbose=False` to
   `AutoTokenizer.from_pretrained`, since the `MistralCommonBackend` rejects this
-  argument, which raised an error for non-Mistral models such as
-  `gordicaleksa/SlovenianGPT`. The vLLM mistral tokeniser fallback is now gated on
-  model identity (model ID and/or model config) rather than the error string, which
-  previously matched the `MistralCommonBackend` message for unrelated models. Fixes
-  #1775.
+  argument. The vLLM mistral tokeniser fallback is now gated on model identity (model
+  ID and/or model config) rather than the error string, which previously matched the
+  `MistralCommonBackend` message for unrelated models.
 
 ## [v17.6.0] - 2026-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Fixed race condition in cache cleanup where `rmtree` would fail with
   `FileNotFoundError` when checkpoint directories were removed concurrently during model
   benchmarking. Now uses `ignore_errors=True` to handle concurrent deletions gracefully.
+- The tokeniser loader no longer passes `verbose=False` to
+  `AutoTokenizer.from_pretrained`, since the `MistralCommonBackend` rejects this
+  argument, which raised an error for non-Mistral models such as
+  `gordicaleksa/SlovenianGPT`. The vLLM mistral tokeniser fallback is now gated on
+  model identity (model ID and/or model config) rather than the error string, which
+  previously matched the `MistralCommonBackend` message for unrelated models. Fixes
+  #1775.
 
 ## [v17.6.0] - 2026-06-30
 

--- a/src/euroeval/benchmark_modules/fresh.py
+++ b/src/euroeval/benchmark_modules/fresh.py
@@ -310,7 +310,6 @@ def load_model_and_tokeniser(
             add_prefix_space=prefix,
             cache_dir=model_config.model_cache_dir,
             use_fast=False if model_config.param == "slow-tokenizer" else True,
-            verbose=False,
             trust_remote_code=benchmark_config.trust_remote_code,
         )
     except (JSONDecodeError, OSError) as e:

--- a/src/euroeval/benchmark_modules/hf.py
+++ b/src/euroeval/benchmark_modules/hf.py
@@ -981,7 +981,6 @@ def load_tokeniser(
     """
     loading_kwargs: dict[str, bool | str] = dict(
         use_fast=False if model_config.param == "slow-tokenizer" else True,
-        verbose=False,
         trust_remote_code=trust_remote_code,
         padding_side="right",
         truncation_side="right",

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -1812,9 +1812,15 @@ def _is_mistral_tokeniser_model(
     Returns:
         Whether the model should be loaded with the Mistral common tokeniser.
     """
-    # Base models do not use the mistral-common tokeniser, so we never fall back to it
-    # for them regardless of their model type or architectures.
-    if "base" in model_id.lower():
+    # Base models do not use the mistral-common tokeniser, so we never fall back
+    # to it for them regardless of their model type or architectures. This
+    # includes IDs containing "base" and versioned base models like
+    # mistralai/Mistral-7B-v0.1 which lack a chat template. Instruction-tuned
+    # models are exempt from this check.
+    model_name = model_id.rsplit("/", 1)[-1].lower()
+    if "instruct" not in model_name and (
+        "base" in model_name or re.search(r"-v\d+\.\d+$", model_name)
+    ):
         return False
     if model_id.startswith("mistralai/"):
         return True

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -1725,7 +1725,6 @@ def load_tokeniser(
                 model_id,
                 revision=revision,
                 use_fast=False if model_config.param == "slow-tokenizer" else True,
-                verbose=False,
                 trust_remote_code=trust_remote_code,
                 padding_side="left",
                 truncation_side="left",
@@ -1756,7 +1755,9 @@ def load_tokeniser(
             sleep(5)
             continue
         except (KeyError, ValueError) as e:
-            if "mistral" in str(e).lower():
+            if _is_mistral_tokeniser_model(
+                model_id=model_id, hf_model_config=hf_model_config
+            ):
                 tokeniser = MistralCommonTokenizer.from_pretrained(
                     model_id,
                     padding_side="left",
@@ -1789,6 +1790,38 @@ def load_tokeniser(
         tokeniser.pad_token, tokeniser.pad_token_id = get_pad_token(tokeniser=tokeniser)
 
     return tokeniser
+
+
+def _is_mistral_tokeniser_model(
+    model_id: str, hf_model_config: "PretrainedConfig"
+) -> bool:
+    """Determine whether a model should use the Mistral common tokeniser.
+
+    Used as a fallback when ``AutoTokenizer.from_pretrained`` fails, to decide whether
+    to retry with ``MistralCommonTokenizer``. The decision is based on the model's
+    identity rather than the error message, since the error raised by
+    ``MistralCommonBackend.from_pretrained`` mentions "MistralCommonBackend", which
+    would otherwise match non-Mistral models whose tokeniser loading happens to fail.
+
+    Args:
+        model_id:
+            The model identifier.
+        hf_model_config:
+            The Hugging Face model configuration.
+
+    Returns:
+        Whether the model should be loaded with the Mistral common tokeniser.
+    """
+    # Base models do not use the mistral-common tokeniser, so we never fall back to it
+    # for them regardless of their model type or architectures.
+    if "base" in model_id.lower():
+        return False
+    if model_id.startswith("mistralai/"):
+        return True
+    if getattr(hf_model_config, "model_type", None) == "mistral":
+        return True
+    architectures = getattr(hf_model_config, "architectures", None) or []
+    return any("Mistral" in architecture for architecture in architectures)
 
 
 def clear_vllm() -> None:

--- a/tests/test_benchmark_modules/test_vllm.py
+++ b/tests/test_benchmark_modules/test_vllm.py
@@ -1018,6 +1018,15 @@ class TestIsMistralTokeniserModel:
             model_id="some-user/MyModel", hf_model_config=config
         )
 
+    def test_mistralai_versioned_base_model_returns_false(self) -> None:
+        """A versioned base model like Mistral-7B-v0.1 is not identified as Mistral."""
+        config = MagicMock()
+        config.model_type = "mistral"
+        config.architectures = ["MistralForCausalLM"]
+        assert not _is_mistral_tokeniser_model(
+            model_id="mistralai/Mistral-7B-v0.1", hf_model_config=config
+        )
+
     def test_non_mistral_community_model_returns_false(self) -> None:
         """A non-Mistral community model is not identified as Mistral."""
         config = MagicMock()

--- a/tests/test_benchmark_modules/test_vllm.py
+++ b/tests/test_benchmark_modules/test_vllm.py
@@ -11,6 +11,7 @@ from transformers.models.auto.image_processing_auto import AutoImageProcessor
 
 from euroeval.benchmark_modules.vllm import (
     VLLMModel,
+    _is_mistral_tokeniser_model,
     _safe_batch_decode,
     _skip_image_processor_context,
     compute_token_budget,
@@ -976,3 +977,52 @@ class TestSafeBatchDecode:
         assert result == ["decoded_[1, 2, 3]", "decoded_[4, 5, 6]"]
         mock_tokeniser.decode.assert_any_call([1, 2, 3], skip_special_tokens=False)
         mock_tokeniser.decode.assert_any_call([4, 5, 6], skip_special_tokens=False)
+
+
+class TestIsMistralTokeniserModel:
+    """Tests for the `_is_mistral_tokeniser_model` helper function."""
+
+    def test_mistralai_instruct_model_returns_true(self) -> None:
+        """A mistralai instruction-tuned model is identified as Mistral."""
+        config = MagicMock()
+        config.model_type = "llama"
+        config.architectures = ["LlamaForCausalLM"]
+        assert _is_mistral_tokeniser_model(
+            model_id="mistralai/Mistral-7B-Instruct-v0.3", hf_model_config=config
+        )
+
+    def test_mistralai_base_model_returns_false(self) -> None:
+        """A mistralai base model is not routed to the Mistral common tokeniser."""
+        config = MagicMock()
+        config.model_type = "mistral"
+        config.architectures = ["MistralForCausalLM"]
+        assert not _is_mistral_tokeniser_model(
+            model_id="mistralai/Mistral-7B-Base-2412", hf_model_config=config
+        )
+
+    def test_model_type_mistral_returns_true(self) -> None:
+        """A non-mistralai model with model_type 'mistral' is identified as Mistral."""
+        config = MagicMock()
+        config.model_type = "mistral"
+        config.architectures = None
+        assert _is_mistral_tokeniser_model(
+            model_id="some-user/MyMistralModel", hf_model_config=config
+        )
+
+    def test_mistral_architecture_returns_true(self) -> None:
+        """A model with a Mistral architecture is identified as Mistral."""
+        config = MagicMock()
+        config.model_type = "llama"
+        config.architectures = ["MistralForCausalLM"]
+        assert _is_mistral_tokeniser_model(
+            model_id="some-user/MyModel", hf_model_config=config
+        )
+
+    def test_non_mistral_community_model_returns_false(self) -> None:
+        """A non-Mistral community model is not identified as Mistral."""
+        config = MagicMock()
+        config.model_type = "gpt2"
+        config.architectures = ["GPT2LMHeadModel"]
+        assert not _is_mistral_tokeniser_model(
+            model_id="gordicaleksa/SlovenianGPT", hf_model_config=config
+        )


### PR DESCRIPTION
Removes the `verbose=False` kwarg from both tokeniser loaders and narrows the
Mistral tokeniser fallback to only trigger for actual Mistral models (not any
error mentioning "mistral"). Fixes #1775.

## Key changes

- `src/euroeval/benchmark_modules/hf.py` — removed `verbose=False` from the
  `loading_kwargs` dict in `load_tokeniser`.
- `src/euroeval/benchmark_modules/vllm.py` — removed `verbose=False` from the
  `AutoTokenizer.from_pretrained` call. Replaced the
  `"mistral" in str(e).lower()` error-string match with a new pure helper
  `_is_mistral_tokeniser_model` that checks model identity only.
- `CHANGELOG.md` — added a Fixed entry under `[Unreleased]`.
- `tests/test_benchmark_modules/test_vllm.py` — added
  `TestIsMistralTokeniserModel` with 5 test cases.

## Why

`MistralCommonBackend.from_pretrained` rejects the `verbose` kwarg that
`AutoTokenizer` passes to all backends, causing a `ValueError` for any model
that transformers routes through the Mistral backend (issue #1775). The
`verbose=False` was unnecessary — euroeval has its own logging.

Worse, the fallback `"mistral" in str(e).lower()` check matched the error
message itself (which contains "MistralCommonBackend") even for non-Mistral
models like `gordicaleksa/SlovenianGPT`, triggering the wrong recovery path.