### PR TITLE
feat: swap official dataset mmlu-fr -> include-fr, multiloko-fr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Swapped official dataset for French:
+`mmlu-fr` → `include-fr`, `multiloko-fr`.
+
 - Bumped minimum `transformers` version to 5.14.0 (required for XLMRoberta/Camembert
   `ForMultipleChoice` heads; see huggingface/transformers#47147).
 - Swapped official datasets for four languages (all performed by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Swapped official dataset for French:
 `mmlu-fr` → `include-fr`, `multiloko-fr`.
 
+- Swapped official dataset for French:
+`mmlu-fr` → `include-fr`, `multiloko-fr`.
+
 - Bumped minimum `transformers` version to 5.14.0 (required for XLMRoberta/Camembert
   `ForMultipleChoice` heads; see huggingface/transformers#47147).
 - Swapped official datasets for four languages (all performed by the

--- a/src/euroeval/dataset_configs/french.py
+++ b/src/euroeval/dataset_configs/french.py
@@ -100,15 +100,33 @@ RAGTRUTH_FR_CONFIG = DatasetConfig(
 )
 
 
+INCLUDE_FR_CONFIG = DatasetConfig(
+    name="include-fr",
+    pretty_name="INCLUDE-fr",
+    source="EuroEval/include-fr-mini",
+    task=KNOW,
+    languages=[FRENCH],
+)
+
+MULTILOKO_FR_CONFIG = DatasetConfig(
+    name="multiloko-fr",
+    pretty_name="MultiLoKo-fr",
+    source="EuroEval/multiloko-fr-mini",
+    task=KNOW,
+    languages=[FRENCH],
+    val_split=None,
+)
+
+# Unofficial datasets ###
+
 MMLU_FR_CONFIG = DatasetConfig(
     name="mmlu-fr",
     pretty_name="MMLU-fr",
     source="EuroEval/mmlu-fr-mini",
     task=KNOW,
     languages=[FRENCH],
+    unofficial=True,
 )
-
-# Unofficial datasets ###
 
 MULTI_IFEVAL_FR_CONFIG = DatasetConfig(
     name="multi-ifeval-fr",
@@ -164,24 +182,5 @@ MULTINRC_FR_CONFIG = DatasetConfig(
     source="EuroEval/multinrc-fr",
     task=KNOW,
     languages=[FRENCH],
-    unofficial=True,
-)
-
-INCLUDE_FR_CONFIG = DatasetConfig(
-    name="include-fr",
-    pretty_name="INCLUDE-fr",
-    source="EuroEval/include-fr-mini",
-    task=KNOW,
-    languages=[FRENCH],
-    unofficial=True,
-)
-
-MULTILOKO_FR_CONFIG = DatasetConfig(
-    name="multiloko-fr",
-    pretty_name="MultiLoKo-fr",
-    source="EuroEval/multiloko-fr-mini",
-    task=KNOW,
-    languages=[FRENCH],
-    val_split=None,
     unofficial=True,
 )

--- a/src/frontend/md/datasets/french.md
+++ b/src/frontend/md/datasets/french.md
@@ -477,7 +477,7 @@ euroeval --model <model-id> --dataset multi-wiki-qa-fr
 
 ## Knowledge
 
-### Unofficial: INCLUDE-fr
+### INCLUDE-fr
 
 > This dataset is **unofficial** — results do not count toward the French leaderboard.
 
@@ -543,7 +543,7 @@ You can evaluate this dataset directly as follows:
 euroeval --model <model-id> --dataset include-fr
 ```
 
-### Unofficial: MultiLoKo-fr
+### MultiLoKo-fr
 
 > This dataset is **unofficial** — results do not count toward the French leaderboard.
 
@@ -606,7 +606,7 @@ You can evaluate this dataset directly as follows:
 euroeval --model <model-id> --dataset multiloko-fr
 ```
 
-### MMLU-fr
+### Unofficial: MMLU-fr
 
 This dataset is a machine translated version of the English
 [MMLU dataset](https://openreview.net/forum?id=d7KBjmI3GmQ) and features questions


### PR DESCRIPTION
Swaps the official dataset `mmlu-fr` for `include-fr`, `multiloko-fr`.

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `include-fr`, `multiloko-fr`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `mmlu-fr` is demoted to unofficial and `include-fr`, `multiloko-fr` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.