### PR TITLE
fix: collapse duplicate leaderboard scores per model+benchmark (#1970)

### DIFF
--- a/src/leaderboards/leaderboard_generation.py
+++ b/src/leaderboards/leaderboard_generation.py
@@ -333,6 +333,11 @@ def generate_dataframe(
     Returns:
         A list of pairs (df, df_simplified), where df is the full leaderboard DataFrame
         and df_simplified is the simplified version.
+
+    Raises:
+        ValueError:
+            If a model has more than two scores for a single dataset, which
+            indicates that duplicate records survived deduplication.
     """
     if model_results == {}:
         logger.error("No model results found, skipping leaderboard generation.")
@@ -462,6 +467,17 @@ def generate_dataframe(
             for dataset in category_to_datasets[category]:
                 if dataset in results:
                     scores = results[dataset]
+                    # A dataset cell holds at most the primary and secondary
+                    # metric (rendered "primary / secondary"), so anything beyond
+                    # two entries means duplicate records survived deduplication —
+                    # fail loudly rather than emit a garbled multi-slash cell.
+                    if len(scores) > 2:
+                        raise ValueError(
+                            f"Model {model_id!r} has {len(scores)} scores for "
+                            f"dataset {dataset!r} (expected at most 2, one per "
+                            f"metric): {[score for _, score, _ in scores]}. This "
+                            "indicates duplicate records survived deduplication."
+                        )
                 else:
                     scores = [(list(), float("nan"), 0)]
                 main_score = scores[0][1]

--- a/src/leaderboards/record_fields.py
+++ b/src/leaderboards/record_fields.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import json
 import re
+import typing as t
 
-from .records import get_bool_field
+from .records import get_bool_field, get_record_hash
 
 
 def get_task(record: dict) -> str | None:
@@ -125,6 +126,33 @@ def get_version(record: dict) -> str | None:
     if version:
         return re.sub(r"\.dev\d+", "", version)
     return None
+
+
+def deduplicate_records(records: list[dict[str, t.Any]]) -> list[dict[str, t.Any]]:
+    """Deduplicate records by hash, keeping the newest EuroEval version per hash.
+
+    Records sharing a :func:`~leaderboards.records.get_record_hash` value render
+    on the same leaderboard row, so only one should survive. Among records with
+    an equal (newest) version, the last one in input order wins. Output is
+    ordered by hash for stable, diff-friendly downstream files.
+
+    Args:
+        records:
+            The records to deduplicate. Every record must carry a dataset (so
+            that hashing succeeds).
+
+    Returns:
+        The deduplicated records, ordered by hash. Note that
+        ``get_record_hash`` raises ``ValueError`` if any record has no dataset.
+    """
+    best: dict[str, tuple[list[int], dict[str, t.Any]]] = {}
+    for record in records:
+        hash_value = get_record_hash(record=record)
+        version = list(map(int, (get_version(record=record) or "0.0.0").split(".")))
+        existing = best.get(hash_value)
+        if existing is None or version >= existing[0]:
+            best[hash_value] = (version, record)
+    return [record for _, (_, record) in sorted(best.items())]
 
 
 def get_few_shot(record: dict) -> bool:

--- a/src/leaderboards/records.py
+++ b/src/leaderboards/records.py
@@ -135,7 +135,13 @@ def get_record_hash(record: dict) -> str:
         ValueError:
             If no dataset is found in the record.
     """
-    model = get_model_name(record)
+    # Strip any anchor tag so a record stored with an already-anchored name
+    # (``<a ...>org/repo</a>``) and one stored with the plain ``org/repo`` name
+    # hash to the same value. This must mirror ``extract_model_ids_from_record``,
+    # which also strips the anchor when building the leaderboard row — otherwise
+    # the two records survive deduplication yet collapse onto a single row,
+    # showing multiple scores for one model+benchmark combination.
+    model = strip_anchor(get_model_name(record))
     dataset = get_dataset(record)
     if dataset is None:
         raise ValueError(f"No dataset found in record: {record}")

--- a/src/leaderboards/records.py
+++ b/src/leaderboards/records.py
@@ -135,24 +135,26 @@ def get_record_hash(record: dict) -> str:
         ValueError:
             If no dataset is found in the record.
     """
-    # Strip any anchor tag so a record stored with an already-anchored name
-    # (``<a ...>org/repo</a>``) and one stored with the plain ``org/repo`` name
-    # hash to the same value. This must mirror ``extract_model_ids_from_record``,
-    # which also strips the anchor when building the leaderboard row — otherwise
-    # the two records survive deduplication yet collapse onto a single row,
-    # showing multiple scores for one model+benchmark combination.
+    # The hash must identify records that render on the same leaderboard row, so
+    # that duplicates collapse during deduplication. A row is identified by
+    # ``extract_model_ids_from_record`` (the stripped model name plus its
+    # zero-shot/val note) and the dataset — nothing else. We therefore hash
+    # exactly those components:
+    #
+    # * strip the anchor tag, so an already-anchored name (``<a ...>org/repo</a>``)
+    #   and the plain ``org/repo`` collapse together;
+    # * include ``validation_split`` and ``few_shot``, which the row note encodes;
+    # * do NOT include ``generative`` — the row label ignores it, so hashing it
+    #   would let two records (e.g. one tagged ``generative: true`` and one
+    #   missing the flag) survive deduplication yet land on the same row, showing
+    #   multiple scores for a single model+benchmark combination.
     model = strip_anchor(get_model_name(record))
     dataset = get_dataset(record)
     if dataset is None:
         raise ValueError(f"No dataset found in record: {record}")
     validation_split = get_bool_field(record, "validation_split", False)
     few_shot = get_bool_field(record, "few_shot", True)
-    additional = record.get("eval_library", {}).get("additional_details", {})
-    generative_val = additional.get("generative", False)
-    if isinstance(generative_val, str):
-        generative_val = generative_val.lower() == "true"
-    generative = int(generative_val)
-    return f"{model}{dataset}{int(validation_split)}{generative * (int(few_shot) + 1)}"
+    return f"{model}{dataset}{int(validation_split)}{int(few_shot)}"
 
 
 def get_bool_field(record: dict, field: str, default: bool) -> bool:

--- a/src/leaderboards/result_processing.py
+++ b/src/leaderboards/result_processing.py
@@ -20,8 +20,8 @@ from .cache import Cache
 from .constants import HF_RESULTS_BUCKET, RESULTS_DIR
 from .eee_validation import dump_jsonl_records
 from .model_metadata import add_missing_entries, fix_metadata, record_is_valid
-from .record_fields import get_version
-from .records import get_model_name, get_record_hash, plain_model_id
+from .record_fields import deduplicate_records
+from .records import get_model_name, plain_model_id
 from .result_loading import load_raw_results
 
 logger = logging.getLogger(__name__)
@@ -58,7 +58,7 @@ def process_results(
     records = load_raw_results()
     num_raw_records = len(records)
 
-    records = _deduplicate_records(records=records)
+    records = deduplicate_records(records=records)
     num_duplicates = num_raw_records - len(records)
     if num_duplicates:
         logger.info(f"Removed {num_duplicates:,} duplicates.")
@@ -102,39 +102,6 @@ def process_results(
     ]
 
     _upload_per_model_files(processed_records=processed_records)
-
-
-def _deduplicate_records(records: list[dict[str, t.Any]]) -> list[dict[str, t.Any]]:
-    """Deduplicate records by hash, keeping the newest EuroEval version per hash.
-
-    Args:
-        records:
-            The raw records.
-
-    Returns:
-        The deduplicated records.
-    """
-    all_hash_values = [get_record_hash(record=dct) for dct in records]
-    unique_hash_values = sorted(set(all_hash_values))
-    new_records = []
-    for unique_hash_value in tqdm(unique_hash_values, desc="Processing records"):
-        matches = [
-            record
-            for record, hash_value in zip(records, all_hash_values)
-            if hash_value == unique_hash_value
-        ]
-        versions = [
-            list(map(int, (get_version(record=match) or "0.0.0").split(".")))
-            for match in matches
-        ]
-        newest_version = max(versions)
-        matches_with_newest_version = [
-            match
-            for match, version in zip(matches, versions)
-            if version == newest_version
-        ]
-        new_records.append(matches_with_newest_version[-1])
-    return new_records
 
 
 def _upload_per_model_files(processed_records: list[dict[str, t.Any]]) -> None:

--- a/src/leaderboards/score_extraction.py
+++ b/src/leaderboards/score_extraction.py
@@ -11,6 +11,7 @@ from euroeval.logging_utils import log_once
 
 from .link_generation import generate_model_url
 from .record_fields import (
+    deduplicate_records,
     get_num_failed_instances,
     get_raw_results,
     get_task,
@@ -43,6 +44,11 @@ def group_results_by_model(
         The results grouped by model ID. The dict structure is
         model_id -> dataset -> list of (raw_scores, total_score, std_err).
     """
+    # Deduplicate up front so each leaderboard row shows one score per metric.
+    # `load_raw_results` is cached and populated before `process_results`
+    # rewrites the per-model files, so the records reaching here can still
+    # contain the pre-dedup duplicates; collapse them by hash regardless.
+    results = deduplicate_records(records=results)
     model_scores: dict[str, dict[str, list[tuple[list[float], float, float]]]] = (
         defaultdict(lambda: defaultdict(list))
     )

--- a/tests/leaderboards/test_record_fields.py
+++ b/tests/leaderboards/test_record_fields.py
@@ -1,0 +1,65 @@
+"""Tests for the `leaderboards.record_fields` module."""
+
+from leaderboards.record_fields import deduplicate_records
+
+
+def _record(
+    name: str = "org/model",
+    dataset: str = "angry-tweets",
+    *,
+    version: str | None = None,
+    generative: bool | None = None,
+) -> dict[str, object]:
+    """Build a minimal EEE-style record.
+
+    Args:
+        name:
+            The model name to store in ``model_info.name``.
+        dataset:
+            The dataset name to store in the record.
+        version:
+            The EuroEval version to store, or None to omit it.
+        generative:
+            Value for the ``generative`` flag, or None to omit it entirely.
+
+    Returns:
+        A minimal EEE-style record.
+    """
+    additional: dict[str, object] = {"dataset": dataset}
+    if generative is not None:
+        additional["generative"] = generative
+    library: dict[str, object] = {"additional_details": additional}
+    if version is not None:
+        library["version"] = version
+    return {"model_info": {"name": name}, "eval_library": library}
+
+
+def test_deduplicate_collapses_generative_flag_variants() -> None:
+    """Records differing only in the ``generative`` flag collapse to one.
+
+    This is the Apertus v1.1 regression (issue #1970): the two records render
+    on the same leaderboard row, so only one must survive deduplication.
+    """
+    records = [_record(generative=True), _record(generative=None)]
+    assert len(deduplicate_records(records=records)) == 1
+
+
+def test_deduplicate_keeps_newest_version() -> None:
+    """Among duplicates, the newest EuroEval version is kept."""
+    old = _record(version="17.5.0", generative=True)
+    new = _record(version="17.6.0", generative=None)
+
+    deduped = deduplicate_records(records=[old, new])
+
+    assert len(deduped) == 1
+    assert deduped[0]["eval_library"]["version"] == "17.6.0"
+
+
+def test_deduplicate_preserves_distinct_datasets() -> None:
+    """Records for genuinely distinct rows are all preserved."""
+    records = [
+        _record(dataset="angry-tweets"),
+        _record(dataset="dansk"),
+        _record(name="org/other", dataset="angry-tweets"),
+    ]
+    assert len(deduplicate_records(records=records)) == 3

--- a/tests/leaderboards/test_records.py
+++ b/tests/leaderboards/test_records.py
@@ -1,0 +1,47 @@
+"""Tests for the `leaderboards.records` module."""
+
+from leaderboards.records import extract_model_ids_from_record, get_record_hash
+
+
+def _record(name: str, dataset: str = "angry-tweets") -> dict:
+    """Build a minimal EEE-style record with the given model name and dataset.
+
+    Args:
+        name:
+            The model name to store in ``model_info.name``.
+        dataset:
+            The dataset name to store in the record.
+
+    Returns:
+        A minimal EEE-style record.
+    """
+    return {
+        "model_info": {"name": name},
+        "eval_library": {"additional_details": {"dataset": dataset}},
+    }
+
+
+def test_anchored_and_plain_names_hash_identically() -> None:
+    """Anchored and plain model names must deduplicate to the same hash.
+
+    Otherwise both records survive deduplication yet collapse onto a single
+    leaderboard row (``extract_model_ids_from_record`` strips the anchor),
+    showing multiple scores for one model+benchmark combination (issue #1970).
+    """
+    anchored = _record(
+        "<a href='https://ollama.com/library/gemma3'>ollama_chat/gemma3</a>"
+    )
+    plain = _record("ollama_chat/gemma3")
+
+    assert get_record_hash(record=anchored) == get_record_hash(record=plain)
+    # The two forms must also collapse to the same leaderboard row identity.
+    assert extract_model_ids_from_record(record=anchored) == (
+        extract_model_ids_from_record(record=plain)
+    )
+
+
+def test_distinct_datasets_hash_differently() -> None:
+    """Records for different datasets must not deduplicate together."""
+    assert get_record_hash(
+        record=_record("org/model", dataset="angry-tweets")
+    ) != get_record_hash(record=_record("org/model", dataset="dansk"))

--- a/tests/leaderboards/test_records.py
+++ b/tests/leaderboards/test_records.py
@@ -3,21 +3,41 @@
 from leaderboards.records import extract_model_ids_from_record, get_record_hash
 
 
-def _record(name: str, dataset: str = "angry-tweets") -> dict[str, object]:
-    """Build a minimal EEE-style record with the given model name and dataset.
+def _record(
+    name: str,
+    dataset: str = "angry-tweets",
+    *,
+    generative: bool | None = None,
+    few_shot: bool = True,
+    validation_split: bool = False,
+) -> dict[str, object]:
+    """Build a minimal EEE-style record.
 
     Args:
         name:
             The model name to store in ``model_info.name``.
         dataset:
             The dataset name to store in the record.
+        generative:
+            Value for the ``generative`` flag, or None to omit it entirely.
+        few_shot:
+            Value for the ``few_shot`` flag.
+        validation_split:
+            Value for the ``validation_split`` flag.
 
     Returns:
         A minimal EEE-style record.
     """
+    additional: dict[str, object] = {
+        "dataset": dataset,
+        "few_shot": few_shot,
+        "validation_split": validation_split,
+    }
+    if generative is not None:
+        additional["generative"] = generative
     return {
         "model_info": {"name": name},
-        "eval_library": {"additional_details": {"dataset": dataset}},
+        "eval_library": {"additional_details": additional},
     }
 
 
@@ -45,3 +65,38 @@ def test_distinct_datasets_hash_differently() -> None:
     assert get_record_hash(
         record=_record(name="org/model", dataset="angry-tweets")
     ) != get_record_hash(record=_record(name="org/model", dataset="dansk"))
+
+
+def test_generative_flag_does_not_split_hash() -> None:
+    """A differing (or missing) ``generative`` flag must not defeat dedup.
+
+    Two records for the same model+dataset+split that differ only in the
+    ``generative`` flag render on the same leaderboard row, so they must hash
+    identically — otherwise both survive deduplication and the row shows the
+    metric twice (issue #1970, Apertus v1.1).
+    """
+    with_flag = _record(name="org/model", generative=True)
+    without_flag = _record(name="org/model", generative=None)
+
+    assert get_record_hash(record=with_flag) == get_record_hash(record=without_flag)
+    assert extract_model_ids_from_record(record=with_flag) == (
+        extract_model_ids_from_record(record=without_flag)
+    )
+
+
+def test_few_shot_and_validation_split_change_hash() -> None:
+    """Zero-shot and validation-split variants must remain distinct.
+
+    These map to distinct leaderboard rows (``(zero-shot)`` / ``(val)`` notes),
+    so their hashes must differ to avoid collapsing genuinely separate rows.
+    """
+    base = _record(name="org/model", few_shot=True, validation_split=False)
+    zero_shot = _record(name="org/model", few_shot=False, validation_split=False)
+    val = _record(name="org/model", few_shot=True, validation_split=True)
+
+    hashes = {
+        get_record_hash(record=base),
+        get_record_hash(record=zero_shot),
+        get_record_hash(record=val),
+    }
+    assert len(hashes) == 3

--- a/tests/leaderboards/test_records.py
+++ b/tests/leaderboards/test_records.py
@@ -3,7 +3,7 @@
 from leaderboards.records import extract_model_ids_from_record, get_record_hash
 
 
-def _record(name: str, dataset: str = "angry-tweets") -> dict:
+def _record(name: str, dataset: str = "angry-tweets") -> dict[str, object]:
     """Build a minimal EEE-style record with the given model name and dataset.
 
     Args:
@@ -29,9 +29,9 @@ def test_anchored_and_plain_names_hash_identically() -> None:
     showing multiple scores for one model+benchmark combination (issue #1970).
     """
     anchored = _record(
-        "<a href='https://ollama.com/library/gemma3'>ollama_chat/gemma3</a>"
+        name="<a href='https://ollama.com/library/gemma3'>ollama_chat/gemma3</a>"
     )
-    plain = _record("ollama_chat/gemma3")
+    plain = _record(name="ollama_chat/gemma3")
 
     assert get_record_hash(record=anchored) == get_record_hash(record=plain)
     # The two forms must also collapse to the same leaderboard row identity.
@@ -43,5 +43,5 @@ def test_anchored_and_plain_names_hash_identically() -> None:
 def test_distinct_datasets_hash_differently() -> None:
     """Records for different datasets must not deduplicate together."""
     assert get_record_hash(
-        record=_record("org/model", dataset="angry-tweets")
-    ) != get_record_hash(record=_record("org/model", dataset="dansk"))
+        record=_record(name="org/model", dataset="angry-tweets")
+    ) != get_record_hash(record=_record(name="org/model", dataset="dansk"))


### PR DESCRIPTION
## Problem

Issue #1970: single model+benchmark combinations show many scores on the leaderboard. Concretely, the Apertus v1.1 rows rendered a metric **repeated**, e.g. in `finnish_all_models.csv`:

```
83.79 ± 0.01 / 91.17 ± 0.01 / 83.79 ± 0.01 / 91.17 ± 0.01
```

That's the primary/secondary pair (`83.79`/`91.17`) duplicated — two records contributing the same two metrics. One or two values per cell is expected (primary, optional secondary); more means duplicate records.

## Root cause

`get_record_hash` (used to deduplicate records) hashed more than what identifies a leaderboard *row*:

- It hashed the **raw model name**, which is stored anchored (`<a ...>org/repo</a>`) for some records and plain for others.
- It hashed the **`generative` flag**, which the row label (`extract_model_ids_from_record`) never uses.

So two records that render on the same row — e.g. one tagged `generative: true` and one missing the flag — got **different hashes**, survived deduplication, and both landed on the same row.

There was also a **caching gotcha**: `load_raw_results` is `@cache`d and is populated by `process_results` *before* it rewrites the per-model files, so `generate_leaderboard` re-used the pre-dedup records within the same run. The dedup done by `process_results` only helped the *next* run.

## Fix

- **Align the hash with the row identity** — `get_record_hash` now strips the anchor, always includes `few_shot`, and drops `generative`. Records that render on the same row hash identically.
- **Deduplicate at the point of consumption** — `group_results_by_model` deduplicates by hash too, so the fix takes effect immediately regardless of the `load_raw_results` cache timing.
- **Guard against regressions** — `generate_dataframe` raises a `ValueError` if any dataset cell would contain more than the primary/secondary pair (more than one slash).
- **Shared helper** — extracted an O(n) `deduplicate_records` helper reused by both `process_results` and `score_extraction`, replacing the previous O(n²) implementation.

## Tests

`tests/leaderboards/test_records.py` and `tests/leaderboards/test_record_fields.py` cover: anchored/plain collapse, generative-flag collapse, newest-version retention, and that genuinely distinct rows (zero-shot / val / different dataset) stay separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)