### PR TITLE
ci: run CI on pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize
@@ -19,16 +19,9 @@ jobs:
     if: github.event.pull_request.draft == false
     permissions:
       contents: read
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-        with:
-          # `pull_request_target` checks out the base branch by default; check out
-          # the PR head so CI validates the proposed changes, not `main`. Combined
-          # with `persist-credentials: false` so the PR code never sees the token.
-          ref: ${{ github.event.pull_request.head.sha }}
-          persist-credentials: false
 
       - name: Install uv and set up Python
         uses: astral-sh/setup-uv@v6
@@ -43,19 +36,12 @@ jobs:
     if: github.event.pull_request.draft == false
     permissions:
       contents: read
-      pull-requests: write
     strategy:
         matrix:
             python-version: ["3.12", "3.13"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-        with:
-          # `pull_request_target` checks out the base branch by default; check out
-          # the PR head so CI validates the proposed changes, not `main`. Combined
-          # with `persist-credentials: false` so the PR code never sees the token.
-          ref: ${{ github.event.pull_request.head.sha }}
-          persist-credentials: false
 
       - name: Install uv and set up Python
         uses: astral-sh/setup-uv@v6
@@ -86,16 +72,9 @@ jobs:
     if: github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'macos')
     permissions:
       contents: read
-      pull-requests: write
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v5
-        with:
-          # `pull_request_target` checks out the base branch by default; check out
-          # the PR head so CI validates the proposed changes, not `main`. Combined
-          # with `persist-credentials: false` so the PR code never sees the token.
-          ref: ${{ github.event.pull_request.head.sha }}
-          persist-credentials: false
 
       - name: Install uv and set up Python
         uses: astral-sh/setup-uv@v6

--- a/src/frontend/md/tasks/logical-reasoning.md
+++ b/src/frontend/md/tasks/logical-reasoning.md
@@ -29,7 +29,7 @@ We report two accuracy metrics for the logical reasoning task:
   attribute assignments. A prediction is correct for each cell (object × attribute) if
   the predicted attribute matches the gold label. This gives credit for partially
   correct solutions.
-  
+
 - **Puzzle-level accuracy**: The strict accuracy where a puzzle is only counted as
   correct if all attribute assignments are correct. This measures the model's ability to
   solve the complete puzzle.

--- a/src/scripts/swap_leaderboard_dataset.py
+++ b/src/scripts/swap_leaderboard_dataset.py
@@ -1163,6 +1163,10 @@ def apply_swap(old_dataset: str, new_dataset: str, dry_run: bool) -> list[Path]:
 
     Returns:
         The paths that were (or would be) modified.
+
+    Raises:
+        click.ClickException:
+            When the dataset configs cannot be fetched.
     """
     changed: list[Path] = []
     for dataset_id, make_official in ((new_dataset, True), (old_dataset, False)):
@@ -1190,7 +1194,8 @@ def apply_swap(old_dataset: str, new_dataset: str, dry_run: bool) -> list[Path]:
         new_config = dataset_config(dataset_id=new_dataset)
         if old_config is None or new_config is None:
             raise click.ClickException(
-                f"Could not fetch dataset configs for {old_dataset!r} or {new_dataset!r}."
+                f"Could not fetch dataset configs for {old_dataset!r} or "
+                f"{new_dataset!r}."
             )
         _update_changelog(
             changelog_path=changelog_path,
@@ -1225,6 +1230,10 @@ def _update_changelog(
             DatasetConfig for the old dataset.
         new_config:
             DatasetConfig for the new dataset.
+
+    Raises:
+        ValueError:
+            When the '### Changed' section under '## [Unreleased]' is not found.
     """
     lines = changelog_path.read_text(encoding="utf-8").split("\n")
 

--- a/tests/leaderboards/test_bucket_sync.py
+++ b/tests/leaderboards/test_bucket_sync.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import typing as t
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -58,7 +57,7 @@ class TestSyncBucket:
             dest: str,
             token: str | None = None,
             ignore_times: bool = False,
-            **kwargs: t.Any,
+            **kwargs,
         ) -> None:
             # Simulate sync removing the local file
             if local_file.exists():
@@ -430,7 +429,7 @@ class TestUploadResultsToBucket:
             dest: str,
             token: str | None = None,
             ignore_times: bool = False,
-            **kwargs: t.Any,
+            **kwargs,
         ) -> None:
             if local_file.exists():
                 local_file.unlink()
@@ -474,7 +473,7 @@ class TestUploadResultsToBucket:
             dest: str,
             token: str | None = None,
             ignore_times: bool = False,
-            **kwargs: t.Any,
+            **kwargs,
         ) -> None:
             # Create an older bucket record
             older_record = {
@@ -525,7 +524,7 @@ class TestUploadResultsToBucket:
             dest: str,
             token: str | None = None,
             ignore_times: bool = False,
-            **kwargs: t.Any,
+            **kwargs,
         ) -> None:
             # Record with different identity but same sanitised path
             # "model_a" also sanitises to "model_a" (no change)

--- a/tests/leaderboards/test_bucket_sync.py
+++ b/tests/leaderboards/test_bucket_sync.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import typing as t
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -52,7 +53,13 @@ class TestSyncBucket:
         local_file.write_text(json.dumps(local_record), encoding="utf-8")
 
         # Mock HfApi.sync_bucket to simulate bucket sync that removes the file
-        def mock_sync(source: str, dest: str, token: str | None = None) -> None:
+        def mock_sync(
+            source: str,
+            dest: str,
+            token: str | None = None,
+            ignore_times: bool = False,
+            **kwargs: t.Any,
+        ) -> None:
             # Simulate sync removing the local file
             if local_file.exists():
                 local_file.unlink()
@@ -84,7 +91,11 @@ class TestSyncBucket:
             bucket_sync.sync_bucket()
 
         mock_sync.assert_called_once_with(
-            source="hf://buckets/test/results/", dest=str(tmp_path), token="token123"
+            source="hf://buckets/test/results/",
+            dest=str(tmp_path),
+            token="token123",
+            ignore_times=True,
+            ignore_sizes=False,
         )
 
     def test_sync_bucket_raises_on_sync_failure(
@@ -291,7 +302,7 @@ class TestUploadResultsToBucket:
         monkeypatch.setattr(bucket_sync, "HF_RESULTS_BUCKET", "test/results")
 
         with patch("leaderboards.bucket_sync.resolve_hf_token", return_value="token"):
-            with patch.object(HfApi, "sync_bucket", return_value=None):
+            with patch.object(HfApi, "batch_bucket_files", return_value=None):
                 bucket_sync.upload_results_to_bucket(results_file=results_file)
 
         # Verify tree layout was created
@@ -333,7 +344,7 @@ class TestUploadResultsToBucket:
         monkeypatch.setattr(bucket_sync, "HF_RESULTS_BUCKET", "test/results")
 
         with patch("leaderboards.bucket_sync.resolve_hf_token", return_value="token"):
-            with patch.object(HfApi, "sync_bucket", return_value=None):
+            with patch.object(HfApi, "batch_bucket_files", return_value=None):
                 bucket_sync.upload_results_to_bucket(results_file=results_file)
 
         # Only valid record should be uploaded
@@ -366,7 +377,7 @@ class TestUploadResultsToBucket:
         with patch("leaderboards.bucket_sync.resolve_hf_token", return_value="token"):
             with patch.object(
                 HfApi,
-                "sync_bucket",
+                "batch_bucket_files",
                 side_effect=HfHubHTTPError(
                     "Upload failed", response=MagicMock(status_code=500)
                 ),
@@ -414,7 +425,13 @@ class TestUploadResultsToBucket:
         local_file.write_text(json.dumps(local_record), encoding="utf-8")
 
         # Mock sync that removes the local file
-        def mock_sync(source: str, dest: str, token: str | None = None) -> None:
+        def mock_sync(
+            source: str,
+            dest: str,
+            token: str | None = None,
+            ignore_times: bool = False,
+            **kwargs: t.Any,
+        ) -> None:
             if local_file.exists():
                 local_file.unlink()
 
@@ -452,7 +469,13 @@ class TestUploadResultsToBucket:
         local_file.write_text(json.dumps(local_record), encoding="utf-8")
 
         # Mock sync that puts an older bucket record
-        def mock_sync(source: str, dest: str, token: str | None = None) -> None:
+        def mock_sync(
+            source: str,
+            dest: str,
+            token: str | None = None,
+            ignore_times: bool = False,
+            **kwargs: t.Any,
+        ) -> None:
             # Create an older bucket record
             older_record = {
                 "model_info": {"id": "test/model"},
@@ -497,7 +520,13 @@ class TestUploadResultsToBucket:
         local_file.write_text(json.dumps(local_record), encoding="utf-8")
 
         # Mock sync that puts a record with different identity at same path
-        def mock_sync(source: str, dest: str, token: str | None = None) -> None:
+        def mock_sync(
+            source: str,
+            dest: str,
+            token: str | None = None,
+            ignore_times: bool = False,
+            **kwargs: t.Any,
+        ) -> None:
             # Record with different identity but same sanitised path
             # "model_a" also sanitises to "model_a" (no change)
             bucket_record = {
@@ -545,7 +574,7 @@ class TestUploadResultsToBucket:
         monkeypatch.setattr(bucket_sync, "HF_RESULTS_BUCKET", "test/results")
 
         with patch("leaderboards.bucket_sync.resolve_hf_token", return_value="token"):
-            with patch.object(HfApi, "sync_bucket", return_value=None):
+            with patch.object(HfApi, "batch_bucket_files", return_value=None):
                 bucket_sync.upload_results_to_bucket(results_file=results_file)
 
         # Stale jsonl should be removed

--- a/tests/leaderboards/test_result_loading.py
+++ b/tests/leaderboards/test_result_loading.py
@@ -158,8 +158,10 @@ class TestLoadRawResults:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Should load records from the tree structure."""
-        # Mock sync_bucket to do nothing
-        monkeypatch.setattr("leaderboards.result_loading.sync_bucket", lambda: None)
+        # Mock download_missing_bucket_files to do nothing
+        monkeypatch.setattr(
+            "leaderboards.result_loading.download_missing_bucket_files", lambda: 0
+        )
         monkeypatch.setattr("leaderboards.result_loading.backup_results", lambda: None)
         monkeypatch.setattr("leaderboards.result_loading.RESULTS_DIR", tmp_path)
 
@@ -181,7 +183,9 @@ class TestLoadRawResults:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Should also load records from NEW_RESULTS_PATH staging file."""
-        monkeypatch.setattr("leaderboards.result_loading.sync_bucket", lambda: None)
+        monkeypatch.setattr(
+            "leaderboards.result_loading.download_missing_bucket_files", lambda: 0
+        )
         monkeypatch.setattr("leaderboards.result_loading.backup_results", lambda: None)
         monkeypatch.setattr("leaderboards.result_loading.RESULTS_DIR", tmp_path)
         monkeypatch.setattr(
@@ -219,7 +223,9 @@ class TestLoadRawResults:
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """Should raise FileNotFoundError if sync produces no files."""
-        monkeypatch.setattr("leaderboards.result_loading.sync_bucket", lambda: None)
+        monkeypatch.setattr(
+            "leaderboards.result_loading.download_missing_bucket_files", lambda: 0
+        )
         monkeypatch.setattr("leaderboards.result_loading.backup_results", lambda: None)
         monkeypatch.setattr("leaderboards.result_loading.RESULTS_DIR", tmp_path)
 
@@ -230,7 +236,9 @@ class TestLoadRawResults:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Should deduplicate records with same identity, keeping newest."""
-        monkeypatch.setattr("leaderboards.result_loading.sync_bucket", lambda: None)
+        monkeypatch.setattr(
+            "leaderboards.result_loading.download_missing_bucket_files", lambda: 0
+        )
         monkeypatch.setattr("leaderboards.result_loading.backup_results", lambda: None)
         monkeypatch.setattr("leaderboards.result_loading.RESULTS_DIR", tmp_path)
         monkeypatch.setattr(

--- a/tests/leaderboards/test_result_processing.py
+++ b/tests/leaderboards/test_result_processing.py
@@ -120,9 +120,10 @@ def test_upload_per_model_files_passes_hf_token(
         ):
             result_processing._upload_per_model_files(processed_records=[record])
 
-    mock_api.sync_bucket.assert_called_once_with(
-        source=str(tmp_path), dest="hf://buckets/EuroEval/results", token="test_token"
-    )
+    mock_api.batch_bucket_files.assert_called_once()
+    call_kwargs = mock_api.batch_bucket_files.call_args.kwargs
+    assert call_kwargs["bucket_id"] == "EuroEval/results"
+    assert call_kwargs["token"] == "test_token"
 
 
 def test_upload_per_model_files_raises_on_sync_failure(
@@ -132,7 +133,7 @@ def test_upload_per_model_files_raises_on_sync_failure(
     monkeypatch.setattr(result_processing, "RESULTS_DIR", tmp_path)
 
     mock_api = MagicMock()
-    mock_api.sync_bucket.side_effect = HfHubHTTPError(
+    mock_api.batch_bucket_files.side_effect = HfHubHTTPError(
         "Bucket sync failed", response=MagicMock(status_code=500)
     )
 
@@ -169,7 +170,11 @@ def test_sync_bucket_passes_hf_token(
             bucket_sync.sync_bucket()
 
     mock_api.sync_bucket.assert_called_once_with(
-        source="hf://buckets/EuroEval/results/", dest=str(tmp_path), token="test_token"
+        source="hf://buckets/EuroEval/results/",
+        dest=str(tmp_path),
+        token="test_token",
+        ignore_times=True,
+        ignore_sizes=False,
     )
 
 
@@ -210,11 +215,10 @@ def test_upload_results_to_bucket_passes_hf_token(
         ):
             bucket_sync.upload_results_to_bucket(results_file=results_file)
 
-    mock_api.sync_bucket.assert_called_once_with(
-        source=str(results_dir),
-        dest="hf://buckets/EuroEval/results/",
-        token="test_token",
-    )
+    mock_api.batch_bucket_files.assert_called_once()
+    call_kwargs = mock_api.batch_bucket_files.call_args.kwargs
+    assert call_kwargs["bucket_id"] == "EuroEval/results"
+    assert call_kwargs["token"] == "test_token"
 
 
 def test_upload_results_to_bucket_raises_on_sync_failure(
@@ -237,7 +241,7 @@ def test_upload_results_to_bucket_raises_on_sync_failure(
     monkeypatch.setattr(bucket_sync, "RESULTS_DIR", results_dir)
 
     mock_api = MagicMock()
-    mock_api.sync_bucket.side_effect = HfHubHTTPError(
+    mock_api.batch_bucket_files.side_effect = HfHubHTTPError(
         "Bucket sync failed", response=MagicMock(status_code=500)
     )
 

--- a/tests/test_scripts/test_collect_evaluation_results.py
+++ b/tests/test_scripts/test_collect_evaluation_results.py
@@ -1,6 +1,7 @@
 """Tests for the collect_evaluation_results script, focusing on upload_results_to_hf."""
 
 import json
+import typing as t
 from pathlib import Path
 
 import pytest
@@ -10,10 +11,27 @@ from src.scripts import collect_evaluation_results
 
 
 class FakeHfApi:
-    """Fake HfApi that mocks sync_bucket calls."""
+    """Fake HfApi that mocks sync_bucket and batch_bucket_files calls."""
 
-    def sync_bucket(self, source: str, dest: str) -> None:
+    def sync_bucket(
+        self,
+        source: str,
+        dest: str,
+        token: str | None = None,
+        ignore_times: bool = False,
+        **kwargs: t.Any,
+    ) -> None:
         """No-op sync for testing."""
+        pass
+
+    def batch_bucket_files(
+        self,
+        bucket_id: str,
+        add: list[tuple[str | Path | bytes, str]] | None = None,
+        delete: list[str] | None = None,
+        **kwargs: t.Any,
+    ) -> None:
+        """No-op batch upload for testing."""
         pass
 
 

--- a/tests/test_scripts/test_collect_evaluation_results.py
+++ b/tests/test_scripts/test_collect_evaluation_results.py
@@ -1,7 +1,6 @@
 """Tests for the collect_evaluation_results script, focusing on upload_results_to_hf."""
 
 import json
-import typing as t
 from pathlib import Path
 
 import pytest
@@ -19,7 +18,7 @@ class FakeHfApi:
         dest: str,
         token: str | None = None,
         ignore_times: bool = False,
-        **kwargs: t.Any,
+        **kwargs,
     ) -> None:
         """No-op sync for testing."""
         pass
@@ -29,7 +28,7 @@ class FakeHfApi:
         bucket_id: str,
         add: list[tuple[str | Path | bytes, str]] | None = None,
         delete: list[str] | None = None,
-        **kwargs: t.Any,
+        **kwargs,
     ) -> None:
         """No-op batch upload for testing."""
         pass

--- a/tests/test_scripts/test_process_evaluation_queue.py
+++ b/tests/test_scripts/test_process_evaluation_queue.py
@@ -1,6 +1,7 @@
 """Tests for the process_evaluation_queue script orchestration."""
 
 import json
+import typing as t
 from pathlib import Path
 
 import pytest
@@ -23,7 +24,14 @@ def test_sync_bucket_preserves_local_only_files(
     )
 
     class FakeHfApi:
-        def sync_bucket(self, source: str, dest: str, token: str) -> None:
+        def sync_bucket(
+            self,
+            source: str,
+            dest: str,
+            token: str,
+            ignore_times: bool = False,
+            **kwargs: t.Any,
+        ) -> None:
             # Tree sync doesn't remove files - local-only files persist
             pass
 
@@ -58,7 +66,14 @@ def test_sync_bucket_prefers_synced_content_for_existing_result_key(
     record_file.write_text(json.dumps(local_content), encoding="utf-8")
 
     class FakeHfApi:
-        def sync_bucket(self, source: str, dest: str, token: str) -> None:
+        def sync_bucket(
+            self,
+            source: str,
+            dest: str,
+            token: str,
+            ignore_times: bool = False,
+            **kwargs: t.Any,
+        ) -> None:
             # Tree sync preserves existing files - remote content merged via file paths
             pass
 
@@ -109,7 +124,14 @@ def test_sync_bucket_handles_separate_result_files(
     )
 
     class FakeHfApi:
-        def sync_bucket(self, source: str, dest: str, token: str) -> None:
+        def sync_bucket(
+            self,
+            source: str,
+            dest: str,
+            token: str,
+            ignore_times: bool = False,
+            **kwargs: t.Any,
+        ) -> None:
             # Tree sync preserves separate files
             pass
 

--- a/tests/test_scripts/test_process_evaluation_queue.py
+++ b/tests/test_scripts/test_process_evaluation_queue.py
@@ -1,7 +1,6 @@
 """Tests for the process_evaluation_queue script orchestration."""
 
 import json
-import typing as t
 from pathlib import Path
 
 import pytest
@@ -30,7 +29,7 @@ def test_sync_bucket_preserves_local_only_files(
             dest: str,
             token: str,
             ignore_times: bool = False,
-            **kwargs: t.Any,
+            **kwargs,
         ) -> None:
             # Tree sync doesn't remove files - local-only files persist
             pass
@@ -72,7 +71,7 @@ def test_sync_bucket_prefers_synced_content_for_existing_result_key(
             dest: str,
             token: str,
             ignore_times: bool = False,
-            **kwargs: t.Any,
+            **kwargs,
         ) -> None:
             # Tree sync preserves existing files - remote content merged via file paths
             pass
@@ -130,7 +129,7 @@ def test_sync_bucket_handles_separate_result_files(
             dest: str,
             token: str,
             ignore_times: bool = False,
-            **kwargs: t.Any,
+            **kwargs,
         ) -> None:
             # Tree sync preserves separate files
             pass

--- a/tests/test_scripts/test_swap_leaderboard_dataset.py
+++ b/tests/test_scripts/test_swap_leaderboard_dataset.py
@@ -7,7 +7,6 @@ import subprocess
 from pathlib import Path
 
 import pytest
-from huggingface_hub import HfApi
 
 from euroeval.data_models import DatasetConfig
 from euroeval.languages import DANISH, SWEDISH
@@ -184,10 +183,19 @@ class TestSyncResults:
         )
 
         # Create empty results dir
-        (tmp_path / "results").mkdir()
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+
+        # Patch RESULTS_DIR in both modules (merge_results reads from bucket_sync.RESULTS_DIR)
+        monkeypatch.setattr(
+            target=swap_leaderboard_dataset, name="RESULTS_DIR", value=results_dir
+        )
+        monkeypatch.setattr(target=bucket_sync, name="RESULTS_DIR", value=results_dir)
 
         # Mock hf_api.sync_bucket to do nothing
-        monkeypatch.setattr(HfApi, "sync_bucket", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            swap_leaderboard_dataset.HfApi, "sync_bucket", lambda *args, **kwargs: None
+        )
 
         with caplog.at_level(logging.WARNING):
             swap_leaderboard_dataset.sync_results_from_bucket()
@@ -247,9 +255,16 @@ class TestSyncResults:
             name="HF_RESULTS_BUCKET",
             value="test/bucket",
         )
+        # Patch RESULTS_DIR in both modules (merge_results reads from bucket_sync.RESULTS_DIR)
+        monkeypatch.setattr(
+            target=swap_leaderboard_dataset, name="RESULTS_DIR", value=results_dir
+        )
+        monkeypatch.setattr(target=bucket_sync, name="RESULTS_DIR", value=results_dir)
 
         # Mock hf_api.sync_bucket to do nothing
-        monkeypatch.setattr(HfApi, "sync_bucket", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            swap_leaderboard_dataset.HfApi, "sync_bucket", lambda *args, **kwargs: None
+        )
 
         with caplog.at_level(logging.INFO):
             swap_leaderboard_dataset.sync_results_from_bucket()

--- a/tests/test_scripts/test_swap_leaderboard_dataset.py
+++ b/tests/test_scripts/test_swap_leaderboard_dataset.py
@@ -186,7 +186,7 @@ class TestSyncResults:
         results_dir = tmp_path / "results"
         results_dir.mkdir()
 
-        # Patch RESULTS_DIR in both modules (merge_results reads from bucket_sync.RESULTS_DIR)
+        # Patch RESULTS_DIR in both modules (merge_results uses bucket_sync.RESULTS_DIR)
         monkeypatch.setattr(
             target=swap_leaderboard_dataset, name="RESULTS_DIR", value=results_dir
         )
@@ -255,7 +255,7 @@ class TestSyncResults:
             name="HF_RESULTS_BUCKET",
             value="test/bucket",
         )
-        # Patch RESULTS_DIR in both modules (merge_results reads from bucket_sync.RESULTS_DIR)
+        # Patch RESULTS_DIR in both modules (merge_results uses bucket_sync.RESULTS_DIR)
         monkeypatch.setattr(
             target=swap_leaderboard_dataset, name="RESULTS_DIR", value=results_dir
         )


### PR DESCRIPTION
Switches the CI workflow from `pull_request_target` to `pull_request`.

## What

The CI workflow ran on `pull_request_target` while checking out the fork PR head (`github.event.pull_request.head.sha`) and exposing repository secrets (`HF_TOKEN`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `XAI_API_KEY`) to `pytest`. That is the classic "pwn request" pattern: untrusted fork code executes in a privileged context with access to secrets. This PR removes that vector.

## Key changes

- `on: pull_request_target` -> `on: pull_request` (same `types` and `branches`, so the staleness fix — `synchronize` + `concurrency` cancel — is preserved).
- Drop the fork-head checkout override (`ref` / `persist-credentials`) in all three jobs; `pull_request` checks out the safe merge ref by default.
- Reduce each job permissions to `contents: read` (test jobs never write to the PR).

## Notes

- Author auto-assignment stays on its own `pull_request_target` workflow — that one only reads PR metadata and never checks out fork code, so it is safe.
- On fork PRs, secret-backed tests will now run without keys; internal-branch PRs are unaffected. If keyed tests must run on fork PRs, gate a `pull_request_target` job behind an approval environment rather than reverting this.