### PR TITLE
fix: import load_records_from_jsonl_files from jsonl_io not records

### DIFF
--- a/src/leaderboards/cache.py
+++ b/src/leaderboards/cache.py
@@ -11,7 +11,7 @@ from tqdm.auto import tqdm
 
 from euroeval.string_utils import split_model_id
 
-from .records import load_records_from_jsonl_files
+from .jsonl_io import load_records_from_jsonl_files
 
 logger = logging.getLogger(__name__)
 

--- a/src/leaderboards/result_loading.py
+++ b/src/leaderboards/result_loading.py
@@ -10,7 +10,7 @@ from .backup import backup_results
 from .bucket_sync import sync_bucket
 from .constants import NEW_RESULTS_PATH, RESULTS_DIR
 from .eee_validation import is_eee_record
-from .records import load_records_from_jsonl_files
+from .jsonl_io import load_records_from_jsonl_files
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
`load_records_from_jsonl_files` was moved to `leaderboards.jsonl_io`, but `cache.py` and `result_loading.py` still imported it from `leaderboards.records`, which no longer defines it. This broke `generate_leaderboards.py` (and therefore `collect_evaluation_results.py`) with:

```
ImportError: cannot import name 'load_records_from_jsonl_files' from 'leaderboards.records'
```

## Fix
Point both imports at `leaderboards.jsonl_io`, where the function actually lives.

Discovered while setting up `collect_evaluation_results.py` to run on the inference server — the harvest + bucket sync succeeded, but leaderboard regeneration crashed on this import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)