### PR TITLE
chore: mark easy ZebraPuzzles datasets as official

### DIFF
--- a/src/euroeval/dataset_configs/danish.py
+++ b/src/euroeval/dataset_configs/danish.py
@@ -256,7 +256,6 @@ ZEBRA_PUZZLE_EASY_DA_CONFIG = DatasetConfig(
     source="EuroEval/zebra-puzzles-easy-da",
     task=LOGIC,
     languages=[DANISH],
-    unofficial=True,
 )
 
 ZEBRA_PUZZLE_HARD_DA_CONFIG = DatasetConfig(

--- a/src/euroeval/dataset_configs/danish.py
+++ b/src/euroeval/dataset_configs/danish.py
@@ -105,6 +105,14 @@ WINOGRANDE_DA_CONFIG = DatasetConfig(
     labels=["a", "b"],
 )
 
+ZEBRA_PUZZLE_EASY_DA_CONFIG = DatasetConfig(
+    name="zebra-puzzles-easy-da",
+    pretty_name="ZebraPuzzlesEasy-da",
+    source="EuroEval/zebra-puzzles-easy-da",
+    task=LOGIC,
+    languages=[DANISH],
+)
+
 # Unofficial datasets ###
 
 HELLASWAG_DA_CONFIG = DatasetConfig(
@@ -248,14 +256,6 @@ GERLANGMOD_DA_CONFIG = DatasetConfig(
     task=GED,
     languages=[DANISH],
     unofficial=True,
-)
-
-ZEBRA_PUZZLE_EASY_DA_CONFIG = DatasetConfig(
-    name="zebra-puzzles-easy-da",
-    pretty_name="ZebraPuzzlesEasy-da",
-    source="EuroEval/zebra-puzzles-easy-da",
-    task=LOGIC,
-    languages=[DANISH],
 )
 
 ZEBRA_PUZZLE_HARD_DA_CONFIG = DatasetConfig(

--- a/src/euroeval/dataset_configs/dutch.py
+++ b/src/euroeval/dataset_configs/dutch.py
@@ -250,7 +250,6 @@ ZEBRA_PUZZLE_EASY_NL_CONFIG = DatasetConfig(
     source="EuroEval/zebra-puzzles-easy-nl",
     task=LOGIC,
     languages=[DUTCH],
-    unofficial=True,
 )
 
 ZEBRA_PUZZLE_HARD_NL_CONFIG = DatasetConfig(

--- a/src/euroeval/dataset_configs/dutch.py
+++ b/src/euroeval/dataset_configs/dutch.py
@@ -119,6 +119,14 @@ MBBQ_NL_CONFIG = DatasetConfig(
     train_split=None,
 )
 
+ZEBRA_PUZZLE_EASY_NL_CONFIG = DatasetConfig(
+    name="zebra-puzzles-easy-nl",
+    pretty_name="ZebraPuzzlesEasy-nl",
+    source="EuroEval/zebra-puzzles-easy-nl",
+    task=LOGIC,
+    languages=[DUTCH],
+)
+
 
 # Unofficial datasets ###
 
@@ -242,14 +250,6 @@ SICK_NL_CONFIG = DatasetConfig(
     task=NLI,
     languages=[DUTCH],
     unofficial=True,
-)
-
-ZEBRA_PUZZLE_EASY_NL_CONFIG = DatasetConfig(
-    name="zebra-puzzles-easy-nl",
-    pretty_name="ZebraPuzzlesEasy-nl",
-    source="EuroEval/zebra-puzzles-easy-nl",
-    task=LOGIC,
-    languages=[DUTCH],
 )
 
 ZEBRA_PUZZLE_HARD_NL_CONFIG = DatasetConfig(

--- a/src/euroeval/dataset_configs/english.py
+++ b/src/euroeval/dataset_configs/english.py
@@ -210,7 +210,6 @@ ZEBRA_PUZZLE_EASY_EN_CONFIG = DatasetConfig(
     source="EuroEval/zebra-puzzles-easy-en",
     task=LOGIC,
     languages=[ENGLISH],
-    unofficial=True,
 )
 
 ZEBRA_PUZZLE_HARD_EN_CONFIG = DatasetConfig(

--- a/src/euroeval/dataset_configs/english.py
+++ b/src/euroeval/dataset_configs/english.py
@@ -106,6 +106,14 @@ VALEU_EN_CONFIG = DatasetConfig(
     instruction_prompt="{text}",
 )
 
+ZEBRA_PUZZLE_EASY_EN_CONFIG = DatasetConfig(
+    name="zebra-puzzles-easy-en",
+    pretty_name="ZebraPuzzlesEasy-en",
+    source="EuroEval/zebra-puzzles-easy-en",
+    task=LOGIC,
+    languages=[ENGLISH],
+)
+
 
 # Unofficial datasets ###
 
@@ -202,14 +210,6 @@ WIC_CONFIG = DatasetConfig(
     task=WIC,
     languages=[ENGLISH],
     unofficial=True,
-)
-
-ZEBRA_PUZZLE_EASY_EN_CONFIG = DatasetConfig(
-    name="zebra-puzzles-easy-en",
-    pretty_name="ZebraPuzzlesEasy-en",
-    source="EuroEval/zebra-puzzles-easy-en",
-    task=LOGIC,
-    languages=[ENGLISH],
 )
 
 ZEBRA_PUZZLE_HARD_EN_CONFIG = DatasetConfig(

--- a/src/euroeval/dataset_configs/faroese.py
+++ b/src/euroeval/dataset_configs/faroese.py
@@ -49,6 +49,14 @@ MULTI_IFEVAL_FO_CONFIG = DatasetConfig(
     val_split=None,
 )
 
+ZEBRA_PUZZLE_EASY_FO_CONFIG = DatasetConfig(
+    name="zebra-puzzles-easy-fo",
+    pretty_name="ZebraPuzzlesEasy-fo",
+    source="EuroEval/zebra-puzzles-easy-fo",
+    task=LOGIC,
+    languages=[FAROESE],
+)
+
 
 # Unofficial datasets ###
 
@@ -77,14 +85,6 @@ GERLANGMOD_FO_CONFIG = DatasetConfig(
     task=GED,
     languages=[FAROESE],
     unofficial=True,
-)
-
-ZEBRA_PUZZLE_EASY_FO_CONFIG = DatasetConfig(
-    name="zebra-puzzles-easy-fo",
-    pretty_name="ZebraPuzzlesEasy-fo",
-    source="EuroEval/zebra-puzzles-easy-fo",
-    task=LOGIC,
-    languages=[FAROESE],
 )
 
 ZEBRA_PUZZLE_HARD_FO_CONFIG = DatasetConfig(

--- a/src/euroeval/dataset_configs/faroese.py
+++ b/src/euroeval/dataset_configs/faroese.py
@@ -85,7 +85,6 @@ ZEBRA_PUZZLE_EASY_FO_CONFIG = DatasetConfig(
     source="EuroEval/zebra-puzzles-easy-fo",
     task=LOGIC,
     languages=[FAROESE],
-    unofficial=True,
 )
 
 ZEBRA_PUZZLE_HARD_FO_CONFIG = DatasetConfig(

--- a/src/euroeval/dataset_configs/german.py
+++ b/src/euroeval/dataset_configs/german.py
@@ -98,6 +98,14 @@ VALEU_DE_CONFIG = DatasetConfig(
     instruction_prompt="{text}",
 )
 
+ZEBRA_PUZZLE_EASY_DE_CONFIG = DatasetConfig(
+    name="zebra-puzzles-easy-de",
+    pretty_name="ZebraPuzzlesEasy-de",
+    source="EuroEval/zebra-puzzles-easy-de",
+    task=LOGIC,
+    languages=[GERMAN],
+)
+
 
 # Unofficial datasets ###
 
@@ -193,14 +201,6 @@ GERLANGMOD_DE_CONFIG = DatasetConfig(
     task=GED,
     languages=[GERMAN],
     unofficial=True,
-)
-
-ZEBRA_PUZZLE_EASY_DE_CONFIG = DatasetConfig(
-    name="zebra-puzzles-easy-de",
-    pretty_name="ZebraPuzzlesEasy-de",
-    source="EuroEval/zebra-puzzles-easy-de",
-    task=LOGIC,
-    languages=[GERMAN],
 )
 
 ZEBRA_PUZZLE_HARD_DE_CONFIG = DatasetConfig(

--- a/src/euroeval/dataset_configs/german.py
+++ b/src/euroeval/dataset_configs/german.py
@@ -201,7 +201,6 @@ ZEBRA_PUZZLE_EASY_DE_CONFIG = DatasetConfig(
     source="EuroEval/zebra-puzzles-easy-de",
     task=LOGIC,
     languages=[GERMAN],
-    unofficial=True,
 )
 
 ZEBRA_PUZZLE_HARD_DE_CONFIG = DatasetConfig(

--- a/src/euroeval/dataset_configs/icelandic.py
+++ b/src/euroeval/dataset_configs/icelandic.py
@@ -218,7 +218,6 @@ ZEBRA_PUZZLE_EASY_IS_CONFIG = DatasetConfig(
     source="EuroEval/zebra-puzzles-easy-is",
     task=LOGIC,
     languages=[ICELANDIC],
-    unofficial=True,
 )
 
 ZEBRA_PUZZLE_HARD_IS_CONFIG = DatasetConfig(

--- a/src/euroeval/dataset_configs/icelandic.py
+++ b/src/euroeval/dataset_configs/icelandic.py
@@ -99,6 +99,14 @@ VALEU_IS_CONFIG = DatasetConfig(
     instruction_prompt="{text}",
 )
 
+ZEBRA_PUZZLE_EASY_IS_CONFIG = DatasetConfig(
+    name="zebra-puzzles-easy-is",
+    pretty_name="ZebraPuzzlesEasy-is",
+    source="EuroEval/zebra-puzzles-easy-is",
+    task=LOGIC,
+    languages=[ICELANDIC],
+)
+
 
 # Unofficial datasets ###
 
@@ -210,14 +218,6 @@ GERLANGMOD_IS_CONFIG = DatasetConfig(
     task=GED,
     languages=[ICELANDIC],
     unofficial=True,
-)
-
-ZEBRA_PUZZLE_EASY_IS_CONFIG = DatasetConfig(
-    name="zebra-puzzles-easy-is",
-    pretty_name="ZebraPuzzlesEasy-is",
-    source="EuroEval/zebra-puzzles-easy-is",
-    task=LOGIC,
-    languages=[ICELANDIC],
 )
 
 ZEBRA_PUZZLE_HARD_IS_CONFIG = DatasetConfig(

--- a/src/euroeval/dataset_configs/norwegian.py
+++ b/src/euroeval/dataset_configs/norwegian.py
@@ -346,7 +346,6 @@ ZEBRA_PUZZLE_EASY_NB_CONFIG = DatasetConfig(
     source="EuroEval/zebra-puzzles-easy-nb",
     task=LOGIC,
     languages=[NORWEGIAN_BOKMÅL, NORWEGIAN],
-    unofficial=True,
 )
 
 ZEBRA_PUZZLE_HARD_NB_CONFIG = DatasetConfig(
@@ -364,7 +363,6 @@ ZEBRA_PUZZLE_EASY_NN_CONFIG = DatasetConfig(
     source="EuroEval/zebra-puzzles-easy-nn",
     task=LOGIC,
     languages=[NORWEGIAN_NYNORSK, NORWEGIAN],
-    unofficial=True,
 )
 
 ZEBRA_PUZZLE_HARD_NN_CONFIG = DatasetConfig(

--- a/src/euroeval/dataset_configs/norwegian.py
+++ b/src/euroeval/dataset_configs/norwegian.py
@@ -135,6 +135,22 @@ MULTI_IFEVAL_NN_CONFIG = DatasetConfig(
     val_split=None,
 )
 
+ZEBRA_PUZZLE_EASY_NB_CONFIG = DatasetConfig(
+    name="zebra-puzzles-easy-nb",
+    pretty_name="ZebraPuzzlesEasy-nb",
+    source="EuroEval/zebra-puzzles-easy-nb",
+    task=LOGIC,
+    languages=[NORWEGIAN_BOKMÅL, NORWEGIAN],
+)
+
+ZEBRA_PUZZLE_EASY_NN_CONFIG = DatasetConfig(
+    name="zebra-puzzles-easy-nn",
+    pretty_name="ZebraPuzzlesEasy-nn",
+    source="EuroEval/zebra-puzzles-easy-nn",
+    task=LOGIC,
+    languages=[NORWEGIAN_NYNORSK, NORWEGIAN],
+)
+
 
 # Unofficial datasets ###
 
@@ -340,14 +356,6 @@ GERLANGMOD_NN_CONFIG = DatasetConfig(
     unofficial=True,
 )
 
-ZEBRA_PUZZLE_EASY_NB_CONFIG = DatasetConfig(
-    name="zebra-puzzles-easy-nb",
-    pretty_name="ZebraPuzzlesEasy-nb",
-    source="EuroEval/zebra-puzzles-easy-nb",
-    task=LOGIC,
-    languages=[NORWEGIAN_BOKMÅL, NORWEGIAN],
-)
-
 ZEBRA_PUZZLE_HARD_NB_CONFIG = DatasetConfig(
     name="zebra-puzzles-hard-nb",
     pretty_name="ZebraPuzzlesHard-nb",
@@ -355,14 +363,6 @@ ZEBRA_PUZZLE_HARD_NB_CONFIG = DatasetConfig(
     task=LOGIC,
     languages=[NORWEGIAN_BOKMÅL, NORWEGIAN],
     unofficial=True,
-)
-
-ZEBRA_PUZZLE_EASY_NN_CONFIG = DatasetConfig(
-    name="zebra-puzzles-easy-nn",
-    pretty_name="ZebraPuzzlesEasy-nn",
-    source="EuroEval/zebra-puzzles-easy-nn",
-    task=LOGIC,
-    languages=[NORWEGIAN_NYNORSK, NORWEGIAN],
 )
 
 ZEBRA_PUZZLE_HARD_NN_CONFIG = DatasetConfig(

--- a/src/euroeval/dataset_configs/swedish.py
+++ b/src/euroeval/dataset_configs/swedish.py
@@ -225,7 +225,6 @@ ZEBRA_PUZZLE_EASY_SV_CONFIG = DatasetConfig(
     source="EuroEval/zebra-puzzles-easy-sv",
     task=LOGIC,
     languages=[SWEDISH],
-    unofficial=True,
 )
 
 ZEBRA_PUZZLE_HARD_SV_CONFIG = DatasetConfig(

--- a/src/euroeval/dataset_configs/swedish.py
+++ b/src/euroeval/dataset_configs/swedish.py
@@ -98,6 +98,14 @@ VALEU_SV_CONFIG = DatasetConfig(
     instruction_prompt="{text}",
 )
 
+ZEBRA_PUZZLE_EASY_SV_CONFIG = DatasetConfig(
+    name="zebra-puzzles-easy-sv",
+    pretty_name="ZebraPuzzlesEasy-sv",
+    source="EuroEval/zebra-puzzles-easy-sv",
+    task=LOGIC,
+    languages=[SWEDISH],
+)
+
 
 # Unofficial datasets ###
 
@@ -217,14 +225,6 @@ GERLANGMOD_SV_CONFIG = DatasetConfig(
     task=GED,
     languages=[SWEDISH],
     unofficial=True,
-)
-
-ZEBRA_PUZZLE_EASY_SV_CONFIG = DatasetConfig(
-    name="zebra-puzzles-easy-sv",
-    pretty_name="ZebraPuzzlesEasy-sv",
-    source="EuroEval/zebra-puzzles-easy-sv",
-    task=LOGIC,
-    languages=[SWEDISH],
 )
 
 ZEBRA_PUZZLE_HARD_SV_CONFIG = DatasetConfig(

--- a/src/frontend/md/datasets/danish.md
+++ b/src/frontend/md/datasets/danish.md
@@ -1593,7 +1593,7 @@ euroeval --model <model-id> --dataset goldenswag-da
 
 ## Logical Reasoning
 
-### Unofficial: ZebraPuzzleEasy-da
+### ZebraPuzzleEasy-da
 
 This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2511.03553)
 and consists of logic grid puzzles (also known as Einstein's riddles or Zebra puzzles),

--- a/src/frontend/md/datasets/dutch.md
+++ b/src/frontend/md/datasets/dutch.md
@@ -1692,7 +1692,7 @@ euroeval --model <model-id> --dataset gerlangmod-nl
 
 ## Logical Reasoning
 
-### Unofficial: ZebraPuzzleEasy-nl
+### ZebraPuzzleEasy-nl
 
 This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2511.03553)
 and consists of logic grid puzzles (also known as Einstein's riddles or Zebra puzzles),

--- a/src/frontend/md/datasets/english.md
+++ b/src/frontend/md/datasets/english.md
@@ -1641,7 +1641,7 @@ euroeval --model <model-id> --dataset bfcl-v2
 
 ## Logical Reasoning
 
-### Unofficial: ZebraPuzzleEasy-en
+### ZebraPuzzleEasy-en
 
 This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2511.03553)
 and consists of logic grid puzzles (also known as Einstein's riddles or Zebra puzzles),

--- a/src/frontend/md/datasets/faroese.md
+++ b/src/frontend/md/datasets/faroese.md
@@ -535,7 +535,7 @@ euroeval --model <model-id> --dataset gerlangmod-fo
 
 ## Logical Reasoning
 
-### Unofficial: ZebraPuzzleEasy-fo
+### ZebraPuzzleEasy-fo
 
 This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2511.03553)
 and consists of logic grid puzzles (also known as Einstein's riddles or Zebra puzzles),

--- a/src/frontend/md/datasets/german.md
+++ b/src/frontend/md/datasets/german.md
@@ -1490,7 +1490,7 @@ euroeval --model <model-id> --dataset gerlangmod-de
 
 ## Logical Reasoning
 
-### Unofficial: ZebraPuzzleEasy-de
+### ZebraPuzzleEasy-de
 
 This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2511.03553)
 and consists of logic grid puzzles (also known as Einstein's riddles or Zebra puzzles),

--- a/src/frontend/md/datasets/icelandic.md
+++ b/src/frontend/md/datasets/icelandic.md
@@ -1484,7 +1484,7 @@ euroeval --model <model-id> --dataset gerlangmod-is
 
 ## Logical Reasoning
 
-### Unofficial: ZebraPuzzleEasy-is
+### ZebraPuzzleEasy-is
 
 This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2511.03553)
 and consists of logic grid puzzles (also known as Einstein's riddles or Zebra puzzles),

--- a/src/frontend/md/datasets/norwegian.md
+++ b/src/frontend/md/datasets/norwegian.md
@@ -2304,7 +2304,7 @@ euroeval --model <model-id> --dataset gerlangmod-nn
 
 ## Logical Reasoning
 
-### Unofficial: ZebraPuzzleEasy-nb
+### ZebraPuzzleEasy-nb
 
 This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2511.03553)
 and consists of logic grid puzzles (also known as Einstein's riddles or Zebra puzzles),
@@ -2442,7 +2442,7 @@ euroeval --model <model-id> --dataset zebra-puzzles-hard-nb
 
 ## Logical Reasoning
 
-### Unofficial: ZebraPuzzleEasy-nn
+### ZebraPuzzleEasy-nn
 
 This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2511.03553)
 and consists of logic grid puzzles (also known as Einstein's riddles or Zebra puzzles),

--- a/src/frontend/md/datasets/swedish.md
+++ b/src/frontend/md/datasets/swedish.md
@@ -1640,7 +1640,7 @@ euroeval --model <model-id> --dataset gerlangmod-sv
 
 ## Logical Reasoning
 
-### Unofficial: ZebraPuzzleEasy-sv
+### ZebraPuzzleEasy-sv
 
 This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2511.03553)
 and consists of logic grid puzzles (also known as Einstein's riddles or Zebra puzzles),


### PR DESCRIPTION
## What

Removes the `unofficial=True` flag from all easy ZebraPuzzles datasets, promoting them to official status.

## Key features

- 8 dataset config files updated (da, nl, en, fo, de, is, nb, nn, sv)
- Hard variants remain unofficial (`unofficial=True` kept)
- Affects logical-reasoning task datasets only

## Why it helps

The easy ZebraPuzzles datasets (2 objects × 3 attributes) are now considered stable and production-ready for benchmarking. Keeping the hard variants (4 objects × 5 attributes) as unofficial allows for further validation before official promotion.