### PR TITLE
feat: swap official dataset scala-nl -> dutch-cola

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   parameter in the filename, preventing incorrect cache reuse when using the `--debug`
   flag.
 
+### Changed
+
+- Swapped official dataset for Dutch: `scala-nl` → `dutch-cola`. The script
+  `swap_leaderboard_dataset.py` now automatically updates CHANGELOG.md when performing
+  dataset swaps.
+
 ## [v17.7.0] - 2026-07-22
 
 ### Added
@@ -48,7 +54,6 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   Platform](https://platform.alexandra.dk/).
 
 ### Changed
-- Swapped official dataset for Dutch: `scala-nl` → `dutch-cola`. The script `swap_leaderboard_dataset.py` now automatically updates CHANGELOG.md when performing dataset swaps.
 
 - Made the Danish linguistic acceptability dataset DaLA the new official such one, over
   the previous ScaLA-da, which has now been demoted to unofficial.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   Platform](https://platform.alexandra.dk/).
 
 ### Changed
+- Swapped official dataset for Dutch: `scala-nl` → `dutch-cola`. The script `swap_leaderboard_dataset.py` now automatically updates CHANGELOG.md when performing dataset swaps.
 
 - Made the Danish linguistic acceptability dataset DaLA the new official such one, over
   the previous ScaLA-da, which has now been demoted to unofficial.

--- a/src/euroeval/dataset_configs/dutch.py
+++ b/src/euroeval/dataset_configs/dutch.py
@@ -32,14 +32,6 @@ DBRD_CONFIG = DatasetConfig(
     labels=["negative", "positive"],
 )
 
-SCALA_NL_CONFIG = DatasetConfig(
-    name="scala-nl",
-    pretty_name="ScaLA-nl",
-    source="EuroEval/scala-nl",
-    task=LA,
-    languages=[DUTCH],
-)
-
 CONLL_NL_CONFIG = DatasetConfig(
     name="conll-nl",
     pretty_name="CoNLL-nl",
@@ -137,12 +129,20 @@ RAGTRUTH_NL_CONFIG = DatasetConfig(
 )
 
 
-# Unofficial datasets ###
-
 DUTCH_COLA_CONFIG = DatasetConfig(
     name="dutch-cola",
     pretty_name="Dutch CoLA",
     source="EuroEval/dutch-cola",
+    task=LA,
+    languages=[DUTCH],
+)
+
+# Unofficial datasets ###
+
+SCALA_NL_CONFIG = DatasetConfig(
+    name="scala-nl",
+    pretty_name="ScaLA-nl",
+    source="EuroEval/scala-nl",
     task=LA,
     languages=[DUTCH],
     unofficial=True,

--- a/src/frontend/md/datasets/dutch.md
+++ b/src/frontend/md/datasets/dutch.md
@@ -157,7 +157,78 @@ euroeval --model <model-id> --dataset conll-nl
 
 ## Linguistic Acceptability
 
-### ScaLA-nl
+### Dutch CoLA
+
+This dataset is published [here](https://huggingface.co/datasets/GroNLP/dutch-cola) and
+is a manually annotated linguistic acceptability dataset, with documents coming from
+descriptions of Dutch syntax.
+
+The original full dataset consists of 19,900 / 2,400 / 2,400 samples for training,
+validation and testing, respectively (so 24,700 samples used in total). We use a 1,024 /
+256 / 1,024 split for training, validation and testing, respectively. The original
+splits were imbalanced, so we ensure a 50/50 split of correct/incorrect samples in the
+new splits. All new splits are subsets of the original splits.
+
+Here are a few examples from the training split:
+
+```json
+{
+  "text": "Tasman heeft geen Maori gezien.",
+  "label": "correct"
+}
+```
+
+```json
+{
+  "text": "Jan is vrij bang voor honden en ik ben het zeer erg voor spinnen.",
+  "label": "incorrect"
+}
+```
+
+```json
+{
+  "text": "Wat is het duidelijk dat Jan zal krijgen?",
+  "label": "incorrect"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 12
+
+- Prefix prompt:
+
+  ```text
+  Hieronder staan zinnen en of ze grammaticaal correct zijn.
+  ```
+
+- Base prompt template:
+
+  ```text
+  Zin: {text}
+  Grammaticaal correct: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Zin: {text}
+
+  Bepaal of de zin grammaticaal correct is of niet. Antwoord met 'ja' als de zin correct is en 'nee' als dat niet het geval is.
+  ```
+
+- Label mapping:
+  - `correct` ➡️ `ja`
+  - `incorrect` ➡️ `nee`
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset dutch-cola
+```
+
+### Unofficial: ScaLA-nl
 
 This dataset was published in [this paper](https://aclanthology.org/2023.nodalida-1.20/)
 and was automatically created from the
@@ -229,77 +300,6 @@ You can evaluate this dataset directly as follows:
 
 ```bash
 euroeval --model <model-id> --dataset scala-nl
-```
-
-### Unofficial: Dutch CoLA
-
-This dataset is published [here](https://huggingface.co/datasets/GroNLP/dutch-cola) and
-is a manually annotated linguistic acceptability dataset, with documents coming from
-descriptions of Dutch syntax.
-
-The original full dataset consists of 19,900 / 2,400 / 2,400 samples for training,
-validation and testing, respectively (so 24,700 samples used in total). We use a 1,024 /
-256 / 1,024 split for training, validation and testing, respectively. The original
-splits were imbalanced, so we ensure a 50/50 split of correct/incorrect samples in the
-new splits. All new splits are subsets of the original splits.
-
-Here are a few examples from the training split:
-
-```json
-{
-  "text": "Tasman heeft geen Maori gezien.",
-  "label": "correct"
-}
-```
-
-```json
-{
-  "text": "Jan is vrij bang voor honden en ik ben het zeer erg voor spinnen.",
-  "label": "incorrect"
-}
-```
-
-```json
-{
-  "text": "Wat is het duidelijk dat Jan zal krijgen?",
-  "label": "incorrect"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 12
-
-- Prefix prompt:
-
-  ```text
-  Hieronder staan zinnen en of ze grammaticaal correct zijn.
-  ```
-
-- Base prompt template:
-
-  ```text
-  Zin: {text}
-  Grammaticaal correct: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Zin: {text}
-
-  Bepaal of de zin grammaticaal correct is of niet. Antwoord met 'ja' als de zin correct is en 'nee' als dat niet het geval is.
-  ```
-
-- Label mapping:
-  - `correct` ➡️ `ja`
-  - `incorrect` ➡️ `nee`
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset dutch-cola
 ```
 
 ## Natural Language Inference


### PR DESCRIPTION
Swaps the official dataset `scala-nl` for `dutch-cola`.

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `dutch-cola`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `scala-nl` is demoted to unofficial and `dutch-cola` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)