### PR TITLE
feat: swap official dataset global-mmlu-lite-sq -> include-sq

### DIFF
--- a/src/euroeval/dataset_configs/albanian.py
+++ b/src/euroeval/dataset_configs/albanian.py
@@ -56,14 +56,6 @@ LR_SUM_SQ_CONFIG = DatasetConfig(
     languages=[ALBANIAN],
 )
 
-GLOBAL_MMLU_LITE_SQ_CONFIG = DatasetConfig(
-    name="global-mmlu-lite-sq",
-    pretty_name="GlobalMMLULite-sq",
-    source="EuroEval/global-mmlu-lite-sq",
-    task=KNOW,
-    languages=[ALBANIAN],
-)
-
 WINOGRANDE_SQ_CONFIG = DatasetConfig(
     name="winogrande-sq",
     pretty_name="Winogrande-sq",
@@ -84,12 +76,20 @@ MULTI_IFEVAL_SQ_CONFIG = DatasetConfig(
 )
 
 
-# Unofficial datasets ###
-
 INCLUDE_SQ_CONFIG = DatasetConfig(
     name="include-sq",
     pretty_name="INCLUDE-sq",
     source="EuroEval/include-sq-mini",
+    task=KNOW,
+    languages=[ALBANIAN],
+)
+
+# Unofficial datasets ###
+
+GLOBAL_MMLU_LITE_SQ_CONFIG = DatasetConfig(
+    name="global-mmlu-lite-sq",
+    pretty_name="GlobalMMLULite-sq",
+    source="EuroEval/global-mmlu-lite-sq",
     task=KNOW,
     languages=[ALBANIAN],
     unofficial=True,

--- a/src/frontend/md/datasets/albanian.md
+++ b/src/frontend/md/datasets/albanian.md
@@ -327,74 +327,7 @@ euroeval --model <model-id> --dataset multi-wiki-qa-sq
 
 ## Knowledge
 
-### GlobalMMLU-lite-sq
-
-Global-MMLU is a machine translated version of the English
-[MMLU dataset](https://openreview.net/forum?id=d7KBjmI3GmQ) and features questions
-within 57 different topics, such as elementary mathematics, US history and law. The
-translation to Albanian was done by the
-[Cohere Labs Community](https://cohere.com/research).
-
-The original full dataset consists of 215 / 400 samples for validation and testing,
-respectively. We use a 128 / 64 / 404 split for training, validation and testing,
-respectively (so 596 samples used in total). The train set is sampled from the
-validation set. Remaining validation samples are used in the test set.
-
-Here are a few examples from the training split:
-
-```json
-{
-  "text": "Projektimi ambiental që sjell bashkë kafshë shtëpiake dhe bimë në shtëpi kujdesi, si dhe të rinj e fëmijë si vizitorë të rregullt, njihet si\nOpsione:\na. Projektimi Instrumental i Jetesës\nb. Zgjedhja humaniste\nc. Harmonia njeri-ambient\nd. Alternativa e Edenit",
-  "label": "d"
-}
-```
-
-```json
-{
-  "text": "Cilën nga të mëposhtmet duhet të bëjë një përdorues kompjuteri për të parandaluar lodhjen e syve të shkaktuar nga ekrani?\nOpsione:\na. Të përdorë pika sysh rregullisht\nb. Të ndryshojë zgjedhjen e softuereve\nc. Të kufizojë rezolucionin në monitor\nd. Të bëjë pushime të rregullta për të parë dritën natyrore",
-  "label": "d"
-}
-```
-
-```json
-{
-  "text": "Cila nga alternativat vijuese është më e gjatë?\nOpsione:\na. Jetëgjatësia në lindje (LEAB)\nb. Kohëzgjatja e jetës\nc. Jetëgjatësia deri në një moshë të caktuar (LEASA)\nd. Nuk ka mënyrë për ta ditur",
-  "label": "b"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 5
-- Prefix prompt:
-
-  ```text
-  Më poshtë janë pyetje me zgjedhje të shumëfishtë (me përgjigje).
-  ```
-
-- Base prompt template:
-
-  ```text
-  Pyetje: {text}
-  Përgjigje: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Pyetje: {text}
-
-  Përgjigjuni pyetjes së mësipërme duke u përgjigjur me {labels_str}, dhe asgjë tjetër.
-  ```
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset global-mmlu-lite-sq
-```
-
-### Unofficial: INCLUDE-sq
+### INCLUDE-sq
 
 This dataset is part of [INCLUDE](https://doi.org/10.48550/arXiv.2411.19799), a
 comprehensive knowledge- and reasoning-centric benchmark that evaluates multilingual
@@ -461,6 +394,73 @@ You can evaluate this dataset directly as follows:
 
 ```bash
 euroeval --model <model-id> --dataset include-sq
+```
+
+### Unofficial: GlobalMMLU-lite-sq
+
+Global-MMLU is a machine translated version of the English
+[MMLU dataset](https://openreview.net/forum?id=d7KBjmI3GmQ) and features questions
+within 57 different topics, such as elementary mathematics, US history and law. The
+translation to Albanian was done by the
+[Cohere Labs Community](https://cohere.com/research).
+
+The original full dataset consists of 215 / 400 samples for validation and testing,
+respectively. We use a 128 / 64 / 404 split for training, validation and testing,
+respectively (so 596 samples used in total). The train set is sampled from the
+validation set. Remaining validation samples are used in the test set.
+
+Here are a few examples from the training split:
+
+```json
+{
+  "text": "Projektimi ambiental që sjell bashkë kafshë shtëpiake dhe bimë në shtëpi kujdesi, si dhe të rinj e fëmijë si vizitorë të rregullt, njihet si\nOpsione:\na. Projektimi Instrumental i Jetesës\nb. Zgjedhja humaniste\nc. Harmonia njeri-ambient\nd. Alternativa e Edenit",
+  "label": "d"
+}
+```
+
+```json
+{
+  "text": "Cilën nga të mëposhtmet duhet të bëjë një përdorues kompjuteri për të parandaluar lodhjen e syve të shkaktuar nga ekrani?\nOpsione:\na. Të përdorë pika sysh rregullisht\nb. Të ndryshojë zgjedhjen e softuereve\nc. Të kufizojë rezolucionin në monitor\nd. Të bëjë pushime të rregullta për të parë dritën natyrore",
+  "label": "d"
+}
+```
+
+```json
+{
+  "text": "Cila nga alternativat vijuese është më e gjatë?\nOpsione:\na. Jetëgjatësia në lindje (LEAB)\nb. Kohëzgjatja e jetës\nc. Jetëgjatësia deri në një moshë të caktuar (LEASA)\nd. Nuk ka mënyrë për ta ditur",
+  "label": "b"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  Më poshtë janë pyetje me zgjedhje të shumëfishtë (me përgjigje).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Pyetje: {text}
+  Përgjigje: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Pyetje: {text}
+
+  Përgjigjuni pyetjes së mësipërme duke u përgjigjur me {labels_str}, dhe asgjë tjetër.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset global-mmlu-lite-sq
 ```
 
 ## Common-sense Reasoning


### PR DESCRIPTION
Swaps the official dataset `global-mmlu-lite-sq` for `include-sq`.

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `include-sq`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `global-mmlu-lite-sq` is demoted to unofficial and `include-sq` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)