### PR TITLE
feat: swap official dataset mmlu-fr -> include-fr, multiloko-fr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   as official.
 
 ### Changed
+- Swapped official dataset for German:
+`mmlu-de` → `include-de`, `multiloko-de`.
 
 Swapped official datasets for six languages (all performed by the
 `swap_leaderboard_dataset.py` script, which now automatically updates this changelog):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   as official.
 
 ### Changed
+
+- Swapped official dataset for French:
+`mmlu-fr` → `include-fr`, `multiloko-fr`.
 - Swapped official dataset for German:
 `mmlu-de` → `include-de`, `multiloko-de`.
 

--- a/src/euroeval/dataset_configs/french.py
+++ b/src/euroeval/dataset_configs/french.py
@@ -102,15 +102,33 @@ RAGTRUTH_FR_CONFIG = DatasetConfig(
 
 
 
+INCLUDE_FR_CONFIG = DatasetConfig(
+    name="include-fr",
+    pretty_name="INCLUDE-fr",
+    source="EuroEval/include-fr-mini",
+    task=KNOW,
+    languages=[FRENCH],
+)
+
+MULTILOKO_FR_CONFIG = DatasetConfig(
+    name="multiloko-fr",
+    pretty_name="MultiLoKo-fr",
+    source="EuroEval/multiloko-fr-mini",
+    task=KNOW,
+    languages=[FRENCH],
+    val_split=None,
+)
+
+# Unofficial datasets ###
+
 MMLU_FR_CONFIG = DatasetConfig(
     name="mmlu-fr",
     pretty_name="MMLU-fr",
     source="EuroEval/mmlu-fr-mini",
     task=KNOW,
     languages=[FRENCH],
+    unofficial=True,
 )
-
-# Unofficial datasets ###
 
 MULTI_IFEVAL_FR_CONFIG = DatasetConfig(
     name="multi-ifeval-fr",
@@ -166,24 +184,5 @@ MULTINRC_FR_CONFIG = DatasetConfig(
     source="EuroEval/multinrc-fr",
     task=KNOW,
     languages=[FRENCH],
-    unofficial=True,
-)
-
-INCLUDE_FR_CONFIG = DatasetConfig(
-    name="include-fr",
-    pretty_name="INCLUDE-fr",
-    source="EuroEval/include-fr-mini",
-    task=KNOW,
-    languages=[FRENCH],
-    unofficial=True,
-)
-
-MULTILOKO_FR_CONFIG = DatasetConfig(
-    name="multiloko-fr",
-    pretty_name="MultiLoKo-fr",
-    source="EuroEval/multiloko-fr-mini",
-    task=KNOW,
-    languages=[FRENCH],
-    val_split=None,
     unofficial=True,
 )

--- a/src/euroeval/dataset_configs/german.py
+++ b/src/euroeval/dataset_configs/german.py
@@ -60,14 +60,6 @@ MLSUM_DE_CONFIG = DatasetConfig(
     languages=[GERMAN],
 )
 
-MMLU_DE_CONFIG = DatasetConfig(
-    name="mmlu-de",
-    pretty_name="MMLU-de",
-    source="EuroEval/mmlu-de-mini",
-    task=KNOW,
-    languages=[GERMAN],
-)
-
 HELLASWAG_DE_CONFIG = DatasetConfig(
     name="hellaswag-de",
     pretty_name="HellaSwag-de",
@@ -116,7 +108,33 @@ RAGTRUTH_DE_CONFIG = DatasetConfig(
 )
 
 
+INCLUDE_DE_CONFIG = DatasetConfig(
+    name="include-de",
+    pretty_name="INCLUDE-de",
+    source="EuroEval/include-de-mini",
+    task=KNOW,
+    languages=[GERMAN],
+)
+
+MULTILOKO_DE_CONFIG = DatasetConfig(
+    name="multiloko-de",
+    pretty_name="MultiLoKo-de",
+    source="EuroEval/multiloko-de-mini",
+    task=KNOW,
+    languages=[GERMAN],
+    val_split=None,
+)
+
 # Unofficial datasets ###
+
+MMLU_DE_CONFIG = DatasetConfig(
+    name="mmlu-de",
+    pretty_name="MMLU-de",
+    source="EuroEval/mmlu-de-mini",
+    task=KNOW,
+    languages=[GERMAN],
+    unofficial=True,
+)
 
 IFEVAL_DE_CONFIG = DatasetConfig(
     name="ifeval-de",
@@ -181,25 +199,6 @@ WINOGRANDE_DE_CONFIG = DatasetConfig(
     task=COMMON_SENSE,
     languages=[GERMAN],
     labels=["a", "b"],
-    unofficial=True,
-)
-
-INCLUDE_DE_CONFIG = DatasetConfig(
-    name="include-de",
-    pretty_name="INCLUDE-de",
-    source="EuroEval/include-de-mini",
-    task=KNOW,
-    languages=[GERMAN],
-    unofficial=True,
-)
-
-MULTILOKO_DE_CONFIG = DatasetConfig(
-    name="multiloko-de",
-    pretty_name="MultiLoKo-de",
-    source="EuroEval/multiloko-de-mini",
-    task=KNOW,
-    languages=[GERMAN],
-    val_split=None,
     unofficial=True,
 )
 

--- a/src/frontend/md/datasets/french.md
+++ b/src/frontend/md/datasets/french.md
@@ -477,7 +477,7 @@ euroeval --model <model-id> --dataset multi-wiki-qa-fr
 
 ## Knowledge
 
-### Unofficial: INCLUDE-fr
+### INCLUDE-fr
 
 > This dataset is **unofficial** — results do not count toward the French leaderboard.
 
@@ -543,7 +543,7 @@ You can evaluate this dataset directly as follows:
 euroeval --model <model-id> --dataset include-fr
 ```
 
-### Unofficial: MultiLoKo-fr
+### MultiLoKo-fr
 
 > This dataset is **unofficial** — results do not count toward the French leaderboard.
 
@@ -606,7 +606,7 @@ You can evaluate this dataset directly as follows:
 euroeval --model <model-id> --dataset multiloko-fr
 ```
 
-### MMLU-fr
+### Unofficial: MMLU-fr
 
 This dataset is a machine translated version of the English
 [MMLU dataset](https://openreview.net/forum?id=d7KBjmI3GmQ) and features questions

--- a/src/frontend/md/datasets/german.md
+++ b/src/frontend/md/datasets/german.md
@@ -540,7 +540,142 @@ euroeval --model <model-id> --dataset multi-wiki-qa-de
 
 ## Knowledge
 
-### MMLU-de
+### INCLUDE-de
+
+This dataset is part of [INCLUDE](https://doi.org/10.48550/arXiv.2411.19799), a
+comprehensive knowledge- and reasoning-centric benchmark that evaluates multilingual
+LLMs across 44 languages. It contains 4-option multiple-choice questions extracted from
+academic and professional exams, covering 57 topics including regional knowledge.
+
+The original dataset consists of a 'validation' split used as training data and a 'test'
+split. We use the 'validation' split as the training split, which has 25 samples. We
+sample 64 samples from the 'test' split for the validation split, and use the remaining
+512 samples for the test split. The sampling is done stratified by the subject column.
+
+Here are a few examples from the dataset:
+
+```json
+{
+  "text": "Wann dürfen Sie in einem Tunnel Ihr Fahrzeug wenden?\nAntwortmöglichkeiten:\na. Wenn Einsatzkräfte das Wenden ausdrücklich anordnen\nb. Wenn ich aus einer Gefahrensituation flüchten möchte\nc. Wenn ich unter Zeitdruck bin und sich vor mir ein Stau gebildet hat\nd. Nur wenn ich mit meinem Fahrzeug in einem Zug umkehren kann",
+  "label": "a",
+  "subject": "Driving License"
+}
+```
+
+```json
+{
+  "text": "Das Industrieland hat in einer Wirtschaftstätigkeit einen komparativen Vorteil, wenn\nAntwortmöglichkeiten:\na. in einer anderen Tätigkeit sein absoluter Vorteil größer ist.\nb. in dieser Tätigkeit sein absoluter Vorteil am größten ist.\nc. es keinen absoluten Vorteil hat.\nd. in dieser Tätigkeit sein absoluter Nachteil am geringsten ist.",
+  "label": "b",
+  "subject": "Economics"
+}
+```
+
+```json
+{
+  "text": "Ein Schiff fährt mit einer geradlinigen, gleichförmigen Bewegung auf dem offenen Meer. Zu gleicher Zeit fliegt auch ein Albatros mit einer in Bezug auf das Meer geradlinigen, gleichförmigen Bewegung in der Luft. Wie bewegt sich der Albatros in Bezug auf das Schiff?\nAntwortmöglichkeiten:\na. Die Bahn des Vogels ist geradlinig, aber seine Geschwindigkeit in Bezug auf das Schiff ist nicht konstant.\nb. Abhängig vom Winkel der zwei Geschwindigkeitsvektoren kann die Bahn des Vogels sowohl krummlinig, als auch geradlinig sein und auch seine Geschwindigkeit in Bezug auf das Schiff kann veränderlich sein.\nc. Der Vogel führt in Bezug auf das Schiff eine gleichförmige, geradlinige Bewegung aus.\nd. In bestimmten Fällen kann die Bahn des Vogels in Bezug auf das Schiff auch krummlinig sein, aber seine Geschwindigkeit hat einen konstanten Betrag.",
+  "label": "c",
+  "subject": "Physics"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  Die folgenden Fragen sind Multiple-Choice-Fragen (mit Antworten).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Frage: {text}
+  Antwort: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Frage: {text}
+
+  Beantworten Sie die obige Frage mit {labels_str}, und nichts anderes.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset include-de
+```
+
+### MultiLoKo-de
+
+This dataset was published in [this paper](https://arxiv.org/abs/2504.10356) and is part
+of MultiLoKo, a multilingual local knowledge benchmark covering 31 languages. The German
+questions are separately sourced and designed to target locally relevant topics for
+German-speaking populations.
+
+We use the 'dev' split (250 samples) from this dataset. The dataset contains open-ended
+questions with correct answers in the 'targets' column. We use the first target answer
+as the correct option and use GPT-4.1 to generate 3 plausible but incorrect alternatives
+per question. We create a 16 / 234 split for training and testing, respectively.
+
+Here are a few examples from the training split:
+
+```json
+{
+  "text": "In welchem Bereich sammelte Reiner Calmund erste berufliche und sportliche Erfahrungen, die später für seine Tätigkeit als Manager bei Bayer 04 Leverkusen relevant wurden?\nAntwortmöglichkeiten:\na. Trainer\nb. Spielerberater\nc. Physiotherapeut\nd. Sportjournalist",
+  "label": "a"
+}
+```
+
+```json
+{
+  "text": "Wie lange war Malu Dreyer Mitglied der SPD, als sie zum ersten Mal Landespräsidentin für den Wahlkreis Trier wurde?\nAntwortmöglichkeiten:\na. vierzehn Jahre\nb. elf Jahre\nc. sieben Jahre\nd. zwanzig Jahre",
+  "label": "b"
+}
+```
+
+```json
+{
+  "text": "Wie lautet der Name des Jungen, der in der vierten Staffel der Fernsehserie „Bettys Diagnose“ zu sehen ist und der der Hauptfigur in der Schule das Leben schwer macht?\nAntwortmöglichkeiten:\na. Tim Weigel\nb. Lukas Kramer\nc. Frank Stern\nd. Jonas Becker",
+  "label": "c"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  Die folgenden Fragen sind Multiple-Choice-Fragen (mit Antworten).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Frage: {text}
+  Antwort: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Frage: {text}
+
+  Beantworten Sie die obige Frage mit 'a', 'b', 'c' oder 'd', und nichts anderes.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset multiloko-de
+```
+
+### Unofficial: MMLU-de
 
 This dataset is a machine translated version of the English
 [MMLU dataset](https://openreview.net/forum?id=d7KBjmI3GmQ) and features questions
@@ -692,141 +827,6 @@ You can evaluate this dataset directly as follows:
 
 ```bash
 euroeval --model <model-id> --dataset arc-de
-```
-
-### Unofficial: INCLUDE-de
-
-This dataset is part of [INCLUDE](https://doi.org/10.48550/arXiv.2411.19799), a
-comprehensive knowledge- and reasoning-centric benchmark that evaluates multilingual
-LLMs across 44 languages. It contains 4-option multiple-choice questions extracted from
-academic and professional exams, covering 57 topics including regional knowledge.
-
-The original dataset consists of a 'validation' split used as training data and a 'test'
-split. We use the 'validation' split as the training split, which has 25 samples. We
-sample 64 samples from the 'test' split for the validation split, and use the remaining
-512 samples for the test split. The sampling is done stratified by the subject column.
-
-Here are a few examples from the dataset:
-
-```json
-{
-  "text": "Wann dürfen Sie in einem Tunnel Ihr Fahrzeug wenden?\nAntwortmöglichkeiten:\na. Wenn Einsatzkräfte das Wenden ausdrücklich anordnen\nb. Wenn ich aus einer Gefahrensituation flüchten möchte\nc. Wenn ich unter Zeitdruck bin und sich vor mir ein Stau gebildet hat\nd. Nur wenn ich mit meinem Fahrzeug in einem Zug umkehren kann",
-  "label": "a",
-  "subject": "Driving License"
-}
-```
-
-```json
-{
-  "text": "Das Industrieland hat in einer Wirtschaftstätigkeit einen komparativen Vorteil, wenn\nAntwortmöglichkeiten:\na. in einer anderen Tätigkeit sein absoluter Vorteil größer ist.\nb. in dieser Tätigkeit sein absoluter Vorteil am größten ist.\nc. es keinen absoluten Vorteil hat.\nd. in dieser Tätigkeit sein absoluter Nachteil am geringsten ist.",
-  "label": "b",
-  "subject": "Economics"
-}
-```
-
-```json
-{
-  "text": "Ein Schiff fährt mit einer geradlinigen, gleichförmigen Bewegung auf dem offenen Meer. Zu gleicher Zeit fliegt auch ein Albatros mit einer in Bezug auf das Meer geradlinigen, gleichförmigen Bewegung in der Luft. Wie bewegt sich der Albatros in Bezug auf das Schiff?\nAntwortmöglichkeiten:\na. Die Bahn des Vogels ist geradlinig, aber seine Geschwindigkeit in Bezug auf das Schiff ist nicht konstant.\nb. Abhängig vom Winkel der zwei Geschwindigkeitsvektoren kann die Bahn des Vogels sowohl krummlinig, als auch geradlinig sein und auch seine Geschwindigkeit in Bezug auf das Schiff kann veränderlich sein.\nc. Der Vogel führt in Bezug auf das Schiff eine gleichförmige, geradlinige Bewegung aus.\nd. In bestimmten Fällen kann die Bahn des Vogels in Bezug auf das Schiff auch krummlinig sein, aber seine Geschwindigkeit hat einen konstanten Betrag.",
-  "label": "c",
-  "subject": "Physics"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 5
-- Prefix prompt:
-
-  ```text
-  Die folgenden Fragen sind Multiple-Choice-Fragen (mit Antworten).
-  ```
-
-- Base prompt template:
-
-  ```text
-  Frage: {text}
-  Antwort: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Frage: {text}
-
-  Beantworten Sie die obige Frage mit {labels_str}, und nichts anderes.
-  ```
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset include-de
-```
-
-### Unofficial: MultiLoKo-de
-
-This dataset was published in [this paper](https://arxiv.org/abs/2504.10356) and is part
-of MultiLoKo, a multilingual local knowledge benchmark covering 31 languages. The German
-questions are separately sourced and designed to target locally relevant topics for
-German-speaking populations.
-
-We use the 'dev' split (250 samples) from this dataset. The dataset contains open-ended
-questions with correct answers in the 'targets' column. We use the first target answer
-as the correct option and use GPT-4.1 to generate 3 plausible but incorrect alternatives
-per question. We create a 16 / 234 split for training and testing, respectively.
-
-Here are a few examples from the training split:
-
-```json
-{
-  "text": "In welchem Bereich sammelte Reiner Calmund erste berufliche und sportliche Erfahrungen, die später für seine Tätigkeit als Manager bei Bayer 04 Leverkusen relevant wurden?\nAntwortmöglichkeiten:\na. Trainer\nb. Spielerberater\nc. Physiotherapeut\nd. Sportjournalist",
-  "label": "a"
-}
-```
-
-```json
-{
-  "text": "Wie lange war Malu Dreyer Mitglied der SPD, als sie zum ersten Mal Landespräsidentin für den Wahlkreis Trier wurde?\nAntwortmöglichkeiten:\na. vierzehn Jahre\nb. elf Jahre\nc. sieben Jahre\nd. zwanzig Jahre",
-  "label": "b"
-}
-```
-
-```json
-{
-  "text": "Wie lautet der Name des Jungen, der in der vierten Staffel der Fernsehserie „Bettys Diagnose“ zu sehen ist und der der Hauptfigur in der Schule das Leben schwer macht?\nAntwortmöglichkeiten:\na. Tim Weigel\nb. Lukas Kramer\nc. Frank Stern\nd. Jonas Becker",
-  "label": "c"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 5
-- Prefix prompt:
-
-  ```text
-  Die folgenden Fragen sind Multiple-Choice-Fragen (mit Antworten).
-  ```
-
-- Base prompt template:
-
-  ```text
-  Frage: {text}
-  Antwort: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Frage: {text}
-
-  Beantworten Sie die obige Frage mit 'a', 'b', 'c' oder 'd', und nichts anderes.
-  ```
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset multiloko-de
 ```
 
 ## Common-sense Reasoning


### PR DESCRIPTION
Swaps the official dataset `mmlu-fr` for `include-fr`, `multiloko-fr`.

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `include-fr`, `multiloko-fr`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `mmlu-fr` is demoted to unofficial and `include-fr`, `multiloko-fr` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.