### PR TITLE
fix: surface worker-prefixed vLLM errors in failure summaries

### DIFF
--- a/src/leaderboards/queue_parsing.py
+++ b/src/leaderboards/queue_parsing.py
@@ -50,6 +50,14 @@ _TRACEBACK_START = "Traceback (most recent call last):"
 _EXCEPTION_LINE_RE = re.compile(r"^[\w.]*(Error|Exception|Timeout|Interrupt)\b.*")
 _SUMMARY_LINE_RE = re.compile(r"errored\s+\d+\s+benchmarks?", re.IGNORECASE)
 
+# vLLM's ``WorkerProc`` runs in a subprocess that logs to stderr with a
+# ``(Worker_TP* pid=*)`` prefix. When initialisation fails the main process only
+# re-raises a generic ``WorkerProc initialization failed`` exception, while the
+# real cause is in the worker-prefixed ``ERROR`` lines that precede it.
+_WORKER_PREFIX_RE = re.compile(r"^\(Worker_TP\d+\s+pid=\d+\)")
+_WORKER_ERROR_RE = re.compile(r"^\(Worker_TP\d+\s+pid=\d+\)\s+ERROR\b", re.IGNORECASE)
+_WORKERPROC_FAILED_RE = re.compile(r"WorkerProc initialization failed", re.IGNORECASE)
+
 # Individual lines longer than this are truncated so a single giant JSON/param
 # dump line can't swamp the summary; the informative head is kept.
 _MAX_LINE_CHARS = 600
@@ -168,6 +176,40 @@ def _last_traceback(lines: list[str]) -> str | None:
     return "\n".join(lines[start : end + 1]).strip()
 
 
+def _worker_errors(lines: list[str]) -> str | None:
+    """Return the first worker-prefixed error block in ``lines``, or None.
+
+    vLLM's ``WorkerProc`` logs the real cause of an initialisation failure from
+    the worker subprocess, prefixing every line with ``(Worker_TP* pid=*)``.
+    The main process only re-raises a generic ``WorkerProc initialization
+    failed`` exception, so without this helper the actual error -- buried in
+    worker-prefixed ``ERROR`` lines -- is never surfaced.
+
+    Args:
+        lines:
+            The cleaned, noise-filtered output lines.
+
+    Returns:
+        The first worker ``ERROR`` line together with the consecutive
+        worker-prefixed lines that follow it (typically the worker's
+        traceback), joined with newlines, or None when no worker error is
+        present.
+    """
+    start = None
+    for i, line in enumerate(lines):
+        if _WORKER_ERROR_RE.match(line.strip()):
+            start = i
+            break
+    if start is None:
+        return None
+    end = start
+    for i in range(start + 1, len(lines)):
+        if not _WORKER_PREFIX_RE.match(lines[i].strip()):
+            break
+        end = i
+    return "\n".join(lines[start : end + 1]).strip()
+
+
 def summarise_evaluation_error(output: str, max_chars: int = 4000) -> str:
     """Extract the meaningful error from a euroeval subprocess's output.
 
@@ -201,9 +243,15 @@ def summarise_evaluation_error(output: str, max_chars: int = 4000) -> str:
     if not lines:
         return "(no output captured)"
 
-    parts: list[str] = []
+    worker_block = _worker_errors(lines=lines)
     traceback = _last_traceback(lines=lines)
-    if traceback:
+    parts: list[str] = []
+    # The main process only re-raises a generic "WorkerProc initialization
+    # failed" exception; the real cause is in the worker-prefixed ERROR lines,
+    # so prefer the worker block unless a genuine traceback was captured.
+    if worker_block and (traceback is None or _WORKERPROC_FAILED_RE.search(traceback)):
+        parts.append(worker_block)
+    elif traceback:
         parts.append(traceback)
     for line in reversed(lines):
         if _LOAD_ERROR_RE.search(line):

--- a/tests/leaderboards/test_queue_parsing.py
+++ b/tests/leaderboards/test_queue_parsing.py
@@ -107,3 +107,57 @@ class TestSummariseEvaluationError:
         )
         summary = summarise_evaluation_error(output=output, max_chars=200)
         assert len(summary) <= 200
+
+    def test_extracts_worker_prefixed_errors(self) -> None:
+        """Worker-prefixed vLLM ``ERROR`` lines are surfaced as the summary."""
+        output = (
+            "Loading model 'm'...\n"
+            "(Worker_TP0 pid=123) ERROR 03-14 12:34:56 -- "
+            "RuntimeError: CUDA error: out of memory\n"
+            '(Worker_TP0 pid=123)   File "/vllm/worker.py", line 100, in run\n'
+            "(Worker_TP0 pid=123)     torch.cuda.empty_cache()\n"
+            "Completed 1 benchmarks, and errored 1 benchmarks\n"
+        )
+        summary = summarise_evaluation_error(output=output)
+        assert "CUDA error: out of memory" in summary
+        assert "(Worker_TP0 pid=123)" in summary
+        assert "errored 1 benchmarks" in summary
+
+    def test_worker_errors_preferred_over_generic_workerproc(self) -> None:
+        """The worker block wins over a generic ``WorkerProc`` traceback."""
+        output = (
+            "Starting vLLM engine...\n"
+            "(Worker_TP0 pid=123) ERROR 03-14 12:34:56 -- "
+            "CUDA out of memory. Tried to allocate 2.00 GiB.\n"
+            '(Worker_TP0 pid=123)   File "/vllm/worker/worker.py", '
+            "line 321, in init_worker\n"
+            "(Worker_TP0 pid=123)     torch.cuda.empty_cache()\n"
+            "Traceback (most recent call last):\n"
+            '  File "/vllm/engine/llm.py", line 102, in LLM.__init__\n'
+            "    self._init_workers()\n"
+            '  File "/vllm/worker/worker.py", line 200, in WorkerProc.__init__\n'
+            "    raise RuntimeError('init failed')\n"
+            "Exception: WorkerProc initialization failed. "
+            "See stack trace for root cause.\n"
+            "Completed 1 benchmarks, and errored 1 benchmarks\n"
+        )
+        summary = summarise_evaluation_error(output=output)
+        assert "CUDA out of memory" in summary
+        assert "WorkerProc initialization failed" not in summary
+
+    def test_real_traceback_still_wins(self) -> None:
+        """A genuine non-generic traceback is not clobbered by worker lines."""
+        output = (
+            "Benchmarking model on CoNLL-en...\n"
+            "(Worker_TP0 pid=123) ERROR 03-14 12:34:56 -- "
+            "some worker noise here\n"
+            '(Worker_TP0 pid=123)   File "/vllm/x.py", line 1, in fn\n'
+            "Traceback (most recent call last):\n"
+            '  File "/x/euroeval.py", line 10, in <module>\n'
+            "    sys.exit(benchmark())\n"
+            "ValueError: the configured KV-cache size is too small for "
+            "sliding-window attention\n"
+        )
+        summary = summarise_evaluation_error(output=output)
+        assert "the configured KV-cache size is too small" in summary
+        assert "some worker noise here" not in summary


### PR DESCRIPTION
Improves `summarise_evaluation_error` to extract the real underlying error
from vLLM worker-process log lines, instead of showing only the generic
"WorkerProc initialization failed ... See stack trace for root cause."
message. Fixes #1943, #1749, #1868.

## Key changes

- `src/leaderboards/queue_parsing.py` — added three module-level regexes for
  worker-prefixed log lines, a `_worker_errors` helper that extracts the
  worker's traceback, and updated `summarise_evaluation_error` to prefer the
  worker block when the main-process traceback is the generic WorkerProc
  exception.
- `tests/leaderboards/test_queue_parsing.py` — three new tests covering:
  worker-prefixed error extraction, worker errors preferred over the generic
  WorkerProc traceback, and genuine tracebacks still taking priority.

## Why

When vLLM's `WorkerProc` fails to initialize, the actual error is logged by
the worker subprocess to stderr (prefixed with `(Worker_TP* pid=*) ERROR`),
but the main process wraps it in `Exception: WorkerProc initialization
failed ... See stack trace for root cause.` (with `raise e from None`, which
strips the cause). The real error is in the captured `FULL_LOG` output but
was not extracted by `summarise_evaluation_error`, so the GitHub failure
comment showed only the uninformative generic message.