### PR TITLE
fix: stop flagging every model as updated when one is added

### DIFF
--- a/src/leaderboards/leaderboard_generation.py
+++ b/src/leaderboards/leaderboard_generation.py
@@ -112,12 +112,26 @@ def generate_leaderboard(
 
         # Check if anything got updated
         new_records: list[str] = []
-        # Exclude rank column (ordinal position) and metadata columns (version,
-        # failures, scored) which change even when model performance doesn't.
+        # Exclude columns that change even when a model's own performance does
+        # not, so that adding one new model doesn't flag nearly every existing
+        # model as "updated":
+        #   * the ordinal "Rank" column (a position relative to the pool);
+        #   * the "Rank score" column and the per-language rank columns
+        #     (bootstrap scores computed over the whole pool, so they shift for
+        #     everyone when the set of models changes);
+        #   * the per-dataset "_version"/"_failures"/"_scored" companion columns.
+        # The remaining columns are the per-dataset scores, which only change
+        # when the model itself is re-evaluated — and additions/removals are
+        # still caught by the membership check below, so the CSV is always
+        # rewritten when it genuinely needs to be.
+        rank_score_columns = {"Rank score"}
+        if len(configs) > 1:
+            rank_score_columns |= {language.title() for language in configs}
         comparison_columns = [
             col
             for col in df.columns
             if col.lower() != "rank"
+            and col not in rank_score_columns
             and not col.endswith(("_version", "_failures", "_scored"))
         ]
         if leaderboard_path.exists():


### PR DESCRIPTION
## Problem

Regenerating the leaderboards after adding just a handful of new models logs an enormous number of "updated" models per language, e.g.:

> Updated the following 227 models in the 'generative' category of the Albanian leaderboard: (...)

— and similarly for every other language.

## Root cause

The change-detection in `generate_leaderboard` compares each model's columns against the previously written CSV to decide which models changed. It already excludes the ordinal `Rank` and the per-dataset `_version`/`_failures`/`_scored` companion columns (which change without a model's own performance changing) — but it still compared the **`Rank score`** column and the **per-language rank columns** (`Danish`, `Norwegian`, …).

Those are bootstrap scores computed over the *whole model pool*. Adding a single new model shifts them for nearly every existing model, so nearly every model gets flagged as "updated".

## Fix

Exclude the rank-score columns (overall `Rank score` and any per-language rank columns) from the comparison, for the same reason the ordinal rank is already excluded. Per-dataset scores still drive detection, and model additions/removals are still caught by the membership check — so the CSV is always rewritten when it genuinely needs to be; only the *reporting* of which models changed becomes accurate.

## Verification

Simulated a pool-wide rank-score shift plus one genuinely new model against the real `mainland_scandinavian_all_models.csv` (750 models):

| logic | models flagged |
|-------|----------------|
| before | 552 |
| after | 1 (the new model) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)