### PR TITLE
fix: handle missing CLS token in prepare_train_examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `ValueError` in `prepare_train_examples` when the CLS token ID is not present
+  in tokenised input IDs for certain tokenisers (e.g. Qwen3 embedding models,
+  codefuse-ai/F2LLM-v2-0.6B). Falls back to position 0 with a debug log message.
+
 ## [v17.7.0] - 2026-07-22
 
 ### Added

--- a/src/euroeval/task_group_utils/question_answering.py
+++ b/src/euroeval/task_group_utils/question_answering.py
@@ -1,6 +1,7 @@
 """Utility functions related to the question-answering task group."""
 
 import collections.abc as c
+import logging
 import typing as t
 from collections import defaultdict
 
@@ -13,6 +14,7 @@ from transformers.trainer import Trainer
 from transformers.trainer_utils import EvalPrediction
 
 from ..exceptions import InvalidBenchmark
+from ..logging_utils import log
 from ..tokenisation_utils import get_special_token_metadata
 from ..types import Predictions
 from ..utils import raise_if_model_output_contains_nan_values
@@ -306,7 +308,15 @@ def prepare_train_examples(
         input_ids = tokenised_examples.input_ids[i]
 
         # We will label impossible answers with the index of the CLS token
-        cls_index = input_ids.index(cls_token_id)
+        try:
+            cls_index = input_ids.index(cls_token_id)
+        except ValueError:
+            log(
+                f"CLS token ID {cls_token_id} not found in input_ids; "
+                f"falling back to position 0",
+                level=logging.DEBUG,
+            )
+            cls_index = 0
 
         # Grab the sequence corresponding to that example (to know what is the context
         # and what is the question).

--- a/src/euroeval/task_group_utils/question_answering.py
+++ b/src/euroeval/task_group_utils/question_answering.py
@@ -14,7 +14,7 @@ from transformers.trainer import Trainer
 from transformers.trainer_utils import EvalPrediction
 
 from ..exceptions import InvalidBenchmark
-from ..logging_utils import log
+from ..logging_utils import log_once
 from ..tokenisation_utils import get_special_token_metadata
 from ..types import Predictions
 from ..utils import raise_if_model_output_contains_nan_values
@@ -311,7 +311,7 @@ def prepare_train_examples(
         try:
             cls_index = input_ids.index(cls_token_id)
         except ValueError:
-            log(
+            log_once(
                 f"CLS token ID {cls_token_id} not found in input_ids; "
                 f"falling back to position 0",
                 level=logging.DEBUG,


### PR DESCRIPTION
## What

Fixed a `ValueError` crash in `prepare_train_examples` that occurred when the CLS
token ID was not present in the tokenised input IDs for certain tokenisers.

## Key features

- Wrapped `input_ids.index(cls_token_id)` in a `try/except ValueError` that falls
  back to position 0 when the CLS token is not found
- Added a `log_once` debug message to help diagnose when this fallback is triggered
- Added `import logging` and `from ..logging_utils import log_once` to match the
  pattern used in `tokenisation_utils.py`

## Why it helps

Some tokenisers (e.g. Qwen3 embedding models, codefuse-ai/F2LLM-v2-0.6B) have a
CLS/BOS token ID set but do not actually add it during sentence-pair tokenisation with
`truncation="only_second"`. This caused the evaluation to crash with
`ValueError: 128245 is not in list`, failing the entire benchmark. The fix allows
these models to be evaluated successfully.

Related issues: #1930, #1932