### PR TITLE
fix(bucket_sync): preserve existing JSONL records in merge_results

### DIFF
--- a/src/leaderboards/bucket_sync.py
+++ b/src/leaderboards/bucket_sync.py
@@ -300,29 +300,24 @@ def merge_results(results_file: Path) -> int:
     # PHASE 1: Read existing records from the JSONL file (if it exists)
     # This preserves results that haven't been synced to the tree yet
     if results_file.exists():
-        logger.info("Reading existing records from %s...", results_file)
-        try:
-            with results_file.open("r", encoding="utf-8") as f:
-                for line in f:
-                    if not line.strip():
-                        continue
-                    try:
-                        record = json.loads(line)
-                        identity = identity_from_eee_record(record)
-                        if identity not in existing:
-                            existing[identity] = record
-                        else:
-                            # Deduplicate: keep newer record (tree records in Phase 2
-                            # will override via dedup_newer_record)
-                            existing[identity] = dedup_newer_record(
-                                existing[identity], record
-                            )
-                    except (json.JSONDecodeError, ValueError, KeyError, TypeError):
-                        pass  # Skip invalid lines (TypeError from normalise_bool_value)
-        except Exception as e:
-            # Fail fast: don't overwrite JSONL if we can't read existing records
-            logger.error("Could not read existing JSONL file: %s", e)
-            return 0
+        logger.info(f"Reading existing records from {results_file}...")
+        with results_file.open("r", encoding="utf-8") as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                try:
+                    record = json.loads(line)
+                    identity = identity_from_eee_record(record)
+                    if identity not in existing:
+                        existing[identity] = record
+                    else:
+                        # Deduplicate: keep newer record (tree records in Phase 2
+                        # will override via dedup_newer_record)
+                        existing[identity] = dedup_newer_record(
+                            existing[identity], record
+                        )
+                except (json.JSONDecodeError, ValueError, KeyError, TypeError):
+                    pass  # Skip invalid lines (TypeError from normalise_bool_value)
 
     # Remove empty JSON files before processing
     remove_empty_json_files(RESULTS_DIR)

--- a/src/leaderboards/bucket_sync.py
+++ b/src/leaderboards/bucket_sync.py
@@ -311,12 +311,18 @@ def merge_results(results_file: Path) -> int:
                         identity = identity_from_eee_record(record)
                         if identity not in existing:
                             existing[identity] = record
-                        # Note: we keep the existing record, tree records will
-                        # override if newer (Phase 2)
-                    except (json.JSONDecodeError, ValueError, KeyError):
-                        pass  # Skip invalid lines
+                        else:
+                            # Deduplicate: keep newer record (tree records in Phase 2
+                            # will override via dedup_newer_record)
+                            existing[identity] = dedup_newer_record(
+                                existing[identity], record
+                            )
+                    except (json.JSONDecodeError, ValueError, KeyError, TypeError):
+                        pass  # Skip invalid lines (TypeError from normalise_bool_value)
         except Exception as e:
-            logger.warning("Could not read existing JSONL file: %s", e)
+            # Fail fast: don't overwrite JSONL if we can't read existing records
+            logger.error("Could not read existing JSONL file: %s", e)
+            return 0
 
     # Remove empty JSON files before processing
     remove_empty_json_files(RESULTS_DIR)

--- a/src/leaderboards/bucket_sync.py
+++ b/src/leaderboards/bucket_sync.py
@@ -282,10 +282,11 @@ def _sort_key(record: dict) -> tuple[str, str]:
 def merge_results(results_file: Path) -> int:
     """Merge per-record JSON tree into a single JSONL file.
 
-    Reads all ``results/*/*.json`` files and writes a deduplicated JSONL file.
-    Deduplication uses canonical result identity
-    ``(model_id, dataset, validation_split, few_shot)`` with newer records
-    winning based on ``eval_library.version`` and ``retrieved_timestamp``.
+    Reads all ``results/*/*.json`` files and existing records from the JSONL
+    file itself, then writes a deduplicated JSONL file. Deduplication uses
+    canonical result identity ``(model_id, dataset, validation_split, few_shot)``
+    with newer records winning based on ``eval_library.version`` and
+    ``retrieved_timestamp``.
 
     Args:
         results_file:
@@ -296,10 +297,31 @@ def merge_results(results_file: Path) -> int:
     """
     existing: dict[ResultIdentity, dict] = {}
 
+    # PHASE 1: Read existing records from the JSONL file (if it exists)
+    # This preserves results that haven't been synced to the tree yet
+    if results_file.exists():
+        logger.info("Reading existing records from %s...", results_file)
+        try:
+            with results_file.open("r", encoding="utf-8") as f:
+                for line in f:
+                    if not line.strip():
+                        continue
+                    try:
+                        record = json.loads(line)
+                        identity = identity_from_eee_record(record)
+                        if identity not in existing:
+                            existing[identity] = record
+                        # Note: we keep the existing record, tree records will
+                        # override if newer (Phase 2)
+                    except (json.JSONDecodeError, ValueError, KeyError):
+                        pass  # Skip invalid lines
+        except Exception as e:
+            logger.warning("Could not read existing JSONL file: %s", e)
+
     # Remove empty JSON files before processing
     remove_empty_json_files(RESULTS_DIR)
 
-    # Read all record files from the tree
+    # PHASE 2: Read all record files from the tree (these override existing)
     if RESULTS_DIR.exists():
         for record_file in RESULTS_DIR.rglob("*.json"):
             if not record_file.is_file():

--- a/src/leaderboards/bucket_sync.py
+++ b/src/leaderboards/bucket_sync.py
@@ -185,7 +185,9 @@ def sync_bucket(ignore_sizes: bool = False, delete_empty: bool = True) -> None:
 
             if local_identity == bucket_identity:
                 # Same identity - keep the newer record
-                winner = dedup_newer_record(local_record, bucket_record)
+                winner = dedup_newer_record(
+                    record_a=local_record, record_b=bucket_record
+                )
                 if winner is local_record:
                     logger.debug(f"Local record newer for {rel_path}, restoring")
                     file_path.write_bytes(local_raw)
@@ -314,10 +316,12 @@ def merge_results(results_file: Path) -> int:
                         # Deduplicate: keep newer record (tree records in Phase 2
                         # will override via dedup_newer_record)
                         existing[identity] = dedup_newer_record(
-                            existing[identity], record
+                            record_a=existing[identity], record_b=record
                         )
-                except (json.JSONDecodeError, ValueError, KeyError, TypeError):
-                    pass  # Skip invalid lines (TypeError from normalise_bool_value)
+                except (json.JSONDecodeError, ValueError, KeyError, TypeError) as e:
+                    logger.debug(
+                        f"Skipping invalid JSONL line in {results_file}: {e}"
+                    )
 
     # Remove empty JSON files before processing
     remove_empty_json_files(RESULTS_DIR)
@@ -331,7 +335,9 @@ def merge_results(results_file: Path) -> int:
                 record = json.loads(record_file.read_text(encoding="utf-8"))
                 identity = identity_from_eee_record(record)
                 if identity in existing:
-                    existing[identity] = dedup_newer_record(existing[identity], record)
+                    existing[identity] = dedup_newer_record(
+                        record_a=existing[identity], record_b=record
+                    )
                 else:
                     existing[identity] = record
             except (json.JSONDecodeError, ValueError, KeyError) as e:

--- a/tests/leaderboards/test_bucket_sync.py
+++ b/tests/leaderboards/test_bucket_sync.py
@@ -265,12 +265,7 @@ class TestMergeResults:
     def test_merge_results_preserves_existing_jsonl(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test that merge_results preserves existing JSONL records.
-
-        This tests the fix for a bug where merge_results would overwrite the JSONL
-        file with only tree records, losing results that hadn't been synced to the
-        tree yet.
-        """
+        """Test that merge_results preserves existing JSONL records."""
         results_dir = tmp_path / "results"
         results_dir.mkdir()
         results_file = tmp_path / "merged.jsonl"
@@ -282,7 +277,7 @@ class TestMergeResults:
                 "additional_details": {"dataset": "existing_ds"},
                 "version": "1.0.0",
             },
-            "retrieved_timestamp": "1704067200",  # Unix timestamp as string
+            "retrieved_timestamp": "1704067200",
         }
         results_file.write_text(json.dumps(existing_record) + "\n", encoding="utf-8")
 
@@ -295,7 +290,7 @@ class TestMergeResults:
                 "additional_details": {"dataset": "tree_ds"},
                 "version": "1.0.0",
             },
-            "retrieved_timestamp": "1704153600",  # Unix timestamp as string (newer)
+            "retrieved_timestamp": "1704153600",
         }
         (model_dir / "tree_ds__test__test.json").write_text(
             json.dumps(tree_record), encoding="utf-8"
@@ -330,8 +325,7 @@ class TestMergeResults:
                 "additional_details": {"dataset": "same_ds"},
                 "version": "1.0.0",
             },
-            "retrieved_timestamp": "2024-01-01T00:00:00Z",
-            "source": "jsonl",
+            "retrieved_timestamp": "1704067200",
         }
         results_file.write_text(json.dumps(old_record) + "\n", encoding="utf-8")
 
@@ -344,8 +338,7 @@ class TestMergeResults:
                 "additional_details": {"dataset": "same_ds"},
                 "version": "2.0.0",
             },
-            "retrieved_timestamp": "2024-01-02T00:00:00Z",
-            "source": "tree",
+            "retrieved_timestamp": "1704153600",
         }
         (model_dir / "same_ds__test__test.json").write_text(
             json.dumps(new_record), encoding="utf-8"
@@ -361,7 +354,7 @@ class TestMergeResults:
         merged_record = json.loads(lines[0])
         # Tree record (newer version) should win
         assert merged_record["eval_library"]["version"] == "2.0.0"
-        assert merged_record["source"] == "tree"
+        assert merged_record["retrieved_timestamp"] == "1704153600"
 
 
 class TestUploadResultsToBucket:

--- a/tests/leaderboards/test_bucket_sync.py
+++ b/tests/leaderboards/test_bucket_sync.py
@@ -282,7 +282,7 @@ class TestMergeResults:
                 "additional_details": {"dataset": "existing_ds"},
                 "version": "1.0.0",
             },
-            "retrieved_timestamp": "2024-01-01T00:00:00Z",
+            "retrieved_timestamp": "1704067200",  # Unix timestamp as string
         }
         results_file.write_text(json.dumps(existing_record) + "\n", encoding="utf-8")
 
@@ -295,7 +295,7 @@ class TestMergeResults:
                 "additional_details": {"dataset": "tree_ds"},
                 "version": "1.0.0",
             },
-            "retrieved_timestamp": "2024-01-02T00:00:00Z",
+            "retrieved_timestamp": "1704153600",  # Unix timestamp as string (newer)
         }
         (model_dir / "tree_ds__test__test.json").write_text(
             json.dumps(tree_record), encoding="utf-8"

--- a/tests/leaderboards/test_bucket_sync.py
+++ b/tests/leaderboards/test_bucket_sync.py
@@ -262,6 +262,107 @@ class TestMergeResults:
 
         assert count == 1
 
+    def test_merge_results_preserves_existing_jsonl(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that merge_results preserves existing JSONL records.
+
+        This tests the fix for a bug where merge_results would overwrite the JSONL
+        file with only tree records, losing results that hadn't been synced to the
+        tree yet.
+        """
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        results_file = tmp_path / "merged.jsonl"
+
+        # Write existing records to the JSONL file
+        existing_record = {
+            "model_info": {"id": "existing/model"},
+            "eval_library": {
+                "additional_details": {"dataset": "existing_ds"},
+                "version": "1.0.0",
+            },
+            "retrieved_timestamp": "2024-01-01T00:00:00Z",
+        }
+        results_file.write_text(json.dumps(existing_record) + "\n", encoding="utf-8")
+
+        # Create a different record in the tree
+        model_dir = results_dir / "tree_model"
+        model_dir.mkdir()
+        tree_record = {
+            "model_info": {"id": "tree/model"},
+            "eval_library": {
+                "additional_details": {"dataset": "tree_ds"},
+                "version": "1.0.0",
+            },
+            "retrieved_timestamp": "2024-01-02T00:00:00Z",
+        }
+        (model_dir / "tree_ds__test__test.json").write_text(
+            json.dumps(tree_record), encoding="utf-8"
+        )
+
+        monkeypatch.setattr(bucket_sync, "RESULTS_DIR", results_dir)
+
+        count = bucket_sync.merge_results(results_file=results_file)
+
+        # Should have both records (1 from JSONL + 1 from tree)
+        assert count == 2
+        lines = results_file.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 2
+
+        # Verify both records are present
+        models = {json.loads(line)["model_info"]["id"] for line in lines}
+        assert "existing/model" in models
+        assert "tree/model" in models
+
+    def test_merge_results_tree_overrides_jsonl(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that tree records override JSONL records with same identity."""
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        results_file = tmp_path / "merged.jsonl"
+
+        # Write older record to JSONL
+        old_record = {
+            "model_info": {"id": "same/model"},
+            "eval_library": {
+                "additional_details": {"dataset": "same_ds"},
+                "version": "1.0.0",
+            },
+            "retrieved_timestamp": "2024-01-01T00:00:00Z",
+            "source": "jsonl",
+        }
+        results_file.write_text(json.dumps(old_record) + "\n", encoding="utf-8")
+
+        # Write newer record with same identity to tree
+        model_dir = results_dir / "same_model"
+        model_dir.mkdir()
+        new_record = {
+            "model_info": {"id": "same/model"},
+            "eval_library": {
+                "additional_details": {"dataset": "same_ds"},
+                "version": "2.0.0",
+            },
+            "retrieved_timestamp": "2024-01-02T00:00:00Z",
+            "source": "tree",
+        }
+        (model_dir / "same_ds__test__test.json").write_text(
+            json.dumps(new_record), encoding="utf-8"
+        )
+
+        monkeypatch.setattr(bucket_sync, "RESULTS_DIR", results_dir)
+
+        count = bucket_sync.merge_results(results_file=results_file)
+
+        # Should deduplicate to 1 record
+        assert count == 1
+        lines = results_file.read_text(encoding="utf-8").splitlines()
+        merged_record = json.loads(lines[0])
+        # Tree record (newer version) should win
+        assert merged_record["eval_library"]["version"] == "2.0.0"
+        assert merged_record["source"] == "tree"
+
 
 class TestUploadResultsToBucket:
     """Tests for ``upload_results_to_bucket``."""


### PR DESCRIPTION
## What

Fixes a data-loss bug in the `merge_results()` function where existing records in `euroeval_benchmark_results.jsonl` were overwritten and lost when the function ran with a partially-synced results tree.

## Key Changes

- **`merge_results()`** now reads existing records from the JSONL file before merging tree records
- Preserves results that haven't been synced to the `results/` tree yet  
- Tree records still override JSONL records with matching identity (existing dedup logic)
- Added 2 new tests covering preservation and override behaviour

## Why This Matters

When the swap script was interrupted mid-evaluation and re-run:
1. Script loaded JSONL, saw 111 models "already had results", skipped them
2. Only ~60 new models were evaluated  
3. `merge_results()` overwrote JSONL with only tree records (~67 models)
4. **Lost**: 111-67 = ~44 models worth of results that were "skipped" but not in tree

## Testing

All 6 `TestMergeResults` tests pass, including 2 new ones:
- `test_merge_results_preserves_existing_jsonl` - JSONL records are preserved
- `test_merge_results_tree_overrides_jsonl` - tree records still win with same identity