### PR TITLE
feat: swap official dataset mmlu-pt -> alba-mcq-pt, cultura-viva-pt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   Platform](https://platform.alexandra.dk/).
 
 ### Changed
+- Swapped official dataset for European Portuguese, Portuguese: `mmlu-pt` → `alba-mcq-pt`, `cultura-viva-pt`. The script `swap_leaderboard_dataset.py` now automatically updates CHANGELOG.md when performing dataset swaps.
 
 - Made the Danish linguistic acceptability dataset DaLA the new official such one, over
   the previous ScaLA-da, which has now been demoted to unofficial.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   parameter in the filename, preventing incorrect cache reuse when using the `--debug`
   flag.
 
+### Changed
+
+- Swapped official dataset for European Portuguese: `mmlu-pt` → `alba-mcq-pt`,
+  `cultura-viva-pt`. The script `swap_leaderboard_dataset.py` now automatically updates
+  CHANGELOG.md when performing dataset swaps.
+
 ## [v17.7.0] - 2026-07-22
 
 ### Added
@@ -48,7 +54,6 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   Platform](https://platform.alexandra.dk/).
 
 ### Changed
-- Swapped official dataset for European Portuguese, Portuguese: `mmlu-pt` → `alba-mcq-pt`, `cultura-viva-pt`. The script `swap_leaderboard_dataset.py` now automatically updates CHANGELOG.md when performing dataset swaps.
 
 - Made the Danish linguistic acceptability dataset DaLA the new official such one, over
   the previous ScaLA-da, which has now been demoted to unofficial.

--- a/src/euroeval/dataset_configs/portuguese.py
+++ b/src/euroeval/dataset_configs/portuguese.py
@@ -59,14 +59,6 @@ PUBLICO_CONFIG = DatasetConfig(
     languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
 )
 
-MMLU_PT_CONFIG = DatasetConfig(
-    name="mmlu-pt",
-    pretty_name="MMLU-pt",
-    source="EuroEval/mmlu-pt-mini",
-    task=KNOW,
-    languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
-)
-
 GOLDENSWAG_PT_CONFIG = DatasetConfig(
     name="goldenswag-pt",
     pretty_name="GoldenSwag-pt",
@@ -107,7 +99,34 @@ RAGTRUTH_PT_CONFIG = DatasetConfig(
 )
 
 
+ALBA_MCQ_PT_CONFIG = DatasetConfig(
+    name="alba-mcq-pt",
+    pretty_name="ALBA-MCQ",
+    source="EuroEval/euroeval-amalia-alba-mcq-pt",
+    task=KNOW,
+    languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
+    labels=["a", "b", "c"],
+    val_split=None,
+)
+
+CULTURA_VIVA_PT_CONFIG = DatasetConfig(
+    name="cultura-viva-pt",
+    pretty_name="CulturaVivaPT",
+    source="EuroEval/euroeval-amalia-cultura-viva-pt",
+    task=KNOW,
+    languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
+)
+
 # Unofficial datasets ###
+
+MMLU_PT_CONFIG = DatasetConfig(
+    name="mmlu-pt",
+    pretty_name="MMLU-pt",
+    source="EuroEval/mmlu-pt-mini",
+    task=KNOW,
+    languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
+    unofficial=True,
+)
 
 IFEVAL_PT_CONFIG = DatasetConfig(
     name="ifeval-pt",
@@ -158,30 +177,10 @@ MULTILOKO_PT_CONFIG = DatasetConfig(
     unofficial=True,
 )
 
-ALBA_MCQ_PT_CONFIG = DatasetConfig(
-    name="alba-mcq-pt",
-    pretty_name="ALBA-MCQ",
-    source="EuroEval/euroeval-amalia-alba-mcq-pt",
-    task=KNOW,
-    languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
-    labels=["a", "b", "c"],
-    val_split=None,
-    unofficial=True,
-)
-
 PT_EXAMS_CONFIG = DatasetConfig(
     name="pt-exams",
     pretty_name="PT Exams",
     source="EuroEval/euroeval-amalia-pt-exams",
-    task=KNOW,
-    languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
-    unofficial=True,
-)
-
-CULTURA_VIVA_PT_CONFIG = DatasetConfig(
-    name="cultura-viva-pt",
-    pretty_name="CulturaVivaPT",
-    source="EuroEval/euroeval-amalia-cultura-viva-pt",
     task=KNOW,
     languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
     unofficial=True,

--- a/src/frontend/md/datasets/portuguese.md
+++ b/src/frontend/md/datasets/portuguese.md
@@ -427,7 +427,163 @@ euroeval --model <model-id> --dataset boolq-pt
 
 ## Knowledge
 
-### MMLU-pt
+### ALBA-MCQ
+
+[ALBA-MCQ](https://huggingface.co/datasets/amalia-llm/alba_mcq) is the multiple-choice
+adaptation of ALBA, an expert-created benchmark introduced in the
+[ALBA paper](https://aclanthology.org/2026.propor-1.69/) for evaluating European
+Portuguese linguistic competence. Its 240 questions cover culture-bound semantics,
+discourse, language variety, lexicology, morphology, phonetics and phonology, syntax,
+and wordplay. Each question has three answers rated for quality and a designated correct
+choice.
+
+EuroEval combines the eight source configurations, reproducibly shuffles the answer
+choices, and creates splits with 32 training and 208 test samples. There is no
+validation split, so evaluation uses the full test split. Accuracy and Matthews
+correlation coefficient are reported through the Knowledge task.
+
+```json
+{
+  "text": "Em que região de Portugal é mais comum usar-se a palavra \"cruzeta\"?\nOpções:\na. A palavra \"cruzeta\" é usada no norte de Portugal. Este regionalismo tem como correspondente, no sul de Portugal, a palavra \"cabide\".\nb. A palavra \"cruzeta\" é usada no centro de Portugal. Este regionalismo tem como correspondente, no sul de Portugal, a palavra \"cabide\".\nc. A palavra \"cruzeta\" refere-se a uma pequena cruz e tem como correspondente, no sul de Portugal, a palavra \"cruzinha\".",
+  "label": "a",
+  "subject": "Language Variety"
+}
+```
+
+```json
+{
+  "text": "Completa esta piada seca: Qual o animal que anda com uma pata?\nOpções:\na. Quase todos... menos as cobras!\nb. O pato.\nc. O macho da pata.",
+  "label": "b",
+  "subject": "Culture-bound Semantics"
+}
+```
+
+```json
+{
+  "text": "Cria um acróstico com a palavra \"mar\".\nOpções:\na. Olha só um acróstico com a palavra \"mar\".\n\nMaresia\nAreia\nb. Olha só um acróstico com a palavra \"mar\".\n\nMaresia\nAreia\nRio\nc. Aqui está um acróstico com a palavra \"mar\".\n\nMaresia\nAreia\nRio",
+  "label": "c",
+  "subject": "Word Plays"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  As seguintes são perguntas de escolha múltipla (com respostas).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Pergunta: {text}
+  Opções:
+  a. {option_a}
+  b. {option_b}
+  c. {option_c}
+  Resposta: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Pergunta: {text}
+  Opções:
+  a. {option_a}
+  b. {option_b}
+  c. {option_c}
+
+  Responde à pergunta acima usando só 'a', 'b' ou 'c', e nada mais.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset alba-mcq-pt
+```
+
+### CulturaVivaPT
+
+[CulturaVivaPT](https://huggingface.co/datasets/amalia-llm/cultura-viva-pt-mcq),
+released as part of the [AMALIA project](https://aclanthology.org/2026.propor-1.38/),
+contains 1,000 multiple-choice questions about Portuguese culture. Its ten balanced
+domains cover audiovisual culture, festivals, gastronomy, geography, heritage, holidays,
+literature, personalities, proverbs, and sports.
+
+The upstream repository exposes all 1,000 samples as a `train` split. EuroEval
+reproducibly shuffles the samples and answer choices, then allocates 32 samples to
+training, 128 to validation, and 840 to testing. Accuracy and Matthews correlation
+coefficient are reported.
+
+```json
+{
+  "text": "Em que local nasceu a artista e escritora Florbela Oliveira?\nOpções:\na. Coimbra\nb. Campolide\nc. Serra da Estrela\nd. Palmela",
+  "label": "b",
+  "subject": "personalities"
+}
+```
+
+```json
+{
+  "text": "Preenche o espaço em falta: «O tempo a tudo _ remédio.»\nOpções:\na. dá\nb. vê\nc. traz\nd. faz",
+  "label": "a",
+  "subject": "proverbs"
+}
+```
+
+```json
+{
+  "text": "Preenche o espaço em falta: «Em Abril cada pulga _ mil.»\nOpções:\na. faz\nb. vê\nc. tem\nd. dá",
+  "label": "d",
+  "subject": "proverbs"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  As seguintes são perguntas de escolha múltipla (com respostas).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Pergunta: {text}
+  Opções:
+  a. {option_a}
+  b. {option_b}
+  c. {option_c}
+  d. {option_d}
+  Resposta: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Pergunta: {text}
+  Opções:
+  a. {option_a}
+  b. {option_b}
+  c. {option_c}
+  d. {option_d}
+
+  Responde à pergunta acima usando só 'a', 'b', 'c' ou 'd', e nada mais.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset cultura-viva-pt
+```
+
+### Unofficial: MMLU-pt
 
 This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2410.08928)
 and is a machine translated version of the English
@@ -639,84 +795,6 @@ You can evaluate this dataset directly as follows:
 euroeval --model <model-id> --dataset multiloko-pt
 ```
 
-### Unofficial: ALBA-MCQ
-
-[ALBA-MCQ](https://huggingface.co/datasets/amalia-llm/alba_mcq) is the multiple-choice
-adaptation of ALBA, an expert-created benchmark introduced in the
-[ALBA paper](https://aclanthology.org/2026.propor-1.69/) for evaluating European
-Portuguese linguistic competence. Its 240 questions cover culture-bound semantics,
-discourse, language variety, lexicology, morphology, phonetics and phonology, syntax,
-and wordplay. Each question has three answers rated for quality and a designated correct
-choice.
-
-EuroEval combines the eight source configurations, reproducibly shuffles the answer
-choices, and creates splits with 32 training and 208 test samples. There is no
-validation split, so evaluation uses the full test split. Accuracy and Matthews
-correlation coefficient are reported through the Knowledge task.
-
-```json
-{
-  "text": "Em que região de Portugal é mais comum usar-se a palavra \"cruzeta\"?\nOpções:\na. A palavra \"cruzeta\" é usada no norte de Portugal. Este regionalismo tem como correspondente, no sul de Portugal, a palavra \"cabide\".\nb. A palavra \"cruzeta\" é usada no centro de Portugal. Este regionalismo tem como correspondente, no sul de Portugal, a palavra \"cabide\".\nc. A palavra \"cruzeta\" refere-se a uma pequena cruz e tem como correspondente, no sul de Portugal, a palavra \"cruzinha\".",
-  "label": "a",
-  "subject": "Language Variety"
-}
-```
-
-```json
-{
-  "text": "Completa esta piada seca: Qual o animal que anda com uma pata?\nOpções:\na. Quase todos... menos as cobras!\nb. O pato.\nc. O macho da pata.",
-  "label": "b",
-  "subject": "Culture-bound Semantics"
-}
-```
-
-```json
-{
-  "text": "Cria um acróstico com a palavra \"mar\".\nOpções:\na. Olha só um acróstico com a palavra \"mar\".\n\nMaresia\nAreia\nb. Olha só um acróstico com a palavra \"mar\".\n\nMaresia\nAreia\nRio\nc. Aqui está um acróstico com a palavra \"mar\".\n\nMaresia\nAreia\nRio",
-  "label": "c",
-  "subject": "Word Plays"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 5
-- Prefix prompt:
-
-  ```text
-  As seguintes são perguntas de escolha múltipla (com respostas).
-  ```
-
-- Base prompt template:
-
-  ```text
-  Pergunta: {text}
-  Opções:
-  a. {option_a}
-  b. {option_b}
-  c. {option_c}
-  Resposta: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Pergunta: {text}
-  Opções:
-  a. {option_a}
-  b. {option_b}
-  c. {option_c}
-
-  Responde à pergunta acima usando só 'a', 'b' ou 'c', e nada mais.
-  ```
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset alba-mcq-pt
-```
-
 ### Unofficial: PT Exams
 
 [PT Exams](https://huggingface.co/datasets/amalia-llm/pt_exams), also known as PHEB or
@@ -795,84 +873,6 @@ You can evaluate this dataset directly as follows:
 
 ```bash
 euroeval --model <model-id> --dataset pt-exams
-```
-
-### Unofficial: CulturaVivaPT
-
-[CulturaVivaPT](https://huggingface.co/datasets/amalia-llm/cultura-viva-pt-mcq),
-released as part of the [AMALIA project](https://aclanthology.org/2026.propor-1.38/),
-contains 1,000 multiple-choice questions about Portuguese culture. Its ten balanced
-domains cover audiovisual culture, festivals, gastronomy, geography, heritage, holidays,
-literature, personalities, proverbs, and sports.
-
-The upstream repository exposes all 1,000 samples as a `train` split. EuroEval
-reproducibly shuffles the samples and answer choices, then allocates 32 samples to
-training, 128 to validation, and 840 to testing. Accuracy and Matthews correlation
-coefficient are reported.
-
-```json
-{
-  "text": "Em que local nasceu a artista e escritora Florbela Oliveira?\nOpções:\na. Coimbra\nb. Campolide\nc. Serra da Estrela\nd. Palmela",
-  "label": "b",
-  "subject": "personalities"
-}
-```
-
-```json
-{
-  "text": "Preenche o espaço em falta: «O tempo a tudo _ remédio.»\nOpções:\na. dá\nb. vê\nc. traz\nd. faz",
-  "label": "a",
-  "subject": "proverbs"
-}
-```
-
-```json
-{
-  "text": "Preenche o espaço em falta: «Em Abril cada pulga _ mil.»\nOpções:\na. faz\nb. vê\nc. tem\nd. dá",
-  "label": "d",
-  "subject": "proverbs"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 5
-- Prefix prompt:
-
-  ```text
-  As seguintes são perguntas de escolha múltipla (com respostas).
-  ```
-
-- Base prompt template:
-
-  ```text
-  Pergunta: {text}
-  Opções:
-  a. {option_a}
-  b. {option_b}
-  c. {option_c}
-  d. {option_d}
-  Resposta: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Pergunta: {text}
-  Opções:
-  a. {option_a}
-  b. {option_b}
-  c. {option_c}
-  d. {option_d}
-
-  Responde à pergunta acima usando só 'a', 'b', 'c' ou 'd', e nada mais.
-  ```
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset cultura-viva-pt
 ```
 
 ### Unofficial: SAUDADE-PT


### PR DESCRIPTION
Swaps the official dataset `mmlu-pt` for `alba-mcq-pt`, `cultura-viva-pt`.

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `alba-mcq-pt`, `cultura-viva-pt`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `mmlu-pt` is demoted to unofficial and `alba-mcq-pt`, `cultura-viva-pt` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.