### PR TITLE
fix: budget queue fit pre-check against vLLM's utilization-capped memory

### DIFF
--- a/src/leaderboards/constants.py
+++ b/src/leaderboards/constants.py
@@ -431,6 +431,15 @@ DTYPE_BYTES: dict[str, int] = {
 # Increased from 1.2 after GLM-4.7-Flash (58 GiB weights) crashed on 64 GiB VM.
 GPU_FIT_OVERHEAD = 1.35
 
+# Default vLLM GPU memory utilization assumed by the fit pre-check when the
+# queue does not override it. Mirrors euroeval's own default (see
+# euroeval.benchmarker, gpu_memory_utilization=0.8). vLLM can only allocate
+# `gpu_memory_utilization * total GPU memory` at runtime, so the pre-check must
+# budget against that fraction -- otherwise a model whose weights fit the card
+# but not the utilization-capped budget passes the gate and then OOMs on the KV
+# cache. Kept in sync with euroeval's default manually.
+DEFAULT_GPU_MEMORY_UTILIZATION = 0.8
+
 # ---------------------------------------------------------------------------
 # Leaderboard generation
 # ---------------------------------------------------------------------------

--- a/src/scripts/process_evaluation_queue.py
+++ b/src/scripts/process_evaluation_queue.py
@@ -45,6 +45,7 @@ from huggingface_hub.errors import HfHubHTTPError
 
 from euroeval import __version__
 from leaderboards.constants import (
+    DEFAULT_GPU_MEMORY_UTILIZATION,
     FAILED_LABEL,
     GATED_LABEL,
     GATED_OUTPUT_RE,
@@ -489,12 +490,27 @@ def process_queue_once() -> None:
     logger.info(f"Found {len(candidates)} processable issue(s).")
 
     gpu_bytes = gpu_total_memory_bytes()
+    # vLLM can only allocate `gpu_memory_utilization * total GPU memory`, so the
+    # fit pre-check must budget against that fraction rather than the whole card;
+    # otherwise a model whose weights fit but whose KV cache does not still slips
+    # through and OOMs at runtime.
+    usable_bytes: int | None = None
     if gpu_bytes is None:
         logger.info(
             "Could not determine local memory budget; skipping the fit pre-check."
         )
     else:
-        logger.info(f"Local memory budget: {gpu_bytes / (1024**3):.1f} GiB.")
+        utilization = (
+            GPU_MEMORY_UTILIZATION
+            if GPU_MEMORY_UTILIZATION is not None
+            else DEFAULT_GPU_MEMORY_UTILIZATION
+        )
+        usable_bytes = int(gpu_bytes * utilization)
+        logger.info(
+            f"Local memory budget: {gpu_bytes / (1024**3):.1f} GiB total, "
+            f"{usable_bytes / (1024**3):.1f} GiB usable at "
+            f"gpu_memory_utilization={utilization}."
+        )
 
     for (
         slow_priority,
@@ -513,15 +529,16 @@ def process_queue_once() -> None:
             f"#{issue['number']}: queueing {model_id!r} ({param_count} params, "
             f"{model_type}, {status}{slow_tag})."
         )
-        if gpu_bytes is not None:
+        if usable_bytes is not None:
             needed = estimated_model_bytes(model_id=model_id)
-            if needed is not None and int(needed * GPU_FIT_OVERHEAD) > gpu_bytes:
+            if needed is not None and int(needed * GPU_FIT_OVERHEAD) > usable_bytes:
                 logger.info(
                     f"#{issue['number']}: skipping -- model {model_id!r} needs "
                     f"~{needed / (1024**3):.1f} GiB of weights "
-                    f"(x {GPU_FIT_OVERHEAD} overhead), which exceeds the local "
-                    f"GPU memory of {gpu_bytes / (1024**3):.1f} GiB. Leaving the "
-                    "issue unassigned so a larger machine can pick it up."
+                    f"(x {GPU_FIT_OVERHEAD} overhead), which exceeds the usable "
+                    f"vLLM budget of {usable_bytes / (1024**3):.1f} GiB. Leaving "
+                    "the issue unassigned so a larger or multi-GPU machine can "
+                    "pick it up."
                 )
                 continue
         try:


### PR DESCRIPTION
## Problem
The evaluation queue's fit pre-check compared `weight_bytes * GPU_FIT_OVERHEAD` against the GPU's (near-total) **free** memory. But vLLM can only allocate `gpu_memory_utilization * total` memory at runtime (default `0.8`). A model whose weights fit the card but whose KV cache doesn't fit *within the utilization cap* passes the gate and then OOMs — and gets marked `evaluation-failed`.

Concrete case: `CohereLabs/aya-23-35B` on a 96 GiB card:
- ~65 GiB weights → `65 * 1.35 = 88 GiB` "required", which is < ~95 GiB free → **passes the old gate**
- at runtime, `util=0.8` → ~77 GiB usable → only **6.89 GiB** left for KV cache, but a single 8192-token request needs **10 GiB** → `ValueError` / OOM

## Fix
Budget the pre-check against `gpu_memory_utilization * memory` (the queue's `--gpu-memory-utilization` override, else euroeval's `0.8` default via the new `DEFAULT_GPU_MEMORY_UTILIZATION` constant). Oversized models now stay **unassigned** for a larger or multi-GPU (tensor-parallel) machine to pick up, instead of OOM-failing.

`run_core_model_evaluations.py` has the same gate pattern (`gpu_total_memory_bytes` + `model_fits_locally`); left unchanged here, can be aligned in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)