### PR TITLE
feat: swap official dataset mmlu-fr -> include-fr, multiloko-fr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   as official.
 
 ### Changed
-- Swapped official dataset for French:
-`mmlu-fr` → `include-fr`, `multiloko-fr`.
+
+- Swapped official dataset for French: `mmlu-fr` → `include-fr`, `multiloko-fr`.
 
 - Swapped official dataset for Croatian: `mmlu-hr` → `include-hr`. The script
   `swap_leaderboard_dataset.py` now automatically updates CHANGELOG.md when performing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Swapped official dataset for French: `mmlu-fr` → `include-fr`, `multiloko-fr`.
-
 - Swapped official dataset for Croatian: `mmlu-hr` → `include-hr`. The script
   `swap_leaderboard_dataset.py` now automatically updates CHANGELOG.md when performing
   dataset swaps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   as official.
 
 ### Changed
+- Swapped official dataset for French:
+`mmlu-fr` → `include-fr`, `multiloko-fr`.
 
 - Swapped official dataset for Croatian: `mmlu-hr` → `include-hr`. The script
   `swap_leaderboard_dataset.py` now automatically updates CHANGELOG.md when performing

--- a/src/euroeval/dataset_configs/french.py
+++ b/src/euroeval/dataset_configs/french.py
@@ -60,14 +60,6 @@ ORANGE_SUM_CONFIG = DatasetConfig(
     languages=[FRENCH],
 )
 
-MMLU_FR_CONFIG = DatasetConfig(
-    name="mmlu-fr",
-    pretty_name="MMLU-fr",
-    source="EuroEval/mmlu-fr-mini",
-    task=KNOW,
-    languages=[FRENCH],
-)
-
 HELLASWAG_FR_CONFIG = DatasetConfig(
     name="hellaswag-fr",
     pretty_name="HellaSwag-fr",
@@ -108,7 +100,33 @@ RAGTRUTH_FR_CONFIG = DatasetConfig(
 )
 
 
+INCLUDE_FR_CONFIG = DatasetConfig(
+    name="include-fr",
+    pretty_name="INCLUDE-fr",
+    source="EuroEval/include-fr-mini",
+    task=KNOW,
+    languages=[FRENCH],
+)
+
+MULTILOKO_FR_CONFIG = DatasetConfig(
+    name="multiloko-fr",
+    pretty_name="MultiLoKo-fr",
+    source="EuroEval/multiloko-fr-mini",
+    task=KNOW,
+    languages=[FRENCH],
+    val_split=None,
+)
+
 # Unofficial datasets ###
+
+MMLU_FR_CONFIG = DatasetConfig(
+    name="mmlu-fr",
+    pretty_name="MMLU-fr",
+    source="EuroEval/mmlu-fr-mini",
+    task=KNOW,
+    languages=[FRENCH],
+    unofficial=True,
+)
 
 MULTI_IFEVAL_FR_CONFIG = DatasetConfig(
     name="multi-ifeval-fr",
@@ -155,25 +173,6 @@ WINOGRANDE_FR_CONFIG = DatasetConfig(
     task=COMMON_SENSE,
     languages=[FRENCH],
     labels=["a", "b"],
-    unofficial=True,
-)
-
-INCLUDE_FR_CONFIG = DatasetConfig(
-    name="include-fr",
-    pretty_name="INCLUDE-fr",
-    source="EuroEval/include-fr-mini",
-    task=KNOW,
-    languages=[FRENCH],
-    unofficial=True,
-)
-
-MULTILOKO_FR_CONFIG = DatasetConfig(
-    name="multiloko-fr",
-    pretty_name="MultiLoKo-fr",
-    source="EuroEval/multiloko-fr-mini",
-    task=KNOW,
-    languages=[FRENCH],
-    val_split=None,
     unofficial=True,
 )
 

--- a/src/frontend/md/datasets/french.md
+++ b/src/frontend/md/datasets/french.md
@@ -477,7 +477,142 @@ euroeval --model <model-id> --dataset multi-wiki-qa-fr
 
 ## Knowledge
 
-### MMLU-fr
+### INCLUDE-fr
+
+This dataset is part of [INCLUDE](https://doi.org/10.48550/arXiv.2411.19799), a
+comprehensive knowledge- and reasoning-centric benchmark that evaluates multilingual
+LLMs across 44 languages. It contains 4-option multiple-choice questions extracted from
+academic and professional exams, covering 57 topics including regional knowledge.
+
+The original dataset consists of a 'validation' split used as training data and a 'test'
+split. We use the 'validation' split as the training split, which has 25 samples. We
+sample 64 samples from the 'test' split for the validation split, and use the remaining
+512 samples for the test split. The sampling is done stratified by the subject column.
+
+Here are a few examples from the dataset:
+
+```json
+{
+  "text": "Qui est le dernier Président de la IVème République ?\nChoix:\na. René Coty\nb. Félix Gaillard\nc. Charles de Gaulle\nd. Alain Poher",
+  "label": "a",
+  "subject": "History"
+}
+```
+
+```json
+{
+  "text": "Qui a réalisé le film « Léon » ?\nChoix:\na. Costa-Gavras\nb. Luc Besson\nc. Martin Scorsese\nd. Steven Spielberg",
+  "label": "b",
+  "subject": "Culturology"
+}
+```
+
+```json
+{
+  "text": "Pour consulter mon solde de points, je me rends sur le site internet :\nChoix:\na. Allopoints.\nb. Info-point.\nc. Telepoint.\nd. Point-permis.",
+  "label": "c",
+  "subject": "Driving License"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  Les questions suivantes sont des questions à choix multiples (avec réponses).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Question: {text}
+  Réponse: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Question: {text}
+
+  Répondez à la question ci-dessus par {labels_str}, et rien d'autre.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset include-fr
+```
+
+### MultiLoKo-fr
+
+This dataset was published in [this paper](https://arxiv.org/abs/2504.10356) and is part
+of MultiLoKo, a multilingual local knowledge benchmark covering 31 languages. The French
+questions are separately sourced and designed to target locally relevant topics for
+French-speaking populations.
+
+We use the 'dev' split (250 samples) from this dataset. The dataset contains open-ended
+questions with correct answers in the 'targets' column. We use the first target answer
+as the correct option and use GPT-4.1 to generate 3 plausible but incorrect alternatives
+per question. We create a 16 / 234 split for training and testing, respectively.
+
+Here are a few examples from the training split:
+
+```json
+{
+  "text": "Quel est le métier de la seconde femme de Joseph Ferdinand Cheval?\nChoix:\na. tailleuse\nb. couturière\nc. institutrice\nd. boulangère",
+  "label": "a"
+}
+```
+
+```json
+{
+  "text": "Qui est le père des quatre enfants de Mercotte ?\nChoix:\na. Cyril Lignac\nb. Mercorelli\nc. Bernard Laurance\nd. Philippe Etchebest",
+  "label": "b"
+}
+```
+
+```json
+{
+  "text": "Dans le film de 2017120 Battements par minute, à quelle association sont rattachées les personnes qui répandent les cendres de Sean sur des petits-fours ?\nChoix:\na. AIDES\nb. SOS Homophobie\nc. Act Up– Paris\nd. Sidaction",
+  "label": "c"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  Les questions suivantes sont des questions à choix multiples (avec réponses).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Question: {text}
+  Réponse: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Question: {text}
+
+  Répondez à la question ci-dessus par 'a', 'b', 'c' ou 'd', et rien d'autre.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset multiloko-fr
+```
+
+### Unofficial: MMLU-fr
 
 This dataset is a machine translated version of the English
 [MMLU dataset](https://openreview.net/forum?id=d7KBjmI3GmQ) and features questions
@@ -553,141 +688,6 @@ You can evaluate this dataset directly as follows:
 
 ```bash
 euroeval --model <model-id> --dataset mmlu-fr
-```
-
-### Unofficial: INCLUDE-fr
-
-This dataset is part of [INCLUDE](https://doi.org/10.48550/arXiv.2411.19799), a
-comprehensive knowledge- and reasoning-centric benchmark that evaluates multilingual
-LLMs across 44 languages. It contains 4-option multiple-choice questions extracted from
-academic and professional exams, covering 57 topics including regional knowledge.
-
-The original dataset consists of a 'validation' split used as training data and a 'test'
-split. We use the 'validation' split as the training split, which has 25 samples. We
-sample 64 samples from the 'test' split for the validation split, and use the remaining
-512 samples for the test split. The sampling is done stratified by the subject column.
-
-Here are a few examples from the dataset:
-
-```json
-{
-  "text": "Qui est le dernier Président de la IVème République ?\nChoix:\na. René Coty\nb. Félix Gaillard\nc. Charles de Gaulle\nd. Alain Poher",
-  "label": "a",
-  "subject": "History"
-}
-```
-
-```json
-{
-  "text": "Qui a réalisé le film « Léon » ?\nChoix:\na. Costa-Gavras\nb. Luc Besson\nc. Martin Scorsese\nd. Steven Spielberg",
-  "label": "b",
-  "subject": "Culturology"
-}
-```
-
-```json
-{
-  "text": "Pour consulter mon solde de points, je me rends sur le site internet :\nChoix:\na. Allopoints.\nb. Info-point.\nc. Telepoint.\nd. Point-permis.",
-  "label": "c",
-  "subject": "Driving License"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 5
-- Prefix prompt:
-
-  ```text
-  Les questions suivantes sont des questions à choix multiples (avec réponses).
-  ```
-
-- Base prompt template:
-
-  ```text
-  Question: {text}
-  Réponse: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Question: {text}
-
-  Répondez à la question ci-dessus par {labels_str}, et rien d'autre.
-  ```
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset include-fr
-```
-
-### Unofficial: MultiLoKo-fr
-
-This dataset was published in [this paper](https://arxiv.org/abs/2504.10356) and is part
-of MultiLoKo, a multilingual local knowledge benchmark covering 31 languages. The French
-questions are separately sourced and designed to target locally relevant topics for
-French-speaking populations.
-
-We use the 'dev' split (250 samples) from this dataset. The dataset contains open-ended
-questions with correct answers in the 'targets' column. We use the first target answer
-as the correct option and use GPT-4.1 to generate 3 plausible but incorrect alternatives
-per question. We create a 16 / 234 split for training and testing, respectively.
-
-Here are a few examples from the training split:
-
-```json
-{
-  "text": "Quel est le métier de la seconde femme de Joseph Ferdinand Cheval?\nChoix:\na. tailleuse\nb. couturière\nc. institutrice\nd. boulangère",
-  "label": "a"
-}
-```
-
-```json
-{
-  "text": "Qui est le père des quatre enfants de Mercotte ?\nChoix:\na. Cyril Lignac\nb. Mercorelli\nc. Bernard Laurance\nd. Philippe Etchebest",
-  "label": "b"
-}
-```
-
-```json
-{
-  "text": "Dans le film de 2017120 Battements par minute, à quelle association sont rattachées les personnes qui répandent les cendres de Sean sur des petits-fours ?\nChoix:\na. AIDES\nb. SOS Homophobie\nc. Act Up– Paris\nd. Sidaction",
-  "label": "c"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 5
-- Prefix prompt:
-
-  ```text
-  Les questions suivantes sont des questions à choix multiples (avec réponses).
-  ```
-
-- Base prompt template:
-
-  ```text
-  Question: {text}
-  Réponse: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Question: {text}
-
-  Répondez à la question ci-dessus par 'a', 'b', 'c' ou 'd', et rien d'autre.
-  ```
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset multiloko-fr
 ```
 
 ### Unofficial: MultiNRC-fr


### PR DESCRIPTION
Swaps the official dataset `mmlu-fr` for `include-fr`, `multiloko-fr`.

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `include-fr`, `multiloko-fr`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `mmlu-fr` is demoted to unofficial and `include-fr`, `multiloko-fr` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.