### PR TITLE
fix: detect signal-death (OOM) in euroeval subprocess

### DIFF
--- a/src/leaderboards/evaluation_common.py
+++ b/src/leaderboards/evaluation_common.py
@@ -197,7 +197,11 @@ def _killed_by_signal_note(returncode: int | None) -> str | None:
     try:
         name = signal.Signals(signum).name
     except ValueError:
-        name = f"signal {signum}"
+        return (
+            f"Process was killed by signal {signum} - likely out of memory."
+            if signum == signal.SIGKILL
+            else f"Process was killed by signal {signum}."
+        )
     if signum == signal.SIGKILL:
         return f"Process was killed by signal {signum} ({name}) - likely out of memory."
     return f"Process was killed by signal {signum} ({name})."

--- a/src/leaderboards/evaluation_common.py
+++ b/src/leaderboards/evaluation_common.py
@@ -22,6 +22,7 @@ import os
 import pty
 import re
 import select
+import signal
 import struct
 import subprocess
 import sys
@@ -167,7 +168,39 @@ def run_euroeval(
         os.close(parent_fd)
     proc.wait()
     output = b"".join(captured).decode("utf-8", errors="replace")
+    note = _killed_by_signal_note(proc.returncode)
+    if note:
+        output += f"\n{note}\n"
     return proc.returncode, output
+
+
+def _killed_by_signal_note(returncode: int | None) -> str | None:
+    """Return a diagnostic note when a subprocess was killed by a signal.
+
+    A negative ``returncode`` (as reported by ``subprocess.Popen``) means the
+    process was terminated by a signal rather than exiting normally. Such
+    deaths leave no Python traceback, so without this note the failure
+    comment falls back to "(no output captured)". Resolving the signal to a
+    name gives the operator a cause; SIGKILL is flagged as a likely
+    out-of-memory kill, the common failure mode for large model evaluations.
+
+    Args:
+        returncode:
+            The ``Popen.returncode`` to interpret.
+
+    Returns:
+        A diagnostic line, or None when ``returncode`` is not a signal death.
+    """
+    if returncode is None or returncode >= 0:
+        return None
+    signum = abs(returncode)
+    try:
+        name = signal.Signals(signum).name
+    except ValueError:
+        name = f"signal {signum}"
+    if signum == signal.SIGKILL:
+        return f"Process was killed by signal {signum} ({name}) - likely out of memory."
+    return f"Process was killed by signal {signum} ({name})."
 
 
 def _set_pty_window_size(fd: int) -> None:

--- a/tests/leaderboards/test_evaluation_common.py
+++ b/tests/leaderboards/test_evaluation_common.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 import pytest
 
 from leaderboards import evaluation_common
+from leaderboards.evaluation_common import _killed_by_signal_note
 
 
 @pytest.mark.parametrize(
@@ -55,3 +56,38 @@ def test_estimated_model_bytes_handles_model_id_extras(
     assert evaluation_common.estimated_model_bytes(model_id=model_id) == 2
     assert calls[0]["repo_id"] == "org/model"
     assert calls[0]["revision"] == "rev"
+
+
+@pytest.mark.parametrize(argnames=["returncode"], argvalues=[(None,), (0,)])
+def test_killed_by_signal_note_returns_none_when_not_signal_death(
+    returncode: int | None,
+) -> None:
+    """A non-negative or absent returncode is not a signal death."""
+    assert _killed_by_signal_note(returncode=returncode) is None
+
+
+def test_killed_by_signal_note_ignores_shell_exit_code_convention() -> None:
+    """``Popen.returncode`` is negative for signal deaths, never 128+N.
+
+    The shell convention (e.g. 130 = 128 + SIGINT) only appears in ``$?``;
+    ``subprocess.Popen.returncode`` reports ``-N`` instead, so a positive 130
+    is an ordinary exit code and must not be misread as a signal death.
+    """
+    assert _killed_by_signal_note(returncode=130) is None
+
+
+@pytest.mark.parametrize(
+    argnames=["returncode", "must_contain"],
+    argvalues=[
+        (-2, ["signal 2", "SIGINT"]),
+        (-9, ["signal 9 (SIGKILL)", "out of memory"]),
+    ],
+)
+def test_killed_by_signal_note_describes_signal_death(
+    returncode: int, must_contain: list[str]
+) -> None:
+    """A negative returncode yields a diagnostic naming the signal."""
+    note = _killed_by_signal_note(returncode=returncode)
+    assert note is not None
+    for needle in must_contain:
+        assert needle in note


### PR DESCRIPTION
Adds signal-death detection to `run_euroeval` so that OOM-killed subprocesses
produce a diagnostic message instead of "(no output captured)". Fixes #1495,
#1662.

## Key changes

- `src/leaderboards/evaluation_common.py` — added `import signal`, a pure
  helper `_killed_by_signal_note(returncode)` that returns a diagnostic line
  for negative returncodes (signal death), and appends it to the captured
  output in `run_euroeval` before returning.
- `tests/leaderboards/test_evaluation_common.py` — parametrised tests for the
  helper covering None, 0, -2 (SIGINT), -9 (SIGKILL), and 130 (shell
  convention, correctly ignored).

## Why

When a model OOMs, the kernel sends SIGKILL (signal 9) to the euroeval
subprocess. `proc.returncode` is negative (e.g. -9) and no Python traceback
is produced. The captured output contains only "Errored N benchmarks" with
no explanation, so the GitHub failure comment is uninformative. This appends
a diagnostic line like "Process was killed by signal 9 (SIGKILL) - likely out
of memory." to the captured output tail, where
`summarise_evaluation_error` will surface it.