### PR TITLE
Feat/add faroese grammatical correctness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   from the paper "Of Words and Meaning: A Grammatical and Semantic Benchmark for
   Faroese LLM Understanding", where the model has to pick the correct explanation of a
   Faroese idiom from four options. This was contributed by @Biorrith ✨
+- Added a new grammatical error correction (GEC) task, where the model is given a
+  sentence containing grammatical errors and has to generate a corrected version of it,
+  evaluated with exact match. A corresponding exact match metric fitting the
+  text-to-text task group was added.
+- Added the unofficial Faroese grammatical error correction dataset
+  `faroese-grammatical-correctness`, from the paper "Of Words and Meaning: A
+  Grammatical and Semantic Benchmark for Faroese LLM Understanding", consisting of
+  minimal pairs of ungrammatical and corrected sentences compiled from high school
+  essays.
 - Added the knowledge datasets `eu-mmlu-cs`, `eu-mmlu-de`, `eu-mmlu-el`, `eu-mmlu-fr`,
   `eu-mmlu-hr`, `eu-mmlu-hu`, `eu-mmlu-it`, `eu-mmlu-lt`, `eu-mmlu-nl`, `eu-mmlu-pl`,
   `eu-mmlu-pt`, `eu-mmlu-ro`, `eu-mmlu-sk` and `eu-mmlu-sl`, based on the

--- a/src/euroeval/dataset_configs/faroese.py
+++ b/src/euroeval/dataset_configs/faroese.py
@@ -2,7 +2,18 @@
 
 from ..data_models import DatasetConfig
 from ..languages import FAROESE
-from ..tasks import GED, HALLU, INSTRUCTION_FOLLOWING, KNOW, LA, LOGIC, NER, RC, SENT
+from ..tasks import (
+    GEC,
+    GED,
+    HALLU,
+    INSTRUCTION_FOLLOWING,
+    KNOW,
+    LA,
+    LOGIC,
+    NER,
+    RC,
+    SENT,
+)
 
 # Official datasets ###
 
@@ -87,6 +98,16 @@ FAROESE_METAPHORICAL_EXPLANATIONS_CONFIG = DatasetConfig(
     languages=[FAROESE],
     unofficial=True,
 )
+
+FAROESE_GRAMMATICAL_CORRECTNESS_CONFIG = DatasetConfig(
+    name="faroese-grammatical-correctness",
+    pretty_name="Faroese Grammatical Correctness",
+    source="EuroEval/faroese-grammatical-correctness",
+    task=GEC,
+    languages=[FAROESE],
+    unofficial=True,
+)
+
 
 WIKIANN_FO_CONFIG = DatasetConfig(
     name="wikiann-fo",

--- a/src/euroeval/metrics/huggingface.py
+++ b/src/euroeval/metrics/huggingface.py
@@ -287,6 +287,15 @@ em_metric = HuggingFaceMetric(
     postprocessing_fn=lambda x: (x, f"{x:.2f}%"),
 )
 
+# Unlike `em_metric` above, which requires SQuAD-format QA inputs and normalises
+# before comparing, this compares plain strings verbatim (used by text-to-text tasks)
+exact_match_metric = HuggingFaceMetric(
+    name="exact_match",
+    pretty_name="Exact Match",
+    huggingface_id="exact_match",
+    results_key="exact_match",
+)
+
 bert_score_metric = HuggingFaceMetric(
     name="bertscore",
     pretty_name="BERTScore",

--- a/src/euroeval/prompt_templates/__init__.py
+++ b/src/euroeval/prompt_templates/__init__.py
@@ -5,6 +5,7 @@ import typing as t
 from ..data_models import PromptConfig
 from ..languages import get_all_languages
 from .classification import CLASSIFICATION_TEMPLATES
+from .grammatical_error_correction import GEC_TEMPLATES
 from .grammatical_error_detection import GED_TEMPLATES
 from .linguistic_acceptability import LA_TEMPLATES
 from .logical_reasoning import LOGIC_TEMPLATES

--- a/src/euroeval/prompt_templates/grammatical_error_correction.py
+++ b/src/euroeval/prompt_templates/grammatical_error_correction.py
@@ -1,0 +1,31 @@
+"""Templates for the Grammatical Error Correction task."""
+
+from ..data_models import PromptConfig
+from ..languages import DANISH, ENGLISH, FAROESE
+
+GEC_TEMPLATES = {
+    DANISH: PromptConfig(
+        default_prompt_prefix="Følgende er sætninger med grammatiske fejl og deres "
+        "korrigerede versioner.",
+        default_prompt_template="Sætning: {text}\nKorrigeret sætning: {target_text}",
+        default_instruction_prompt="Sætning: {text}\n\nKorriger de grammatiske fejl "
+        "i sætningen og skriv den korrigerede sætning, og intet andet.",
+        default_prompt_label_mapping=dict(),
+    ),
+    ENGLISH: PromptConfig(
+        default_prompt_prefix="The following are sentences with grammatical errors "
+        "and their corrected versions.",
+        default_prompt_template="Sentence: {text}\nCorrected sentence: {target_text}",
+        default_instruction_prompt="Sentence: {text}\n\nCorrect the grammatical "
+        "errors in the sentence and write the corrected sentence, and nothing else.",
+        default_prompt_label_mapping=dict(),
+    ),
+    FAROESE: PromptConfig(
+        default_prompt_prefix="Hetta eru setningar við málvillum og teirra "
+        "rættaðu útgávur.",
+        default_prompt_template="Setningur: {text}\nRættaður setningur: {target_text}",
+        default_instruction_prompt="Setningur: {text}\n\nRætta málvillurnar í "
+        "setninginum og skriva rættaða setningin, og einki annað.",
+        default_prompt_label_mapping=dict(),
+    ),
+}

--- a/src/euroeval/tasks.py
+++ b/src/euroeval/tasks.py
@@ -8,6 +8,7 @@ from .metrics.llm_as_a_judge import create_model_graded_fact_metric
 from .prompt_templates import (
     CLASSIFICATION_TEMPLATES,
     EMPTY_TEMPLATES,
+    GEC_TEMPLATES,
     GED_TEMPLATES,
     LA_TEMPLATES,
     LOGIC_TEMPLATES,
@@ -166,6 +167,18 @@ COMMON_SENSE = Task(
 
 
 # Tasks that can be run for generative models only
+
+GEC = Task(
+    name="grammatical-error-correction",
+    task_group=TaskGroup.TEXT_TO_TEXT,
+    template_dict=GEC_TEMPLATES,
+    metrics=[m.exact_match_metric],
+    default_num_few_shot_examples=5,
+    default_max_generated_tokens=256,
+    default_labels=[],
+    default_allowed_model_types=[ModelType.GENERATIVE],
+)
+
 
 SIMPL = Task(
     name="simplification",

--- a/src/frontend/md/datasets/faroese.md
+++ b/src/frontend/md/datasets/faroese.md
@@ -689,6 +689,68 @@ You can evaluate this dataset directly as follows:
 euroeval --model <model-id> --dataset gerlangmod-fo
 ```
 
+## Grammatical Error Correction
+
+### Unofficial: Faroese Grammatical Correctness
+
+This dataset was published in [this paper](https://doi.org/10.63317/4u4i99hc8co8)
+and consists of minimal pairs of an ungrammatical Faroese sentence and its
+corrected version, compiled from high school essays. The model is given the
+ungrammatical sentence and has to generate the corrected version, which is evaluated
+against the reference correction.
+
+The original full dataset consists of 6,628 minimal pairs. We use a 1,024 / 256 / 2,048
+split for training, validation and testing, respectively, and the samples left over
+after creating these splits are stored in a `full_train` split together with the
+training samples.
+
+Here are a few examples from the training split:
+
+```json
+{
+  "text": "Suðurstatirnir høvdu 9 mió. Íbúgvar, harav vóru 3,5 mió. Trælir.",
+  "target_text": "Suðurstatirnir høvdu níggju mió. íbúgvar - harímillum 3,5 mió. trælir"
+}
+```
+
+```json
+{
+  "text": "Kvinnur ið gista sleppa at fáa gratis sálarfrøðing.",
+  "target_text": "Kvinnur, ið gista, sleppa ókeypis til sálarfrøðing."
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  Hetta eru setningar við málvillum og teirra rættaðu útgávur.
+  ```
+
+- Base prompt template:
+
+  ```text
+  Setningur: {text}
+  Rættaður setningur: {target_text}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Setningur: {text}
+
+  Rætta málvillurnar í setninginum og skriva rættaða setningin, og einki annað.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset faroese-grammatical-correctness
+```
+
 ## Logical Reasoning
 
 ### ZebraPuzzleEasy-fo

--- a/src/frontend/md/tasks/grammatical-error-correction.md
+++ b/src/frontend/md/tasks/grammatical-error-correction.md
@@ -1,0 +1,32 @@
+# Grammatical Error Correction
+
+## 📚 Overview
+
+Grammatical error correction is the task of correcting the grammatical errors in a
+given text. The model is presented with a sentence containing one or more grammatical
+errors and has to generate a corrected version of the sentence, which is evaluated
+against a reference correction. Unlike grammatical error detection, which only requires
+identifying where the errors are, this task requires the model to produce the corrected
+text itself.
+
+When evaluating generative models, we allow the model to generate 256 tokens on this
+task.
+
+## 📊 Metrics
+
+The metric used to evaluate the performance of a model on the grammatical error
+correction task is exact match, being the percentage of generated corrections that are
+identical to the reference correction. As the datasets for this task consist of minimal
+pairs, where the corrected sentence differs from the erroneous sentence by only a small
+edit, exact match is a fair and strict measure: similarity-based metrics such as chrF or
+SARI would assign high scores to a model that simply copies its input, while exact
+match only rewards producing the actual correction.
+
+## 🛠️ How to run
+
+In the command line interface of the [EuroEval Python package](/python-package), you
+can benchmark your favorite model on the grammatical error correction task like so:
+
+```bash
+euroeval --model <model-id> --task grammatical-error-correction
+```

--- a/src/scripts/dataset_creation/create_faroese_grammatical_correctness.py
+++ b/src/scripts/dataset_creation/create_faroese_grammatical_correctness.py
@@ -1,0 +1,116 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets==3.5.0",
+#     "huggingface-hub==0.24.0",
+#     "pandas==2.2.0",
+#     "scikit-learn<1.6.0",
+# ]
+# ///
+
+"""Create the Faroese Grammatical Correctness dataset and upload it to the HF Hub."""
+
+import logging
+import sys
+
+import pandas as pd
+from datasets import Dataset, DatasetDict, Split, load_dataset
+from huggingface_hub import HfApi
+from sklearn.model_selection import train_test_split
+
+logging.basicConfig(format="%(asctime)s ⋅ %(message)s", level=logging.INFO)
+logger = logging.getLogger("create_faroese_grammatical_correctness")
+
+
+def main(source: str) -> None:
+    """Create the Faroese Grammatical Correctness dataset and upload it to the HF Hub.
+
+    The source dataset consists of minimal pairs of an ungrammatical sentence and
+    its corrected version, compiled from high school essays. This is a grammatical
+    error correction dataset, where the model must correct the grammar of the
+    ungrammatical sentence, and the result is evaluated against the corrected
+    version.
+
+    Args:
+        source:
+            Path or URL to the source JSONL file.
+    """
+    dataset = load_dataset("json", data_files=source, split="train")
+    df = dataset.to_pandas()
+    assert isinstance(df, pd.DataFrame)
+
+    # Verify the schema of the source dataset
+    expected_columns = {"index_number", "original_sentence", "corrected_sentence"}
+    assert expected_columns <= set(df.columns), (
+        f"Expected columns {expected_columns}, but got {set(df.columns)}."
+    )
+    logger.info(f"Loaded {len(df)} minimal pairs from {source}.")
+
+    # Build the samples, with the ungrammatical sentence as the input text and the
+    # corrected sentence as the target text
+    records: list[dict[str, str]] = []
+    num_skipped = 0
+    for _, row in df.iterrows():
+        original = str(row.original_sentence).replace("\n", " ").strip()
+        corrected = str(row.corrected_sentence).replace("\n", " ").strip()
+        if not original or not corrected or original == corrected:
+            num_skipped += 1
+            continue
+        records.append({"text": original, "target_text": corrected})
+    new_df = pd.DataFrame(records)
+
+    if num_skipped > 0:
+        logger.warning(f"Skipped {num_skipped} malformed minimal pairs.")
+
+    # Remove duplicates
+    new_df.drop_duplicates(inplace=True)
+    new_df.reset_index(drop=True, inplace=True)
+    logger.info(f"Built {len(new_df)} samples from {len(df)} minimal pairs.")
+
+    # Create the splits: train, val and test follow the standard EuroEval sizes, and
+    # the samples left over after the test split go into the full training pool
+    train_df, remaining_df = train_test_split(
+        new_df, train_size=1_024, random_state=4242
+    )
+    val_df, remaining_df = train_test_split(
+        remaining_df, train_size=256, random_state=4242
+    )
+    test_df, leftover_df = train_test_split(
+        remaining_df, train_size=2_048, random_state=4242
+    )
+    full_train_df = pd.concat([train_df, leftover_df])
+
+    # Reset the index
+    train_df = train_df.reset_index(drop=True)
+    val_df = val_df.reset_index(drop=True)
+    test_df = test_df.reset_index(drop=True)
+    full_train_df = full_train_df.reset_index(drop=True)
+
+    logger.info(
+        f"Split sizes: train={len(train_df)}, val={len(val_df)}, "
+        f"test={len(test_df)}, full_train={len(full_train_df)}."
+    )
+
+    # Collect datasets in a dataset dictionary
+    dataset_dict = DatasetDict(
+        {
+            "train": Dataset.from_pandas(train_df, split=Split.TRAIN),
+            "val": Dataset.from_pandas(val_df, split=Split.VALIDATION),
+            "test": Dataset.from_pandas(test_df, split=Split.TEST),
+            "full_train": Dataset.from_pandas(full_train_df, split="full_train"),  # ty: ignore[invalid-argument-type]
+        }
+    )
+
+    dataset_id = "EuroEval/faroese-grammatical-correctness"
+
+    # Remove the dataset from Hugging Face Hub if it already exists
+    HfApi().delete_repo(dataset_id, repo_type="dataset", missing_ok=True)
+
+    # Push the dataset to the Hugging Face Hub
+    dataset_dict.push_to_hub(dataset_id, private=True)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit(f"Usage: {sys.argv[0]} <path-or-url-to-jsonl>")
+    main(source=sys.argv[1])


### PR DESCRIPTION
## What

Added a new grammatical error correction (GEC) task and the
faroese-grammatical-correctness dataset from
this paper, following #2045

## Key features

- New grammatical-error-correction task: the model is given a sentence with grammatical errors and generates the corrected version (text-to-text)
- New generic exact_match metric fitting the text-to-text task group — the existing em_metric is tied to the SQuAD QA format and normalises casing and punctuation, which are part of what this task tests
- Prompt templates for Danish, English and Faroese, plus a task documentation page
- 6,628 minimal pairs from high school essays, split 1,024 / 256 / 2,048, with leftovers kept in a full_train split
- Includes creation script, documentation section and changelog entry