### PR TITLE
feat: swap official dataset hellaswag-de -> winogrande-de

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,17 +27,12 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Swapped official dataset for German:
-`hellaswag-de` → `winogrande-de`.
-
 - Bumped minimum `transformers` version to 5.14.0 (required for XLMRoberta/Camembert
   `ForMultipleChoice` heads; see huggingface/transformers#47147).
 - Swapped official datasets for four languages (all performed by the
   `swap_leaderboard_dataset.py` script, which now automatically updates this changelog):
   - Croatian: `mmlu-hr` → `include-hr`
-  - Dutch: `scala-nl` → `dutch-cola`
-  - Dutch: `mmlu-nl` → `include-nl`, `multiloko-nl`
-  - Dutch: `hellaswag-nl` → `winogrande-nl`
+  - German: `hellaswag-de` → `winogrande-de`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Swapped official dataset for German:
+`hellaswag-de` → `winogrande-de`.
+
 - Bumped minimum `transformers` version to 5.14.0 (required for XLMRoberta/Camembert
   `ForMultipleChoice` heads; see huggingface/transformers#47147).
 - Swapped official datasets for four languages (all performed by the

--- a/src/euroeval/dataset_configs/german.py
+++ b/src/euroeval/dataset_configs/german.py
@@ -68,14 +68,6 @@ MMLU_DE_CONFIG = DatasetConfig(
     languages=[GERMAN],
 )
 
-HELLASWAG_DE_CONFIG = DatasetConfig(
-    name="hellaswag-de",
-    pretty_name="HellaSwag-de",
-    source="EuroEval/hellaswag-de-mini",
-    task=COMMON_SENSE,
-    languages=[GERMAN],
-)
-
 MULTI_IFEVAL_DE_CONFIG = DatasetConfig(
     name="multi-ifeval-de",
     pretty_name="MultiIFEval-de",
@@ -116,7 +108,25 @@ RAGTRUTH_DE_CONFIG = DatasetConfig(
 )
 
 
+WINOGRANDE_DE_CONFIG = DatasetConfig(
+    name="winogrande-de",
+    pretty_name="Winogrande-de",
+    source="EuroEval/winogrande-de",
+    task=COMMON_SENSE,
+    languages=[GERMAN],
+    labels=["a", "b"],
+)
+
 # Unofficial datasets ###
+
+HELLASWAG_DE_CONFIG = DatasetConfig(
+    name="hellaswag-de",
+    pretty_name="HellaSwag-de",
+    source="EuroEval/hellaswag-de-mini",
+    task=COMMON_SENSE,
+    languages=[GERMAN],
+    unofficial=True,
+)
 
 IFEVAL_DE_CONFIG = DatasetConfig(
     name="ifeval-de",
@@ -171,16 +181,6 @@ GOLDENSWAG_DE_CONFIG = DatasetConfig(
     source="EuroEval/goldenswag-de-mini",
     task=COMMON_SENSE,
     languages=[GERMAN],
-    unofficial=True,
-)
-
-WINOGRANDE_DE_CONFIG = DatasetConfig(
-    name="winogrande-de",
-    pretty_name="Winogrande-de",
-    source="EuroEval/winogrande-de",
-    task=COMMON_SENSE,
-    languages=[GERMAN],
-    labels=["a", "b"],
     unofficial=True,
 )
 

--- a/src/frontend/md/datasets/german.md
+++ b/src/frontend/md/datasets/german.md
@@ -831,7 +831,77 @@ euroeval --model <model-id> --dataset multiloko-de
 
 ## Common-sense Reasoning
 
-### HellaSwag-de
+### Winogrande-de
+
+This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2506.19468)
+and is a translated and filtered version of the English
+[Winogrande dataset](https://doi.org/10.1145/3474381).
+
+The original full dataset consists of 47 / 1,210 samples for training and testing, and
+we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
+training, validation and testing, respectively.
+
+Here are a few examples from the training split:
+
+```json
+{
+  "text": "Einmal in Polen genoss Dennis die Reise mehr als Jason, weil _ ein tieferes Verständnis der polnischen Sprache hatte. Worauf bezieht sich der leere _?\nAntwortmöglichkeiten:\na. Dennis\nb. Jason",
+  "label": "a"
+}
+```
+
+```json
+{
+  "text": "Johns Zertifizierung war weniger wichtig als Jims Abschluss, weil die _ von einer unbedeutenden Universität war. Worauf bezieht sich der leere _?\nAntwortmöglichkeiten:\na. Zertifizierung\nb. Abschluss",
+  "label": "a"
+}
+```
+
+```json
+{
+  "text": "Um Verhaltensverzerrungen zu überwinden, müssen wir uns mehr darauf konzentrieren, die bewussten Handlungen zu ändern, anstatt die unbewussten Handlungen, weil die _ Handlungen freiwillig sind. Worauf bezieht sich der leere _?\nAntwortmöglichkeiten:\na. unbewusst\nb. bewusst",
+  "label": "b"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  Die folgenden Fragen sind Multiple-Choice-Fragen (mit Antworten).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Frage: {text}
+  Antwortmöglichkeiten:
+  a. {option_a}
+  b. {option_b}
+  Antwort: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Frage: {text}
+  Antwortmöglichkeiten:
+  a. {option_a}
+  b. {option_b}
+
+  Beantworten Sie die obige Frage mit 'a' oder 'b', und nichts anderes.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset winogrande-de
+```
+
+### Unofficial: HellaSwag-de
 
 This dataset is a machine translated version of the English
 [HellaSwag dataset](https://aclanthology.org/P19-1472/). The original dataset was based
@@ -982,76 +1052,6 @@ You can evaluate this dataset directly as follows:
 
 ```bash
 euroeval --model <model-id> --dataset goldenswag-de
-```
-
-### Unofficial: Winogrande-de
-
-This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2506.19468)
-and is a translated and filtered version of the English
-[Winogrande dataset](https://doi.org/10.1145/3474381).
-
-The original full dataset consists of 47 / 1,210 samples for training and testing, and
-we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
-training, validation and testing, respectively.
-
-Here are a few examples from the training split:
-
-```json
-{
-  "text": "Einmal in Polen genoss Dennis die Reise mehr als Jason, weil _ ein tieferes Verständnis der polnischen Sprache hatte. Worauf bezieht sich der leere _?\nAntwortmöglichkeiten:\na. Dennis\nb. Jason",
-  "label": "a"
-}
-```
-
-```json
-{
-  "text": "Johns Zertifizierung war weniger wichtig als Jims Abschluss, weil die _ von einer unbedeutenden Universität war. Worauf bezieht sich der leere _?\nAntwortmöglichkeiten:\na. Zertifizierung\nb. Abschluss",
-  "label": "a"
-}
-```
-
-```json
-{
-  "text": "Um Verhaltensverzerrungen zu überwinden, müssen wir uns mehr darauf konzentrieren, die bewussten Handlungen zu ändern, anstatt die unbewussten Handlungen, weil die _ Handlungen freiwillig sind. Worauf bezieht sich der leere _?\nAntwortmöglichkeiten:\na. unbewusst\nb. bewusst",
-  "label": "b"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 5
-- Prefix prompt:
-
-  ```text
-  Die folgenden Fragen sind Multiple-Choice-Fragen (mit Antworten).
-  ```
-
-- Base prompt template:
-
-  ```text
-  Frage: {text}
-  Antwortmöglichkeiten:
-  a. {option_a}
-  b. {option_b}
-  Antwort: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Frage: {text}
-  Antwortmöglichkeiten:
-  a. {option_a}
-  b. {option_b}
-
-  Beantworten Sie die obige Frage mit 'a' oder 'b', und nichts anderes.
-  ```
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset winogrande-de
 ```
 
 ## Summarisation


### PR DESCRIPTION
Swaps the official dataset `hellaswag-de` for `winogrande-de`.

## What
- Every model with a rank score on the affected leaderboard(s) was evaluated on `winogrande-de`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `hellaswag-de` is demoted to unofficial and `winogrande-de` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.