### PR TITLE
feat: swap official dataset hellaswag-nl -> winogrande-nl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Swapped official dataset for Dutch: `hellaswag-nl` → `winogrande-nl`.
-
 - Swapped official dataset for Croatian: `mmlu-hr` → `include-hr`. The script
   `swap_leaderboard_dataset.py` now automatically updates CHANGELOG.md when performing
   dataset swaps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   as official.
 
 ### Changed
-- Swapped official dataset for Dutch:
-`hellaswag-nl` → `winogrande-nl`.
+
+- Swapped official dataset for Dutch: `hellaswag-nl` → `winogrande-nl`.
 
 - Swapped official dataset for Croatian: `mmlu-hr` → `include-hr`. The script
   `swap_leaderboard_dataset.py` now automatically updates CHANGELOG.md when performing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   as official.
 
 ### Changed
+- Swapped official dataset for Dutch:
+`hellaswag-nl` → `winogrande-nl`.
 
 - Swapped official dataset for Croatian: `mmlu-hr` → `include-hr`. The script
   `swap_leaderboard_dataset.py` now automatically updates CHANGELOG.md when performing

--- a/src/euroeval/dataset_configs/dutch.py
+++ b/src/euroeval/dataset_configs/dutch.py
@@ -72,14 +72,6 @@ MMLU_NL_CONFIG = DatasetConfig(
     languages=[DUTCH],
 )
 
-HELLASWAG_NL_CONFIG = DatasetConfig(
-    name="hellaswag-nl",
-    pretty_name="HellaSwag-nl",
-    source="EuroEval/hellaswag-nl-mini",
-    task=COMMON_SENSE,
-    languages=[DUTCH],
-)
-
 DUIDELIJKE_TAAL_NL_CONFIG = DatasetConfig(
     name="duidelijke-taal",
     pretty_name="Duidelijke Taal",
@@ -137,7 +129,25 @@ RAGTRUTH_NL_CONFIG = DatasetConfig(
 )
 
 
+WINOGRANDE_NL_CONFIG = DatasetConfig(
+    name="winogrande-nl",
+    pretty_name="Winogrande-nl",
+    source="EuroEval/winogrande-nl",
+    task=COMMON_SENSE,
+    languages=[DUTCH],
+    labels=["a", "b"],
+)
+
 # Unofficial datasets ###
+
+HELLASWAG_NL_CONFIG = DatasetConfig(
+    name="hellaswag-nl",
+    pretty_name="HellaSwag-nl",
+    source="EuroEval/hellaswag-nl-mini",
+    task=COMMON_SENSE,
+    languages=[DUTCH],
+    unofficial=True,
+)
 
 DUTCH_COLA_CONFIG = DatasetConfig(
     name="dutch-cola",
@@ -211,16 +221,6 @@ GOLDENSWAG_NL_CONFIG = DatasetConfig(
     source="EuroEval/goldenswag-nl-mini",
     task=COMMON_SENSE,
     languages=[DUTCH],
-    unofficial=True,
-)
-
-WINOGRANDE_NL_CONFIG = DatasetConfig(
-    name="winogrande-nl",
-    pretty_name="Winogrande-nl",
-    source="EuroEval/winogrande-nl",
-    task=COMMON_SENSE,
-    languages=[DUTCH],
-    labels=["a", "b"],
     unofficial=True,
 )
 

--- a/src/frontend/md/datasets/dutch.md
+++ b/src/frontend/md/datasets/dutch.md
@@ -990,7 +990,78 @@ euroeval --model <model-id> --dataset multiloko-nl
 
 ## Common-sense Reasoning
 
-### HellaSwag-nl
+### Winogrande-nl
+
+This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2506.19468)
+and is a translated and filtered version of the English
+[Winogrande dataset](https://doi.org/10.1145/3474381).
+
+The original full dataset consists of 47 / 1,210 samples for training and testing, and
+we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
+training, validation and testing, respectively.
+
+Here are a few examples from the training split:
+
+```json
+{
+  "text": "Emily vroeg haar zus Sarah of ze tampons of maandverband nodig had uit de winkel, hoewel _ dat niet nodig had omdat ze was overgestapt op het gebruik van menstruatiecups. Waar verwijst de lege _ naar?\nAntwoordopties:\na. Emily\nb. Sarah",
+  "label": "a"
+}
+```
+
+```json
+{
+  "text": "Bij het kopen van een huis heeft Patricia niet zoveel geld te besteden als Tanya, dus _ koopt een huis met 1 slaapkamer. Waar verwijst de lege _ naar?\nAntwoordopties:\na. Patricia\nb. Tanya",
+  "label": "a"
+}
+```
+
+```json
+{
+  "text": "Eenmaal in Polen genoot Dennis meer van de reis dan Jason omdat _ een oppervlakkige kennis van de Poolse taal had. Waar verwijst de lege _ naar?\nAntwoordopties:\na. Dennis\nb. Jason",
+  "label": "b"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+
+- Prefix prompt:
+
+  ```text
+  Hieronder staan meerkeuzevragen (met antwoorden).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Vraag: {text}
+  Antwoordopties:
+  a. {option_a}
+  b. {option_b}
+  Antwoord: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Vraag: {text}
+  Antwoordopties:
+  a. {option_a}
+  b. {option_b}
+
+  Beantwoord de bovenstaande vraag met 'a' of 'b', en niets anders.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset winogrande-nl
+```
+
+### Unofficial: HellaSwag-nl
 
 This dataset is a machine translated version of the English
 [HellaSwag dataset](https://aclanthology.org/P19-1472/). The original dataset was based
@@ -1209,77 +1280,6 @@ You can evaluate this dataset directly as follows:
 
 ```bash
 euroeval --model <model-id> --dataset goldenswag-nl
-```
-
-### Unofficial: Winogrande-nl
-
-This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2506.19468)
-and is a translated and filtered version of the English
-[Winogrande dataset](https://doi.org/10.1145/3474381).
-
-The original full dataset consists of 47 / 1,210 samples for training and testing, and
-we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
-training, validation and testing, respectively.
-
-Here are a few examples from the training split:
-
-```json
-{
-  "text": "Emily vroeg haar zus Sarah of ze tampons of maandverband nodig had uit de winkel, hoewel _ dat niet nodig had omdat ze was overgestapt op het gebruik van menstruatiecups. Waar verwijst de lege _ naar?\nAntwoordopties:\na. Emily\nb. Sarah",
-  "label": "a"
-}
-```
-
-```json
-{
-  "text": "Bij het kopen van een huis heeft Patricia niet zoveel geld te besteden als Tanya, dus _ koopt een huis met 1 slaapkamer. Waar verwijst de lege _ naar?\nAntwoordopties:\na. Patricia\nb. Tanya",
-  "label": "a"
-}
-```
-
-```json
-{
-  "text": "Eenmaal in Polen genoot Dennis meer van de reis dan Jason omdat _ een oppervlakkige kennis van de Poolse taal had. Waar verwijst de lege _ naar?\nAntwoordopties:\na. Dennis\nb. Jason",
-  "label": "b"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 5
-
-- Prefix prompt:
-
-  ```text
-  Hieronder staan meerkeuzevragen (met antwoorden).
-  ```
-
-- Base prompt template:
-
-  ```text
-  Vraag: {text}
-  Antwoordopties:
-  a. {option_a}
-  b. {option_b}
-  Antwoord: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Vraag: {text}
-  Antwoordopties:
-  a. {option_a}
-  b. {option_b}
-
-  Beantwoord de bovenstaande vraag met 'a' of 'b', en niets anders.
-  ```
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset winogrande-nl
 ```
 
 ## Summarisation


### PR DESCRIPTION
Swaps the official dataset `hellaswag-nl` for `winogrande-nl`.

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `winogrande-nl`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `hellaswag-nl` is demoted to unofficial and `winogrande-nl` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.