### PR TITLE
fix: include model params in debug cache filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Fixed `ValueError` in `prepare_train_examples` when the CLS token ID is not present
   in tokenised input IDs for certain tokenisers (e.g. Qwen3 embedding models,
   codefuse-ai/F2LLM-v2-0.6B). Falls back to position 0 with a debug log message.
+- Fixed debug cache filename collision when running evaluations with different model
+  parameters (e.g. `#thinking` vs `#no-thinking`). The cache file now includes the
+  parameter in the filename, preventing incorrect cache reuse when using the `--debug`
+  flag.
 
 ## [v17.7.0] - 2026-07-22
 

--- a/src/euroeval/generation.py
+++ b/src/euroeval/generation.py
@@ -105,8 +105,10 @@ def generate(
         (model_cache_dir / cache_name).unlink(missing_ok=True)
     elif benchmark_config.debug:
         cache_name = (
-            f"{model_config.model_id}-{dataset_config.name}{cache_suffix}"
-            "-model-outputs.json"
+            f"{model_config.model_id}"
+            + (f"-{model_config.param}" if model_config.param else "")
+            + f"-{dataset_config.name}{cache_suffix}"
+            + "-model-outputs.json"
         )
     else:
         cache_name = f"{dataset_config.name}{cache_suffix}-model-outputs.json"


### PR DESCRIPTION
## What

When running evaluations with the `--debug` flag, model output cache files are written to the current working directory. The filename includes the model ID and dataset name, but previously did not include model parameters (e.g., `#no-thinking`, `#thinking`). This caused cache collisions when running the same model with different parameters.

## Key features

- Debug cache filenames now include the model parameter when present (e.g., `mistralai/Mistral-7B-v0.1-#no-thinking-nome-dataset-model-outputs.json`)
- Cache files are now correctly namespaced by model parameters, preventing incorrect cache reuse
- Aligns with how model parameters are included in result storage elsewhere in the codebase (see `benchmarker.py` lines 1099-1100 and 1266-1267)

## Examples

Before this fix, running these commands would incorrectly share the same cache file:
```bash
euroeval benchmark --model mistralai/Mistral-7B-v0.1#thinking --dataset nome --debug
euroeval benchmark --model mistralai/Mistral-7B-v0.1#no-thinking --dataset nome --debug
```

After this fix, they produce separate cache files:
```bash
mistralai/Mistral-7B-v0.1-#thinking-nome-model-outputs.json
mistralai/Mistral-7B-v0.1-#no-thinking-nome-model-outputs.json
```

## Why it helps

This ensures that when debugging model evaluations with different parameters, each run gets its own cache file rather than incorrectly reusing cached outputs from a different parameter configuration.