### PR TITLE
Add five European Portuguese datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Added the unofficial European Portuguese ALBA-MCQ, PT Exams, CulturaVivaPT,
+  SAUDADE-PT, and PT-PT Completions datasets. This was contributed by @duarteocarmo ✨
 - Evaluation hallucination detection task, reporting a hallucination rate
   (hallucinated_tokens/total_tokens). This includes RAGTruth-based datasets for 30
   European languages (Danish, Albanian, Belarusian, Bosnian, Bulgarian, Catalan,

--- a/src/euroeval/dataset_configs/portuguese.py
+++ b/src/euroeval/dataset_configs/portuguese.py
@@ -158,3 +158,58 @@ RAGTRUTH_PT_CONFIG = DatasetConfig(
     train_split=None,
     unofficial=True,
 )
+
+ALBA_MCQ_PT_CONFIG = DatasetConfig(
+    name="alba-mcq-pt",
+    pretty_name="ALBA-MCQ",
+    source="EuroEval/euroeval-amalia-alba-mcq-pt",
+    task=KNOW,
+    languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
+    labels=["a", "b", "c"],
+    val_split=None,
+    unofficial=True,
+)
+
+PT_EXAMS_CONFIG = DatasetConfig(
+    name="pt-exams",
+    pretty_name="PT Exams",
+    source="EuroEval/euroeval-amalia-pt-exams",
+    task=KNOW,
+    languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
+    unofficial=True,
+)
+
+CULTURA_VIVA_PT_CONFIG = DatasetConfig(
+    name="cultura-viva-pt",
+    pretty_name="CulturaVivaPT",
+    source="EuroEval/euroeval-amalia-cultura-viva-pt",
+    task=KNOW,
+    languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
+    unofficial=True,
+)
+
+SAUDADE_PT_CONFIG = DatasetConfig(
+    name="saudade-pt",
+    pretty_name="SAUDADE-PT",
+    source="EuroEval/euroeval-amalia-saudade-pt-mini",
+    task=KNOW,
+    languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
+    labels=["a", "b"],
+    unofficial=True,
+)
+
+PT_COMPLETIONS_CONFIG = DatasetConfig(
+    name="pt-completions",
+    pretty_name="PT-PT Completions",
+    source="EuroEval/euroeval-amalia-pt-completions",
+    task=KNOW,
+    languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
+    labels=["a", "b"],
+    prompt_template="Pergunta: {text}\nVariante em português europeu: {label}",
+    instruction_prompt=(
+        "{text}\nPergunta: Qual opção está em português europeu?\n\n"
+        "Responde à pergunta acima usando só {labels_str}, e nada mais."
+    ),
+    val_split=None,
+    unofficial=True,
+)

--- a/src/frontend/md/datasets/portuguese.md
+++ b/src/frontend/md/datasets/portuguese.md
@@ -639,6 +639,386 @@ You can evaluate this dataset directly as follows:
 euroeval --model <model-id> --dataset multiloko-pt
 ```
 
+### Unofficial: ALBA-MCQ
+
+[ALBA-MCQ](https://huggingface.co/datasets/amalia-llm/alba_mcq) is the
+multiple-choice adaptation of ALBA, an expert-created benchmark introduced in the
+[ALBA paper](https://aclanthology.org/2026.propor-1.69/) for evaluating European
+Portuguese linguistic competence. Its 240 questions cover culture-bound semantics,
+discourse, language variety, lexicology, morphology, phonetics and phonology, syntax,
+and wordplay. Each question has three answers rated for quality and a designated correct
+choice.
+
+EuroEval combines the eight source configurations, reproducibly shuffles the answer
+choices, and creates splits with 32 training and 208 test samples. There is no
+validation split, so evaluation uses the full test split. Accuracy and Matthews
+correlation coefficient are reported through the Knowledge task.
+
+```json
+{
+  "text": "Em que região de Portugal é mais comum usar-se a palavra \"cruzeta\"?\nOpções:\na. A palavra \"cruzeta\" é usada no norte de Portugal. Este regionalismo tem como correspondente, no sul de Portugal, a palavra \"cabide\".\nb. A palavra \"cruzeta\" é usada no centro de Portugal. Este regionalismo tem como correspondente, no sul de Portugal, a palavra \"cabide\".\nc. A palavra \"cruzeta\" refere-se a uma pequena cruz e tem como correspondente, no sul de Portugal, a palavra \"cruzinha\".",
+  "label": "a",
+  "subject": "Language Variety"
+}
+```
+
+```json
+{
+  "text": "Completa esta piada seca: Qual o animal que anda com uma pata?\nOpções:\na. Quase todos... menos as cobras!\nb. O pato.\nc. O macho da pata.",
+  "label": "b",
+  "subject": "Culture-bound Semantics"
+}
+```
+
+```json
+{
+  "text": "Cria um acróstico com a palavra \"mar\".\nOpções:\na. Olha só um acróstico com a palavra \"mar\".\n\nMaresia\nAreia\nb. Olha só um acróstico com a palavra \"mar\".\n\nMaresia\nAreia\nRio\nc. Aqui está um acróstico com a palavra \"mar\".\n\nMaresia\nAreia\nRio",
+  "label": "c",
+  "subject": "Word Plays"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  As seguintes são perguntas de escolha múltipla (com respostas).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Pergunta: {text}
+  Opções:
+  a. {option_a}
+  b. {option_b}
+  c. {option_c}
+  Resposta: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Pergunta: {text}
+  Opções:
+  a. {option_a}
+  b. {option_b}
+  c. {option_c}
+
+  Responde à pergunta acima usando só 'a', 'b' ou 'c', e nada mais.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset alba-mcq-pt
+```
+
+### Unofficial: PT Exams
+
+[PT Exams](https://huggingface.co/datasets/amalia-llm/pt_exams), also known as PHEB or
+PT-E, was introduced in the [PHEB paper](https://lrec.elra.info/lrec2026-main-367).
+It contains 1,819 multiple-choice questions from Portuguese national secondary-school
+exams between 2006 and 2023. It covers Portuguese, Mathematics A, History A, Geography,
+Philosophy, and Biology and Geology.
+
+The complete source test split with 1,819 samples is retained, with answer choices
+shuffled reproducibly. EuroEval allocates 32 samples to training, 256 to validation,
+and 1,531 to testing. Accuracy and Matthews correlation coefficient are reported.
+
+```json
+{
+  "text": "Qual é o valor de $\\lim_{x \\to 1} \\frac{f(x) - f(1)}{1 - x^2}$?\nOpções:\na. -2\nb. 2\nc. -1\nd. 0",
+  "label": "c",
+  "subject": "Mathematics A",
+  "year": 2020
+}
+```
+
+```json
+{
+  "text": "Sabemos que a relva é verde. Este conhecimento é\nOpções:\na. a posteriori.\nb. formal.\nc. inato.\nd. a priori.",
+  "label": "b",
+  "subject": "Philosophy",
+  "year": 2006
+}
+```
+
+```json
+{
+  "text": "A maior parte da precipitação que ocorre em Portugal continental é de tipo\nOpções:\na. convectivo.\nb. frontal.\nc. orográfico.\nd. convergente.",
+  "label": "b",
+  "subject": "Geography",
+  "year": 2013
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  As seguintes são perguntas de escolha múltipla (com respostas).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Pergunta: {text}
+  Opções:
+  a. {option_a}
+  b. {option_b}
+  c. {option_c}
+  d. {option_d}
+  Resposta: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Pergunta: {text}
+  Opções:
+  a. {option_a}
+  b. {option_b}
+  c. {option_c}
+  d. {option_d}
+
+  Responde à pergunta acima usando só 'a', 'b', 'c' ou 'd', e nada mais.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset pt-exams
+```
+
+### Unofficial: CulturaVivaPT
+
+[CulturaVivaPT](https://huggingface.co/datasets/amalia-llm/cultura-viva-pt-mcq),
+released as part of the [AMALIA project](https://aclanthology.org/2026.propor-1.38/),
+contains 1,000 multiple-choice questions about Portuguese culture. Its ten balanced
+domains cover audiovisual culture, festivals, gastronomy, geography, heritage,
+holidays, literature, personalities, proverbs, and sports.
+
+The upstream repository exposes all 1,000 samples as a `train` split. EuroEval
+reproducibly shuffles the samples and answer choices, then allocates 32 samples to
+training, 128 to validation, and 840 to testing. Accuracy and Matthews correlation
+coefficient are reported.
+
+```json
+{
+  "text": "Em que local nasceu a artista e escritora Florbela Oliveira?\nOpções:\na. Coimbra\nb. Campolide\nc. Serra da Estrela\nd. Palmela",
+  "label": "b",
+  "subject": "personalities"
+}
+```
+
+```json
+{
+  "text": "Preenche o espaço em falta: «O tempo a tudo _ remédio.»\nOpções:\na. dá\nb. vê\nc. traz\nd. faz",
+  "label": "a",
+  "subject": "proverbs"
+}
+```
+
+```json
+{
+  "text": "Preenche o espaço em falta: «Em Abril cada pulga _ mil.»\nOpções:\na. faz\nb. vê\nc. tem\nd. dá",
+  "label": "d",
+  "subject": "proverbs"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  As seguintes são perguntas de escolha múltipla (com respostas).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Pergunta: {text}
+  Opções:
+  a. {option_a}
+  b. {option_b}
+  c. {option_c}
+  d. {option_d}
+  Resposta: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Pergunta: {text}
+  Opções:
+  a. {option_a}
+  b. {option_b}
+  c. {option_c}
+  d. {option_d}
+
+  Responde à pergunta acima usando só 'a', 'b', 'c' ou 'd', e nada mais.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset cultura-viva-pt
+```
+
+### Unofficial: SAUDADE-PT
+
+[SAUDADE-PT](https://huggingface.co/datasets/amalia-llm/saudade-pt), released as
+part of the [AMALIA project](https://aclanthology.org/2026.propor-1.38/), evaluates
+reasoning about the chronological order of events related to Portugal. Its questions
+cover people, places, organisations, cultural works, politics, sports, and historical
+events.
+
+The source provides 8,573 test samples. EuroEval reproducibly selects 32 training, 256
+validation, and 2,048 test samples, shuffles the two answer choices, and retains the
+entity and category metadata. The Knowledge task reports accuracy and Matthews
+correlation coefficient.
+
+```json
+{
+  "text": "Em Moura, qual ocorreu primeiro:\nOpções:\na. Castelo de Moura classificado como Imóvel de Interesse Público\nb. Domínio cristão efetivado em Moura",
+  "label": "b",
+  "entity": "Moura",
+  "category": "Municipio_Portugal"
+}
+```
+
+```json
+{
+  "text": "O que ocorreu primeiro:\nOpções:\na. Treinador da seleção húngara\nb. Falecimento de Lajos Baróti",
+  "label": "a",
+  "entity": "Lajos Baróti",
+  "category": "Futebol"
+}
+```
+
+```json
+{
+  "text": "Em Teixeira (Seia), qual ocorreu primeiro:\nOpções:\na. Freguesia autónoma\nb. Anexação à freguesia de Vide",
+  "label": "a",
+  "entity": "Teixeira (Seia)",
+  "category": "Freguesia_Portugal"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  As seguintes são perguntas de escolha múltipla (com respostas).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Pergunta: {text}
+  Opções:
+  a. {option_a}
+  b. {option_b}
+  Resposta: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Pergunta: {text}
+  Opções:
+  a. {option_a}
+  b. {option_b}
+
+  Responde à pergunta acima usando só 'a' ou 'b', e nada mais.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset saudade-pt
+```
+
+### Unofficial: PT-PT Completions
+
+[PT-PT Completions](https://huggingface.co/datasets/amalia-llm/pt_text_completion),
+released as part of the [AMALIA project](https://aclanthology.org/2026.propor-1.38/),
+tests whether a model can select the correct European Portuguese completion instead of
+a Brazilian Portuguese alternative. The source contains 3 validation and 70 test
+examples, with no training split.
+
+EuroEval explicitly asks which option is in European Portuguese. It moves eight
+balanced test examples into a small training split and combines the remaining 62 with
+the three validation examples, resulting in 65 test examples and no validation split.
+Matthews correlation coefficient and accuracy are reported as part of the Knowledge
+task.
+
+```json
+{
+  "text": "Frase: Para longas distâncias, prefiro viajar de _______.\nOpções:\na. trem\nb. comboio",
+  "label": "b"
+}
+```
+
+```json
+{
+  "text": "Frase: Moro no _______.\nOpções:\na. térreo\nb. rés do chão",
+  "label": "b"
+}
+```
+
+```json
+{
+  "text": "Frase: _______ vamos ao cinema.\nOpções:\na. malta\nb. galera",
+  "label": "a"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  As seguintes são perguntas de escolha múltipla (com respostas).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Pergunta: {text}
+  Variante em português europeu: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  {text}
+  Pergunta: Qual opção está em português europeu?
+
+  Responde à pergunta acima usando só 'a' ou 'b', e nada mais.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset pt-completions
+```
+
 ## Common-sense Reasoning
 
 ### GoldenSwag-pt

--- a/src/leaderboards/dataset_split_sizes.json
+++ b/src/leaderboards/dataset_split_sizes.json
@@ -1324,6 +1324,29 @@
     "train": 1024,
     "val": 256
   },
+  "EuroEval/euroeval-amalia-alba-mcq-pt": {
+    "test": 208,
+    "train": 32
+  },
+  "EuroEval/euroeval-amalia-cultura-viva-pt": {
+    "test": 840,
+    "train": 32,
+    "val": 128
+  },
+  "EuroEval/euroeval-amalia-pt-completions": {
+    "test": 65,
+    "train": 8
+  },
+  "EuroEval/euroeval-amalia-pt-exams": {
+    "test": 1531,
+    "train": 32,
+    "val": 256
+  },
+  "EuroEval/euroeval-amalia-saudade-pt-mini": {
+    "test": 2048,
+    "train": 32,
+    "val": 256
+  },
   "giannor/dala": {
     "full_train": 5352,
     "test": 2048,

--- a/src/scripts/dataset_creation/create_alba_mcq_pt.py
+++ b/src/scripts/dataset_creation/create_alba_mcq_pt.py
@@ -1,0 +1,65 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets==3.5.0",
+#     "huggingface-hub==0.24.0",
+# ]
+# ///
+
+"""Create the ALBA-MCQ European Portuguese dataset and upload it to HF Hub."""
+
+import random
+
+from constants import CHOICES_MAPPING
+from datasets import Dataset, DatasetDict, load_dataset
+
+SOURCE_ID = "amalia-llm/alba_mcq"
+TARGET_ID = "EuroEval/euroeval-amalia-alba-mcq-pt"
+TRAIN_SIZE = 32
+CONFIGS = [
+    "culture_bound_semantics",
+    "discourse_analysis",
+    "language_variety",
+    "lexicology",
+    "morphology",
+    "phonetics_phonology",
+    "syntax",
+    "word_play",
+]
+
+
+def main() -> None:
+    """Create and upload the combined ALBA-MCQ dataset."""
+    rows: list[dict] = []
+    for config in CONFIGS:
+        dataset = load_dataset(path=SOURCE_ID, name=config, split="test")
+        assert isinstance(dataset, Dataset)
+        for row in dataset:
+            choices = list(row["choices"])
+            permutation = list(range(len(choices)))
+            random.Random(x=f"{config}:{row['id']}").shuffle(x=permutation)
+            text = f"{row['question'].strip()}\n{CHOICES_MAPPING['pt']}:\n" + "\n".join(
+                f"{'abc'[label_index]}. {choices[choice_index].strip()}"
+                for label_index, choice_index in enumerate(permutation)
+            )
+            rows.append(
+                {
+                    "text": text,
+                    "label": "abc"[permutation.index(row["correct_choice"])],
+                    "subject": row["subject"],
+                }
+            )
+
+    dataset = Dataset.from_list(mapping=rows).shuffle(seed=4242)
+    output = DatasetDict(
+        {
+            "train": dataset.select(indices=range(TRAIN_SIZE)),
+            "test": dataset.select(indices=range(TRAIN_SIZE, len(dataset))),
+        }
+    )
+    output.push_to_hub(repo_id=TARGET_ID, private=True)
+    print(f"Uploaded {len(rows):,} ALBA-MCQ samples to {TARGET_ID}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/dataset_creation/create_cultura_viva_pt.py
+++ b/src/scripts/dataset_creation/create_cultura_viva_pt.py
@@ -1,0 +1,59 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets==3.5.0",
+#     "huggingface-hub==0.24.0",
+# ]
+# ///
+
+"""Create the CulturaVivaPT dataset and upload it to HF Hub."""
+
+import random
+
+from constants import CHOICES_MAPPING
+from datasets import Dataset, DatasetDict, load_dataset
+
+SOURCE_ID = "amalia-llm/cultura-viva-pt-mcq"
+TARGET_ID = "EuroEval/euroeval-amalia-cultura-viva-pt"
+TRAIN_SIZE = 32
+VAL_SIZE = 128
+
+
+def main() -> None:
+    """Create and upload the CulturaVivaPT dataset."""
+    dataset = load_dataset(path=SOURCE_ID, split="train")
+    assert isinstance(dataset, Dataset)
+
+    rows: list[dict] = []
+    for row in dataset:
+        labels = list(row["choices"]["label"])
+        choices = list(row["choices"]["text"])
+        correct_index = labels.index(row["answerKey"])
+        permutation = list(range(len(choices)))
+        random.Random(x=row["id"]).shuffle(x=permutation)
+        text = f"{row['question'].strip()}\n{CHOICES_MAPPING['pt']}:\n" + "\n".join(
+            f"{'abcd'[label_index]}. {choices[choice_index].strip()}"
+            for label_index, choice_index in enumerate(permutation)
+        )
+        rows.append(
+            {
+                "text": text,
+                "label": "abcd"[permutation.index(correct_index)],
+                "subject": row["domain"],
+            }
+        )
+
+    dataset = Dataset.from_list(mapping=rows).shuffle(seed=4242)
+    output = DatasetDict(
+        {
+            "train": dataset.select(indices=range(TRAIN_SIZE)),
+            "val": dataset.select(indices=range(TRAIN_SIZE, TRAIN_SIZE + VAL_SIZE)),
+            "test": dataset.select(indices=range(TRAIN_SIZE + VAL_SIZE, len(dataset))),
+        }
+    )
+    output.push_to_hub(repo_id=TARGET_ID, private=True)
+    print(f"Uploaded {len(rows):,} CulturaVivaPT samples to {TARGET_ID}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/dataset_creation/create_pt_completions.py
+++ b/src/scripts/dataset_creation/create_pt_completions.py
@@ -1,0 +1,62 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets==3.5.0",
+#     "huggingface-hub==0.24.0",
+# ]
+# ///
+
+"""Create the PT-PT Completions dataset and upload it to HF Hub."""
+
+from constants import CHOICES_MAPPING
+from datasets import Dataset, DatasetDict, concatenate_datasets, load_dataset
+
+SOURCE_ID = "amalia-llm/pt_text_completion"
+TARGET_ID = "EuroEval/euroeval-amalia-pt-completions"
+TRAIN_SIZE = 8
+
+
+def _process_split(dataset: Dataset) -> Dataset:
+    """Convert a PT-PT Completions split to EuroEval format.
+
+    Returns:
+        Processed dataset split.
+    """
+    rows: list[dict] = []
+    for index, row in enumerate(dataset):
+        choices = [row["pt-pt"], row["pt-br"]]
+        permutation = [0, 1] if index % 2 == 0 else [1, 0]
+        shuffled_choices = [choices[choice_index] for choice_index in permutation]
+        text = (
+            f"Frase: {row['text'].strip()}\n{CHOICES_MAPPING['pt']}:\n"
+            f"a. {shuffled_choices[0].strip()}\n"
+            f"b. {shuffled_choices[1].strip()}"
+        )
+        rows.append({"text": text, "label": "a" if permutation[0] == 0 else "b"})
+    return Dataset.from_list(mapping=rows)
+
+
+def main() -> None:
+    """Create and upload the PT-PT Completions dataset."""
+    dataset = load_dataset(path=SOURCE_ID, name="default")
+    assert isinstance(dataset, DatasetDict)
+
+    processed_test = _process_split(dataset=dataset["test"])
+    test = concatenate_datasets(
+        dsets=[
+            processed_test.select(indices=range(TRAIN_SIZE, len(processed_test))),
+            _process_split(dataset=dataset["valid"]),
+        ]
+    )
+    output = DatasetDict(
+        {"train": processed_test.select(indices=range(TRAIN_SIZE)), "test": test}
+    )
+    output.push_to_hub(repo_id=TARGET_ID, private=True)
+    print(
+        f"Uploaded {sum(len(split) for split in output.values()):,} "
+        f"PT-PT Completions samples to {TARGET_ID}."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/dataset_creation/create_pt_exams.py
+++ b/src/scripts/dataset_creation/create_pt_exams.py
@@ -1,0 +1,60 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets==3.5.0",
+#     "huggingface-hub==0.24.0",
+# ]
+# ///
+
+"""Create the PT Exams dataset and upload it to HF Hub."""
+
+import random
+
+from constants import CHOICES_MAPPING
+from datasets import Dataset, DatasetDict, load_dataset
+
+SOURCE_ID = "amalia-llm/pt_exams"
+TARGET_ID = "EuroEval/euroeval-amalia-pt-exams"
+TRAIN_SIZE = 32
+VAL_SIZE = 256
+
+
+def main() -> None:
+    """Create and upload the PT Exams dataset."""
+    dataset = load_dataset(path=SOURCE_ID, name="default", split="test")
+    assert isinstance(dataset, Dataset)
+
+    rows: list[dict] = []
+    for index, row in enumerate(dataset):
+        choices = list(row["choices"])
+        permutation = list(range(len(choices)))
+        random.Random(x=f"{row['year']}:{row['subject']}:{index}").shuffle(
+            x=permutation
+        )
+        text = f"{row['question'].strip()}\n{CHOICES_MAPPING['pt']}:\n" + "\n".join(
+            f"{'abcd'[label_index]}. {choices[choice_index].strip()}"
+            for label_index, choice_index in enumerate(permutation)
+        )
+        rows.append(
+            {
+                "text": text,
+                "label": "abcd"[permutation.index(row["answer"])],
+                "subject": row["subject"],
+                "year": row["year"],
+            }
+        )
+
+    dataset = Dataset.from_list(mapping=rows).shuffle(seed=4242)
+    output = DatasetDict(
+        {
+            "train": dataset.select(indices=range(TRAIN_SIZE)),
+            "val": dataset.select(indices=range(TRAIN_SIZE, TRAIN_SIZE + VAL_SIZE)),
+            "test": dataset.select(indices=range(TRAIN_SIZE + VAL_SIZE, len(dataset))),
+        }
+    )
+    output.push_to_hub(repo_id=TARGET_ID, private=True)
+    print(f"Uploaded {len(rows):,} PT Exams samples to {TARGET_ID}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/dataset_creation/create_saudade_pt.py
+++ b/src/scripts/dataset_creation/create_saudade_pt.py
@@ -1,0 +1,63 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets==5.0.0",
+# ]
+# ///
+
+"""Create the SAUDADE European Portuguese dataset and upload it to HF Hub."""
+
+import random
+
+from constants import CHOICES_MAPPING
+from datasets import Dataset, DatasetDict, load_dataset
+
+SOURCE_ID = "amalia-llm/saudade-pt"
+TARGET_ID = "EuroEval/euroeval-amalia-saudade-pt-mini"
+TRAIN_SIZE = 32
+VAL_SIZE = 256
+TEST_SIZE = 2048
+
+
+def main() -> None:
+    """Create and upload the SAUDADE-PT dataset."""
+    dataset = load_dataset(path=SOURCE_ID, split="test")
+    assert isinstance(dataset, Dataset)
+    dataset = dataset.shuffle(seed=4242).select(
+        indices=range(TRAIN_SIZE + VAL_SIZE + TEST_SIZE)
+    )
+
+    rows: list[dict] = []
+    for row in dataset:
+        choices = list(row["facts_pair"])
+        permutation = list(range(len(choices)))
+        random.Random(x=f"{row['entity']}:{row['prompt']}").shuffle(x=permutation)
+        text = f"{row['prompt'].strip()}\n{CHOICES_MAPPING['pt']}:\n" + "\n".join(
+            f"{'ab'[label_index]}. {choices[choice_index].strip()}"
+            for label_index, choice_index in enumerate(permutation)
+        )
+        rows.append(
+            {
+                "text": text,
+                "label": "ab"[permutation.index(row["answer_index"])],
+                "entity": row["entity"],
+                "category": row["category"],
+            }
+        )
+
+    dataset = Dataset.from_list(mapping=rows)
+    output = DatasetDict(
+        {
+            "train": dataset.select(indices=range(TRAIN_SIZE)),
+            "val": dataset.select(indices=range(TRAIN_SIZE, TRAIN_SIZE + VAL_SIZE)),
+            "test": dataset.select(
+                indices=range(TRAIN_SIZE + VAL_SIZE, TRAIN_SIZE + VAL_SIZE + TEST_SIZE)
+            ),
+        }
+    )
+    output.push_to_hub(repo_id=TARGET_ID, private=True)
+    print(f"Uploaded {len(rows):,} SAUDADE-PT samples to {TARGET_ID}.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hey @saattrupdan ! Thanks for the fast eval for the AMALIA models. 

The [AMALIA](https://arxiv.org/pdf/2603.26511) team also released a bunch of nice datasets + evals. This PR adds some of them to EuroEval: 


- ALBA-MCQ (https://huggingface.co/datasets/duarteocarmo/euroeval-amalia-alba-mcq-pt)
- PT Exams (PHEB / PT-E) (https://huggingface.co/datasets/duarteocarmo/euroeval-amalia-pt-exams)
- CulturaVivaPT (https://huggingface.co/datasets/duarteocarmo/euroeval-amalia-cultura-viva-pt)
- SAUDADE-PT (https://huggingface.co/datasets/duarteocarmo/euroeval-amalia-saudade-pt-mini)
- PT-PT Completions (https://huggingface.co/datasets/duarteocarmo/euroeval-amalia-pt-completions)

Notes: 
- most of these don't have training samples
- I'm using the duarteocarmo namespace for now (I'll change to euroeval if/when you say so) 
- Set everything to unofficial for now

Let me know if you have any feedback! 
