### PR TITLE
fix: OLMo-3 rope_parameters compatibility with vLLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   the top-level `rope_theta` and `rope_scaling` fields into the nested structure
   expected by vLLM's `olmo2.py` implementation.
 
-
 ## [v17.7.0] - 2026-07-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   parallel size. This fixes evaluation failures for models like SmolLM series (9/15
   heads) on multi-GPU setups, which previously raised errors like "Total number of
   attention heads (X) must be divisible by tensor parallel size (Y)".
+- Fixed `KeyError: 'rope_theta'` when loading OLMo-3 models (e.g. `allenai/Olmo-3-1125-32B`)
+  with vLLM. The model config now includes a `rope_parameters` override that converts
+  the top-level `rope_theta` and `rope_scaling` fields into the nested structure
+  expected by vLLM's `olmo2.py` implementation.
 
 
 ## [v17.7.0] - 2026-07-22

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -1513,7 +1513,7 @@ def load_model(
 
     clear_vllm()
 
-    hf_overrides: dict[str, list[str]] = {}
+    hf_overrides: dict[str, t.Any] = {}
     if hf_model_config.architectures:
         remapped = [
             _ARCHITECTURE_ALIASES.get(arch, arch)
@@ -1527,6 +1527,39 @@ def load_model(
             )
             hf_model_config.architectures = remapped
             hf_overrides["architectures"] = remapped
+
+    # OLMo-3 models have rope_theta and rope_scaling at the top level of config.json,
+    # but vLLM's olmo2.py implementation expects them nested in rope_parameters.
+    # Construct the rope_parameters override for OLMo-3 models.
+    is_olmo3 = hf_model_config.model_type == "olmo3" or (
+        hf_model_config.architectures
+        and "Olmo3ForCausalLM" in hf_model_config.architectures
+    )
+    if is_olmo3 and not getattr(hf_model_config, "rope_parameters", None):
+        rope_theta = getattr(hf_model_config, "rope_theta", 10000)
+        rope_scaling = getattr(hf_model_config, "rope_scaling", None) or {}
+        rope_parameters: dict[str, t.Any] = {
+            "rope_theta": rope_theta,
+            "rope_type": rope_scaling.get("rope_type", "default"),
+        }
+        # Add optional RoPE scaling parameters if present
+        for key in [
+            "factor",
+            "original_max_position_embeddings",
+            "attention_factor",
+            "beta_fast",
+            "beta_slow",
+            "short_factor",
+            "long_factor",
+        ]:
+            if key in rope_scaling:
+                rope_parameters[key] = rope_scaling[key]
+        log_once(
+            f"Adding rope_parameters override for OLMo-3 model {model_id!r}: "
+            f"{rope_parameters!r}",
+            level=logging.DEBUG,
+        )
+        hf_overrides["rope_parameters"] = rope_parameters
 
     distributed_executor_backend, tensor_parallel_size, pipeline_parallel_size = (
         select_backend_and_parallelism(force_single_gpu=False)

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -1382,8 +1382,7 @@ class VLLMModel(HuggingFaceEncoderModel):
 
 
 def _get_olmo3_rope_parameters(
-    model_id: str,
-    hf_model_config: "PretrainedConfig",
+    model_id: str, hf_model_config: "PretrainedConfig"
 ) -> dict[str, str | int | float] | None:
     """Build rope_parameters override for OLMo-3 models.
 
@@ -1580,6 +1579,7 @@ def load_model(
             hf_model_config.architectures = remapped
             hf_overrides["architectures"] = remapped
 
+    # TODO: Remove this block when we don't care about OLMo-3 anymore
     olmo3_rope_parameters = _get_olmo3_rope_parameters(
         model_id=model_id, hf_model_config=hf_model_config
     )

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -1381,6 +1381,58 @@ class VLLMModel(HuggingFaceEncoderModel):
         )
 
 
+def _get_olmo3_rope_parameters(
+    model_id: str,
+    hf_model_config: "PretrainedConfig",
+) -> dict[str, str | int | float] | None:
+    """Build rope_parameters override for OLMo-3 models.
+
+    OLMo-3 models store rope_theta and rope_scaling at the top level of config.json,
+    but vLLM's olmo2.py implementation expects them nested in rope_parameters.
+
+    Args:
+        model_id:
+            The model identifier.
+        hf_model_config:
+            The Hugging Face model configuration.
+
+    Returns:
+        A rope_parameters dict if the model is OLMo-3 and lacks existing
+        rope_parameters; otherwise None.
+    """
+    is_olmo3 = hf_model_config.model_type == "olmo3" or (
+        hf_model_config.architectures
+        and "Olmo3ForCausalLM" in hf_model_config.architectures
+    )
+    if not is_olmo3 or getattr(hf_model_config, "rope_parameters", None):
+        return None
+
+    rope_theta = getattr(hf_model_config, "rope_theta", 10000)
+    rope_scaling = getattr(hf_model_config, "rope_scaling", None) or {}
+    rope_parameters: dict[str, str | int | float] = {
+        "rope_theta": rope_theta,
+        "rope_type": rope_scaling.get("rope_type", "default"),
+    }
+    for key in [
+        "factor",
+        "original_max_position_embeddings",
+        "attention_factor",
+        "beta_fast",
+        "beta_slow",
+        "short_factor",
+        "long_factor",
+    ]:
+        if key in rope_scaling:
+            rope_parameters[key] = rope_scaling[key]
+
+    log_once(
+        f"Adding rope_parameters override for OLMo-3 model {model_id!r}: "
+        f"{rope_parameters!r}",
+        level=logging.DEBUG,
+    )
+    return rope_parameters
+
+
 def load_model(
     model_config: "ModelConfig",
     benchmark_config: "BenchmarkConfig",
@@ -1513,7 +1565,7 @@ def load_model(
 
     clear_vllm()
 
-    hf_overrides: dict[str, t.Any] = {}
+    hf_overrides: dict[str, dict[str, str | int | float] | list[str]] = {}
     if hf_model_config.architectures:
         remapped = [
             _ARCHITECTURE_ALIASES.get(arch, arch)
@@ -1528,38 +1580,11 @@ def load_model(
             hf_model_config.architectures = remapped
             hf_overrides["architectures"] = remapped
 
-    # OLMo-3 models have rope_theta and rope_scaling at the top level of config.json,
-    # but vLLM's olmo2.py implementation expects them nested in rope_parameters.
-    # Construct the rope_parameters override for OLMo-3 models.
-    is_olmo3 = hf_model_config.model_type == "olmo3" or (
-        hf_model_config.architectures
-        and "Olmo3ForCausalLM" in hf_model_config.architectures
+    olmo3_rope_parameters = _get_olmo3_rope_parameters(
+        model_id=model_id, hf_model_config=hf_model_config
     )
-    if is_olmo3 and not getattr(hf_model_config, "rope_parameters", None):
-        rope_theta = getattr(hf_model_config, "rope_theta", 10000)
-        rope_scaling = getattr(hf_model_config, "rope_scaling", None) or {}
-        rope_parameters: dict[str, t.Any] = {
-            "rope_theta": rope_theta,
-            "rope_type": rope_scaling.get("rope_type", "default"),
-        }
-        # Add optional RoPE scaling parameters if present
-        for key in [
-            "factor",
-            "original_max_position_embeddings",
-            "attention_factor",
-            "beta_fast",
-            "beta_slow",
-            "short_factor",
-            "long_factor",
-        ]:
-            if key in rope_scaling:
-                rope_parameters[key] = rope_scaling[key]
-        log_once(
-            f"Adding rope_parameters override for OLMo-3 model {model_id!r}: "
-            f"{rope_parameters!r}",
-            level=logging.DEBUG,
-        )
-        hf_overrides["rope_parameters"] = rope_parameters
+    if olmo3_rope_parameters is not None:
+        hf_overrides["rope_parameters"] = olmo3_rope_parameters
 
     distributed_executor_backend, tensor_parallel_size, pipeline_parallel_size = (
         select_backend_and_parallelism(force_single_gpu=False)

--- a/src/frontend/md/datasets/french.md
+++ b/src/frontend/md/datasets/french.md
@@ -555,7 +555,6 @@ You can evaluate this dataset directly as follows:
 euroeval --model <model-id> --dataset mmlu-fr
 ```
 
-
 ### Unofficial: INCLUDE-fr
 
 > This dataset is **unofficial** — results do not count toward the French leaderboard.

--- a/tests/test_benchmark_modules/test_vllm.py
+++ b/tests/test_benchmark_modules/test_vllm.py
@@ -1035,3 +1035,258 @@ class TestIsMistralTokeniserModel:
         assert not _is_mistral_tokeniser_model(
             model_id="gordicaleksa/SlovenianGPT", hf_model_config=config
         )
+
+
+class TestOlmo3RopeParameters:
+    """Tests for the OLMo-3 rope_parameters override fix."""
+
+    def test_olmo3_model_gets_rope_parameters_override(
+        self, model_config: ModelConfig, benchmark_config: BenchmarkConfig
+    ) -> None:
+        """Test that OLMo-3 models receive a rope_parameters override.
+
+        OLMo-3 models have rope_theta and rope_scaling at the top level of
+        config.json, but vLLM's olmo2.py implementation expects them nested in
+        rope_parameters. This test verifies the fix in load_model() constructs
+        the correct override.
+        """
+        mock_llm_instance = MagicMock()
+        mock_hf_model_config = MagicMock(
+            spec=["dtype", "architectures", "model_type", "rope_theta", "rope_scaling"]
+        )
+        mock_hf_model_config.dtype = torch.bfloat16
+        mock_hf_model_config.model_type = "olmo3"
+        mock_hf_model_config.architectures = ["Olmo3ForCausalLM"]
+        mock_hf_model_config.rope_theta = 500000
+        mock_hf_model_config.rope_scaling = {
+            "rope_type": "yarn",
+            "factor": 8.0,
+            "original_max_position_embeddings": 8192,
+            "attention_factor": 1.2079441541679836,
+            "beta_fast": 32.0,
+            "beta_slow": 1.0,
+        }
+        mock_tokeniser = MagicMock()
+
+        mock_vllm_module = MagicMock()
+        mock_vllm_module.config = MagicMock(spec=[])
+
+        with (
+            patch(
+                "euroeval.benchmark_modules.vllm.LLM",
+                return_value=mock_llm_instance,
+                create=True,
+            ) as mock_llm_cls,
+            patch(
+                "euroeval.benchmark_modules.vllm.vllm",
+                new=mock_vllm_module,
+                create=True,
+            ),
+            patch("euroeval.benchmark_modules.vllm.clear_vllm"),
+            patch(
+                "euroeval.benchmark_modules.vllm.select_backend_and_parallelism",
+                return_value=("mp", 1, 1),
+            ),
+            patch(
+                "euroeval.benchmark_modules.vllm.internet_connection_available",
+                return_value=True,
+            ),
+            patch(
+                "euroeval.benchmark_modules.vllm.get_vllm_tokenisation_params",
+                return_value={},
+            ),
+        ):
+            load_model(
+                model_config=model_config,
+                benchmark_config=benchmark_config,
+                attention_backend=None,
+                generative_type=GenerativeType.INSTRUCTION_TUNED,
+                true_max_model_len=65536,
+                tokeniser=mock_tokeniser,
+                hf_model_config=mock_hf_model_config,
+            )
+
+        mock_llm_cls.assert_called_once()
+        call_kwargs = mock_llm_cls.call_args.kwargs
+        assert "hf_overrides" in call_kwargs
+        assert "rope_parameters" in call_kwargs["hf_overrides"]
+        rope_params = call_kwargs["hf_overrides"]["rope_parameters"]
+        assert rope_params["rope_theta"] == 500000
+        assert rope_params["rope_type"] == "yarn"
+        assert rope_params["factor"] == 8.0
+        assert rope_params["original_max_position_embeddings"] == 8192
+        assert rope_params["attention_factor"] == 1.2079441541679836
+        assert rope_params["beta_fast"] == 32.0
+        assert rope_params["beta_slow"] == 1.0
+
+    def test_olmo3_model_by_architecture_only(
+        self, model_config: ModelConfig, benchmark_config: BenchmarkConfig
+    ) -> None:
+        """Test OLMo-3 detection by architecture name alone."""
+        mock_llm_instance = MagicMock()
+        mock_hf_model_config = MagicMock(
+            spec=["dtype", "architectures", "model_type", "rope_theta", "rope_scaling"]
+        )
+        mock_hf_model_config.dtype = torch.bfloat16
+        mock_hf_model_config.model_type = "olmo3"
+        mock_hf_model_config.architectures = ["Olmo3ForCausalLM"]
+        mock_hf_model_config.rope_theta = 10000
+        mock_hf_model_config.rope_scaling = None
+        mock_tokeniser = MagicMock()
+
+        mock_vllm_module = MagicMock()
+        mock_vllm_module.config = MagicMock(spec=[])
+
+        with (
+            patch(
+                "euroeval.benchmark_modules.vllm.LLM",
+                return_value=mock_llm_instance,
+                create=True,
+            ) as mock_llm_cls,
+            patch(
+                "euroeval.benchmark_modules.vllm.vllm",
+                new=mock_vllm_module,
+                create=True,
+            ),
+            patch("euroeval.benchmark_modules.vllm.clear_vllm"),
+            patch(
+                "euroeval.benchmark_modules.vllm.select_backend_and_parallelism",
+                return_value=("mp", 1, 1),
+            ),
+            patch(
+                "euroeval.benchmark_modules.vllm.internet_connection_available",
+                return_value=True,
+            ),
+            patch(
+                "euroeval.benchmark_modules.vllm.get_vllm_tokenisation_params",
+                return_value={},
+            ),
+        ):
+            load_model(
+                model_config=model_config,
+                benchmark_config=benchmark_config,
+                attention_backend=None,
+                generative_type=GenerativeType.INSTRUCTION_TUNED,
+                true_max_model_len=8192,
+                tokeniser=mock_tokeniser,
+                hf_model_config=mock_hf_model_config,
+            )
+
+        call_kwargs = mock_llm_cls.call_args.kwargs
+        rope_params = call_kwargs["hf_overrides"]["rope_parameters"]
+        assert rope_params["rope_theta"] == 10000
+        assert rope_params["rope_type"] == "default"
+
+    def test_non_olmo3_model_no_rope_parameters_override(
+        self, model_config: ModelConfig, benchmark_config: BenchmarkConfig
+    ) -> None:
+        """Test that non-OLMo-3 models don't get rope_parameters override."""
+        mock_llm_instance = MagicMock()
+        mock_hf_model_config = MagicMock(spec=["dtype", "architectures", "model_type"])
+        mock_hf_model_config.dtype = torch.float16
+        mock_hf_model_config.model_type = "llama"
+        mock_hf_model_config.architectures = ["LlamaForCausalLM"]
+        mock_tokeniser = MagicMock()
+
+        mock_vllm_module = MagicMock()
+        mock_vllm_module.config = MagicMock(spec=[])
+
+        with (
+            patch(
+                "euroeval.benchmark_modules.vllm.LLM",
+                return_value=mock_llm_instance,
+                create=True,
+            ) as mock_llm_cls,
+            patch(
+                "euroeval.benchmark_modules.vllm.vllm",
+                new=mock_vllm_module,
+                create=True,
+            ),
+            patch("euroeval.benchmark_modules.vllm.clear_vllm"),
+            patch(
+                "euroeval.benchmark_modules.vllm.select_backend_and_parallelism",
+                return_value=("mp", 1, 1),
+            ),
+            patch(
+                "euroeval.benchmark_modules.vllm.internet_connection_available",
+                return_value=True,
+            ),
+            patch(
+                "euroeval.benchmark_modules.vllm.get_vllm_tokenisation_params",
+                return_value={},
+            ),
+        ):
+            load_model(
+                model_config=model_config,
+                benchmark_config=benchmark_config,
+                attention_backend=None,
+                generative_type=GenerativeType.INSTRUCTION_TUNED,
+                true_max_model_len=4096,
+                tokeniser=mock_tokeniser,
+                hf_model_config=mock_hf_model_config,
+            )
+
+        call_kwargs = mock_llm_cls.call_args.kwargs
+        # hf_overrides should be empty or not contain rope_parameters
+        hf_overrides = call_kwargs.get("hf_overrides", {})
+        assert "rope_parameters" not in hf_overrides
+
+    def test_olmo3_with_existing_rope_parameters_not_overridden(
+        self, model_config: ModelConfig, benchmark_config: BenchmarkConfig
+    ) -> None:
+        """Test that OLMo-3 models with existing rope_parameters are not overridden."""
+        mock_llm_instance = MagicMock()
+        mock_hf_model_config = MagicMock(
+            spec=["dtype", "architectures", "model_type", "rope_parameters"]
+        )
+        mock_hf_model_config.dtype = torch.bfloat16
+        mock_hf_model_config.model_type = "olmo3"
+        mock_hf_model_config.architectures = ["Olmo3ForCausalLM"]
+        mock_hf_model_config.rope_parameters = {
+            "rope_theta": 999999,
+            "rope_type": "custom",
+        }
+        mock_tokeniser = MagicMock()
+
+        mock_vllm_module = MagicMock()
+        mock_vllm_module.config = MagicMock(spec=[])
+
+        with (
+            patch(
+                "euroeval.benchmark_modules.vllm.LLM",
+                return_value=mock_llm_instance,
+                create=True,
+            ) as mock_llm_cls,
+            patch(
+                "euroeval.benchmark_modules.vllm.vllm",
+                new=mock_vllm_module,
+                create=True,
+            ),
+            patch("euroeval.benchmark_modules.vllm.clear_vllm"),
+            patch(
+                "euroeval.benchmark_modules.vllm.select_backend_and_parallelism",
+                return_value=("mp", 1, 1),
+            ),
+            patch(
+                "euroeval.benchmark_modules.vllm.internet_connection_available",
+                return_value=True,
+            ),
+            patch(
+                "euroeval.benchmark_modules.vllm.get_vllm_tokenisation_params",
+                return_value={},
+            ),
+        ):
+            load_model(
+                model_config=model_config,
+                benchmark_config=benchmark_config,
+                attention_backend=None,
+                generative_type=GenerativeType.INSTRUCTION_TUNED,
+                true_max_model_len=8192,
+                tokeniser=mock_tokeniser,
+                hf_model_config=mock_hf_model_config,
+            )
+
+        call_kwargs = mock_llm_cls.call_args.kwargs
+        hf_overrides = call_kwargs.get("hf_overrides", {})
+        # Should not override if rope_parameters already exists
+        assert "rope_parameters" not in hf_overrides


### PR DESCRIPTION
## What

Fixes `KeyError: 'rope_theta'` when loading OLMo-3 models (e.g. `allenai/Olmo-3-1125-32B`, `allenai/Olmo-3-7B-Instruct-DPO`) with vLLM.

## Key features

- Automatically constructs `rope_parameters` override for OLMo-3 models from top-level `rope_theta` and `rope_scaling` config fields
- Detects OLMo-3 models by `model_type == "olmo3"` or architecture name `Olmo3ForCausalLM`
- Adds 4 regression tests covering OLMo-3 detection and override behavior

## Examples

Before this fix, running EuroEval on OLMo-3 models failed immediately:

```
KeyError: 'rope_theta'
  File ".../vllm/model_executor/models/olmo2.py", line 144
    rope_theta = self.config.rope_parameters["rope_theta"]
```

After this fix, OLMo-3 models load successfully:

```bash
euroeval --model allenai/Olmo-3-1125-32B --dataset ...
```

## Why it helps

OLMo-3 models store RoPE configuration at the top level of config.json, but vLLM's olmo2.py implementation expects them nested in a `rope_parameters` dict. This fix bridges the gap by constructing the expected structure automatically.