### PR TITLE
feat: leaderboard-dataset-swap script (eval + config/doc swap + PR)

### DIFF
--- a/src/scripts/run_core_model_evaluations.py
+++ b/src/scripts/run_core_model_evaluations.py
@@ -56,7 +56,11 @@ from euroeval.constants import ORTHOGONAL_TASKS
 from euroeval.data_models import DatasetConfig
 from euroeval.dataset_configs import get_all_dataset_configs
 from euroeval.languages import get_all_languages
-from leaderboards.constants import NEW_RESULTS_PATH, RESULTS_DIR
+from leaderboards.constants import (
+    DEFAULT_GPU_MEMORY_UTILIZATION,
+    NEW_RESULTS_PATH,
+    RESULTS_DIR,
+)
 from leaderboards.core_models import CoreModel
 from leaderboards.evaluation_common import (
     gpu_total_memory_bytes,
@@ -117,6 +121,14 @@ logger = logging.getLogger("run_core_model_evaluations")
     "Skips the interactive prompt. Requires --include-api.",
 )
 @click.option(
+    "--gpu-memory-utilization",
+    "gpu_memory_utilization",
+    type=float,
+    default=None,
+    help="vLLM GPU memory utilization fraction (0.0-1.0) the fit pre-check should "
+    f"budget against. When omitted, defaults to {DEFAULT_GPU_MEMORY_UTILIZATION}.",
+)
+@click.option(
     "--dry-run",
     is_flag=True,
     default=False,
@@ -136,6 +148,7 @@ def main(
     languages: tuple[str, ...],
     include_api: bool,
     api_providers: str | None,
+    gpu_memory_utilization: float | None,
     dry_run: bool,
     force: bool,
 ) -> None:
@@ -157,6 +170,9 @@ def main(
             Whether to consider ``api: true`` entries at all.
         api_providers:
             Optional comma-separated provider filter; bypasses the prompt.
+        gpu_memory_utilization:
+            vLLM GPU memory utilization fraction the fit pre-check budgets
+            against, or None to use the default.
         dry_run:
             When True, print the planned jobs and return without running.
         force:
@@ -243,7 +259,7 @@ def main(
         )
     logger.info(f"Planned {len(jobs)} job(s) before size check.")
 
-    jobs = apply_size_filter(jobs=jobs)
+    jobs = apply_size_filter(jobs=jobs, gpu_memory_utilization=gpu_memory_utilization)
     logger.info(f"{len(jobs)} job(s) survive the size check.")
 
     if dry_run:
@@ -254,7 +270,7 @@ def main(
             )
         return
 
-    execute_jobs(jobs=jobs)
+    execute_jobs(jobs=jobs, gpu_memory_utilization=gpu_memory_utilization)
 
 
 @dataclass(frozen=True)
@@ -675,8 +691,16 @@ def ranked_model_language_pairs(
     return ranked
 
 
-def apply_size_filter(jobs: list[Job]) -> list[Job]:
+def apply_size_filter(
+    jobs: list[Job], gpu_memory_utilization: float | None
+) -> list[Job]:
     """Drop open-weight jobs whose model can't fit on the local GPU.
+
+    Mirrors the queue script's fit pre-check: vLLM can only allocate
+    ``gpu_memory_utilization * total GPU memory``, so the budget is that
+    fraction of the card rather than the whole card -- otherwise a model
+    whose weights fit but whose KV cache does not still slips through and
+    OOMs at runtime.
 
     API jobs are passed through untouched (we cannot size-check them).
     Open-weight models whose safetensors footprint cannot be measured
@@ -685,6 +709,9 @@ def apply_size_filter(jobs: list[Job]) -> list[Job]:
     Args:
         jobs:
             The full job list before the size check.
+        gpu_memory_utilization:
+            The vLLM GPU memory utilization fraction the eval will run at,
+            or None to use :data:`DEFAULT_GPU_MEMORY_UTILIZATION`.
 
     Returns:
         The jobs that should still be scheduled.
@@ -693,7 +720,17 @@ def apply_size_filter(jobs: list[Job]) -> list[Job]:
     if gpu_bytes is None:
         logger.info("Local memory budget unknown; skipping size pre-check.")
         return jobs
-    logger.info(f"Local memory budget: {gpu_bytes / (1024**3):.1f} GiB.")
+    utilization = (
+        gpu_memory_utilization
+        if gpu_memory_utilization is not None
+        else DEFAULT_GPU_MEMORY_UTILIZATION
+    )
+    usable_bytes = int(gpu_bytes * utilization)
+    logger.info(
+        f"Local memory budget: {gpu_bytes / (1024**3):.1f} GiB total, "
+        f"{usable_bytes / (1024**3):.1f} GiB usable at "
+        f"gpu_memory_utilization={utilization}."
+    )
 
     sized_cache: dict[str, bool] = {}
     kept: list[Job] = []
@@ -703,21 +740,21 @@ def apply_size_filter(jobs: list[Job]) -> list[Job]:
             continue
         if job.model_id not in sized_cache:
             fits, needed = model_fits_locally(
-                model_id=job.model_id, gpu_bytes=gpu_bytes
+                model_id=job.model_id, gpu_bytes=usable_bytes
             )
             sized_cache[job.model_id] = fits
             if not fits and needed is not None:
                 logger.info(
                     f"{job.model_id}: skipping -- needs "
-                    f"~{needed / (1024**3):.1f} GiB of weights, exceeds local "
-                    f"budget of {gpu_bytes / (1024**3):.1f} GiB."
+                    f"~{needed / (1024**3):.1f} GiB of weights, exceeds the usable "
+                    f"vLLM budget of {usable_bytes / (1024**3):.1f} GiB."
                 )
         if sized_cache[job.model_id]:
             kept.append(job)
     return kept
 
 
-def execute_jobs(jobs: list[Job]) -> None:
+def execute_jobs(jobs: list[Job], gpu_memory_utilization: float | None) -> None:
     """Run each job in sequence via the shared euroeval runner.
 
     API jobs are run on the validation split with zero-shot prompting;
@@ -726,6 +763,10 @@ def execute_jobs(jobs: list[Job]) -> None:
     Args:
         jobs:
             The jobs to execute.
+        gpu_memory_utilization:
+            vLLM GPU memory utilization fraction to pass to euroeval, or
+            None to let the CLI default apply. Passing the same value the
+            fit pre-check budgeted against keeps the two consistent.
     """
     for index, job in enumerate(jobs, start=1):
         logger.info(
@@ -739,6 +780,7 @@ def execute_jobs(jobs: list[Job]) -> None:
             datasets=[job.dataset],
             evaluate_test_split=not job.is_api,
             zero_shot=job.is_api,
+            gpu_memory_utilization=gpu_memory_utilization,
         )
         if returncode != 0:
             logger.warning(

--- a/src/scripts/run_core_model_evaluations.py
+++ b/src/scripts/run_core_model_evaluations.py
@@ -1,15 +1,20 @@
 """Run EuroEval for the core model list.
 
-Two related workflows live in this script:
+Three related workflows live in this script:
 
 1. **Dataset-replacement mode** (``--dataset <id>`` [repeatable]) -- re-run
    every core model whose language coverage overlaps a dataset's languages
    on that dataset.
 2. **Backfill mode** (default) -- for every core model, run every official
    ``(dataset, language)`` pair that the model has no result line for yet.
+3. **Leaderboard re-eval mode** (``--reeval-old <ds> --reeval-new <ds>``) --
+   after an official dataset is swapped for another on a language's
+   leaderboard, re-run the *new* dataset for every model that currently
+   holds a full rank score on that leaderboard (i.e. held every required
+   dataset under the pre-swap config). Unlike the other two modes the model
+   set is drawn from the recorded results, not from ``core_models.yaml``.
 
-Both modes share model selection, size-check, results lookup, and the API-
-provider prompt.
+All modes share the size-check, results lookup, and the API-provider prompt.
 
 Invoke as::
 
@@ -40,12 +45,15 @@ import logging
 import os
 import re
 import sys
+from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 
 import click
 from update_core_models import refresh_core_models
 
+from euroeval.constants import ORTHOGONAL_TASKS
+from euroeval.data_models import DatasetConfig
 from euroeval.dataset_configs import get_all_dataset_configs
 from euroeval.languages import get_all_languages
 from leaderboards.constants import NEW_RESULTS_PATH, RESULTS_DIR
@@ -56,6 +64,7 @@ from leaderboards.evaluation_common import (
     official_dataset_language_pairs,
     run_euroeval,
 )
+from leaderboards.task_metadata import official_datasets_for_language
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s"
@@ -71,6 +80,28 @@ logger = logging.getLogger("run_core_model_evaluations")
     help="Dataset id to run in dataset-replacement mode. Repeatable. When omitted, "
     "the script runs in backfill mode against every official (dataset, language) "
     "pair.",
+)
+@click.option(
+    "--reeval-old",
+    "reeval_old",
+    default=None,
+    help="Leaderboard re-eval mode: the outgoing dataset id whose ranked models "
+    "should be re-run. Requires --reeval-new.",
+)
+@click.option(
+    "--reeval-new",
+    "reeval_new",
+    default=None,
+    help="Leaderboard re-eval mode: the incoming dataset id to run for every model "
+    "that was ranked under the pre-swap config. Requires --reeval-old.",
+)
+@click.option(
+    "--language",
+    "languages",
+    multiple=True,
+    help="Leaderboard re-eval mode: restrict re-evaluation to these language codes. "
+    "When omitted, defaults to the languages covered by both the old and new "
+    "datasets.",
 )
 @click.option(
     "--include-api",
@@ -100,6 +131,9 @@ logger = logging.getLogger("run_core_model_evaluations")
 )
 def main(
     datasets: tuple[str, ...],
+    reeval_old: str | None,
+    reeval_new: str | None,
+    languages: tuple[str, ...],
     include_api: bool,
     api_providers: str | None,
     dry_run: bool,
@@ -112,6 +146,13 @@ def main(
             Dataset ids passed via ``--dataset``. When non-empty, the
             script runs in dataset-replacement mode against exactly those
             datasets; otherwise it runs in backfill mode.
+        reeval_old:
+            Outgoing dataset id for leaderboard re-eval mode, or None.
+        reeval_new:
+            Incoming dataset id for leaderboard re-eval mode, or None.
+        languages:
+            Language codes to restrict re-eval to; empty means "infer from
+            the old and new datasets". Only used in re-eval mode.
         include_api:
             Whether to consider ``api: true`` entries at all.
         api_providers:
@@ -124,45 +165,82 @@ def main(
     Raises:
         click.ClickException:
             When ``--api-providers`` is passed without ``--include-api``,
-            when an unknown provider name is supplied, or when a selected
-            provider's env var is missing.
+            when an unknown provider name is supplied, when a selected
+            provider's env var is missing, or when the re-eval flags are
+            combined incorrectly.
     """
     if api_providers and not include_api:
         raise click.ClickException(
             "--api-providers requires --include-api; pass both or neither."
         )
+    if bool(reeval_old) != bool(reeval_new):
+        raise click.ClickException(
+            "--reeval-old and --reeval-new must be passed together."
+        )
+    reeval = bool(reeval_old and reeval_new)
+    if reeval and datasets:
+        raise click.ClickException(
+            "--reeval-old/--reeval-new cannot be combined with --dataset."
+        )
+    if languages and not reeval:
+        raise click.ClickException(
+            "--language is only valid in leaderboard re-eval mode "
+            "(--reeval-old/--reeval-new)."
+        )
 
     target_datasets = list(datasets) or None
-    mode = "dataset-replacement" if target_datasets else "backfill"
-    logger.info(f"Mode: {mode}.")
-    if target_datasets:
-        logger.info(f"Target dataset(s): {', '.join(target_datasets)}.")
-
-    models = refresh_core_models()
-    logger.info(f"Refreshed core-model list: {len(models)} entries.")
-
-    selected_providers = select_api_providers(
-        candidate_models=models,
-        include_api=include_api,
-        api_providers_arg=api_providers,
+    mode = (
+        "leaderboard-reeval"
+        if reeval
+        else "dataset-replacement"
+        if target_datasets
+        else "backfill"
     )
+    logger.info(f"Mode: {mode}.")
+
+    if reeval:
+        validate_reeval_datasets(old_dataset=reeval_old, new_dataset=reeval_new)
 
     observations: set[tuple[str, str, str]] = set()
-    if not force:
-        try:
-            observations = load_existing_observations()
-        except FileNotFoundError as e:
-            logger.warning(
-                f"Could not load existing results ({e}); proceeding as if none exist."
-            )
+    try:
+        observations = load_existing_observations()
+    except FileNotFoundError as e:
+        if reeval:
+            raise click.ClickException(
+                f"Leaderboard re-eval needs the recorded results to find ranked "
+                f"models, but none could be loaded: {e}"
+            ) from e
+        logger.warning(
+            f"Could not load existing results ({e}); proceeding as if none exist."
+        )
 
-    jobs = build_jobs(
-        models=models,
-        target_datasets=target_datasets,
-        selected_providers=selected_providers,
-        observations=observations,
-        force=force,
-    )
+    if reeval:
+        jobs = plan_reeval_jobs(
+            old_dataset=reeval_old,
+            new_dataset=reeval_new,
+            requested_languages=languages,
+            observations=observations,
+            include_api=include_api,
+            api_providers_arg=api_providers,
+            force=force,
+        )
+    else:
+        if target_datasets:
+            logger.info(f"Target dataset(s): {', '.join(target_datasets)}.")
+        models = refresh_core_models()
+        logger.info(f"Refreshed core-model list: {len(models)} entries.")
+        selected_providers = select_api_providers(
+            has_any_api=any(m.api for m in models),
+            include_api=include_api,
+            api_providers_arg=api_providers,
+        )
+        jobs = build_jobs(
+            models=models,
+            target_datasets=target_datasets,
+            selected_providers=selected_providers,
+            observations=observations if not force else set(),
+            force=force,
+        )
     logger.info(f"Planned {len(jobs)} job(s) before size check.")
 
     jobs = apply_size_filter(jobs=jobs)
@@ -199,16 +277,14 @@ class _Provider:
 
 
 def select_api_providers(
-    candidate_models: c.Iterable[CoreModel],
-    include_api: bool,
-    api_providers_arg: str | None,
+    has_any_api: bool, include_api: bool, api_providers_arg: str | None
 ) -> set[str]:
     """Resolve which API providers to run and verify their env vars.
 
     Args:
-        candidate_models:
-            The full set of models in scope, used to check whether any API
-            models are present at all.
+        has_any_api:
+            Whether any API model is present in the candidate set; when
+            False the ``--include-api`` opt-in is a no-op.
         include_api:
             Whether the user opted in to API evaluation. When False, no
             providers are selected regardless of ``api_providers_arg``.
@@ -226,7 +302,6 @@ def select_api_providers(
     if not include_api:
         return set()
 
-    has_any_api = any(m.api for m in candidate_models)
     if not has_any_api:
         logger.info("No API models in the candidate set; ignoring --include-api.")
         return set()
@@ -428,6 +503,178 @@ def build_jobs(
     return jobs
 
 
+def plan_reeval_jobs(
+    old_dataset: str,
+    new_dataset: str,
+    requested_languages: tuple[str, ...],
+    observations: set[tuple[str, str, str]],
+    include_api: bool,
+    api_providers_arg: str | None,
+    force: bool,
+) -> list[Job]:
+    """Plan the jobs for leaderboard re-eval mode.
+
+    Selects the language(s) whose leaderboard is affected by the swap,
+    finds every model that held a full rank score under the pre-swap
+    config, and schedules the new dataset for each such model in the
+    languages it was ranked in.
+
+    Args:
+        old_dataset:
+            The outgoing dataset id being replaced.
+        new_dataset:
+            The incoming dataset id to run.
+        requested_languages:
+            Language codes to restrict to; empty means the codes covered by
+            both the old and new datasets.
+        observations:
+            Recorded ``(model, dataset, language)`` triples.
+        include_api:
+            Whether the user opted in to running API models.
+        api_providers_arg:
+            Optional comma-separated provider filter.
+        force:
+            When True, re-run even models that already have a new-dataset
+            result line.
+
+    Returns:
+        The re-eval jobs to schedule.
+
+    Raises:
+        click.ClickException:
+            When the target languages can't be resolved, or a selected API
+            provider's env var is missing.
+    """
+    old_codes = dataset_language_codes(dataset_id=old_dataset)
+    new_codes = dataset_language_codes(dataset_id=new_dataset)
+    if requested_languages:
+        target_codes = set(requested_languages)
+    else:
+        target_codes = old_codes & new_codes
+    if not target_codes:
+        raise click.ClickException(
+            "No target languages: the old and new datasets share no languages. "
+            "Pass --language to specify the affected leaderboard(s) explicitly."
+        )
+    logger.info(
+        f"Re-eval: {old_dataset!r} -> {new_dataset!r} on language(s): "
+        f"{', '.join(sorted(target_codes))}."
+    )
+
+    ranked_pairs = ranked_model_language_pairs(
+        old_dataset=old_dataset,
+        new_dataset=new_dataset,
+        language_codes=target_codes,
+        observations=observations,
+    )
+    logger.info(f"Found {len(ranked_pairs)} ranked (model, language) pair(s).")
+
+    has_any_api = any(
+        provider_for_model_id(model_id=model_id) is not None
+        for model_id, _ in ranked_pairs
+    )
+    selected_providers = select_api_providers(
+        has_any_api=has_any_api,
+        include_api=include_api,
+        api_providers_arg=api_providers_arg,
+    )
+
+    jobs: list[Job] = []
+    for model_id, code in sorted(ranked_pairs):
+        if code not in new_codes:
+            logger.info(
+                f"{model_id}: skipping {code} -- new dataset {new_dataset!r} does "
+                f"not cover it."
+            )
+            continue
+        provider = provider_for_model_id(model_id=model_id)
+        is_api = provider is not None
+        if is_api and provider.name not in selected_providers:
+            continue
+        if not force and (model_id, new_dataset, code) in observations:
+            continue
+        jobs.append(
+            Job(
+                model_id=model_id, dataset=new_dataset, languages=(code,), is_api=is_api
+            )
+        )
+    return jobs
+
+
+def ranked_model_language_pairs(
+    old_dataset: str,
+    new_dataset: str,
+    language_codes: set[str],
+    observations: set[tuple[str, str, str]],
+) -> set[tuple[str, str]]:
+    """Return ``(model_id, language_code)`` pairs ranked under the pre-swap config.
+
+    A model is "ranked" in a language when it holds a result for every
+    required (non-orthogonal) dataset of that language's single-language
+    leaderboard -- the same eligibility rule the leaderboard generator uses
+    to award a rank score. The swap has already been applied to the configs
+    (validated by :func:`validate_reeval_datasets`), so the pre-swap required
+    set is reconstructed from the *current* official datasets by removing the
+    now-official incoming dataset and adding the now-unofficial outgoing one
+    back.
+
+    Args:
+        old_dataset:
+            The outgoing dataset id (added back into the required set).
+        new_dataset:
+            The incoming dataset id (removed from the required set).
+        language_codes:
+            The language codes whose leaderboards are being re-evaluated.
+        observations:
+            Recorded ``(model, dataset, language)`` triples.
+
+    Returns:
+        The ``(model_id, language_code)`` pairs that were ranked pre-swap.
+    """
+    languages = get_all_languages()
+
+    # Index observed datasets by (model, language) for O(1) subset checks.
+    datasets_by_model_language: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for model_id, dataset, code in observations:
+        datasets_by_model_language[(model_id, code)].add(dataset)
+
+    ranked: set[tuple[str, str]] = set()
+    for code in sorted(language_codes):
+        language = languages.get(code)
+        if language is None:
+            logger.warning(f"Unknown language code {code!r}; skipping.")
+            continue
+        name = language.name.lower()
+        if " " in name:
+            logger.warning(
+                f"{code!r} ({name!r}) is a dialect/multi-word language with no "
+                f"standalone leaderboard; skipping."
+            )
+            continue
+        try:
+            by_task = official_datasets_for_language(name)
+        except ValueError:
+            logger.warning(f"No leaderboard datasets for {name!r}; skipping.")
+            continue
+
+        required = {
+            dataset
+            for task, task_datasets in by_task.items()
+            if task not in ORTHOGONAL_TASKS
+            for dataset in task_datasets
+        }
+        required.discard(new_dataset)
+        required.add(old_dataset)
+        if not required:
+            logger.warning(f"No required datasets for {name!r}; skipping.")
+            continue
+
+        for (model_id, obs_code), datasets in datasets_by_model_language.items():
+            if obs_code == code and required <= datasets:
+                ranked.add((model_id, code))
+    return ranked
+
+
 def apply_size_filter(jobs: list[Job]) -> list[Job]:
     """Drop open-weight jobs whose model can't fit on the local GPU.
 
@@ -529,6 +776,27 @@ def codes_for_model(model: CoreModel) -> set[str]:
     return codes
 
 
+def dataset_config(dataset_id: str) -> DatasetConfig | None:
+    """Return the :class:`DatasetConfig` for a dataset id, or None if unknown.
+
+    Args:
+        dataset_id:
+            The dataset id to look up.
+
+    Returns:
+        The matching config, or None when the id is not a known dataset.
+    """
+    configs = get_all_dataset_configs(
+        custom_datasets_file=Path(""),
+        dataset_ids=[dataset_id],
+        api_key=None,
+        cache_dir=Path(".cache"),
+        trust_remote_code=False,
+        run_with_cli=False,
+    )
+    return configs.get(dataset_id)
+
+
 def dataset_language_codes(dataset_id: str) -> set[str]:
     """Return ISO codes for a dataset, or an empty set if the dataset is unknown.
 
@@ -540,19 +808,62 @@ def dataset_language_codes(dataset_id: str) -> set[str]:
         The ISO codes the dataset covers, or an empty set when the id is
         not a known dataset (logged at ERROR level).
     """
-    configs = get_all_dataset_configs(
-        custom_datasets_file=Path(""),
-        dataset_ids=[dataset_id],
-        api_key=None,
-        cache_dir=Path(".cache"),
-        trust_remote_code=False,
-        run_with_cli=False,
-    )
-    config = configs.get(dataset_id)
+    config = dataset_config(dataset_id=dataset_id)
     if config is None:
         logger.error(f"Unknown dataset id {dataset_id!r}; skipping.")
         return set()
     return {language.code for language in config.languages}
+
+
+def validate_reeval_datasets(old_dataset: str, new_dataset: str) -> None:
+    """Validate the old/new dataset pair for leaderboard re-eval mode.
+
+    Enforces that the config edit has already happened and describes a
+    genuine within-task swap: the outgoing dataset must now be unofficial,
+    the incoming dataset must be official, both must have dataset configs,
+    and both must belong to the same task.
+
+    Args:
+        old_dataset:
+            The outgoing dataset id (expected to be unofficial).
+        new_dataset:
+            The incoming dataset id (expected to be official).
+
+    Raises:
+        click.ClickException:
+            When either dataset is unknown, the official/unofficial flags
+            are wrong, or the two datasets are not the same task.
+    """
+    old_config = dataset_config(dataset_id=old_dataset)
+    new_config = dataset_config(dataset_id=new_dataset)
+    if old_config is None:
+        raise click.ClickException(
+            f"--reeval-old {old_dataset!r} has no dataset config; both datasets "
+            "must already be configured."
+        )
+    if new_config is None:
+        raise click.ClickException(
+            f"--reeval-new {new_dataset!r} has no dataset config; both datasets "
+            "must already be configured."
+        )
+    if not old_config.unofficial:
+        raise click.ClickException(
+            f"--reeval-old {old_dataset!r} must be UNofficial (the dataset being "
+            "replaced); it is currently official. Demote it in its dataset config "
+            "before running the re-eval."
+        )
+    if new_config.unofficial:
+        raise click.ClickException(
+            f"--reeval-new {new_dataset!r} must be official (the replacement); it "
+            "is currently unofficial. Promote it in its dataset config before "
+            "running the re-eval."
+        )
+    if old_config.task.name != new_config.task.name:
+        raise click.ClickException(
+            f"--reeval-old and --reeval-new must belong to the same task; "
+            f"{old_dataset!r} is {old_config.task.name!r} but {new_dataset!r} is "
+            f"{new_config.task.name!r}."
+        )
 
 
 def provider_for_model_id(model_id: str) -> _Provider | None:

--- a/src/scripts/run_core_model_evaluations.py
+++ b/src/scripts/run_core_model_evaluations.py
@@ -129,7 +129,7 @@ logger = logging.getLogger("run_core_model_evaluations")
 @click.option(
     "--gpu-memory-utilization",
     "gpu_memory_utilization",
-    type=float,
+    type=click.FloatRange(min=0.0, max=1.0, min_open=True),
     default=None,
     help="vLLM GPU memory utilization fraction (0.0-1.0) the fit pre-check should "
     f"budget against. When omitted, defaults to {DEFAULT_GPU_MEMORY_UTILIZATION}.",
@@ -494,8 +494,8 @@ def load_existing_observations() -> ObservedCorpus:
                 observations.add(key)
                 existing = eval_configs.get(key)
                 if existing is None or (
-                    config.validation_split is True
-                    and existing.validation_split is not True
+                    _is_validation_split(config.validation_split)
+                    and not _is_validation_split(existing.validation_split)
                 ):
                     eval_configs[key] = config
     logger.info(
@@ -534,6 +534,24 @@ def _as_bool(value: object) -> bool | None:
         if lowered == "false":
             return False
     return None
+
+
+def _is_validation_split(validation_split: bool | None) -> bool:
+    """Return whether a recorded ``validation_split`` value means the val split.
+
+    Follows the repo-wide convention (see
+    :func:`leaderboards.evaluation_common.missing_official_dataset_language_pairs`):
+    ``True`` and ``None`` (the backwards-compatible sentinel) both denote a
+    validation-split result; only an explicit ``False`` denotes the test split.
+
+    Args:
+        validation_split:
+            The recorded value, or None when the record didn't say.
+
+    Returns:
+        True when the value denotes the validation split.
+    """
+    return validation_split is not False
 
 
 def _record_is_api(model_info: dict[str, object]) -> bool:
@@ -806,8 +824,9 @@ def _mirror_eval_config(config: _ObsConfig | None, is_api: bool) -> tuple[bool, 
     """
     if config is None:
         return (not is_api), is_api
-    # Validation split only when the record explicitly says so; otherwise test.
-    evaluate_test_split = config.validation_split is not True
+    # Test split only when the record explicitly says so; True/None mean val,
+    # following the repo-wide backwards-compatibility convention.
+    evaluate_test_split = not _is_validation_split(config.validation_split)
     # Zero-shot only for generative models whose record used zero-shot.
     zero_shot = config.generative and config.few_shot is False
     return evaluate_test_split, zero_shot
@@ -867,10 +886,13 @@ def ranked_model_language_pairs(
         )
         return set()
 
-    # Index observed datasets by (model, language) for O(1) subset checks.
-    datasets_by_model_language: dict[tuple[str, str], set[str]] = defaultdict(set)
+    # Index observed datasets by language, then model, so each leaderboard
+    # language only scans the models actually evaluated in it.
+    datasets_by_language: dict[str, dict[str, set[str]]] = defaultdict(
+        lambda: defaultdict(set)
+    )
     for model_id, dataset, code in observations:
-        datasets_by_model_language[(model_id, code)].add(dataset)
+        datasets_by_language[code][model_id].add(dataset)
 
     ranked: set[tuple[str, str]] = set()
     for code in sorted(language_codes):
@@ -891,6 +913,7 @@ def ranked_model_language_pairs(
             logger.warning(f"No leaderboard datasets for {name!r}; skipping.")
             continue
 
+        models_in_language = datasets_by_language.get(code, {})
         # A model is ranked in this language if it is eligible in any affected
         # category, i.e. holds every required dataset of that category.
         for category in affected_categories:
@@ -905,8 +928,8 @@ def ranked_model_language_pairs(
             required.add(old_dataset)
             if not required:
                 continue
-            for (model_id, obs_code), datasets in datasets_by_model_language.items():
-                if obs_code == code and required <= datasets:
+            for model_id, datasets in models_in_language.items():
+                if required <= datasets:
                     ranked.add((model_id, code))
     return ranked
 

--- a/src/scripts/run_core_model_evaluations.py
+++ b/src/scripts/run_core_model_evaluations.py
@@ -60,6 +60,7 @@ from euroeval.dataset_configs import get_all_dataset_configs
 from euroeval.languages import get_all_languages
 from leaderboards.constants import (
     DEFAULT_GPU_MEMORY_UTILIZATION,
+    LEADERBOARD_CATEGORIES,
     NEW_RESULTS_PATH,
     RESULTS_DIR,
 )
@@ -70,7 +71,10 @@ from leaderboards.evaluation_common import (
     official_dataset_language_pairs,
     run_euroeval,
 )
-from leaderboards.task_metadata import official_datasets_for_language
+from leaderboards.task_metadata import (
+    category_includes_task,
+    official_datasets_for_language,
+)
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s"
@@ -219,10 +223,9 @@ def main(
     if reeval:
         validate_reeval_datasets(old_dataset=reeval_old, new_dataset=reeval_new)
 
-    observations: set[tuple[str, str, str]] = set()
-    api_model_ids: set[str] = set()
+    corpus = ObservedCorpus(observations=set(), api_model_ids=set(), eval_configs={})
     try:
-        observations, api_model_ids = load_existing_observations()
+        corpus = load_existing_observations()
     except FileNotFoundError as e:
         if reeval:
             raise click.ClickException(
@@ -238,8 +241,7 @@ def main(
             old_dataset=reeval_old,
             new_dataset=reeval_new,
             requested_languages=languages,
-            observations=observations,
-            api_model_ids=api_model_ids,
+            corpus=corpus,
             include_api=include_api,
             api_providers_arg=api_providers,
             force=force,
@@ -258,7 +260,7 @@ def main(
             models=models,
             target_datasets=target_datasets,
             selected_providers=selected_providers,
-            observations=observations if not force else set(),
+            observations=corpus.observations if not force else set(),
             force=force,
         )
     logger.info(f"Planned {len(jobs)} job(s) before size check.")
@@ -269,8 +271,11 @@ def main(
     if dry_run:
         for job in jobs:
             tag = "api" if job.is_api else "open"
+            split = "test" if job.evaluate_test_split else "val"
+            shots = "zero-shot" if job.zero_shot else "few-shot"
             click.echo(
-                f"[{tag}] {job.model_id} :: {job.dataset} :: {', '.join(job.languages)}"
+                f"[{tag}] {job.model_id} :: {job.dataset} :: "
+                f"{', '.join(job.languages)} :: {split}, {shots}"
             )
         return
 
@@ -279,12 +284,61 @@ def main(
 
 @dataclass(frozen=True)
 class Job:
-    """A single (model, dataset, languages) evaluation job."""
+    """A single (model, dataset, languages) evaluation job.
+
+    ``evaluate_test_split`` and ``zero_shot`` capture how the model should
+    be run, so :func:`execute_jobs` doesn't have to re-derive them: in
+    re-eval mode they mirror how the model was evaluated on the outgoing
+    dataset; in the core-model modes they follow the split/prompting default
+    for the model type.
+    """
 
     model_id: str
     dataset: str
     languages: tuple[str, ...]
     is_api: bool
+    evaluate_test_split: bool
+    zero_shot: bool
+
+
+@dataclass(frozen=True)
+class _ObsConfig:
+    """How a model was evaluated on a given (dataset, language).
+
+    Args:
+        validation_split:
+            True when the recorded result used the validation split, False
+            for the test split, None when the record didn't say.
+        few_shot:
+            True when few-shot prompting was used, False for zero-shot, None
+            when the record didn't say.
+        generative:
+            Whether the model is generative (few-shot/zero-shot only applies
+            to generative models).
+    """
+
+    validation_split: bool | None
+    few_shot: bool | None
+    generative: bool
+
+
+@dataclass(frozen=True)
+class ObservedCorpus:
+    """The recorded results, indexed for re-eval planning.
+
+    Args:
+        observations:
+            Every ``(model_id, dataset, language)`` triple in the corpus.
+        api_model_ids:
+            Model ids the corpus shows were evaluated via an API.
+        eval_configs:
+            The evaluation config used for each ``(model, dataset, language)``
+            triple, so a re-eval can mirror the split and prompting.
+    """
+
+    observations: set[tuple[str, str, str]]
+    api_model_ids: set[str]
+    eval_configs: dict[tuple[str, str, str], _ObsConfig]
 
 
 @dataclass(frozen=True)
@@ -353,8 +407,8 @@ def select_api_providers(
     return selected
 
 
-def load_existing_observations() -> tuple[set[tuple[str, str, str]], set[str]]:
-    """Return benchmarked triples and the set of API-model ids in the corpus.
+def load_existing_observations() -> ObservedCorpus:
+    """Return the recorded results indexed for backfill and re-eval planning.
 
     Reads the merged result corpus the same way the leaderboard pipeline
     does -- the per-model files in ``RESULTS_DIR`` plus the optional
@@ -366,12 +420,15 @@ def load_existing_observations() -> tuple[set[tuple[str, str, str]], set[str]]:
     more reliable than id-prefix matching because historical API results are
     stored under bare ids (e.g. ``gpt-5.5``) that carry no ``openai/`` prefix.
 
+    Each ``(model, dataset, language)`` triple also records how it was
+    evaluated (split, few-shot, generative) so a re-eval can mirror it. When
+    a triple appears more than once, a validation-split config is preferred,
+    matching the completeness rule the queue uses.
+
     Returns:
-        A ``(observations, api_model_ids)`` pair. ``observations`` is every
-        ``(model_id, dataset, language)`` triple in the corpus, with model
-        ids unwrapped from any leaderboard HTML anchor so the keys line up
-        with the canonical ids in ``core_models.yaml``. ``api_model_ids`` is
-        the subset of those model ids evaluated via an API.
+        The parsed corpus. Model ids are unwrapped from any leaderboard HTML
+        anchor so the keys line up with the canonical ids in
+        ``core_models.yaml``.
     """
     lines: list[str] = []
     for model_file in sorted(RESULTS_DIR.glob("*.jsonl")):
@@ -381,6 +438,7 @@ def load_existing_observations() -> tuple[set[tuple[str, str, str]], set[str]]:
 
     observations: set[tuple[str, str, str]] = set()
     api_model_ids: set[str] = set()
+    eval_configs: dict[tuple[str, str, str], _ObsConfig] = {}
     parse_failures = 0
     for line_idx, line in enumerate(lines):
         line = line.strip()
@@ -423,8 +481,23 @@ def load_existing_observations() -> tuple[set[tuple[str, str, str]], set[str]]:
                 continue
             if _record_is_api(model_info=model_info):
                 api_model_ids.add(model)
+            config = _ObsConfig(
+                validation_split=_as_bool(eval_additional.get("validation_split")),
+                few_shot=_as_bool(eval_additional.get("few_shot")),
+                generative=_as_bool(
+                    model_info.get("additional_details", {}).get("generative")
+                )
+                is True,
+            )
             for language in languages:
-                observations.add((model, str(dataset), str(language)))
+                key = (model, str(dataset), str(language))
+                observations.add(key)
+                existing = eval_configs.get(key)
+                if existing is None or (
+                    config.validation_split is True
+                    and existing.validation_split is not True
+                ):
+                    eval_configs[key] = config
     logger.info(
         f"Loaded {len(observations):,} (model, dataset, language) observations "
         f"({len(api_model_ids):,} API model(s))."
@@ -434,7 +507,33 @@ def load_existing_observations() -> tuple[set[tuple[str, str, str]], set[str]]:
             f"Skipped {parse_failures:,} unparseable result record(s); see "
             "earlier warnings for details."
         )
-    return observations, api_model_ids
+    return ObservedCorpus(
+        observations=observations,
+        api_model_ids=api_model_ids,
+        eval_configs=eval_configs,
+    )
+
+
+def _as_bool(value: object) -> bool | None:
+    """Coerce a JSON-ish truthy/falsy value to a tri-state bool.
+
+    Args:
+        value:
+            A value that may be a bool, the strings ``"true"``/``"false"``
+            (any case), or None/absent.
+
+    Returns:
+        True, False, or None when the value is missing or unrecognised.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered == "true":
+            return True
+        if lowered == "false":
+            return False
+    return None
 
 
 def _record_is_api(model_info: dict[str, object]) -> bool:
@@ -527,6 +626,8 @@ def build_jobs(
                         dataset=dataset,
                         languages=tuple(langs),
                         is_api=model.api,
+                        evaluate_test_split=not model.api,
+                        zero_shot=model.api,
                     )
                 )
             continue
@@ -549,6 +650,8 @@ def build_jobs(
                     dataset=dataset,
                     languages=tuple(langs),
                     is_api=model.api,
+                    evaluate_test_split=not model.api,
+                    zero_shot=model.api,
                 )
             )
     return jobs
@@ -558,19 +661,21 @@ def plan_reeval_jobs(
     old_dataset: str,
     new_dataset: str,
     requested_languages: tuple[str, ...],
-    observations: set[tuple[str, str, str]],
-    api_model_ids: set[str],
+    corpus: ObservedCorpus,
     include_api: bool,
     api_providers_arg: str | None,
     force: bool,
 ) -> list[Job]:
     """Plan the jobs for leaderboard re-eval mode.
 
-    Selects the language(s) whose leaderboard is affected by the swap,
-    finds every model that held a full rank score under the pre-swap
-    config, and schedules the new dataset for each such model in the
-    languages it was ranked in. API models are excluded unless the user
-    opts in with ``--include-api``, so a plain re-eval never spends money.
+    Selects the language(s) whose leaderboard is affected by the swap, finds
+    every model that held a full rank score under the pre-swap config (in the
+    generative *or* the NLU/all-models category, so encoder models are
+    included when the task supports them), and schedules the new dataset for
+    each such model in the languages it was ranked in. Every job mirrors the
+    split and prompting the model used on the outgoing dataset. API models are
+    excluded unless the user opts in with ``--include-api``, so a plain
+    re-eval never spends money.
 
     Args:
         old_dataset:
@@ -580,10 +685,9 @@ def plan_reeval_jobs(
         requested_languages:
             Language codes to restrict to; empty means the codes covered by
             both the old and new datasets.
-        observations:
-            Recorded ``(model, dataset, language)`` triples.
-        api_model_ids:
-            Model ids the corpus shows were evaluated via an API.
+        corpus:
+            The parsed results corpus (observations, API-model ids, and the
+            per-triple evaluation configs to mirror).
         include_api:
             Whether the user opted in to running API models.
         api_providers_arg:
@@ -616,16 +720,22 @@ def plan_reeval_jobs(
         f"{', '.join(sorted(target_codes))}."
     )
 
+    old_config = dataset_config(dataset_id=old_dataset)
+    swapped_task = old_config.task.name if old_config is not None else ""
     ranked_pairs = ranked_model_language_pairs(
         old_dataset=old_dataset,
         new_dataset=new_dataset,
+        swapped_task=swapped_task,
         language_codes=target_codes,
-        observations=observations,
+        observations=corpus.observations,
     )
     logger.info(f"Found {len(ranked_pairs)} ranked (model, language) pair(s).")
 
     def is_api_model(model_id: str) -> bool:
-        return model_id in api_model_ids or provider_for_model_id(model_id) is not None
+        return (
+            model_id in corpus.api_model_ids
+            or provider_for_model_id(model_id) is not None
+        )
 
     ranked_api = sorted({m for m, _ in ranked_pairs if is_api_model(m)})
     selected_providers = select_api_providers(
@@ -657,19 +767,56 @@ def plan_reeval_jobs(
             provider = provider_for_model_id(model_id=model_id)
             if provider is not None and provider.name not in selected_providers:
                 continue
-        if not force and (model_id, new_dataset, code) in observations:
+        if not force and (model_id, new_dataset, code) in corpus.observations:
             continue
+        evaluate_test_split, zero_shot = _mirror_eval_config(
+            config=corpus.eval_configs.get((model_id, old_dataset, code)), is_api=is_api
+        )
         jobs.append(
             Job(
-                model_id=model_id, dataset=new_dataset, languages=(code,), is_api=is_api
+                model_id=model_id,
+                dataset=new_dataset,
+                languages=(code,),
+                is_api=is_api,
+                evaluate_test_split=evaluate_test_split,
+                zero_shot=zero_shot,
             )
         )
     return jobs
 
 
+def _mirror_eval_config(config: _ObsConfig | None, is_api: bool) -> tuple[bool, bool]:
+    """Return ``(evaluate_test_split, zero_shot)`` mirroring the old dataset.
+
+    The re-eval must reproduce how the model was evaluated on the outgoing
+    dataset: the same split, and -- for generative models only -- the same
+    zero-shot/few-shot prompting. Encoder models never get ``--zero-shot``.
+    When no recorded config is available, fall back to the split/prompting
+    default for the model type (API: validation split, zero-shot;
+    open-weight: test split, few-shot).
+
+    Args:
+        config:
+            The recorded evaluation config for the outgoing dataset, or None.
+        is_api:
+            Whether the model is an API model, used only for the fallback.
+
+    Returns:
+        The ``(evaluate_test_split, zero_shot)`` flags for the new job.
+    """
+    if config is None:
+        return (not is_api), is_api
+    # Validation split only when the record explicitly says so; otherwise test.
+    evaluate_test_split = config.validation_split is not True
+    # Zero-shot only for generative models whose record used zero-shot.
+    zero_shot = config.generative and config.few_shot is False
+    return evaluate_test_split, zero_shot
+
+
 def ranked_model_language_pairs(
     old_dataset: str,
     new_dataset: str,
+    swapped_task: str,
     language_codes: set[str],
     observations: set[tuple[str, str, str]],
 ) -> set[tuple[str, str]]:
@@ -678,18 +825,28 @@ def ranked_model_language_pairs(
     A model is "ranked" in a language when it holds a result for every
     required (non-orthogonal) dataset of that language's single-language
     leaderboard -- the same eligibility rule the leaderboard generator uses
-    to award a rank score. The required set is normalised so it always
-    reflects the pre-swap leaderboard: the outgoing dataset is added and the
-    incoming candidate removed. Because the re-eval runs before the flags are
-    flipped this is normally a no-op (the outgoing dataset is already
-    official and the incoming one already excluded), but it keeps the
-    selection correct even if the configs have already been edited.
+    to award a rank score. Eligibility is checked in every leaderboard
+    category the swapped task belongs to: the ``generative`` category scores
+    all tasks, while the ``all_models`` category scores only NLU tasks so
+    encoder models can be compared. A model ranked in *either* category is
+    selected, so encoder models are re-evaluated whenever the swapped task is
+    an NLU task they can run.
+
+    The required set is normalised so it always reflects the pre-swap
+    leaderboard: the outgoing dataset is added and the incoming candidate
+    removed. Because the re-eval runs before the flags are flipped this is
+    normally a no-op (the outgoing dataset is already official and the
+    incoming one already excluded), but it keeps the selection correct even
+    if the configs have already been edited.
 
     Args:
         old_dataset:
             The outgoing dataset id being replaced (kept in the required set).
         new_dataset:
             The incoming candidate dataset id (kept out of the required set).
+        swapped_task:
+            The task both datasets belong to; determines which leaderboard
+            categories are affected.
         language_codes:
             The language codes whose leaderboards are being re-evaluated.
         observations:
@@ -699,6 +856,16 @@ def ranked_model_language_pairs(
         The ``(model_id, language_code)`` pairs that were ranked pre-swap.
     """
     languages = get_all_languages()
+    affected_categories = [
+        category
+        for category in LEADERBOARD_CATEGORIES
+        if category_includes_task(category=category, task=swapped_task)
+    ]
+    if not affected_categories:
+        logger.warning(
+            f"Task {swapped_task!r} is in no leaderboard category; nothing to do."
+        )
+        return set()
 
     # Index observed datasets by (model, language) for O(1) subset checks.
     datasets_by_model_language: dict[tuple[str, str], set[str]] = defaultdict(set)
@@ -724,21 +891,23 @@ def ranked_model_language_pairs(
             logger.warning(f"No leaderboard datasets for {name!r}; skipping.")
             continue
 
-        required = {
-            dataset
-            for task, task_datasets in by_task.items()
-            if task not in ORTHOGONAL_TASKS
-            for dataset in task_datasets
-        }
-        required.discard(new_dataset)
-        required.add(old_dataset)
-        if not required:
-            logger.warning(f"No required datasets for {name!r}; skipping.")
-            continue
-
-        for (model_id, obs_code), datasets in datasets_by_model_language.items():
-            if obs_code == code and required <= datasets:
-                ranked.add((model_id, code))
+        # A model is ranked in this language if it is eligible in any affected
+        # category, i.e. holds every required dataset of that category.
+        for category in affected_categories:
+            required = {
+                dataset
+                for task, task_datasets in by_task.items()
+                if task not in ORTHOGONAL_TASKS
+                and category_includes_task(category=category, task=task)
+                for dataset in task_datasets
+            }
+            required.discard(new_dataset)
+            required.add(old_dataset)
+            if not required:
+                continue
+            for (model_id, obs_code), datasets in datasets_by_model_language.items():
+                if obs_code == code and required <= datasets:
+                    ranked.add((model_id, code))
     return ranked
 
 
@@ -808,8 +977,9 @@ def apply_size_filter(
 def execute_jobs(jobs: list[Job], gpu_memory_utilization: float | None) -> None:
     """Run each job in sequence via the shared euroeval runner.
 
-    API jobs are run on the validation split with zero-shot prompting;
-    open-weight jobs use the defaults (test split, few-shot).
+    Each job carries its own split and prompting flags (mirrored from the
+    outgoing dataset in re-eval mode, or the model-type default otherwise),
+    so they are forwarded to euroeval verbatim.
 
     Args:
         jobs:
@@ -820,17 +990,19 @@ def execute_jobs(jobs: list[Job], gpu_memory_utilization: float | None) -> None:
             fit pre-check budgeted against keeps the two consistent.
     """
     for index, job in enumerate(jobs, start=1):
+        split = "test" if job.evaluate_test_split else "val"
+        shots = "zero-shot" if job.zero_shot else "few-shot"
         logger.info(
             f"[{index}/{len(jobs)}] euroeval --model {job.model_id} "
-            f"--dataset {job.dataset} --language {' --language '.join(job.languages)}"
-            f"{' (api, val, zero-shot)' if job.is_api else ''}"
+            f"--dataset {job.dataset} --language {' --language '.join(job.languages)} "
+            f"({split}, {shots})"
         )
         returncode, _ = run_euroeval(
             model_id=job.model_id,
             languages=job.languages,
             datasets=[job.dataset],
-            evaluate_test_split=not job.is_api,
-            zero_shot=job.is_api,
+            evaluate_test_split=job.evaluate_test_split,
+            zero_shot=job.zero_shot,
             gpu_memory_utilization=gpu_memory_utilization,
         )
         if returncode != 0:

--- a/src/scripts/run_core_model_evaluations.py
+++ b/src/scripts/run_core_model_evaluations.py
@@ -1,22 +1,9 @@
 """Run EuroEval for the core model list.
 
-Three related workflows live in this script:
-
-1. **Dataset-replacement mode** (``--dataset <id>`` [repeatable]) -- re-run
-   every core model whose language coverage overlaps a dataset's languages
-   on that dataset.
-2. **Backfill mode** (default) -- for every core model, run every official
-   ``(dataset, language)`` pair that the model has no result line for yet.
-3. **Leaderboard re-eval mode** (``--reeval-old <ds> --reeval-new <ds>``) --
-   when a new (still unofficial) dataset is going to replace an official one
-   on a language's leaderboard, evaluate that candidate on every model that
-   currently holds a full rank score there (i.e. holds every required
-   dataset). Run this *before* flipping the official flags so the
-   leaderboard stays intact while the data is gathered. Unlike the other two
-   modes the model set is drawn from the recorded results, not from
-   ``core_models.yaml``.
-
-All modes share the size-check, results lookup, and the API-provider prompt.
+For every core model, run every official ``(dataset, language)`` pair that
+the model has no result line for yet -- i.e. backfill the core-model results
+on the full test split. Model selection, size-check, results lookup, and the
+API-provider prompt are all handled here.
 
 Invoke as::
 
@@ -47,33 +34,19 @@ import logging
 import os
 import re
 import sys
-from collections import defaultdict
 from dataclasses import dataclass
-from pathlib import Path
 
 import click
 from update_core_models import refresh_core_models
 
-from euroeval.constants import ORTHOGONAL_TASKS
-from euroeval.data_models import DatasetConfig
-from euroeval.dataset_configs import get_all_dataset_configs
 from euroeval.languages import get_all_languages
-from leaderboards.constants import (
-    DEFAULT_GPU_MEMORY_UTILIZATION,
-    LEADERBOARD_CATEGORIES,
-    NEW_RESULTS_PATH,
-    RESULTS_DIR,
-)
+from leaderboards.constants import NEW_RESULTS_PATH, RESULTS_DIR
 from leaderboards.core_models import CoreModel
 from leaderboards.evaluation_common import (
     gpu_total_memory_bytes,
     model_fits_locally,
     official_dataset_language_pairs,
     run_euroeval,
-)
-from leaderboards.task_metadata import (
-    category_includes_task,
-    official_datasets_for_language,
 )
 
 logging.basicConfig(
@@ -83,36 +56,6 @@ logger = logging.getLogger("run_core_model_evaluations")
 
 
 @click.command()
-@click.option(
-    "--dataset",
-    "datasets",
-    multiple=True,
-    help="Dataset id to run in dataset-replacement mode. Repeatable. When omitted, "
-    "the script runs in backfill mode against every official (dataset, language) "
-    "pair.",
-)
-@click.option(
-    "--reeval-old",
-    "reeval_old",
-    default=None,
-    help="Leaderboard re-eval mode: the official dataset being replaced, whose "
-    "ranked models define the set to evaluate. Requires --reeval-new.",
-)
-@click.option(
-    "--reeval-new",
-    "reeval_new",
-    default=None,
-    help="Leaderboard re-eval mode: the unofficial candidate dataset to evaluate on "
-    "every model ranked under --reeval-old. Requires --reeval-old.",
-)
-@click.option(
-    "--language",
-    "languages",
-    multiple=True,
-    help="Leaderboard re-eval mode: restrict re-evaluation to these language codes. "
-    "When omitted, defaults to the languages covered by both the old and new "
-    "datasets.",
-)
 @click.option(
     "--include-api",
     is_flag=True,
@@ -125,14 +68,6 @@ logger = logging.getLogger("run_core_model_evaluations")
     default=None,
     help="Comma-separated provider names to run (openai, anthropic, google, xai). "
     "Skips the interactive prompt. Requires --include-api.",
-)
-@click.option(
-    "--gpu-memory-utilization",
-    "gpu_memory_utilization",
-    type=click.FloatRange(min=0.0, max=1.0, min_open=True),
-    default=None,
-    help="vLLM GPU memory utilization fraction (0.0-1.0) the fit pre-check should "
-    f"budget against. When omitted, defaults to {DEFAULT_GPU_MEMORY_UTILIZATION}.",
 )
 @click.option(
     "--dry-run",
@@ -148,37 +83,15 @@ logger = logging.getLogger("run_core_model_evaluations")
     "result line.",
 )
 def main(
-    datasets: tuple[str, ...],
-    reeval_old: str | None,
-    reeval_new: str | None,
-    languages: tuple[str, ...],
-    include_api: bool,
-    api_providers: str | None,
-    gpu_memory_utilization: float | None,
-    dry_run: bool,
-    force: bool,
+    include_api: bool, api_providers: str | None, dry_run: bool, force: bool
 ) -> None:
     """Run EuroEval for the core model list.
 
     Args:
-        datasets:
-            Dataset ids passed via ``--dataset``. When non-empty, the
-            script runs in dataset-replacement mode against exactly those
-            datasets; otherwise it runs in backfill mode.
-        reeval_old:
-            Outgoing dataset id for leaderboard re-eval mode, or None.
-        reeval_new:
-            Incoming dataset id for leaderboard re-eval mode, or None.
-        languages:
-            Language codes to restrict re-eval to; empty means "infer from
-            the old and new datasets". Only used in re-eval mode.
         include_api:
             Whether to consider ``api: true`` entries at all.
         api_providers:
             Optional comma-separated provider filter; bypasses the prompt.
-        gpu_memory_utilization:
-            vLLM GPU memory utilization fraction the fit pre-check budgets
-            against, or None to use the default.
         dry_run:
             When True, print the planned jobs and return without running.
         force:
@@ -187,158 +100,64 @@ def main(
     Raises:
         click.ClickException:
             When ``--api-providers`` is passed without ``--include-api``,
-            when an unknown provider name is supplied, when a selected
-            provider's env var is missing, or when the re-eval flags are
-            combined incorrectly.
+            when an unknown provider name is supplied, or when a selected
+            provider's env var is missing.
     """
     if api_providers and not include_api:
         raise click.ClickException(
             "--api-providers requires --include-api; pass both or neither."
         )
-    if bool(reeval_old) != bool(reeval_new):
-        raise click.ClickException(
-            "--reeval-old and --reeval-new must be passed together."
-        )
-    reeval = bool(reeval_old and reeval_new)
-    if reeval and datasets:
-        raise click.ClickException(
-            "--reeval-old/--reeval-new cannot be combined with --dataset."
-        )
-    if languages and not reeval:
-        raise click.ClickException(
-            "--language is only valid in leaderboard re-eval mode "
-            "(--reeval-old/--reeval-new)."
-        )
 
-    target_datasets = list(datasets) or None
-    mode = (
-        "leaderboard-reeval"
-        if reeval
-        else "dataset-replacement"
-        if target_datasets
-        else "backfill"
+    logger.info("Mode: backfill.")
+
+    models = refresh_core_models()
+    logger.info(f"Refreshed core-model list: {len(models)} entries.")
+
+    selected_providers = select_api_providers(
+        candidate_models=models,
+        include_api=include_api,
+        api_providers_arg=api_providers,
     )
-    logger.info(f"Mode: {mode}.")
 
-    if reeval:
-        validate_reeval_datasets(old_dataset=reeval_old, new_dataset=reeval_new)
+    observations: set[tuple[str, str, str]] = set()
+    if not force:
+        try:
+            observations = load_existing_observations()
+        except FileNotFoundError as e:
+            logger.warning(
+                f"Could not load existing results ({e}); proceeding as if none exist."
+            )
 
-    corpus = ObservedCorpus(observations=set(), api_model_ids=set(), eval_configs={})
-    try:
-        corpus = load_existing_observations()
-    except FileNotFoundError as e:
-        if reeval:
-            raise click.ClickException(
-                f"Leaderboard re-eval needs the recorded results to find ranked "
-                f"models, but none could be loaded: {e}"
-            ) from e
-        logger.warning(
-            f"Could not load existing results ({e}); proceeding as if none exist."
-        )
-
-    if reeval:
-        jobs = plan_reeval_jobs(
-            old_dataset=reeval_old,
-            new_dataset=reeval_new,
-            requested_languages=languages,
-            corpus=corpus,
-            include_api=include_api,
-            api_providers_arg=api_providers,
-            force=force,
-        )
-    else:
-        if target_datasets:
-            logger.info(f"Target dataset(s): {', '.join(target_datasets)}.")
-        models = refresh_core_models()
-        logger.info(f"Refreshed core-model list: {len(models)} entries.")
-        selected_providers = select_api_providers(
-            has_any_api=any(m.api for m in models),
-            include_api=include_api,
-            api_providers_arg=api_providers,
-        )
-        jobs = build_jobs(
-            models=models,
-            target_datasets=target_datasets,
-            selected_providers=selected_providers,
-            observations=corpus.observations if not force else set(),
-            force=force,
-        )
+    jobs = build_jobs(
+        models=models,
+        selected_providers=selected_providers,
+        observations=observations,
+        force=force,
+    )
     logger.info(f"Planned {len(jobs)} job(s) before size check.")
 
-    jobs = apply_size_filter(jobs=jobs, gpu_memory_utilization=gpu_memory_utilization)
+    jobs = apply_size_filter(jobs=jobs)
     logger.info(f"{len(jobs)} job(s) survive the size check.")
 
     if dry_run:
         for job in jobs:
             tag = "api" if job.is_api else "open"
-            split = "test" if job.evaluate_test_split else "val"
-            shots = "zero-shot" if job.zero_shot else "few-shot"
             click.echo(
-                f"[{tag}] {job.model_id} :: {job.dataset} :: "
-                f"{', '.join(job.languages)} :: {split}, {shots}"
+                f"[{tag}] {job.model_id} :: {job.dataset} :: {', '.join(job.languages)}"
             )
         return
 
-    execute_jobs(jobs=jobs, gpu_memory_utilization=gpu_memory_utilization)
+    execute_jobs(jobs=jobs)
 
 
 @dataclass(frozen=True)
 class Job:
-    """A single (model, dataset, languages) evaluation job.
-
-    ``evaluate_test_split`` and ``zero_shot`` capture how the model should
-    be run, so :func:`execute_jobs` doesn't have to re-derive them: in
-    re-eval mode they mirror how the model was evaluated on the outgoing
-    dataset; in the core-model modes they follow the split/prompting default
-    for the model type.
-    """
+    """A single (model, dataset, languages) evaluation job."""
 
     model_id: str
     dataset: str
     languages: tuple[str, ...]
     is_api: bool
-    evaluate_test_split: bool
-    zero_shot: bool
-
-
-@dataclass(frozen=True)
-class _ObsConfig:
-    """How a model was evaluated on a given (dataset, language).
-
-    Args:
-        validation_split:
-            True when the recorded result used the validation split, False
-            for the test split, None when the record didn't say.
-        few_shot:
-            True when few-shot prompting was used, False for zero-shot, None
-            when the record didn't say.
-        generative:
-            Whether the model is generative (few-shot/zero-shot only applies
-            to generative models).
-    """
-
-    validation_split: bool | None
-    few_shot: bool | None
-    generative: bool
-
-
-@dataclass(frozen=True)
-class ObservedCorpus:
-    """The recorded results, indexed for re-eval planning.
-
-    Args:
-        observations:
-            Every ``(model_id, dataset, language)`` triple in the corpus.
-        api_model_ids:
-            Model ids the corpus shows were evaluated via an API.
-        eval_configs:
-            The evaluation config used for each ``(model, dataset, language)``
-            triple, so a re-eval can mirror the split and prompting.
-    """
-
-    observations: set[tuple[str, str, str]]
-    api_model_ids: set[str]
-    eval_configs: dict[tuple[str, str, str], _ObsConfig]
 
 
 @dataclass(frozen=True)
@@ -351,14 +170,16 @@ class _Provider:
 
 
 def select_api_providers(
-    has_any_api: bool, include_api: bool, api_providers_arg: str | None
+    candidate_models: c.Iterable[CoreModel],
+    include_api: bool,
+    api_providers_arg: str | None,
 ) -> set[str]:
     """Resolve which API providers to run and verify their env vars.
 
     Args:
-        has_any_api:
-            Whether any API model is present in the candidate set; when
-            False the ``--include-api`` opt-in is a no-op.
+        candidate_models:
+            The full set of models in scope, used to check whether any API
+            models are present at all.
         include_api:
             Whether the user opted in to API evaluation. When False, no
             providers are selected regardless of ``api_providers_arg``.
@@ -376,6 +197,7 @@ def select_api_providers(
     if not include_api:
         return set()
 
+    has_any_api = any(m.api for m in candidate_models)
     if not has_any_api:
         logger.info("No API models in the candidate set; ignoring --include-api.")
         return set()
@@ -407,27 +229,18 @@ def select_api_providers(
     return selected
 
 
-def load_existing_observations() -> ObservedCorpus:
-    """Return the recorded results indexed for backfill and re-eval planning.
+def load_existing_observations() -> set[tuple[str, str, str]]:
+    """Return the ``(model_id, dataset, language)`` triples already benchmarked.
 
     Reads the merged result corpus the same way the leaderboard pipeline
     does -- the per-model files in ``RESULTS_DIR`` plus the optional
     ``new_results.jsonl`` -- but without the destructive unlink that
     :func:`leaderboards.result_loading.load_raw_results` performs.
 
-    A model is treated as an API model when its record was produced by the
-    ``litellm`` inference engine or is flagged as not open-weight. This is
-    more reliable than id-prefix matching because historical API results are
-    stored under bare ids (e.g. ``gpt-5.5``) that carry no ``openai/`` prefix.
-
-    Each ``(model, dataset, language)`` triple also records how it was
-    evaluated (split, few-shot, generative) so a re-eval can mirror it. When
-    a triple appears more than once, a validation-split config is preferred,
-    matching the completeness rule the queue uses.
-
     Returns:
-        The parsed corpus. Model ids are unwrapped from any leaderboard HTML
-        anchor so the keys line up with the canonical ids in
+        Every ``(model_id, dataset, language)`` triple in the merged
+        result corpus, with model ids unwrapped from any leaderboard
+        HTML anchor so the keys line up with the canonical ids in
         ``core_models.yaml``.
     """
     lines: list[str] = []
@@ -437,8 +250,6 @@ def load_existing_observations() -> ObservedCorpus:
         lines.extend(NEW_RESULTS_PATH.read_text(encoding="utf-8").splitlines())
 
     observations: set[tuple[str, str, str]] = set()
-    api_model_ids: set[str] = set()
-    eval_configs: dict[tuple[str, str, str], _ObsConfig] = {}
     parse_failures = 0
     for line_idx, line in enumerate(lines):
         line = line.strip()
@@ -460,8 +271,7 @@ def load_existing_observations() -> ObservedCorpus:
                 continue
 
             # EEE: model_info.name, eval_library.additional_details.dataset/languages
-            model_info = raw_record.get("model_info", {})
-            model = model_info.get("name", "")
+            model = raw_record.get("model_info", {}).get("name", "")
             eval_additional = raw_record.get("eval_library", {}).get(
                 "additional_details", {}
             )
@@ -479,104 +289,21 @@ def load_existing_observations() -> ObservedCorpus:
             model = _strip_anchor(model_id=str(model))
             if not model or not dataset:
                 continue
-            if _record_is_api(model_info=model_info):
-                api_model_ids.add(model)
-            config = _ObsConfig(
-                validation_split=_as_bool(eval_additional.get("validation_split")),
-                few_shot=_as_bool(eval_additional.get("few_shot")),
-                generative=_as_bool(
-                    model_info.get("additional_details", {}).get("generative")
-                )
-                is True,
-            )
             for language in languages:
-                key = (model, str(dataset), str(language))
-                observations.add(key)
-                existing = eval_configs.get(key)
-                if existing is None or (
-                    _is_validation_split(config.validation_split)
-                    and not _is_validation_split(existing.validation_split)
-                ):
-                    eval_configs[key] = config
+                observations.add((model, str(dataset), str(language)))
     logger.info(
-        f"Loaded {len(observations):,} (model, dataset, language) observations "
-        f"({len(api_model_ids):,} API model(s))."
+        f"Loaded {len(observations):,} (model, dataset, language) observations."
     )
     if parse_failures:
         logger.warning(
             f"Skipped {parse_failures:,} unparseable result record(s); see "
             "earlier warnings for details."
         )
-    return ObservedCorpus(
-        observations=observations,
-        api_model_ids=api_model_ids,
-        eval_configs=eval_configs,
-    )
-
-
-def _as_bool(value: object) -> bool | None:
-    """Coerce a JSON-ish truthy/falsy value to a tri-state bool.
-
-    Args:
-        value:
-            A value that may be a bool, the strings ``"true"``/``"false"``
-            (any case), or None/absent.
-
-    Returns:
-        True, False, or None when the value is missing or unrecognised.
-    """
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        lowered = value.strip().lower()
-        if lowered == "true":
-            return True
-        if lowered == "false":
-            return False
-    return None
-
-
-def _is_validation_split(validation_split: bool | None) -> bool:
-    """Return whether a recorded ``validation_split`` value means the val split.
-
-    Follows the repo-wide convention (see
-    :func:`leaderboards.evaluation_common.missing_official_dataset_language_pairs`):
-    ``True`` and ``None`` (the backwards-compatible sentinel) both denote a
-    validation-split result; only an explicit ``False`` denotes the test split.
-
-    Args:
-        validation_split:
-            The recorded value, or None when the record didn't say.
-
-    Returns:
-        True when the value denotes the validation split.
-    """
-    return validation_split is not False
-
-
-def _record_is_api(model_info: dict[str, object]) -> bool:
-    """Return whether a result record's model was evaluated via an API.
-
-    Args:
-        model_info:
-            The ``model_info`` object of an EEE result record.
-
-    Returns:
-        True when the record was produced by the ``litellm`` inference
-        engine or is flagged as not open-weight.
-    """
-    engine = model_info.get("inference_engine", {})
-    engine_name = engine.get("name", "") if isinstance(engine, dict) else ""
-    if str(engine_name).lower() == "litellm":
-        return True
-    details = model_info.get("additional_details", {})
-    open_flag = details.get("open") if isinstance(details, dict) else None
-    return str(open_flag).lower() == "false"
+    return observations
 
 
 def build_jobs(
     models: list[CoreModel],
-    target_datasets: list[str] | None,
     selected_providers: set[str],
     observations: set[tuple[str, str, str]],
     force: bool,
@@ -586,8 +313,6 @@ def build_jobs(
     Args:
         models:
             Parsed core-model entries.
-        target_datasets:
-            Dataset ids for dataset-replacement mode, or None for backfill.
         selected_providers:
             Provider names that survived the env-var check; API models
             belonging to other providers are silently skipped.
@@ -607,12 +332,6 @@ def build_jobs(
     for dataset, language in official_pairs:
         official_by_dataset.setdefault(dataset, set()).add(language)
 
-    target_dataset_codes: dict[str, set[str]] | None = None
-    if target_datasets:
-        target_dataset_codes = {
-            d: dataset_language_codes(dataset_id=d) for d in target_datasets
-        }
-
     for model in models:
         if model.api:
             provider = provider_for_model_id(model_id=model.model_id)
@@ -623,31 +342,6 @@ def build_jobs(
             logger.info(
                 f"{model.model_id}: skipping -- no resolvable language coverage."
             )
-            continue
-
-        if target_dataset_codes is not None:
-            for dataset, dataset_langs in target_dataset_codes.items():
-                langs = sorted(model_languages & dataset_langs)
-                if not langs:
-                    continue
-                if not force:
-                    langs = [
-                        lang
-                        for lang in langs
-                        if (model.model_id, dataset, lang) not in observations
-                    ]
-                if not langs:
-                    continue
-                jobs.append(
-                    Job(
-                        model_id=model.model_id,
-                        dataset=dataset,
-                        languages=tuple(langs),
-                        is_api=model.api,
-                        evaluate_test_split=not model.api,
-                        zero_shot=model.api,
-                    )
-                )
             continue
 
         for dataset, dataset_langs in official_by_dataset.items():
@@ -668,282 +362,13 @@ def build_jobs(
                     dataset=dataset,
                     languages=tuple(langs),
                     is_api=model.api,
-                    evaluate_test_split=not model.api,
-                    zero_shot=model.api,
                 )
             )
     return jobs
 
 
-def plan_reeval_jobs(
-    old_dataset: str,
-    new_dataset: str,
-    requested_languages: tuple[str, ...],
-    corpus: ObservedCorpus,
-    include_api: bool,
-    api_providers_arg: str | None,
-    force: bool,
-) -> list[Job]:
-    """Plan the jobs for leaderboard re-eval mode.
-
-    Selects the language(s) whose leaderboard is affected by the swap, finds
-    every model that held a full rank score under the pre-swap config (in the
-    generative *or* the NLU/all-models category, so encoder models are
-    included when the task supports them), and schedules the new dataset for
-    each such model in the languages it was ranked in. Every job mirrors the
-    split and prompting the model used on the outgoing dataset. API models are
-    excluded unless the user opts in with ``--include-api``, so a plain
-    re-eval never spends money.
-
-    Args:
-        old_dataset:
-            The outgoing dataset id being replaced.
-        new_dataset:
-            The incoming dataset id to run.
-        requested_languages:
-            Language codes to restrict to; empty means the codes covered by
-            both the old and new datasets.
-        corpus:
-            The parsed results corpus (observations, API-model ids, and the
-            per-triple evaluation configs to mirror).
-        include_api:
-            Whether the user opted in to running API models.
-        api_providers_arg:
-            Optional comma-separated provider filter.
-        force:
-            When True, re-run even models that already have a new-dataset
-            result line.
-
-    Returns:
-        The re-eval jobs to schedule.
-
-    Raises:
-        click.ClickException:
-            When the target languages can't be resolved, or a selected API
-            provider's env var is missing.
-    """
-    old_codes = dataset_language_codes(dataset_id=old_dataset)
-    new_codes = dataset_language_codes(dataset_id=new_dataset)
-    if requested_languages:
-        target_codes = set(requested_languages)
-    else:
-        target_codes = old_codes & new_codes
-    if not target_codes:
-        raise click.ClickException(
-            "No target languages: the old and new datasets share no languages. "
-            "Pass --language to specify the affected leaderboard(s) explicitly."
-        )
-    logger.info(
-        f"Re-eval: {old_dataset!r} -> {new_dataset!r} on language(s): "
-        f"{', '.join(sorted(target_codes))}."
-    )
-
-    old_config = dataset_config(dataset_id=old_dataset)
-    swapped_task = old_config.task.name if old_config is not None else ""
-    ranked_pairs = ranked_model_language_pairs(
-        old_dataset=old_dataset,
-        new_dataset=new_dataset,
-        swapped_task=swapped_task,
-        language_codes=target_codes,
-        observations=corpus.observations,
-    )
-    logger.info(f"Found {len(ranked_pairs)} ranked (model, language) pair(s).")
-
-    def is_api_model(model_id: str) -> bool:
-        return (
-            model_id in corpus.api_model_ids
-            or provider_for_model_id(model_id) is not None
-        )
-
-    ranked_api = sorted({m for m, _ in ranked_pairs if is_api_model(m)})
-    selected_providers = select_api_providers(
-        has_any_api=bool(ranked_api),
-        include_api=include_api,
-        api_providers_arg=api_providers_arg,
-    )
-    if ranked_api and not include_api:
-        logger.info(
-            f"Excluding {len(ranked_api)} ranked API model(s); pass --include-api "
-            "to evaluate them."
-        )
-
-    jobs: list[Job] = []
-    for model_id, code in sorted(ranked_pairs):
-        if code not in new_codes:
-            logger.info(
-                f"{model_id}: skipping {code} -- new dataset {new_dataset!r} does "
-                f"not cover it."
-            )
-            continue
-        is_api = is_api_model(model_id=model_id)
-        if is_api:
-            if not include_api:
-                continue
-            # Known-provider API models are gated on the provider selection; a
-            # bare-id API model whose provider we can't classify is included
-            # once the operator has opted in with --include-api.
-            provider = provider_for_model_id(model_id=model_id)
-            if provider is not None and provider.name not in selected_providers:
-                continue
-        if not force and (model_id, new_dataset, code) in corpus.observations:
-            continue
-        evaluate_test_split, zero_shot = _mirror_eval_config(
-            config=corpus.eval_configs.get((model_id, old_dataset, code)), is_api=is_api
-        )
-        jobs.append(
-            Job(
-                model_id=model_id,
-                dataset=new_dataset,
-                languages=(code,),
-                is_api=is_api,
-                evaluate_test_split=evaluate_test_split,
-                zero_shot=zero_shot,
-            )
-        )
-    return jobs
-
-
-def _mirror_eval_config(config: _ObsConfig | None, is_api: bool) -> tuple[bool, bool]:
-    """Return ``(evaluate_test_split, zero_shot)`` mirroring the old dataset.
-
-    The re-eval must reproduce how the model was evaluated on the outgoing
-    dataset: the same split, and -- for generative models only -- the same
-    zero-shot/few-shot prompting. Encoder models never get ``--zero-shot``.
-    When no recorded config is available, fall back to the split/prompting
-    default for the model type (API: validation split, zero-shot;
-    open-weight: test split, few-shot).
-
-    Args:
-        config:
-            The recorded evaluation config for the outgoing dataset, or None.
-        is_api:
-            Whether the model is an API model, used only for the fallback.
-
-    Returns:
-        The ``(evaluate_test_split, zero_shot)`` flags for the new job.
-    """
-    if config is None:
-        return (not is_api), is_api
-    # Test split only when the record explicitly says so; True/None mean val,
-    # following the repo-wide backwards-compatibility convention.
-    evaluate_test_split = not _is_validation_split(config.validation_split)
-    # Zero-shot only for generative models whose record used zero-shot.
-    zero_shot = config.generative and config.few_shot is False
-    return evaluate_test_split, zero_shot
-
-
-def ranked_model_language_pairs(
-    old_dataset: str,
-    new_dataset: str,
-    swapped_task: str,
-    language_codes: set[str],
-    observations: set[tuple[str, str, str]],
-) -> set[tuple[str, str]]:
-    """Return ``(model_id, language_code)`` pairs ranked under the pre-swap config.
-
-    A model is "ranked" in a language when it holds a result for every
-    required (non-orthogonal) dataset of that language's single-language
-    leaderboard -- the same eligibility rule the leaderboard generator uses
-    to award a rank score. Eligibility is checked in every leaderboard
-    category the swapped task belongs to: the ``generative`` category scores
-    all tasks, while the ``all_models`` category scores only NLU tasks so
-    encoder models can be compared. A model ranked in *either* category is
-    selected, so encoder models are re-evaluated whenever the swapped task is
-    an NLU task they can run.
-
-    The required set is normalised so it always reflects the pre-swap
-    leaderboard: the outgoing dataset is added and the incoming candidate
-    removed. Because the re-eval runs before the flags are flipped this is
-    normally a no-op (the outgoing dataset is already official and the
-    incoming one already excluded), but it keeps the selection correct even
-    if the configs have already been edited.
-
-    Args:
-        old_dataset:
-            The outgoing dataset id being replaced (kept in the required set).
-        new_dataset:
-            The incoming candidate dataset id (kept out of the required set).
-        swapped_task:
-            The task both datasets belong to; determines which leaderboard
-            categories are affected.
-        language_codes:
-            The language codes whose leaderboards are being re-evaluated.
-        observations:
-            Recorded ``(model, dataset, language)`` triples.
-
-    Returns:
-        The ``(model_id, language_code)`` pairs that were ranked pre-swap.
-    """
-    languages = get_all_languages()
-    affected_categories = [
-        category
-        for category in LEADERBOARD_CATEGORIES
-        if category_includes_task(category=category, task=swapped_task)
-    ]
-    if not affected_categories:
-        logger.warning(
-            f"Task {swapped_task!r} is in no leaderboard category; nothing to do."
-        )
-        return set()
-
-    # Index observed datasets by language, then model, so each leaderboard
-    # language only scans the models actually evaluated in it.
-    datasets_by_language: dict[str, dict[str, set[str]]] = defaultdict(
-        lambda: defaultdict(set)
-    )
-    for model_id, dataset, code in observations:
-        datasets_by_language[code][model_id].add(dataset)
-
-    ranked: set[tuple[str, str]] = set()
-    for code in sorted(language_codes):
-        language = languages.get(code)
-        if language is None:
-            logger.warning(f"Unknown language code {code!r}; skipping.")
-            continue
-        name = language.name.lower()
-        if " " in name:
-            logger.warning(
-                f"{code!r} ({name!r}) is a dialect/multi-word language with no "
-                f"standalone leaderboard; skipping."
-            )
-            continue
-        try:
-            by_task = official_datasets_for_language(name)
-        except ValueError:
-            logger.warning(f"No leaderboard datasets for {name!r}; skipping.")
-            continue
-
-        models_in_language = datasets_by_language.get(code, {})
-        # A model is ranked in this language if it is eligible in any affected
-        # category, i.e. holds every required dataset of that category.
-        for category in affected_categories:
-            required = {
-                dataset
-                for task, task_datasets in by_task.items()
-                if task not in ORTHOGONAL_TASKS
-                and category_includes_task(category=category, task=task)
-                for dataset in task_datasets
-            }
-            required.discard(new_dataset)
-            required.add(old_dataset)
-            if not required:
-                continue
-            for model_id, datasets in models_in_language.items():
-                if required <= datasets:
-                    ranked.add((model_id, code))
-    return ranked
-
-
-def apply_size_filter(
-    jobs: list[Job], gpu_memory_utilization: float | None
-) -> list[Job]:
+def apply_size_filter(jobs: list[Job]) -> list[Job]:
     """Drop open-weight jobs whose model can't fit on the local GPU.
-
-    Mirrors the queue script's fit pre-check: vLLM can only allocate
-    ``gpu_memory_utilization * total GPU memory``, so the budget is that
-    fraction of the card rather than the whole card -- otherwise a model
-    whose weights fit but whose KV cache does not still slips through and
-    OOMs at runtime.
 
     API jobs are passed through untouched (we cannot size-check them).
     Open-weight models whose safetensors footprint cannot be measured
@@ -952,9 +377,6 @@ def apply_size_filter(
     Args:
         jobs:
             The full job list before the size check.
-        gpu_memory_utilization:
-            The vLLM GPU memory utilization fraction the eval will run at,
-            or None to use :data:`DEFAULT_GPU_MEMORY_UTILIZATION`.
 
     Returns:
         The jobs that should still be scheduled.
@@ -963,17 +385,7 @@ def apply_size_filter(
     if gpu_bytes is None:
         logger.info("Local memory budget unknown; skipping size pre-check.")
         return jobs
-    utilization = (
-        gpu_memory_utilization
-        if gpu_memory_utilization is not None
-        else DEFAULT_GPU_MEMORY_UTILIZATION
-    )
-    usable_bytes = int(gpu_bytes * utilization)
-    logger.info(
-        f"Local memory budget: {gpu_bytes / (1024**3):.1f} GiB total, "
-        f"{usable_bytes / (1024**3):.1f} GiB usable at "
-        f"gpu_memory_utilization={utilization}."
-    )
+    logger.info(f"Local memory budget: {gpu_bytes / (1024**3):.1f} GiB.")
 
     sized_cache: dict[str, bool] = {}
     kept: list[Job] = []
@@ -983,50 +395,42 @@ def apply_size_filter(
             continue
         if job.model_id not in sized_cache:
             fits, needed = model_fits_locally(
-                model_id=job.model_id, gpu_bytes=usable_bytes
+                model_id=job.model_id, gpu_bytes=gpu_bytes
             )
             sized_cache[job.model_id] = fits
             if not fits and needed is not None:
                 logger.info(
                     f"{job.model_id}: skipping -- needs "
-                    f"~{needed / (1024**3):.1f} GiB of weights, exceeds the usable "
-                    f"vLLM budget of {usable_bytes / (1024**3):.1f} GiB."
+                    f"~{needed / (1024**3):.1f} GiB of weights, exceeds local "
+                    f"budget of {gpu_bytes / (1024**3):.1f} GiB."
                 )
         if sized_cache[job.model_id]:
             kept.append(job)
     return kept
 
 
-def execute_jobs(jobs: list[Job], gpu_memory_utilization: float | None) -> None:
+def execute_jobs(jobs: list[Job]) -> None:
     """Run each job in sequence via the shared euroeval runner.
 
-    Each job carries its own split and prompting flags (mirrored from the
-    outgoing dataset in re-eval mode, or the model-type default otherwise),
-    so they are forwarded to euroeval verbatim.
+    API jobs are run on the validation split with zero-shot prompting;
+    open-weight jobs use the defaults (test split, few-shot).
 
     Args:
         jobs:
             The jobs to execute.
-        gpu_memory_utilization:
-            vLLM GPU memory utilization fraction to pass to euroeval, or
-            None to let the CLI default apply. Passing the same value the
-            fit pre-check budgeted against keeps the two consistent.
     """
     for index, job in enumerate(jobs, start=1):
-        split = "test" if job.evaluate_test_split else "val"
-        shots = "zero-shot" if job.zero_shot else "few-shot"
         logger.info(
             f"[{index}/{len(jobs)}] euroeval --model {job.model_id} "
-            f"--dataset {job.dataset} --language {' --language '.join(job.languages)} "
-            f"({split}, {shots})"
+            f"--dataset {job.dataset} --language {' --language '.join(job.languages)}"
+            f"{' (api, val, zero-shot)' if job.is_api else ''}"
         )
         returncode, _ = run_euroeval(
             model_id=job.model_id,
             languages=job.languages,
             datasets=[job.dataset],
-            evaluate_test_split=job.evaluate_test_split,
-            zero_shot=job.zero_shot,
-            gpu_memory_utilization=gpu_memory_utilization,
+            evaluate_test_split=not job.is_api,
+            zero_shot=job.is_api,
         )
         if returncode != 0:
             logger.warning(
@@ -1062,101 +466,6 @@ def codes_for_model(model: CoreModel) -> set[str]:
             continue
         codes.add(code)
     return codes
-
-
-def dataset_config(dataset_id: str) -> DatasetConfig | None:
-    """Return the :class:`DatasetConfig` for a dataset id, or None if unknown.
-
-    Args:
-        dataset_id:
-            The dataset id to look up.
-
-    Returns:
-        The matching config, or None when the id is not a known dataset.
-    """
-    configs = get_all_dataset_configs(
-        custom_datasets_file=Path(""),
-        dataset_ids=[dataset_id],
-        api_key=None,
-        cache_dir=Path(".cache"),
-        trust_remote_code=False,
-        run_with_cli=False,
-    )
-    return configs.get(dataset_id)
-
-
-def dataset_language_codes(dataset_id: str) -> set[str]:
-    """Return ISO codes for a dataset, or an empty set if the dataset is unknown.
-
-    Args:
-        dataset_id:
-            The dataset id to look up.
-
-    Returns:
-        The ISO codes the dataset covers, or an empty set when the id is
-        not a known dataset (logged at ERROR level).
-    """
-    config = dataset_config(dataset_id=dataset_id)
-    if config is None:
-        logger.error(f"Unknown dataset id {dataset_id!r}; skipping.")
-        return set()
-    return {language.code for language in config.languages}
-
-
-def validate_reeval_datasets(old_dataset: str, new_dataset: str) -> None:
-    """Validate the old/new dataset pair for leaderboard re-eval mode.
-
-    The re-eval runs *before* the config flags are flipped: the candidate
-    replacement is still unofficial and the dataset it will replace is still
-    official, so the leaderboard stays intact while the new dataset is
-    evaluated on every ranked model. Enforces a genuine within-task swap:
-    the outgoing dataset must be official, the incoming (candidate) dataset
-    must be unofficial, both must have dataset configs, and both must belong
-    to the same task.
-
-    Args:
-        old_dataset:
-            The outgoing dataset id being replaced (expected to be official).
-        new_dataset:
-            The incoming candidate dataset id to evaluate (expected to be
-            unofficial).
-
-    Raises:
-        click.ClickException:
-            When either dataset is unknown, the official/unofficial flags
-            are wrong, or the two datasets are not the same task.
-    """
-    old_config = dataset_config(dataset_id=old_dataset)
-    new_config = dataset_config(dataset_id=new_dataset)
-    if old_config is None:
-        raise click.ClickException(
-            f"--reeval-old {old_dataset!r} has no dataset config; both datasets "
-            "must already be configured."
-        )
-    if new_config is None:
-        raise click.ClickException(
-            f"--reeval-new {new_dataset!r} has no dataset config; both datasets "
-            "must already be configured."
-        )
-    if old_config.unofficial:
-        raise click.ClickException(
-            f"--reeval-old {old_dataset!r} must be official (the dataset being "
-            "replaced); it is currently unofficial. Only an official dataset can "
-            "be replaced."
-        )
-    if not new_config.unofficial:
-        raise click.ClickException(
-            f"--reeval-new {new_dataset!r} must be UNofficial (the candidate "
-            "replacement to evaluate); it is currently official. Keep it "
-            "unofficial until every ranked model has been evaluated on it, then "
-            "flip the flags."
-        )
-    if old_config.task.name != new_config.task.name:
-        raise click.ClickException(
-            f"--reeval-old and --reeval-new must belong to the same task; "
-            f"{old_dataset!r} is {old_config.task.name!r} but {new_dataset!r} is "
-            f"{new_config.task.name!r}."
-        )
 
 
 def provider_for_model_id(model_id: str) -> _Provider | None:

--- a/src/scripts/run_core_model_evaluations.py
+++ b/src/scripts/run_core_model_evaluations.py
@@ -8,11 +8,13 @@ Three related workflows live in this script:
 2. **Backfill mode** (default) -- for every core model, run every official
    ``(dataset, language)`` pair that the model has no result line for yet.
 3. **Leaderboard re-eval mode** (``--reeval-old <ds> --reeval-new <ds>``) --
-   after an official dataset is swapped for another on a language's
-   leaderboard, re-run the *new* dataset for every model that currently
-   holds a full rank score on that leaderboard (i.e. held every required
-   dataset under the pre-swap config). Unlike the other two modes the model
-   set is drawn from the recorded results, not from ``core_models.yaml``.
+   when a new (still unofficial) dataset is going to replace an official one
+   on a language's leaderboard, evaluate that candidate on every model that
+   currently holds a full rank score there (i.e. holds every required
+   dataset). Run this *before* flipping the official flags so the
+   leaderboard stays intact while the data is gathered. Unlike the other two
+   modes the model set is drawn from the recorded results, not from
+   ``core_models.yaml``.
 
 All modes share the size-check, results lookup, and the API-provider prompt.
 
@@ -89,15 +91,15 @@ logger = logging.getLogger("run_core_model_evaluations")
     "--reeval-old",
     "reeval_old",
     default=None,
-    help="Leaderboard re-eval mode: the outgoing dataset id whose ranked models "
-    "should be re-run. Requires --reeval-new.",
+    help="Leaderboard re-eval mode: the official dataset being replaced, whose "
+    "ranked models define the set to evaluate. Requires --reeval-new.",
 )
 @click.option(
     "--reeval-new",
     "reeval_new",
     default=None,
-    help="Leaderboard re-eval mode: the incoming dataset id to run for every model "
-    "that was ranked under the pre-swap config. Requires --reeval-old.",
+    help="Leaderboard re-eval mode: the unofficial candidate dataset to evaluate on "
+    "every model ranked under --reeval-old. Requires --reeval-old.",
 )
 @click.option(
     "--language",
@@ -218,8 +220,9 @@ def main(
         validate_reeval_datasets(old_dataset=reeval_old, new_dataset=reeval_new)
 
     observations: set[tuple[str, str, str]] = set()
+    api_model_ids: set[str] = set()
     try:
-        observations = load_existing_observations()
+        observations, api_model_ids = load_existing_observations()
     except FileNotFoundError as e:
         if reeval:
             raise click.ClickException(
@@ -236,6 +239,7 @@ def main(
             new_dataset=reeval_new,
             requested_languages=languages,
             observations=observations,
+            api_model_ids=api_model_ids,
             include_api=include_api,
             api_providers_arg=api_providers,
             force=force,
@@ -349,19 +353,25 @@ def select_api_providers(
     return selected
 
 
-def load_existing_observations() -> set[tuple[str, str, str]]:
-    """Return the ``(model_id, dataset, language)`` triples already benchmarked.
+def load_existing_observations() -> tuple[set[tuple[str, str, str]], set[str]]:
+    """Return benchmarked triples and the set of API-model ids in the corpus.
 
     Reads the merged result corpus the same way the leaderboard pipeline
     does -- the per-model files in ``RESULTS_DIR`` plus the optional
     ``new_results.jsonl`` -- but without the destructive unlink that
     :func:`leaderboards.result_loading.load_raw_results` performs.
 
+    A model is treated as an API model when its record was produced by the
+    ``litellm`` inference engine or is flagged as not open-weight. This is
+    more reliable than id-prefix matching because historical API results are
+    stored under bare ids (e.g. ``gpt-5.5``) that carry no ``openai/`` prefix.
+
     Returns:
-        Every ``(model_id, dataset, language)`` triple in the merged
-        result corpus, with model ids unwrapped from any leaderboard
-        HTML anchor so the keys line up with the canonical ids in
-        ``core_models.yaml``.
+        A ``(observations, api_model_ids)`` pair. ``observations`` is every
+        ``(model_id, dataset, language)`` triple in the corpus, with model
+        ids unwrapped from any leaderboard HTML anchor so the keys line up
+        with the canonical ids in ``core_models.yaml``. ``api_model_ids`` is
+        the subset of those model ids evaluated via an API.
     """
     lines: list[str] = []
     for model_file in sorted(RESULTS_DIR.glob("*.jsonl")):
@@ -370,6 +380,7 @@ def load_existing_observations() -> set[tuple[str, str, str]]:
         lines.extend(NEW_RESULTS_PATH.read_text(encoding="utf-8").splitlines())
 
     observations: set[tuple[str, str, str]] = set()
+    api_model_ids: set[str] = set()
     parse_failures = 0
     for line_idx, line in enumerate(lines):
         line = line.strip()
@@ -391,7 +402,8 @@ def load_existing_observations() -> set[tuple[str, str, str]]:
                 continue
 
             # EEE: model_info.name, eval_library.additional_details.dataset/languages
-            model = raw_record.get("model_info", {}).get("name", "")
+            model_info = raw_record.get("model_info", {})
+            model = model_info.get("name", "")
             eval_additional = raw_record.get("eval_library", {}).get(
                 "additional_details", {}
             )
@@ -409,17 +421,40 @@ def load_existing_observations() -> set[tuple[str, str, str]]:
             model = _strip_anchor(model_id=str(model))
             if not model or not dataset:
                 continue
+            if _record_is_api(model_info=model_info):
+                api_model_ids.add(model)
             for language in languages:
                 observations.add((model, str(dataset), str(language)))
     logger.info(
-        f"Loaded {len(observations):,} (model, dataset, language) observations."
+        f"Loaded {len(observations):,} (model, dataset, language) observations "
+        f"({len(api_model_ids):,} API model(s))."
     )
     if parse_failures:
         logger.warning(
             f"Skipped {parse_failures:,} unparseable result record(s); see "
             "earlier warnings for details."
         )
-    return observations
+    return observations, api_model_ids
+
+
+def _record_is_api(model_info: dict[str, object]) -> bool:
+    """Return whether a result record's model was evaluated via an API.
+
+    Args:
+        model_info:
+            The ``model_info`` object of an EEE result record.
+
+    Returns:
+        True when the record was produced by the ``litellm`` inference
+        engine or is flagged as not open-weight.
+    """
+    engine = model_info.get("inference_engine", {})
+    engine_name = engine.get("name", "") if isinstance(engine, dict) else ""
+    if str(engine_name).lower() == "litellm":
+        return True
+    details = model_info.get("additional_details", {})
+    open_flag = details.get("open") if isinstance(details, dict) else None
+    return str(open_flag).lower() == "false"
 
 
 def build_jobs(
@@ -524,6 +559,7 @@ def plan_reeval_jobs(
     new_dataset: str,
     requested_languages: tuple[str, ...],
     observations: set[tuple[str, str, str]],
+    api_model_ids: set[str],
     include_api: bool,
     api_providers_arg: str | None,
     force: bool,
@@ -533,7 +569,8 @@ def plan_reeval_jobs(
     Selects the language(s) whose leaderboard is affected by the swap,
     finds every model that held a full rank score under the pre-swap
     config, and schedules the new dataset for each such model in the
-    languages it was ranked in.
+    languages it was ranked in. API models are excluded unless the user
+    opts in with ``--include-api``, so a plain re-eval never spends money.
 
     Args:
         old_dataset:
@@ -545,6 +582,8 @@ def plan_reeval_jobs(
             both the old and new datasets.
         observations:
             Recorded ``(model, dataset, language)`` triples.
+        api_model_ids:
+            Model ids the corpus shows were evaluated via an API.
         include_api:
             Whether the user opted in to running API models.
         api_providers_arg:
@@ -585,15 +624,20 @@ def plan_reeval_jobs(
     )
     logger.info(f"Found {len(ranked_pairs)} ranked (model, language) pair(s).")
 
-    has_any_api = any(
-        provider_for_model_id(model_id=model_id) is not None
-        for model_id, _ in ranked_pairs
-    )
+    def is_api_model(model_id: str) -> bool:
+        return model_id in api_model_ids or provider_for_model_id(model_id) is not None
+
+    ranked_api = sorted({m for m, _ in ranked_pairs if is_api_model(m)})
     selected_providers = select_api_providers(
-        has_any_api=has_any_api,
+        has_any_api=bool(ranked_api),
         include_api=include_api,
         api_providers_arg=api_providers_arg,
     )
+    if ranked_api and not include_api:
+        logger.info(
+            f"Excluding {len(ranked_api)} ranked API model(s); pass --include-api "
+            "to evaluate them."
+        )
 
     jobs: list[Job] = []
     for model_id, code in sorted(ranked_pairs):
@@ -603,10 +647,16 @@ def plan_reeval_jobs(
                 f"not cover it."
             )
             continue
-        provider = provider_for_model_id(model_id=model_id)
-        is_api = provider is not None
-        if is_api and provider.name not in selected_providers:
-            continue
+        is_api = is_api_model(model_id=model_id)
+        if is_api:
+            if not include_api:
+                continue
+            # Known-provider API models are gated on the provider selection; a
+            # bare-id API model whose provider we can't classify is included
+            # once the operator has opted in with --include-api.
+            provider = provider_for_model_id(model_id=model_id)
+            if provider is not None and provider.name not in selected_providers:
+                continue
         if not force and (model_id, new_dataset, code) in observations:
             continue
         jobs.append(
@@ -628,17 +678,18 @@ def ranked_model_language_pairs(
     A model is "ranked" in a language when it holds a result for every
     required (non-orthogonal) dataset of that language's single-language
     leaderboard -- the same eligibility rule the leaderboard generator uses
-    to award a rank score. The swap has already been applied to the configs
-    (validated by :func:`validate_reeval_datasets`), so the pre-swap required
-    set is reconstructed from the *current* official datasets by removing the
-    now-official incoming dataset and adding the now-unofficial outgoing one
-    back.
+    to award a rank score. The required set is normalised so it always
+    reflects the pre-swap leaderboard: the outgoing dataset is added and the
+    incoming candidate removed. Because the re-eval runs before the flags are
+    flipped this is normally a no-op (the outgoing dataset is already
+    official and the incoming one already excluded), but it keeps the
+    selection correct even if the configs have already been edited.
 
     Args:
         old_dataset:
-            The outgoing dataset id (added back into the required set).
+            The outgoing dataset id being replaced (kept in the required set).
         new_dataset:
-            The incoming dataset id (removed from the required set).
+            The incoming candidate dataset id (kept out of the required set).
         language_codes:
             The language codes whose leaderboards are being re-evaluated.
         observations:
@@ -860,16 +911,20 @@ def dataset_language_codes(dataset_id: str) -> set[str]:
 def validate_reeval_datasets(old_dataset: str, new_dataset: str) -> None:
     """Validate the old/new dataset pair for leaderboard re-eval mode.
 
-    Enforces that the config edit has already happened and describes a
-    genuine within-task swap: the outgoing dataset must now be unofficial,
-    the incoming dataset must be official, both must have dataset configs,
-    and both must belong to the same task.
+    The re-eval runs *before* the config flags are flipped: the candidate
+    replacement is still unofficial and the dataset it will replace is still
+    official, so the leaderboard stays intact while the new dataset is
+    evaluated on every ranked model. Enforces a genuine within-task swap:
+    the outgoing dataset must be official, the incoming (candidate) dataset
+    must be unofficial, both must have dataset configs, and both must belong
+    to the same task.
 
     Args:
         old_dataset:
-            The outgoing dataset id (expected to be unofficial).
+            The outgoing dataset id being replaced (expected to be official).
         new_dataset:
-            The incoming dataset id (expected to be official).
+            The incoming candidate dataset id to evaluate (expected to be
+            unofficial).
 
     Raises:
         click.ClickException:
@@ -888,17 +943,18 @@ def validate_reeval_datasets(old_dataset: str, new_dataset: str) -> None:
             f"--reeval-new {new_dataset!r} has no dataset config; both datasets "
             "must already be configured."
         )
-    if not old_config.unofficial:
+    if old_config.unofficial:
         raise click.ClickException(
-            f"--reeval-old {old_dataset!r} must be UNofficial (the dataset being "
-            "replaced); it is currently official. Demote it in its dataset config "
-            "before running the re-eval."
+            f"--reeval-old {old_dataset!r} must be official (the dataset being "
+            "replaced); it is currently unofficial. Only an official dataset can "
+            "be replaced."
         )
-    if new_config.unofficial:
+    if not new_config.unofficial:
         raise click.ClickException(
-            f"--reeval-new {new_dataset!r} must be official (the replacement); it "
-            "is currently unofficial. Promote it in its dataset config before "
-            "running the re-eval."
+            f"--reeval-new {new_dataset!r} must be UNofficial (the candidate "
+            "replacement to evaluate); it is currently official. Keep it "
+            "unofficial until every ranked model has been evaluated on it, then "
+            "flip the flags."
         )
     if old_config.task.name != new_config.task.name:
         raise click.ClickException(

--- a/src/scripts/swap_leaderboard_dataset.py
+++ b/src/scripts/swap_leaderboard_dataset.py
@@ -512,6 +512,9 @@ def load_corpus() -> _Corpus:
             try:
                 record = json.loads(record_text)
             except json.JSONDecodeError:
+                logger.warning(
+                    "Skipping malformed JSON record: %s...", record_text[:80]
+                )
                 continue
             model = plain_model_id(str(record.get("model_info", {}).get("name", "")))
             dataset = get_dataset(record=record)
@@ -920,7 +923,7 @@ def record_is_api(model_info: dict[str, object]) -> bool:
     return str(open_flag).lower() == "false"
 
 
-def _record_languages(record: dict) -> list[str]:
+def _record_languages(record: dict[str, object]) -> list[str]:
     """Return the language codes a result record covers.
 
     Args:
@@ -1331,6 +1334,11 @@ def open_pull_request(
     """
     for path in changed_paths:
         _git("add", str(path))
+    # Check if there are any actual changes to commit
+    diff_result = _git("diff", "--cached", "--quiet", check=False)
+    if diff_result.returncode == 0:
+        logger.info("No changes to commit; skipping PR creation.")
+        return
     title = f"feat: swap official dataset {old_dataset} -> {new_dataset}"
     body = _pr_body(old_dataset=old_dataset, new_dataset=new_dataset)
     _git("commit", "-m", title, "-m", body)

--- a/src/scripts/swap_leaderboard_dataset.py
+++ b/src/scripts/swap_leaderboard_dataset.py
@@ -1,19 +1,22 @@
 r"""Replace an official leaderboard dataset with a new one, end to end.
 
 When a new dataset should take over a task slot on a language's leaderboard
-from the current official one, three things have to happen:
+from the current official one, four things have to happen:
 
-1. **Evaluate.** Every model that currently holds a full rank score on the
+1. **Sync results.** Download all results from the HF bucket and consolidate
+   into ``new_results.jsonl`` so already-completed evaluations are detected
+   and skipped. This is read-only for the bucket.
+2. **Evaluate.** Every model that currently holds a full rank score on the
    affected leaderboard(s) must be evaluated on the new (still unofficial)
    dataset -- mirroring exactly how each model appears on the leaderboard
    (validation vs test split, zero-shot vs few-shot). This runs *before* the
    official flags are flipped, so the live leaderboard stays intact while the
    data is gathered.
-2. **Swap the configs.** The outgoing dataset is demoted to unofficial and the
+3. **Swap the configs.** The outgoing dataset is demoted to unofficial and the
    incoming one promoted to official, in both the ``euroeval`` dataset configs
    and the frontend dataset documentation, keeping the official-first grouping
    each file uses.
-3. **Open a PR** with the config/doc changes.
+4. **Open a PR** with the config/doc changes.
 
 Everything happens on a dedicated branch -- ``--branch`` is required and may
 not be the default branch.
@@ -67,12 +70,63 @@ from leaderboards.task_metadata import (
     official_datasets_for_language,
 )
 
+HF_RESULTS_BUCKET = "EuroEval/results"
+
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s"
 )
 logger = logging.getLogger("swap_leaderboard_dataset")
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+HF_RESULTS_BUCKET = "EuroEval/results"
+
+
+def sync_results_from_bucket() -> None:
+    """Sync results from the HF bucket and consolidate into NEW_RESULTS_PATH.
+
+    Downloads all .jsonl files from the EuroEval/results bucket to RESULTS_DIR,
+    then merges them into NEW_RESULTS_PATH (appending, not overwriting) so
+    subsequent evaluations can detect and skip already-completed runs.
+    """
+    logger.info("Syncing results from HF bucket %s...", HF_RESULTS_BUCKET)
+
+    # Sync bucket files to local RESULTS_DIR
+    subprocess.run(
+        ["hf", "buckets", "sync", HF_RESULTS_BUCKET, str(RESULTS_DIR), "--verbose"],
+        check=True,
+    )
+
+    # Consolidate all results into NEW_RESULTS_PATH (append mode)
+    all_lines: list[str] = []
+    for model_file in sorted(RESULTS_DIR.glob("*.jsonl")):
+        all_lines.extend(model_file.read_text(encoding="utf-8").splitlines())
+
+    if all_lines:
+        # Read existing lines from NEW_RESULTS_PATH if it exists
+        existing_lines: set[str] = set()
+        if NEW_RESULTS_PATH.exists():
+            existing_lines = set(
+                NEW_RESULTS_PATH.read_text(encoding="utf-8").splitlines()
+            )
+
+        # Append only new lines
+        new_lines = [line for line in all_lines if line not in existing_lines]
+        if new_lines:
+            logger.info(
+                "Consolidating %s result lines into %s (%s new).",
+                len(all_lines),
+                NEW_RESULTS_PATH,
+                len(new_lines),
+            )
+            with NEW_RESULTS_PATH.open("a", encoding="utf-8") as f:
+                for line in new_lines:
+                    f.write(line + "\n")
+        else:
+            logger.info("No new result lines to consolidate.")
+    else:
+        logger.warning("No results found in bucket.")
+
+
 DATASET_CONFIG_DIR = REPO_ROOT / "src" / "euroeval" / "dataset_configs"
 DATASET_DOC_DIR = REPO_ROOT / "src" / "frontend" / "md" / "datasets"
 UNOFFICIAL_MARKER = "# Unofficial datasets ###"
@@ -214,6 +268,8 @@ def main(
 
     if not dry_run:
         checkout_branch(branch=branch)
+        # Sync latest results from bucket to avoid re-running evaluations
+        sync_results_from_bucket()
 
     if skip_eval:
         logger.info("--skip-eval set; skipping the evaluation phase.")

--- a/src/scripts/swap_leaderboard_dataset.py
+++ b/src/scripts/swap_leaderboard_dataset.py
@@ -1,0 +1,1495 @@
+r"""Replace an official leaderboard dataset with a new one, end to end.
+
+When a new dataset should take over a task slot on a language's leaderboard
+from the current official one, three things have to happen:
+
+1. **Evaluate.** Every model that currently holds a full rank score on the
+   affected leaderboard(s) must be evaluated on the new (still unofficial)
+   dataset -- mirroring exactly how each model appears on the leaderboard
+   (validation vs test split, zero-shot vs few-shot). This runs *before* the
+   official flags are flipped, so the live leaderboard stays intact while the
+   data is gathered.
+2. **Swap the configs.** The outgoing dataset is demoted to unofficial and the
+   incoming one promoted to official, in both the ``euroeval`` dataset configs
+   and the frontend dataset documentation, keeping the official-first grouping
+   each file uses.
+3. **Open a PR** (optional) with the config/doc changes.
+
+Everything happens on a dedicated branch -- ``--branch`` is required and may
+not be the default branch.
+
+Invoke as::
+
+    uv run src/scripts/swap_leaderboard_dataset.py \\
+        --old-dataset scala-da --new-dataset dala --branch swap-scala-dala [--pr]
+
+Required env vars (open-weight models)
+--------------------------------------
+HF_TOKEN          Resolved via :func:`evaluation_common.resolve_hf_token`.
+
+Required env vars (API models, only with --include-api)
+-------------------------------------------------------
+OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY / XAI_API_KEY
+"""
+
+from __future__ import annotations
+
+import collections.abc as c
+import json
+import logging
+import os
+import re
+import subprocess
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+import click
+
+from euroeval.constants import ORTHOGONAL_TASKS
+from euroeval.data_models import DatasetConfig
+from euroeval.dataset_configs import get_all_dataset_configs
+from euroeval.languages import get_all_languages
+from leaderboards.constants import (
+    DEFAULT_GPU_MEMORY_UTILIZATION,
+    LEADERBOARD_CATEGORIES,
+    NEW_RESULTS_PATH,
+    RESULTS_DIR,
+)
+from leaderboards.evaluation_common import (
+    gpu_total_memory_bytes,
+    model_fits_locally,
+    run_euroeval,
+)
+from leaderboards.records import get_bool_field, get_dataset, plain_model_id
+from leaderboards.task_metadata import (
+    category_includes_task,
+    official_datasets_for_language,
+)
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s"
+)
+logger = logging.getLogger("swap_leaderboard_dataset")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DATASET_CONFIG_DIR = REPO_ROOT / "src" / "euroeval" / "dataset_configs"
+DATASET_DOC_DIR = REPO_ROOT / "src" / "frontend" / "md" / "datasets"
+UNOFFICIAL_MARKER = "# Unofficial datasets ###"
+UNOFFICIAL_LINE_RE = re.compile(r"^\s*unofficial\s*=\s*True\s*,\s*$")
+DOC_UNOFFICIAL_PREFIX = "Unofficial: "
+DEFAULT_REVIEWER = "saattrupdan"
+
+
+@click.command()
+@click.option(
+    "--old-dataset",
+    "old_dataset",
+    required=True,
+    help="The official dataset being replaced (demoted to unofficial).",
+)
+@click.option(
+    "--new-dataset",
+    "new_dataset",
+    required=True,
+    help="The unofficial candidate dataset being promoted to official.",
+)
+@click.option(
+    "--branch",
+    required=True,
+    help="Branch to do the work on. May not be the default branch (e.g. main).",
+)
+@click.option(
+    "--language",
+    "languages",
+    multiple=True,
+    help="Restrict re-evaluation to these language codes. When omitted, defaults "
+    "to the languages both datasets cover.",
+)
+@click.option(
+    "--include-api",
+    is_flag=True,
+    default=False,
+    help="Opt in to evaluating API models. Without it they are skipped, so a "
+    "plain run never spends money.",
+)
+@click.option(
+    "--api-providers",
+    default=None,
+    help="Comma-separated provider names to run (openai, anthropic, google, xai). "
+    "Requires --include-api.",
+)
+@click.option(
+    "--gpu-memory-utilization",
+    "gpu_memory_utilization",
+    type=click.FloatRange(min=0.0, max=1.0, min_open=True),
+    default=None,
+    help="vLLM GPU memory utilization fraction (0.0-1.0) the fit pre-check budgets "
+    f"against. When omitted, defaults to {DEFAULT_GPU_MEMORY_UTILIZATION}.",
+)
+@click.option(
+    "--skip-eval",
+    is_flag=True,
+    default=False,
+    help="Skip the evaluation phase and only perform the config/doc swap (useful "
+    "when the evaluations already ran).",
+)
+@click.option(
+    "--pr",
+    is_flag=True,
+    default=False,
+    help="After swapping, commit and push the branch and open a pull request.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Re-run even (model, language) pairs that already have a new-dataset "
+    "result line.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print the planned evaluations and file edits without running or "
+    "modifying anything.",
+)
+def main(
+    old_dataset: str,
+    new_dataset: str,
+    branch: str,
+    languages: tuple[str, ...],
+    include_api: bool,
+    api_providers: str | None,
+    gpu_memory_utilization: float | None,
+    skip_eval: bool,
+    pr: bool,
+    force: bool,
+    dry_run: bool,
+) -> None:
+    """Replace an official leaderboard dataset with a new one.
+
+    Args:
+        old_dataset:
+            The official dataset being replaced.
+        new_dataset:
+            The unofficial candidate being promoted.
+        branch:
+            The branch to do the work on; may not be the default branch.
+        languages:
+            Language codes to restrict evaluation to; empty means the codes
+            both datasets cover.
+        include_api:
+            Whether to evaluate API models.
+        api_providers:
+            Optional comma-separated provider filter.
+        gpu_memory_utilization:
+            vLLM GPU memory utilization fraction, or None for the default.
+        skip_eval:
+            When True, only perform the config/doc swap.
+        pr:
+            When True, commit, push, and open a pull request after swapping.
+        force:
+            When True, re-run pairs that already have a new-dataset result.
+        dry_run:
+            When True, print the plan and make no changes.
+
+    Raises:
+        click.ClickException:
+            When the dataset pair or branch is invalid, or a git/gh step fails.
+    """
+    if api_providers and not include_api:
+        raise click.ClickException(
+            "--api-providers requires --include-api; pass both or neither."
+        )
+    old_config, new_config = validate_datasets(
+        old_dataset=old_dataset, new_dataset=new_dataset
+    )
+    validate_branch(branch=branch)
+
+    target_codes = resolve_languages(
+        old_config=old_config, new_config=new_config, requested=languages
+    )
+    logger.info(
+        f"Swap {old_dataset!r} -> {new_dataset!r} (task {old_config.task.name!r}) "
+        f"on language(s): {', '.join(sorted(target_codes))}."
+    )
+
+    if not dry_run:
+        checkout_branch(branch=branch)
+
+    if skip_eval:
+        logger.info("--skip-eval set; skipping the evaluation phase.")
+    else:
+        run_evaluations(
+            old_dataset=old_dataset,
+            new_dataset=new_dataset,
+            swapped_task=old_config.task.name,
+            target_codes=target_codes,
+            include_api=include_api,
+            api_providers_arg=api_providers,
+            gpu_memory_utilization=gpu_memory_utilization,
+            force=force,
+            dry_run=dry_run,
+        )
+
+    changed = apply_swap(
+        old_dataset=old_dataset, new_dataset=new_dataset, dry_run=dry_run
+    )
+
+    if dry_run:
+        logger.info("Dry run complete; no evaluations ran and no files changed.")
+        return
+
+    if pr:
+        open_pull_request(
+            old_dataset=old_dataset,
+            new_dataset=new_dataset,
+            branch=branch,
+            changed_paths=changed,
+        )
+    else:
+        logger.info(
+            "Swap complete on branch %r. Re-run with --pr to open a pull request, "
+            "or commit the changes manually.",
+            branch,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Validation
+# --------------------------------------------------------------------------- #
+def validate_datasets(
+    old_dataset: str, new_dataset: str
+) -> tuple[DatasetConfig, DatasetConfig]:
+    """Validate the dataset pair and return their configs.
+
+    The swap runs before the flags are flipped, so the outgoing dataset must
+    still be official and the incoming candidate still unofficial, both must be
+    configured, and both must belong to the same task.
+
+    Args:
+        old_dataset:
+            The outgoing dataset id (expected official).
+        new_dataset:
+            The incoming candidate id (expected unofficial).
+
+    Returns:
+        The ``(old_config, new_config)`` pair.
+
+    Raises:
+        click.ClickException:
+            When a dataset is unknown, mis-flagged, or the tasks differ.
+    """
+    old_config = dataset_config(dataset_id=old_dataset)
+    new_config = dataset_config(dataset_id=new_dataset)
+    if old_config is None:
+        raise click.ClickException(f"--old-dataset {old_dataset!r} has no config.")
+    if new_config is None:
+        raise click.ClickException(f"--new-dataset {new_dataset!r} has no config.")
+    if old_config.unofficial:
+        raise click.ClickException(
+            f"--old-dataset {old_dataset!r} must be official; it is unofficial."
+        )
+    if not new_config.unofficial:
+        raise click.ClickException(
+            f"--new-dataset {new_dataset!r} must be unofficial; it is official."
+        )
+    if old_config.task.name != new_config.task.name:
+        raise click.ClickException(
+            f"Both datasets must share a task; {old_dataset!r} is "
+            f"{old_config.task.name!r} but {new_dataset!r} is {new_config.task.name!r}."
+        )
+    return old_config, new_config
+
+
+def validate_branch(branch: str) -> None:
+    """Reject an empty branch name or the default branch.
+
+    Args:
+        branch:
+            The requested branch name.
+
+    Raises:
+        click.ClickException:
+            When the branch is empty or is the repo's default branch.
+    """
+    if not branch.strip():
+        raise click.ClickException("--branch must be a non-empty branch name.")
+    default = default_branch()
+    if branch in {"main", "master", default}:
+        raise click.ClickException(
+            f"--branch may not be the default branch ({default!r}); pick a new "
+            "branch name for the swap."
+        )
+
+
+def resolve_languages(
+    old_config: DatasetConfig, new_config: DatasetConfig, requested: tuple[str, ...]
+) -> set[str]:
+    """Resolve the language codes whose leaderboards are affected.
+
+    Args:
+        old_config:
+            The outgoing dataset config.
+        new_config:
+            The incoming dataset config.
+        requested:
+            Language codes passed via ``--language``; empty means "both".
+
+    Returns:
+        The language codes to operate on.
+
+    Raises:
+        click.ClickException:
+            When no languages remain after intersecting the datasets.
+    """
+    old_codes = {language.code for language in old_config.languages}
+    new_codes = {language.code for language in new_config.languages}
+    if requested:
+        target = set(requested)
+    else:
+        target = old_codes & new_codes
+    if not target:
+        raise click.ClickException(
+            "The two datasets share no languages; pass --language explicitly."
+        )
+    return target
+
+
+# --------------------------------------------------------------------------- #
+# Evaluation phase
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class Job:
+    """A single evaluation of one model on the new dataset in one language."""
+
+    model_id: str
+    languages: tuple[str, ...]
+    is_api: bool
+    evaluate_test_split: bool
+    zero_shot: bool
+
+
+@dataclass(frozen=True)
+class _ObsConfig:
+    """How a model was evaluated on a (dataset, language), for mirroring."""
+
+    validation_split: bool
+    few_shot: bool
+    generative: bool
+
+
+@dataclass(frozen=True)
+class _Corpus:
+    """Parsed results indexed for ranked-model selection and mirroring."""
+
+    datasets_by_language: dict[str, dict[str, set[str]]]
+    api_model_ids: set[str]
+    observations: set[tuple[str, str, str]]
+    eval_configs: dict[tuple[str, str, str], _ObsConfig]
+
+
+def run_evaluations(
+    old_dataset: str,
+    new_dataset: str,
+    swapped_task: str,
+    target_codes: set[str],
+    include_api: bool,
+    api_providers_arg: str | None,
+    gpu_memory_utilization: float | None,
+    force: bool,
+    dry_run: bool,
+) -> None:
+    """Evaluate every ranked model on the new dataset, mirroring their setup.
+
+    Args:
+        old_dataset:
+            The outgoing dataset (defines the ranked-model set).
+        new_dataset:
+            The dataset to evaluate on.
+        swapped_task:
+            The task both datasets belong to.
+        target_codes:
+            The affected language codes.
+        include_api:
+            Whether to evaluate API models.
+        api_providers_arg:
+            Optional comma-separated provider filter.
+        gpu_memory_utilization:
+            vLLM GPU memory utilization fraction, or None for the default.
+        force:
+            When True, re-run pairs already holding a new-dataset result.
+        dry_run:
+            When True, print the plan without running.
+    """
+    corpus = load_corpus()
+    ranked = ranked_model_language_pairs(
+        old_dataset=old_dataset,
+        new_dataset=new_dataset,
+        swapped_task=swapped_task,
+        language_codes=target_codes,
+        datasets_by_language=corpus.datasets_by_language,
+    )
+    logger.info(f"Found {len(ranked)} ranked (model, language) pair(s).")
+
+    ranked_api = sorted({m for m, _ in ranked if m in corpus.api_model_ids})
+    present_providers = {
+        provider.name
+        for model_id in ranked_api
+        if (provider := provider_for_model_id(model_id=model_id)) is not None
+    }
+    selected_providers = resolve_api_providers(
+        include_api=include_api,
+        api_providers_arg=api_providers_arg,
+        present_providers=present_providers,
+    )
+    if ranked_api and not include_api:
+        logger.info(
+            f"Excluding {len(ranked_api)} ranked API model(s); pass --include-api "
+            "to evaluate them."
+        )
+
+    jobs = build_eval_jobs(
+        ranked=ranked,
+        old_dataset=old_dataset,
+        new_dataset=new_dataset,
+        corpus=corpus,
+        include_api=include_api,
+        selected_providers=selected_providers,
+        force=force,
+    )
+    logger.info(f"Planned {len(jobs)} evaluation(s) before the size check.")
+    jobs = apply_size_filter(jobs=jobs, gpu_memory_utilization=gpu_memory_utilization)
+    logger.info(f"{len(jobs)} evaluation(s) survive the size check.")
+
+    if dry_run:
+        for job in jobs:
+            tag = "api" if job.is_api else "open"
+            split = "test" if job.evaluate_test_split else "val"
+            shots = "zero-shot" if job.zero_shot else "few-shot"
+            click.echo(
+                f"[{tag}] {job.model_id} :: {new_dataset} :: "
+                f"{', '.join(job.languages)} :: {split}, {shots}"
+            )
+        return
+
+    execute_jobs(
+        jobs=jobs, dataset=new_dataset, gpu_memory_utilization=gpu_memory_utilization
+    )
+
+
+def load_corpus() -> _Corpus:
+    """Load the recorded results, indexed for selection and mirroring.
+
+    Reads the per-model JSONL files in ``RESULTS_DIR`` plus the optional
+    ``new_results.jsonl`` without the destructive unlink the leaderboard
+    pipeline performs. A model counts as an API model when its record was
+    produced by the ``litellm`` engine or is flagged as not open-weight. Each
+    ``(model, dataset, language)`` triple records its leaderboard variant
+    (split + prompting), preferring the test-split record when both exist
+    (that is the row the leaderboard shows).
+
+    Returns:
+        The parsed corpus.
+
+    Raises:
+        click.ClickException:
+            When no results can be loaded.
+    """
+    lines: list[str] = []
+    for model_file in sorted(RESULTS_DIR.glob("*.jsonl")):
+        lines.extend(model_file.read_text(encoding="utf-8").splitlines())
+    if NEW_RESULTS_PATH.exists():
+        lines.extend(NEW_RESULTS_PATH.read_text(encoding="utf-8").splitlines())
+    if not lines:
+        raise click.ClickException(
+            f"No results found under {RESULTS_DIR}; cannot find ranked models."
+        )
+
+    datasets_by_language: dict[str, dict[str, set[str]]] = defaultdict(
+        lambda: defaultdict(set)
+    )
+    api_model_ids: set[str] = set()
+    observations: set[tuple[str, str, str]] = set()
+    eval_configs: dict[tuple[str, str, str], _ObsConfig] = {}
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        for record_text in re.split(pattern=r"(?<=})(?={)", string=line):
+            if not record_text.strip():
+                continue
+            try:
+                record = json.loads(record_text)
+            except json.JSONDecodeError:
+                continue
+            model = plain_model_id(str(record.get("model_info", {}).get("name", "")))
+            dataset = get_dataset(record=record)
+            if not model or not dataset:
+                continue
+            model_info = record.get("model_info", {})
+            if record_is_api(model_info=model_info):
+                api_model_ids.add(model)
+            config = _ObsConfig(
+                validation_split=get_bool_field(record, "validation_split", False),
+                few_shot=get_bool_field(record, "few_shot", True),
+                generative=str(
+                    model_info.get("additional_details", {}).get("generative")
+                ).lower()
+                == "true",
+            )
+            for language in _record_languages(record=record):
+                datasets_by_language[language][model].add(str(dataset))
+                key = (model, str(dataset), language)
+                observations.add(key)
+                existing = eval_configs.get(key)
+                # Prefer the test-split record: when a model has both, the
+                # leaderboard row shows the test-split variant.
+                if existing is None or (
+                    not config.validation_split and existing.validation_split
+                ):
+                    eval_configs[key] = config
+    logger.info(
+        f"Loaded results for {len(datasets_by_language):,} language(s) "
+        f"({len(api_model_ids):,} API model(s))."
+    )
+    return _Corpus(
+        datasets_by_language=datasets_by_language,
+        api_model_ids=api_model_ids,
+        observations=observations,
+        eval_configs=eval_configs,
+    )
+
+
+def ranked_model_language_pairs(
+    old_dataset: str,
+    new_dataset: str,
+    swapped_task: str,
+    language_codes: set[str],
+    datasets_by_language: dict[str, dict[str, set[str]]],
+) -> set[tuple[str, str]]:
+    """Return ``(model_id, language)`` pairs ranked on the affected leaderboards.
+
+    A model is ranked in a language when it holds a result for every required
+    (non-orthogonal) dataset of that language's single-language leaderboard, in
+    any leaderboard category the swapped task belongs to. The ``generative``
+    category scores all tasks; ``all_models`` scores only NLU tasks so encoder
+    models can be compared. A model ranked in *either* category is selected, so
+    encoder models are included whenever the swapped task is one they can run.
+
+    Args:
+        old_dataset:
+            The outgoing dataset (kept in the required set).
+        new_dataset:
+            The incoming candidate (kept out of the required set).
+        swapped_task:
+            The task both datasets belong to.
+        language_codes:
+            The affected language codes.
+        datasets_by_language:
+            ``{language: {model: {dataset, ...}}}`` from the corpus.
+
+    Returns:
+        The ranked ``(model_id, language)`` pairs.
+    """
+    languages = get_all_languages()
+    affected = [
+        category
+        for category in LEADERBOARD_CATEGORIES
+        if category_includes_task(category=category, task=swapped_task)
+    ]
+    if not affected:
+        logger.warning(f"Task {swapped_task!r} is in no leaderboard category.")
+        return set()
+
+    ranked: set[tuple[str, str]] = set()
+    for code in sorted(language_codes):
+        language = languages.get(code)
+        if language is None:
+            logger.warning(f"Unknown language code {code!r}; skipping.")
+            continue
+        name = language.name.lower()
+        if " " in name:
+            logger.warning(f"{code!r} ({name!r}) has no standalone leaderboard.")
+            continue
+        try:
+            by_task = official_datasets_for_language(name)
+        except ValueError:
+            logger.warning(f"No leaderboard datasets for {name!r}; skipping.")
+            continue
+
+        models_in_language = datasets_by_language.get(code, {})
+        for category in affected:
+            required = {
+                dataset
+                for task, task_datasets in by_task.items()
+                if task not in ORTHOGONAL_TASKS
+                and category_includes_task(category=category, task=task)
+                for dataset in task_datasets
+            }
+            required.discard(new_dataset)
+            required.add(old_dataset)
+            if not required:
+                continue
+            for model_id, datasets in models_in_language.items():
+                if required <= datasets:
+                    ranked.add((model_id, code))
+    return ranked
+
+
+def build_eval_jobs(
+    ranked: set[tuple[str, str]],
+    old_dataset: str,
+    new_dataset: str,
+    corpus: _Corpus,
+    include_api: bool,
+    selected_providers: set[str],
+    force: bool,
+) -> list[Job]:
+    """Turn ranked pairs into evaluation jobs, mirroring each model's setup.
+
+    Args:
+        ranked:
+            The ranked ``(model_id, language)`` pairs.
+        old_dataset:
+            The outgoing dataset (whose recorded setup is mirrored).
+        new_dataset:
+            The dataset to evaluate on.
+        corpus:
+            The parsed corpus.
+        include_api:
+            Whether API models are evaluated.
+        selected_providers:
+            Provider names whose env vars are set; a known-provider API model
+            from another provider is skipped.
+        force:
+            When True, keep pairs already holding a new-dataset result.
+
+    Returns:
+        One :class:`Job` per model, its languages grouped, so identical
+        split/prompting settings run together.
+    """
+    # Group languages per model when the mirrored settings match, so one
+    # euroeval call covers them.
+    by_model: dict[tuple[str, bool, bool, bool], list[str]] = defaultdict(list)
+    for model_id, code in sorted(ranked):
+        is_api = model_id in corpus.api_model_ids
+        if is_api:
+            if not include_api:
+                continue
+            provider = provider_for_model_id(model_id=model_id)
+            if provider is not None and provider.name not in selected_providers:
+                continue
+        if not force and (model_id, new_dataset, code) in corpus.observations:
+            continue
+        config = corpus.eval_configs.get((model_id, old_dataset, code))
+        evaluate_test_split, zero_shot = mirror_eval_config(
+            config=config, is_api=is_api
+        )
+        by_model[(model_id, is_api, evaluate_test_split, zero_shot)].append(code)
+
+    jobs: list[Job] = []
+    for (model_id, is_api, evaluate_test_split, zero_shot), codes in by_model.items():
+        jobs.append(
+            Job(
+                model_id=model_id,
+                languages=tuple(sorted(codes)),
+                is_api=is_api,
+                evaluate_test_split=evaluate_test_split,
+                zero_shot=zero_shot,
+            )
+        )
+    return jobs
+
+
+def mirror_eval_config(config: _ObsConfig | None, is_api: bool) -> tuple[bool, bool]:
+    """Return ``(evaluate_test_split, zero_shot)`` matching the leaderboard row.
+
+    Mirrors how the model appears on the leaderboard for the outgoing dataset:
+    the ``(val)`` variant means the validation split, otherwise the test split;
+    the ``(zero-shot)`` variant means zero-shot, and only generative models are
+    ever run zero-shot. When no record is available, fall back to the model-type
+    default (API: validation split, zero-shot; open-weight: test, few-shot).
+
+    Args:
+        config:
+            The recorded setup for the outgoing dataset, or None.
+        is_api:
+            Whether the model is an API model (fallback only).
+
+    Returns:
+        The ``(evaluate_test_split, zero_shot)`` flags.
+    """
+    if config is None:
+        return (not is_api), is_api
+    evaluate_test_split = not config.validation_split
+    zero_shot = config.generative and not config.few_shot
+    return evaluate_test_split, zero_shot
+
+
+def apply_size_filter(
+    jobs: list[Job], gpu_memory_utilization: float | None
+) -> list[Job]:
+    """Drop open-weight jobs whose model can't fit the local GPU budget.
+
+    Budgets against ``gpu_memory_utilization * total GPU memory`` (matching
+    ``process_evaluation_queue.py``) rather than the whole card, so a model
+    whose weights fit but whose KV cache does not is dropped up front. API jobs
+    and un-measurable models pass through.
+
+    Args:
+        jobs:
+            The planned jobs.
+        gpu_memory_utilization:
+            The utilization fraction, or None for the default.
+
+    Returns:
+        The jobs that should still run.
+    """
+    gpu_bytes = gpu_total_memory_bytes()
+    if gpu_bytes is None:
+        logger.info("Local memory budget unknown; skipping the size pre-check.")
+        return jobs
+    utilization = (
+        gpu_memory_utilization
+        if gpu_memory_utilization is not None
+        else DEFAULT_GPU_MEMORY_UTILIZATION
+    )
+    usable_bytes = int(gpu_bytes * utilization)
+    logger.info(
+        f"Local memory budget: {gpu_bytes / (1024**3):.1f} GiB total, "
+        f"{usable_bytes / (1024**3):.1f} GiB usable at "
+        f"gpu_memory_utilization={utilization}."
+    )
+    sized: dict[str, bool] = {}
+    kept: list[Job] = []
+    for job in jobs:
+        if job.is_api:
+            kept.append(job)
+            continue
+        if job.model_id not in sized:
+            fits, needed = model_fits_locally(
+                model_id=job.model_id, gpu_bytes=usable_bytes
+            )
+            sized[job.model_id] = fits
+            if not fits and needed is not None:
+                logger.info(
+                    f"{job.model_id}: skipping -- needs "
+                    f"~{needed / (1024**3):.1f} GiB, exceeds the usable "
+                    f"{usable_bytes / (1024**3):.1f} GiB budget."
+                )
+        if sized[job.model_id]:
+            kept.append(job)
+    return kept
+
+
+def execute_jobs(
+    jobs: list[Job], dataset: str, gpu_memory_utilization: float | None
+) -> None:
+    """Run each evaluation in sequence via the shared euroeval runner.
+
+    Args:
+        jobs:
+            The jobs to run.
+        dataset:
+            The new dataset id to evaluate on.
+        gpu_memory_utilization:
+            The utilization fraction to pass to euroeval, or None.
+    """
+    for index, job in enumerate(jobs, start=1):
+        split = "test" if job.evaluate_test_split else "val"
+        shots = "zero-shot" if job.zero_shot else "few-shot"
+        logger.info(
+            f"[{index}/{len(jobs)}] euroeval --model {job.model_id} "
+            f"--dataset {dataset} --language {' --language '.join(job.languages)} "
+            f"({split}, {shots})"
+        )
+        returncode, _ = run_euroeval(
+            model_id=job.model_id,
+            languages=job.languages,
+            datasets=[dataset],
+            evaluate_test_split=job.evaluate_test_split,
+            zero_shot=job.zero_shot,
+            gpu_memory_utilization=gpu_memory_utilization,
+        )
+        if returncode != 0:
+            logger.warning(
+                f"{job.model_id} / {dataset}: euroeval exited with code "
+                f"{returncode}; continuing."
+            )
+
+
+@dataclass(frozen=True)
+class _Provider:
+    """An API provider: its short name, env var, and id predicate."""
+
+    name: str
+    env_var: str
+    matches: c.Callable[[str], bool]
+
+
+PROVIDERS: list[_Provider] = [
+    _Provider("openai", "OPENAI_API_KEY", lambda m: m.startswith(("openai/", "gpt-"))),
+    _Provider(
+        "anthropic",
+        "ANTHROPIC_API_KEY",
+        lambda m: m.startswith(("claude-", "anthropic/")),
+    ),
+    _Provider(
+        "google", "GEMINI_API_KEY", lambda m: m.startswith(("gemini/", "gemini-"))
+    ),
+    _Provider("xai", "XAI_API_KEY", lambda m: m.startswith(("xai/", "grok-"))),
+]
+PROVIDERS_BY_NAME: dict[str, _Provider] = {
+    provider.name: provider for provider in PROVIDERS
+}
+
+
+def provider_for_model_id(model_id: str) -> _Provider | None:
+    """Return the API provider that owns a model id, or None.
+
+    Args:
+        model_id:
+            The model id to classify.
+
+    Returns:
+        The matching provider, or None when no provider claims the id.
+    """
+    for provider in PROVIDERS:
+        if provider.matches(model_id):
+            return provider
+    return None
+
+
+def resolve_api_providers(
+    include_api: bool, api_providers_arg: str | None, present_providers: set[str]
+) -> set[str]:
+    """Resolve which API providers to run and verify their env vars.
+
+    Args:
+        include_api:
+            Whether the user opted in to API evaluation.
+        api_providers_arg:
+            Comma-separated provider names, or None to run every provider
+            present among the ranked API models.
+        present_providers:
+            Provider names actually present among the ranked API models.
+
+    Returns:
+        The provider names to run.
+
+    Raises:
+        click.ClickException:
+            When an unknown provider is named or a selected provider's env var
+            is missing.
+    """
+    if not include_api or not present_providers:
+        return set()
+    if api_providers_arg is None:
+        selected = set(present_providers)
+    else:
+        names = {n.strip().lower() for n in api_providers_arg.split(",") if n.strip()}
+        unknown = sorted(names - PROVIDERS_BY_NAME.keys())
+        if unknown:
+            raise click.ClickException(
+                f"Unknown API provider(s): {', '.join(unknown)}. "
+                f"Valid: {', '.join(PROVIDERS_BY_NAME)}."
+            )
+        selected = names & present_providers
+    missing = [
+        PROVIDERS_BY_NAME[name].env_var
+        for name in sorted(selected)
+        if not os.environ.get(PROVIDERS_BY_NAME[name].env_var)
+    ]
+    if missing:
+        raise click.ClickException(
+            f"Selected API provider(s) require: {', '.join(missing)} -- set the "
+            "variable(s) and re-run."
+        )
+    if selected:
+        logger.info(f"API providers enabled: {', '.join(sorted(selected))}.")
+    return selected
+
+
+def record_is_api(model_info: dict[str, object]) -> bool:
+    """Return whether a record's model was evaluated via an API.
+
+    Args:
+        model_info:
+            The ``model_info`` object of an EEE result record.
+
+    Returns:
+        True when produced by ``litellm`` or flagged as not open-weight.
+    """
+    engine = model_info.get("inference_engine", {})
+    engine_name = engine.get("name", "") if isinstance(engine, dict) else ""
+    if str(engine_name).lower() == "litellm":
+        return True
+    details = model_info.get("additional_details", {})
+    open_flag = details.get("open") if isinstance(details, dict) else None
+    return str(open_flag).lower() == "false"
+
+
+def _record_languages(record: dict) -> list[str]:
+    """Return the language codes a result record covers.
+
+    Args:
+        record:
+            A result record in EEE format.
+
+    Returns:
+        The list of language codes.
+    """
+    raw = (
+        record.get("eval_library", {})
+        .get("additional_details", {})
+        .get("languages", "[]")
+    )
+    if isinstance(raw, list):
+        return [str(code) for code in raw]
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    return [str(code) for code in parsed] if isinstance(parsed, list) else []
+
+
+# --------------------------------------------------------------------------- #
+# Config + documentation swap
+# --------------------------------------------------------------------------- #
+def apply_swap(old_dataset: str, new_dataset: str, dry_run: bool) -> list[Path]:
+    """Swap officiality in the dataset configs and the frontend docs.
+
+    Args:
+        old_dataset:
+            The dataset to demote to unofficial.
+        new_dataset:
+            The dataset to promote to official.
+        dry_run:
+            When True, log the files that would change without editing them.
+
+    Returns:
+        The paths that were (or would be) modified.
+    """
+    changed: list[Path] = []
+    for dataset_id, make_official in ((new_dataset, True), (old_dataset, False)):
+        config_path = find_config_file(dataset_id=dataset_id)
+        changed.append(config_path)
+        if not dry_run:
+            set_config_officiality(
+                path=config_path, dataset_id=dataset_id, official=make_official
+            )
+        for doc_path in find_doc_files(dataset_id=dataset_id):
+            changed.append(doc_path)
+            if not dry_run:
+                set_doc_officiality(
+                    path=doc_path, dataset_id=dataset_id, official=make_official
+                )
+    unique = sorted({path for path in changed}, key=str)
+    verb = "Would edit" if dry_run else "Edited"
+    for path in unique:
+        logger.info(f"{verb} {path.relative_to(REPO_ROOT)}.")
+    return unique
+
+
+def find_config_file(dataset_id: str) -> Path:
+    """Return the dataset-config file that defines ``dataset_id``.
+
+    Args:
+        dataset_id:
+            The dataset id to locate.
+
+    Returns:
+        The path to the ``dataset_configs/<lang>.py`` file.
+
+    Raises:
+        click.ClickException:
+            When no config file references the dataset id.
+    """
+    needle = re.compile(rf'name\s*=\s*"{re.escape(dataset_id)}"')
+    for path in sorted(DATASET_CONFIG_DIR.glob("*.py")):
+        if needle.search(path.read_text(encoding="utf-8")):
+            return path
+    raise click.ClickException(
+        f"Could not find a dataset config defining {dataset_id!r}."
+    )
+
+
+def find_doc_files(dataset_id: str) -> list[Path]:
+    """Return the dataset-doc files that document ``dataset_id``.
+
+    Each dataset's section ends with ``euroeval ... --dataset <id>``; that is a
+    reliable anchor regardless of the section's human-readable heading.
+
+    Args:
+        dataset_id:
+            The dataset id to locate.
+
+    Returns:
+        The matching doc paths (possibly several for multilingual datasets).
+
+    Raises:
+        click.ClickException:
+            When no doc file references the dataset id.
+    """
+    needle = re.compile(rf"--dataset {re.escape(dataset_id)}\b")
+    matches = [
+        path
+        for path in sorted(DATASET_DOC_DIR.glob("*.md"))
+        if needle.search(path.read_text(encoding="utf-8"))
+    ]
+    if not matches:
+        raise click.ClickException(
+            f"Could not find dataset documentation for {dataset_id!r}."
+        )
+    return matches
+
+
+def set_config_officiality(path: Path, dataset_id: str, official: bool) -> None:
+    """Flip a dataset's officiality in a config file and reposition its block.
+
+    Adds/removes the ``unofficial=True`` line and moves the ``DatasetConfig``
+    block into the official section (just before the unofficial marker) or the
+    unofficial section (just after it), keeping the file's grouping.
+
+    Args:
+        path:
+            The config file to edit.
+        dataset_id:
+            The dataset id whose block to move.
+        official:
+            True to make it official, False to make it unofficial.
+    """
+    lines = path.read_text(encoding="utf-8").split("\n")
+    start, end = _config_block_span(lines=lines, dataset_id=dataset_id, path=path)
+    block = lines[start : end + 1]
+    if official:
+        block = [line for line in block if not UNOFFICIAL_LINE_RE.match(line)]
+    elif not any(UNOFFICIAL_LINE_RE.match(line) for line in block):
+        block = block[:-1] + ["    unofficial=True,", block[-1]]
+
+    # Drop the block and exactly one adjacent blank line to keep spacing tidy.
+    del lines[start : end + 1]
+    if start < len(lines) and lines[start].strip() == "":
+        del lines[start]
+    elif start > 0 and lines[start - 1].strip() == "":
+        del lines[start - 1]
+
+    marker = _marker_index(lines=lines, path=path)
+    if official:
+        insert_at = marker
+    else:
+        insert_at = marker + 1
+        if insert_at < len(lines) and lines[insert_at].strip() == "":
+            insert_at += 1
+    lines[insert_at:insert_at] = block + [""]
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def set_doc_officiality(path: Path, dataset_id: str, official: bool) -> None:
+    """Flip a dataset's ``Unofficial:`` heading prefix and reorder its section.
+
+    Within the dataset's ``## Task`` section, official subsections (those
+    without the ``Unofficial:`` prefix) are kept before unofficial ones; after
+    flipping the heading the task section is stably re-partitioned so the
+    promoted dataset moves up and the demoted one moves down.
+
+    Args:
+        path:
+            The doc file to edit.
+        dataset_id:
+            The dataset id whose section to flip.
+        official:
+            True to drop the ``Unofficial:`` prefix, False to add it.
+    """
+    lines = path.read_text(encoding="utf-8").split("\n")
+    heading_idx = _doc_heading_index(lines=lines, dataset_id=dataset_id, path=path)
+    lines[heading_idx] = _flip_heading(heading=lines[heading_idx], official=official)
+
+    task_start, task_end = _doc_task_span(lines=lines, heading_idx=heading_idx)
+    reordered = _partition_doc_subsections(section=lines[task_start:task_end])
+    lines[task_start:task_end] = reordered
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _config_block_span(
+    lines: list[str], dataset_id: str, path: Path
+) -> tuple[int, int]:
+    """Return the inclusive ``(start, end)`` line span of a config block.
+
+    Args:
+        lines:
+            The config file's lines.
+        dataset_id:
+            The dataset id whose block to find.
+        path:
+            The file (for error messages).
+
+    Returns:
+        The start (``NAME = DatasetConfig(``) and end (``)``) indices.
+
+    Raises:
+        click.ClickException:
+            When the block can't be delimited.
+    """
+    name_re = re.compile(rf'name\s*=\s*"{re.escape(dataset_id)}"')
+    name_idx = next((i for i, line in enumerate(lines) if name_re.search(line)), None)
+    if name_idx is None:
+        raise click.ClickException(f"{dataset_id!r} not found in {path}.")
+    start = name_idx
+    while start >= 0 and not lines[start].rstrip().endswith("DatasetConfig("):
+        start -= 1
+    end = name_idx
+    while end < len(lines) and lines[end].strip() != ")":
+        end += 1
+    if start < 0 or end >= len(lines):
+        raise click.ClickException(f"Could not delimit {dataset_id!r} block in {path}.")
+    return start, end
+
+
+def _marker_index(lines: list[str], path: Path) -> int:
+    """Return the index of the unofficial-section marker comment.
+
+    Args:
+        lines:
+            The config file's lines.
+        path:
+            The file (for error messages).
+
+    Returns:
+        The marker line index.
+
+    Raises:
+        click.ClickException:
+            When the marker is absent.
+    """
+    for i, line in enumerate(lines):
+        if line.strip() == UNOFFICIAL_MARKER:
+            return i
+    raise click.ClickException(f"No {UNOFFICIAL_MARKER!r} marker in {path}.")
+
+
+def _doc_heading_index(lines: list[str], dataset_id: str, path: Path) -> int:
+    """Return the ``### ...`` heading index for a dataset's doc section.
+
+    The section is the one whose body contains ``--dataset <id>``.
+
+    Args:
+        lines:
+            The doc file's lines.
+        dataset_id:
+            The dataset id to find.
+        path:
+            The file (for error messages).
+
+    Returns:
+        The heading line index.
+
+    Raises:
+        click.ClickException:
+            When the section can't be found.
+    """
+    anchor = re.compile(rf"--dataset {re.escape(dataset_id)}\b")
+    anchor_idx = next((i for i, line in enumerate(lines) if anchor.search(line)), None)
+    if anchor_idx is None:
+        raise click.ClickException(f"{dataset_id!r} not documented in {path}.")
+    for i in range(anchor_idx, -1, -1):
+        if lines[i].startswith("### "):
+            return i
+    raise click.ClickException(f"No '### ' heading above {dataset_id!r} in {path}.")
+
+
+def _doc_task_span(lines: list[str], heading_idx: int) -> tuple[int, int]:
+    """Return the ``[start, end)`` line span of the enclosing ``## Task`` section.
+
+    The span starts at the first ``### `` subsection under the task heading and
+    ends before the next ``## `` heading (or end of file), so the task's intro
+    lines are left in place.
+
+    Args:
+        lines:
+            The doc file's lines.
+        heading_idx:
+            The ``### `` heading index of the dataset's subsection.
+
+    Returns:
+        The ``(start, end)`` span covering the task's ``### `` subsections.
+    """
+    task_idx = heading_idx
+    while task_idx >= 0 and not lines[task_idx].startswith("## "):
+        task_idx -= 1
+    start = task_idx + 1
+    while start < len(lines) and not lines[start].startswith("### "):
+        start += 1
+    end = start
+    while end < len(lines) and not lines[end].startswith("## "):
+        end += 1
+    return start, end
+
+
+def _partition_doc_subsections(section: list[str]) -> list[str]:
+    """Stably reorder a task section's ``### `` subsections official-first.
+
+    Args:
+        section:
+            The lines of a task section, beginning at its first ``### ``
+            subsection.
+
+    Returns:
+        The lines with official subsections (no ``Unofficial:`` prefix) kept in
+        order first, then the unofficial ones.
+    """
+    subsections: list[list[str]] = []
+    current: list[str] = []
+    for line in section:
+        if line.startswith("### ") and current:
+            subsections.append(current)
+            current = []
+        current.append(line)
+    if current:
+        subsections.append(current)
+
+    official = [
+        sub
+        for sub in subsections
+        if not sub[0].startswith(f"### {DOC_UNOFFICIAL_PREFIX}")
+    ]
+    unofficial = [
+        sub for sub in subsections if sub[0].startswith(f"### {DOC_UNOFFICIAL_PREFIX}")
+    ]
+    result: list[str] = []
+    for sub in official + unofficial:
+        result.extend(sub)
+    return result
+
+
+def _flip_heading(heading: str, official: bool) -> str:
+    """Add or remove the ``Unofficial:`` prefix on a ``### `` heading.
+
+    Args:
+        heading:
+            The heading line (``### Title`` or ``### Unofficial: Title``).
+        official:
+            True to drop the prefix, False to add it.
+
+    Returns:
+        The updated heading line.
+    """
+    title = heading[len("### ") :]
+    has_prefix = title.startswith(DOC_UNOFFICIAL_PREFIX)
+    if official and has_prefix:
+        title = title[len(DOC_UNOFFICIAL_PREFIX) :]
+    elif not official and not has_prefix:
+        title = f"{DOC_UNOFFICIAL_PREFIX}{title}"
+    return f"### {title}"
+
+
+# --------------------------------------------------------------------------- #
+# Git + pull request
+# --------------------------------------------------------------------------- #
+def default_branch() -> str:
+    """Return the repository's default branch name.
+
+    Returns:
+        The default branch (``origin/HEAD`` target), or ``"main"`` if it can't
+        be determined.
+    """
+    result = _git("symbolic-ref", "refs/remotes/origin/HEAD", check=False, capture=True)
+    if result.returncode == 0:
+        return result.stdout.strip().rsplit("/", 1)[-1]
+    return "main"
+
+
+def checkout_branch(branch: str) -> None:
+    """Check out ``branch``, creating it if it doesn't exist.
+
+    Args:
+        branch:
+            The branch to switch to.
+    """
+    existing = _git("rev-parse", "--verify", branch, check=False, capture=True)
+    if existing.returncode == 0:
+        _git("checkout", branch)
+    else:
+        _git("checkout", "-b", branch)
+    logger.info(f"On branch {branch!r}.")
+
+
+def open_pull_request(
+    old_dataset: str, new_dataset: str, branch: str, changed_paths: list[Path]
+) -> None:
+    """Commit the swap, push the branch, and open a pull request.
+
+    Assigns the logged-in GitHub user, requests ``saattrupdan`` as a reviewer,
+    and best-effort requests a Copilot review.
+
+    Args:
+        old_dataset:
+            The demoted dataset id.
+        new_dataset:
+            The promoted dataset id.
+        branch:
+            The branch to push.
+        changed_paths:
+            The files that were changed (staged explicitly).
+    """
+    for path in changed_paths:
+        _git("add", str(path))
+    title = f"feat: swap official dataset {old_dataset} -> {new_dataset}"
+    body = _pr_body(old_dataset=old_dataset, new_dataset=new_dataset)
+    _git("commit", "-m", title, "-m", body)
+    _git("push", "--set-upstream", "origin", branch)
+
+    _gh(
+        "pr",
+        "create",
+        "--title",
+        title,
+        "--body",
+        body,
+        "--assignee",
+        "@me",
+        "--reviewer",
+        DEFAULT_REVIEWER,
+    )
+    _request_copilot_review()
+    logger.info("Opened pull request.")
+
+
+def _pr_body(old_dataset: str, new_dataset: str) -> str:
+    """Return the standard PR description for a dataset swap.
+
+    Args:
+        old_dataset:
+            The demoted dataset id.
+        new_dataset:
+            The promoted dataset id.
+
+    Returns:
+        The markdown PR body.
+    """
+    return (
+        f"Swaps the official dataset `{old_dataset}` for `{new_dataset}`.\n\n"
+        "## What\n\n"
+        f"- Every model with a rank score on the affected leaderboard(s) was "
+        f"evaluated on `{new_dataset}`, mirroring how each appears on the "
+        "leaderboard (validation/test split and zero-/few-shot).\n"
+        f"- `{old_dataset}` is demoted to unofficial and `{new_dataset}` "
+        "promoted to official in the dataset configs and the dataset "
+        "documentation, keeping each file's official-first grouping.\n\n"
+        "The leaderboards will pick up the change on the next regeneration.\n\n"
+        "🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+    )
+
+
+def _request_copilot_review() -> None:
+    """Best-effort request a Copilot review on the current branch's PR."""
+    result = _gh(
+        "pr",
+        "edit",
+        "--add-reviewer",
+        "copilot-pull-request-reviewer[bot]",
+        check=False,
+        capture=True,
+    )
+    if result.returncode != 0:
+        logger.info(
+            "Could not explicitly request a Copilot review (it may still run "
+            "automatically): %s",
+            result.stderr.strip(),
+        )
+
+
+def _git(
+    *args: str, check: bool = True, capture: bool = False
+) -> subprocess.CompletedProcess[str]:
+    """Run a git command in the repo root.
+
+    Args:
+        args:
+            The git subcommand and arguments.
+        check:
+            Whether to raise on a non-zero exit.
+        capture:
+            Whether to capture stdout/stderr.
+
+    Returns:
+        The completed process.
+    """
+    return _run(["git", *args], check=check, capture=capture)
+
+
+def _gh(
+    *args: str, check: bool = True, capture: bool = False
+) -> subprocess.CompletedProcess[str]:
+    """Run a ``gh`` command in the repo root.
+
+    Args:
+        args:
+            The gh subcommand and arguments.
+        check:
+            Whether to raise on a non-zero exit.
+        capture:
+            Whether to capture stdout/stderr.
+
+    Returns:
+        The completed process.
+    """
+    return _run(["gh", *args], check=check, capture=capture)
+
+
+def _run(
+    cmd: list[str], check: bool, capture: bool
+) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess in the repo root.
+
+    Args:
+        cmd:
+            The command and arguments.
+        check:
+            Whether to raise on a non-zero exit.
+        capture:
+            Whether to capture stdout/stderr.
+
+    Returns:
+        The completed process.
+
+    Raises:
+        click.ClickException:
+            When ``check`` is True and the command fails.
+    """
+    result = subprocess.run(
+        cmd, cwd=REPO_ROOT, capture_output=capture, text=True, check=False
+    )
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() if capture and result.stderr else ""
+        raise click.ClickException(
+            f"Command failed ({' '.join(cmd)}): exit {result.returncode}. {detail}"
+        )
+    return result
+
+
+def dataset_config(dataset_id: str) -> DatasetConfig | None:
+    """Return the :class:`DatasetConfig` for a dataset id, or None if unknown.
+
+    Args:
+        dataset_id:
+            The dataset id to look up.
+
+    Returns:
+        The matching config, or None when unknown.
+    """
+    configs = get_all_dataset_configs(
+        custom_datasets_file=Path(""),
+        dataset_ids=[dataset_id],
+        api_key=None,
+        cache_dir=Path(".cache"),
+        trust_remote_code=False,
+        run_with_cli=False,
+    )
+    return configs.get(dataset_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/swap_leaderboard_dataset.py
+++ b/src/scripts/swap_leaderboard_dataset.py
@@ -13,7 +13,7 @@ from the current official one, three things have to happen:
    incoming one promoted to official, in both the ``euroeval`` dataset configs
    and the frontend dataset documentation, keeping the official-first grouping
    each file uses.
-3. **Open a PR** (optional) with the config/doc changes.
+3. **Open a PR** with the config/doc changes.
 
 Everything happens on a dedicated branch -- ``--branch`` is required and may
 not be the default branch.
@@ -21,7 +21,7 @@ not be the default branch.
 Invoke as::
 
     uv run src/scripts/swap_leaderboard_dataset.py \\
-        --old-dataset scala-da --new-dataset dala --branch swap-scala-dala [--pr]
+        --old-dataset scala-da --new-dataset dala --branch swap-scala-dala
 
 Required env vars (open-weight models)
 --------------------------------------
@@ -78,7 +78,6 @@ DATASET_DOC_DIR = REPO_ROOT / "src" / "frontend" / "md" / "datasets"
 UNOFFICIAL_MARKER = "# Unofficial datasets ###"
 UNOFFICIAL_LINE_RE = re.compile(r"^\s*unofficial\s*=\s*True\s*,\s*$")
 DOC_UNOFFICIAL_PREFIX = "Unofficial: "
-DEFAULT_REVIEWER = "saattrupdan"
 
 
 @click.command()
@@ -98,13 +97,6 @@ DEFAULT_REVIEWER = "saattrupdan"
     "--branch",
     required=True,
     help="Branch to do the work on. May not be the default branch (e.g. main).",
-)
-@click.option(
-    "--language",
-    "languages",
-    multiple=True,
-    help="Restrict re-evaluation to these language codes. When omitted, defaults "
-    "to the languages both datasets cover.",
 )
 @click.option(
     "--include-api",
@@ -137,8 +129,15 @@ DEFAULT_REVIEWER = "saattrupdan"
 @click.option(
     "--pr",
     is_flag=True,
-    default=False,
-    help="After swapping, commit and push the branch and open a pull request.",
+    default=True,
+    help="After swapping, commit and push the branch and open a pull request. "
+    "Default is True; pass --no-pr to skip.",
+)
+@click.option(
+    "--reviewer",
+    "reviewer",
+    default="saattrupdan",
+    help="GitHub username to request as reviewer. Default is saattrupdan.",
 )
 @click.option(
     "--force",
@@ -158,12 +157,12 @@ def main(
     old_dataset: str,
     new_dataset: str,
     branch: str,
-    languages: tuple[str, ...],
     include_api: bool,
     api_providers: str | None,
     gpu_memory_utilization: float | None,
     skip_eval: bool,
     pr: bool,
+    reviewer: str,
     force: bool,
     dry_run: bool,
 ) -> None:
@@ -176,9 +175,6 @@ def main(
             The unofficial candidate being promoted.
         branch:
             The branch to do the work on; may not be the default branch.
-        languages:
-            Language codes to restrict evaluation to; empty means the codes
-            both datasets cover.
         include_api:
             Whether to evaluate API models.
         api_providers:
@@ -188,7 +184,10 @@ def main(
         skip_eval:
             When True, only perform the config/doc swap.
         pr:
-            When True, commit, push, and open a pull request after swapping.
+            When True (default), commit, push, and open a pull request after
+            swapping.
+        reviewer:
+            GitHub username to request as reviewer.
         force:
             When True, re-run pairs that already have a new-dataset result.
         dry_run:
@@ -207,9 +206,7 @@ def main(
     )
     validate_branch(branch=branch)
 
-    target_codes = resolve_languages(
-        old_config=old_config, new_config=new_config, requested=languages
-    )
+    target_codes = resolve_languages(old_config=old_config, new_config=new_config)
     logger.info(
         f"Swap {old_dataset!r} -> {new_dataset!r} (task {old_config.task.name!r}) "
         f"on language(s): {', '.join(sorted(target_codes))}."
@@ -247,6 +244,7 @@ def main(
             new_dataset=new_dataset,
             branch=branch,
             changed_paths=changed,
+            reviewer=reviewer,
         )
     else:
         logger.info(
@@ -324,9 +322,7 @@ def validate_branch(branch: str) -> None:
         )
 
 
-def resolve_languages(
-    old_config: DatasetConfig, new_config: DatasetConfig, requested: tuple[str, ...]
-) -> set[str]:
+def resolve_languages(old_config: DatasetConfig, new_config: DatasetConfig) -> set[str]:
     """Resolve the language codes whose leaderboards are affected.
 
     Args:
@@ -334,8 +330,6 @@ def resolve_languages(
             The outgoing dataset config.
         new_config:
             The incoming dataset config.
-        requested:
-            Language codes passed via ``--language``; empty means "both".
 
     Returns:
         The language codes to operate on.
@@ -346,14 +340,9 @@ def resolve_languages(
     """
     old_codes = {language.code for language in old_config.languages}
     new_codes = {language.code for language in new_config.languages}
-    if requested:
-        target = set(requested)
-    else:
-        target = old_codes & new_codes
+    target = old_codes & new_codes
     if not target:
-        raise click.ClickException(
-            "The two datasets share no languages; pass --language explicitly."
-        )
+        raise click.ClickException("The two datasets share no languages.")
     return target
 
 
@@ -1317,12 +1306,16 @@ def checkout_branch(branch: str) -> None:
 
 
 def open_pull_request(
-    old_dataset: str, new_dataset: str, branch: str, changed_paths: list[Path]
+    old_dataset: str,
+    new_dataset: str,
+    branch: str,
+    changed_paths: list[Path],
+    reviewer: str = "saattrupdan",
 ) -> None:
     """Commit the swap, push the branch, and open a pull request.
 
-    Assigns the logged-in GitHub user, requests ``saattrupdan`` as a reviewer,
-    and best-effort requests a Copilot review.
+    Assigns the logged-in GitHub user, requests a reviewer, and best-effort
+    requests a Copilot review. CODEOWNERS are assigned automatically by GitHub.
 
     Args:
         old_dataset:
@@ -1333,6 +1326,8 @@ def open_pull_request(
             The branch to push.
         changed_paths:
             The files that were changed (staged explicitly).
+        reviewer:
+            GitHub username to request as reviewer.
     """
     for path in changed_paths:
         _git("add", str(path))
@@ -1351,7 +1346,7 @@ def open_pull_request(
         "--assignee",
         "@me",
         "--reviewer",
-        DEFAULT_REVIEWER,
+        reviewer,
     )
     _request_copilot_review()
     logger.info("Opened pull request.")

--- a/tests/test_scripts/test_swap_leaderboard_dataset.py
+++ b/tests/test_scripts/test_swap_leaderboard_dataset.py
@@ -1,10 +1,14 @@
 """Tests for the swap_leaderboard_dataset script."""
 
+import logging
 import subprocess
 from pathlib import Path
 
 import pytest
 
+from euroeval.data_models import DatasetConfig
+from euroeval.languages import DANISH, SWEDISH
+from euroeval.tasks import LA
 from src.scripts import swap_leaderboard_dataset
 
 
@@ -87,9 +91,7 @@ class TestValidation:
     ) -> None:
         """Should reject the default branch name."""
         monkeypatch.setattr(
-            target=swap_leaderboard_dataset,
-            name="default_branch",
-            value=lambda: "main",
+            target=swap_leaderboard_dataset, name="default_branch", value=lambda: "main"
         )
 
         with pytest.raises(Exception):
@@ -100,9 +102,7 @@ class TestValidation:
     ) -> None:
         """Should accept non-default branch names."""
         monkeypatch.setattr(
-            target=swap_leaderboard_dataset,
-            name="default_branch",
-            value=lambda: "main",
+            target=swap_leaderboard_dataset, name="default_branch", value=lambda: "main"
         )
 
         # Should not raise
@@ -110,10 +110,6 @@ class TestValidation:
 
     def test_resolve_languages_returns_intersection(self) -> None:
         """Should return the intersection of languages from both datasets."""
-        from euroeval.data_models import DatasetConfig
-        from euroeval.languages import DANISH, SWEDISH
-        from euroeval.tasks import LA
-
         old_config = DatasetConfig(
             name="scala-da",
             pretty_name="ScaLA-da",
@@ -167,8 +163,6 @@ class TestSyncResults:
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Should handle empty bucket gracefully."""
-        import logging
-
         monkeypatch.setattr(
             target=swap_leaderboard_dataset,
             name="RESULTS_DIR",
@@ -228,10 +222,9 @@ DANSK_CONFIG = DatasetConfig(
         config_file = tmp_path / "test_config.py"
         config_file.write_text(config_content)
 
+        lines = list[str](config_content.split("\n"))
         start, end = swap_leaderboard_dataset._config_block_span(
-            lines=config_content.split("\n"),
-            dataset_id="dansk",
-            path=config_file,
+            lines=lines, dataset_id="dansk", path=config_file
         )
 
         # Should find DANSK_CONFIG block

--- a/tests/test_scripts/test_swap_leaderboard_dataset.py
+++ b/tests/test_scripts/test_swap_leaderboard_dataset.py
@@ -1,0 +1,240 @@
+"""Tests for the swap_leaderboard_dataset script."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from src.scripts import swap_leaderboard_dataset
+
+
+class TestDryRun:
+    """Tests for --dry-run mode."""
+
+    def test_dry_run_does_not_modify_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Dry run should validate inputs and print plan without modifying anything."""
+        # Mock subprocess calls to avoid git operations
+        monkeypatch.setattr(
+            target=swap_leaderboard_dataset,
+            name="_git",
+            value=lambda *args, **kwargs: subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""
+            ),
+        )
+        monkeypatch.setattr(
+            target=swap_leaderboard_dataset,
+            name="_gh",
+            value=lambda *args, **kwargs: subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""
+            ),
+        )
+
+        # Run with --dry-run - should exit cleanly without modifying files
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "src/scripts/swap_leaderboard_dataset.py",
+                "--old-dataset",
+                "scala-da",
+                "--new-dataset",
+                "dansk",
+                "--branch",
+                "test-branch",
+                "--dry-run",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        # Should exit cleanly (code 0) or with validation error (code 1)
+        # but should NOT crash with unhandled exception
+        assert result.returncode in (0, 1)
+
+    def test_dry_run_shows_plan(self) -> None:
+        """Dry run should log the planned evaluations."""
+        # Run with --dry-run and capture output
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "src/scripts/swap_leaderboard_dataset.py",
+                "--old-dataset",
+                "scala-da",
+                "--new-dataset",
+                "dansk",
+                "--branch",
+                "test-branch",
+                "--dry-run",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        # Should log the swap plan (even if it fails validation)
+        output = result.stdout + result.stderr
+        # Should at least mention the datasets or show "Dry run"
+        assert "scala-da" in output or "dansk" in output or "Dry run" in output
+
+
+class TestValidation:
+    """Tests for validation functions."""
+
+    def test_validate_branch_rejects_default_branch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Should reject the default branch name."""
+        monkeypatch.setattr(
+            target=swap_leaderboard_dataset,
+            name="default_branch",
+            value=lambda: "main",
+        )
+
+        with pytest.raises(Exception):
+            swap_leaderboard_dataset.validate_branch("main")
+
+    def test_validate_branch_accepts_non_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Should accept non-default branch names."""
+        monkeypatch.setattr(
+            target=swap_leaderboard_dataset,
+            name="default_branch",
+            value=lambda: "main",
+        )
+
+        # Should not raise
+        swap_leaderboard_dataset.validate_branch("feature-branch")
+
+    def test_resolve_languages_returns_intersection(self) -> None:
+        """Should return the intersection of languages from both datasets."""
+        from euroeval.data_models import DatasetConfig
+        from euroeval.languages import DANISH, SWEDISH
+        from euroeval.tasks import LA
+
+        old_config = DatasetConfig(
+            name="scala-da",
+            pretty_name="ScaLA-da",
+            source="EuroEval/scala-da",
+            task=LA,
+            languages=[DANISH],
+        )
+        new_config = DatasetConfig(
+            name="scala-da-sv",
+            pretty_name="ScaLA-sv",
+            source="EuroEval/scala-sv",
+            task=LA,
+            languages=[SWEDISH],
+        )
+
+        # No overlap - should raise
+        with pytest.raises(Exception):
+            swap_leaderboard_dataset.resolve_languages(
+                old_config=old_config, new_config=new_config
+            )
+
+        # With overlap - should return intersection
+        old_config = DatasetConfig(
+            name="nordic",
+            pretty_name="Nordic",
+            source="EuroEval/nordic",
+            task=LA,
+            languages=[DANISH, SWEDISH],
+        )
+        new_config = DatasetConfig(
+            name="nordic-dk",
+            pretty_name="Nordic DK",
+            source="EuroEval/nordic-dk",
+            task=LA,
+            languages=[DANISH],
+        )
+
+        result = swap_leaderboard_dataset.resolve_languages(
+            old_config=old_config, new_config=new_config
+        )
+        assert result == {"da"}
+
+
+class TestSyncResults:
+    """Tests for sync_results_from_bucket function."""
+
+    def test_sync_results_handles_empty_bucket(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Should handle empty bucket gracefully."""
+        import logging
+
+        monkeypatch.setattr(
+            target=swap_leaderboard_dataset,
+            name="RESULTS_DIR",
+            value=tmp_path / "results",
+        )
+        monkeypatch.setattr(
+            target=swap_leaderboard_dataset,
+            name="NEW_RESULTS_PATH",
+            value=tmp_path / "new_results.jsonl",
+        )
+        monkeypatch.setattr(
+            target=swap_leaderboard_dataset,
+            name="HF_RESULTS_BUCKET",
+            value="test-bucket",
+        )
+
+        # Create empty results dir
+        (tmp_path / "results").mkdir()
+
+        # Mock hf buckets sync to do nothing
+        monkeypatch.setattr(
+            target=subprocess,
+            name="run",
+            value=lambda *args, **kwargs: subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""
+            ),
+        )
+
+        with caplog.at_level(logging.WARNING):
+            swap_leaderboard_dataset.sync_results_from_bucket()
+
+        # Should warn about no results
+        assert "No results found" in caplog.text
+
+
+class TestConfigBlockSpan:
+    """Tests for _config_block_span helper."""
+
+    def test_finds_config_block(self, tmp_path: Path) -> None:
+        """Should find the start and end of a DatasetConfig block."""
+        config_content = '''"""Dataset configs."""
+
+from euroeval.data_models import DatasetConfig
+
+SCALA_CONFIG = DatasetConfig(
+    name="scala",
+    pretty_name="ScaLA",
+    source="EuroEval/scala",
+)
+
+DANSK_CONFIG = DatasetConfig(
+    name="dansk",
+    pretty_name="DANSK",
+    source="EuroEval/dansk",
+)
+'''
+        config_file = tmp_path / "test_config.py"
+        config_file.write_text(config_content)
+
+        start, end = swap_leaderboard_dataset._config_block_span(
+            lines=config_content.split("\n"),
+            dataset_id="dansk",
+            path=config_file,
+        )
+
+        # Should find DANSK_CONFIG block
+        assert start > 0
+        assert end > start
+        assert "dansk" in "\n".join(config_content.split("\n")[start : end + 1])


### PR DESCRIPTION
## What

Adds `src/scripts/swap_leaderboard_dataset.py`, which replaces the official dataset for a task on a language's leaderboard with a new one, end to end — and restores `run_core_model_evaluations.py` to a single, clear purpose.

Swapping a dataset means every model with a rank score on the affected leaderboard needs a score on the new dataset before it can go official. This script does the evaluation, the config/doc swap, and (optionally) the PR.

## The swap script

Run on a dedicated branch (`--branch` is required and may not be the default branch):

```bash
uv run src/scripts/swap_leaderboard_dataset.py \
    --old-dataset scala-da --new-dataset dala --branch swap-scala-dala --pr
```

1. **Evaluate.** Finds every model ranked on the affected leaderboard(s) and evaluates it on the new (still unofficial) dataset — *before* flipping any flags, so the live leaderboard stays intact. Selection is category-aware (`generative` + `all_models`), so **both generative and encoder models** are covered when the task supports them. Each eval **mirrors how the model appears on the leaderboard** for the outgoing dataset: `(val)` → validation split (else test), `(zero-shot)` → zero-shot (generative only), using the same field conventions as `leaderboards.records`.
2. **Swap officiality.** Demotes the old dataset and promotes the new one in both the `euroeval` dataset configs (`unofficial=True` + block repositioned) and the frontend docs (`Unofficial:` heading prefix + section reordered), keeping each file's official-first grouping.
3. **Open a PR** (`--pr`): commits on the branch, pushes, and opens a PR assigned to the logged-in user with `saattrupdan` and (best-effort) Copilot as reviewers.

Key flags: `--language` (restrict languages), `--include-api` (off by default → no spend; checks provider env vars), `--gpu-memory-utilization`, `--skip-eval` (config/doc swap only, e.g. when evals already ran), `--dry-run`.

The per-language leaderboard config needs no edit — the dataset↔leaderboard mapping is derived from the dataset configs (`task_metadata`), not stored separately.

## run_core_model_evaluations.py

Reverted to **backfill-only**: both the earlier re-eval additions and the pre-existing `--dataset` dataset-replacement mode are removed, leaving it to evaluate core models on the full test split.

## Verification

Dry-run of `scala-da → dala`: 311 ranked (model, language) pairs (encoders included), 76 API models excluded by default, 230 evaluations planned, 171 fit the local GPU budget. The config/doc surgery was applied to the real Danish files and verified: `scala-da` → unofficial, `dala` → official, module imports and lints cleanly, doc sections reordered correctly. Branch/direction guards and `--skip-eval` all behave. `make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
