### PR TITLE
fix(changelog): remove stray leftover merge conflict marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -526,8 +526,6 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   the maximum context length of the model, which gave errors with models that had a
   maximum context length of less than 8,192.
 
->>>>>>> main
-
 ## [v16.11.0] - 2026-01-21
 
 ### Added


### PR DESCRIPTION
`CHANGELOG.md` has a leftover `>>>>>>> main` merge conflict marker between the `### Fixed` section and the `## [v16.11.0]` header. There's no matching `<<<<<<<`/`=======`, so it's a stray tail from a previously resolved conflict, not an unresolved block. This removes the marker line and keeps a single blank line at the seam so `markdownlint` stays green. Docs-only, no content changes.
