### PR TITLE
feat: swap official dataset hellaswag-da -> winogrande-da

### DIFF
--- a/src/euroeval/dataset_configs/danish.py
+++ b/src/euroeval/dataset_configs/danish.py
@@ -74,14 +74,6 @@ DANISH_CITIZEN_TESTS_CONFIG = DatasetConfig(
     languages=[DANISH],
 )
 
-HELLASWAG_DA_CONFIG = DatasetConfig(
-    name="hellaswag-da",
-    pretty_name="HellaSwag-da",
-    source="EuroEval/hellaswag-da-mini",
-    task=COMMON_SENSE,
-    languages=[DANISH],
-)
-
 IFEVAL_DA_CONFIG = DatasetConfig(
     name="ifeval-da",
     pretty_name="IFEval-da",
@@ -104,7 +96,25 @@ VALEU_DA_CONFIG = DatasetConfig(
 )
 
 
+WINOGRANDE_DA_CONFIG = DatasetConfig(
+    name="winogrande-da",
+    pretty_name="Winogrande-da",
+    source="EuroEval/winogrande-da",
+    task=COMMON_SENSE,
+    languages=[DANISH],
+    labels=["a", "b"],
+)
+
 # Unofficial datasets ###
+
+HELLASWAG_DA_CONFIG = DatasetConfig(
+    name="hellaswag-da",
+    pretty_name="HellaSwag-da",
+    source="EuroEval/hellaswag-da-mini",
+    task=COMMON_SENSE,
+    languages=[DANISH],
+    unofficial=True,
+)
 
 SCALA_DA_CONFIG = DatasetConfig(
     name="scala-da",
@@ -176,16 +186,6 @@ GOLDENSWAG_DA_CONFIG = DatasetConfig(
     source="EuroEval/goldenswag-da-mini",
     task=COMMON_SENSE,
     languages=[DANISH],
-    unofficial=True,
-)
-
-WINOGRANDE_DA_CONFIG = DatasetConfig(
-    name="winogrande-da",
-    pretty_name="Winogrande-da",
-    source="EuroEval/winogrande-da",
-    task=COMMON_SENSE,
-    languages=[DANISH],
-    labels=["a", "b"],
     unofficial=True,
 )
 

--- a/src/frontend/md/datasets/danish.md
+++ b/src/frontend/md/datasets/danish.md
@@ -1368,7 +1368,77 @@ euroeval --model <model-id> --dataset dameta
 
 ## Common-sense Reasoning
 
-### HellaSwag-da
+### Winogrande-da
+
+This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2506.19468)
+and is a translated and filtered version of the English
+[Winogrande dataset](https://doi.org/10.1145/3474381).
+
+The original full dataset consists of 47 / 1,210 samples for training and testing, and
+we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
+training, validation and testing, respectively.
+
+Here are a few examples from the training split:
+
+```json
+{
+  "text": "Natalie synes, at smaragder er smukke ædelstene, men Betty gør ikke. _ købte en halskæde med en stor smaragd. Hvad refererer det tomme _ til?\nSvarmuligheder:\na. Natalie\nb. Betty",
+  "label": "a"
+}
+```
+
+```json
+{
+  "text": "Jeg kunne ikke kontrollere fugten, som jeg kontrollerede regnen, fordi _ kom ind overalt. Hvad refererer det tomme _ til?\nSvarmuligheder:\na. fugt\nb. regn",
+  "label": "a"
+}
+```
+
+```json
+{
+  "text": "At håndtere nødsituationer var aldrig særlig svært for Kevin, men det var det for Nelson, fordi _ ikke var i stand til at forblive rolig under pres. Hvad refererer det tomme _ til?\nSvarmuligheder:\na. Kevin\nb. Nelson",
+  "label": "b"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  Følgende er multiple choice spørgsmål (med svar).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Spørgsmål: {text}
+  Svarmuligheder:
+  a. {option_a}
+  b. {option_b}
+  Svar: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Spørgsmål: {text}
+  Svarmuligheder:
+  a. {option_a}
+  b. {option_b}
+
+  Besvar ovenstående spørgsmål ved at svare med 'a' eller 'b', og intet andet.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset winogrande-da
+```
+
+### Unofficial: HellaSwag-da
 
 This dataset is a machine translated version of the English
 [HellaSwag dataset](https://aclanthology.org/P19-1472/). The original dataset was based
@@ -1519,76 +1589,6 @@ You can evaluate this dataset directly as follows:
 
 ```bash
 euroeval --model <model-id> --dataset goldenswag-da
-```
-
-### Unofficial: Winogrande-da
-
-This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2506.19468)
-and is a translated and filtered version of the English
-[Winogrande dataset](https://doi.org/10.1145/3474381).
-
-The original full dataset consists of 47 / 1,210 samples for training and testing, and
-we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
-training, validation and testing, respectively.
-
-Here are a few examples from the training split:
-
-```json
-{
-  "text": "Natalie synes, at smaragder er smukke ædelstene, men Betty gør ikke. _ købte en halskæde med en stor smaragd. Hvad refererer det tomme _ til?\nSvarmuligheder:\na. Natalie\nb. Betty",
-  "label": "a"
-}
-```
-
-```json
-{
-  "text": "Jeg kunne ikke kontrollere fugten, som jeg kontrollerede regnen, fordi _ kom ind overalt. Hvad refererer det tomme _ til?\nSvarmuligheder:\na. fugt\nb. regn",
-  "label": "a"
-}
-```
-
-```json
-{
-  "text": "At håndtere nødsituationer var aldrig særlig svært for Kevin, men det var det for Nelson, fordi _ ikke var i stand til at forblive rolig under pres. Hvad refererer det tomme _ til?\nSvarmuligheder:\na. Kevin\nb. Nelson",
-  "label": "b"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 5
-- Prefix prompt:
-
-  ```text
-  Følgende er multiple choice spørgsmål (med svar).
-  ```
-
-- Base prompt template:
-
-  ```text
-  Spørgsmål: {text}
-  Svarmuligheder:
-  a. {option_a}
-  b. {option_b}
-  Svar: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Spørgsmål: {text}
-  Svarmuligheder:
-  a. {option_a}
-  b. {option_b}
-
-  Besvar ovenstående spørgsmål ved at svare med 'a' eller 'b', og intet andet.
-  ```
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset winogrande-da
 ```
 
 ## Logical Reasoning

--- a/src/scripts/swap_leaderboard_dataset.py
+++ b/src/scripts/swap_leaderboard_dataset.py
@@ -412,7 +412,12 @@ def resolve_languages(old_config: DatasetConfig, new_config: DatasetConfig) -> s
 
 
 def validate_gh_installed() -> None:
-    """Check that the GitHub CLI is installed."""
+    """Check that the GitHub CLI is installed.
+
+    Raises:
+        ClickException:
+            If the Github CLI wasn't found.
+    """
     try:
         subprocess.run(["gh", "version"], check=True, capture_output=True)
     except FileNotFoundError:


### PR DESCRIPTION
Swaps the official dataset `hellaswag-da` for `winogrande-da`.

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `winogrande-da`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `hellaswag-da` is demoted to unofficial and `winogrande-da` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.