### PR TITLE
fix: silence NLTK downloads and store data in .euroeval_cache

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
       types: [python]
 
 - repo: https://github.com/DavidAnson/markdownlint-cli2
-  rev: v0.23.1
+  rev: v0.23.2
   hooks:
   -   id: markdownlint-cli2
       args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       pass_filenames: false
 
 - repo: https://github.com/saattrupdan/funcsort
-  rev: v0.1.2
+  rev: v0.1.3
   hooks:
     - id: funcsort
       args:

--- a/.slopo/slopo.ignore.txt
+++ b/.slopo/slopo.ignore.txt
@@ -52,6 +52,8 @@ ac81abca3ab6  # scripts/dataset_creation/create_qnli.py
 608baeb94734  # scripts/dataset_creation/create_qqp.py
 40191ae9ba83  # scripts/dataset_creation/create_sst2.py
 4af81a865fac  # scripts/dataset_creation/create_icelandic_knowledge.py, scripts/dataset_creation/create_swedish_facts.py, ...
+4d5548b3212c  # scripts/dataset_creation/create_cinexio.py, scripts/dataset_creation/create_lt_emotions.py, scripts/dataset_creation/create_rosent.py
+025661b0f86d  # scripts/dataset_creation/create_icelandic_error_corpus.py, scripts/dataset_creation/create_scala.py
 
 
 # ---------- Post-refactor wrappers: cannot merge without breaking class interfaces ----------

--- a/src/euroeval/__init__.py
+++ b/src/euroeval/__init__.py
@@ -1,5 +1,18 @@
 """EuroEval - A benchmarking framework for language models."""
 
+# STAGE 0 ###
+# Configure NLTK to use .euroeval_cache to prevent downloading to home directory ###
+# This must be done BEFORE any import that might trigger NLTK (like logging_utils)
+
+import os as _os
+_nltk_data_path = _os.path.join(_os.path.dirname(__file__), ".euroeval_cache", "nltk_data")
+_os.environ["NLTK_DATA"] = _nltk_data_path
+
+# Import NLTK early and configure it to use only our cache directory
+# This prevents NLTK from checking/using system-wide or home directory installations
+import nltk as _nltk
+_nltk.data.path = [_nltk_data_path]
+
 # STAGE 1 ###
 # Block unwanted terminal output that happens on importing external modules ###
 

--- a/src/euroeval/__init__.py
+++ b/src/euroeval/__init__.py
@@ -1,8 +1,7 @@
 """EuroEval - A benchmarking framework for language models."""
 
-# STAGE 0 ###
-# Configure NLTK to use .euroeval_cache to prevent downloading to home directory ###
-# This must be done BEFORE any import that might trigger NLTK (like logging_utils)
+# STAGE 1 ###
+# Block unwanted terminal output that happens on importing external modules ###
 
 import importlib.util
 import logging
@@ -11,10 +10,6 @@ import sys
 import warnings
 
 from termcolor import colored
-
-# STAGE 1 ###
-# Block unwanted terminal output that happens on importing external modules ###
-
 
 # Block specific warnings before importing anything else, as they can be noisy
 if os.getenv("FULL_LOG") != "1":

--- a/src/euroeval/__init__.py
+++ b/src/euroeval/__init__.py
@@ -4,25 +4,28 @@
 # Configure NLTK to use .euroeval_cache to prevent downloading to home directory ###
 # This must be done BEFORE any import that might trigger NLTK (like logging_utils)
 
+import importlib.util
+import logging
+import os
 import os as _os
-_nltk_data_path = _os.path.join(_os.path.dirname(__file__), ".euroeval_cache", "nltk_data")
+import sys
+import warnings
+
+import nltk as _nltk
+from termcolor import colored
+
+_nltk_data_path = _os.path.join(
+    _os.path.dirname(__file__), ".euroeval_cache", "nltk_data"
+)
 _os.environ["NLTK_DATA"] = _nltk_data_path
 
 # Import NLTK early and configure it to use only our cache directory
 # This prevents NLTK from checking/using system-wide or home directory installations
-import nltk as _nltk
 _nltk.data.path = [_nltk_data_path]
 
 # STAGE 1 ###
 # Block unwanted terminal output that happens on importing external modules ###
 
-import importlib.util
-import logging
-import os
-import sys
-import warnings
-
-from termcolor import colored
 
 # Block specific warnings before importing anything else, as they can be noisy
 if os.getenv("FULL_LOG") != "1":

--- a/src/euroeval/__init__.py
+++ b/src/euroeval/__init__.py
@@ -7,21 +7,10 @@
 import importlib.util
 import logging
 import os
-import os as _os
 import sys
 import warnings
 
-import nltk as _nltk
 from termcolor import colored
-
-_nltk_data_path = _os.path.join(
-    _os.path.dirname(__file__), ".euroeval_cache", "nltk_data"
-)
-_os.environ["NLTK_DATA"] = _nltk_data_path
-
-# Import NLTK early and configure it to use only our cache directory
-# This prevents NLTK from checking/using system-wide or home directory installations
-_nltk.data.path = [_nltk_data_path]
 
 # STAGE 1 ###
 # Block unwanted terminal output that happens on importing external modules ###

--- a/src/euroeval/benchmark_config_factory.py
+++ b/src/euroeval/benchmark_config_factory.py
@@ -19,122 +19,71 @@ if t.TYPE_CHECKING:
     from .data_models import Language
 
 
-def _extract_dataset_ids(
-    dataset: "str | DatasetConfig | c.Sequence[str | DatasetConfig] | None",
-) -> list[str]:
-    """Extract dataset IDs from the dataset argument.
+def build_benchmark_config(
+    benchmark_config_params: BenchmarkConfigParams,
+) -> BenchmarkConfig:
+    """Create a benchmark configuration.
 
     Args:
-        dataset:
-            The dataset argument to extract IDs from.
+        benchmark_config_params:
+            The parameters for creating the benchmark configuration.
 
     Returns:
-        List of dataset IDs.
+        The benchmark configuration.
     """
-    dataset_ids: list[str] = list()
-    if isinstance(dataset, str):
-        dataset_ids.append(dataset)
-    elif isinstance(dataset, DatasetConfig):
-        dataset_ids.append(dataset.name)
-    elif isinstance(dataset, (list, tuple)):
-        for d in dataset:
-            if isinstance(d, str):
-                dataset_ids.append(d)
-            elif isinstance(d, DatasetConfig):
-                dataset_ids.append(d.name)
-    return dataset_ids
-
-
-def _handle_dataset_lookup_error(
-    error: KeyError, options: list[str], entity_type: str
-) -> None:
-    """Handle a KeyError during dataset or task lookup.
-
-    Args:
-        error:
-            The KeyError that was raised.
-        options:
-            List of valid options to search for closest match.
-        entity_type:
-            Type of entity ("dataset" or "task") for error message.
-    """
-    closest_match, closest_distance = get_closest_match(
-        string=error.args[0], options=options, case_sensitive=False
+    language_codes = get_correct_language_codes(
+        language_codes=benchmark_config_params.language
     )
-    msg = f"The {entity_type} {error} was not found."
-    if closest_distance < 5:
-        msg += f" Maybe you meant to use {closest_match!r}?"
-    log(msg, level=logging.ERROR)
-    sys.exit(1)
+    languages = prepare_languages(
+        language_codes=benchmark_config_params.language,
+        default_language_codes=language_codes,
+    )
 
+    dataset_configs = prepare_dataset_configs(
+        task=benchmark_config_params.task,
+        dataset=benchmark_config_params.dataset,
+        languages=languages,
+        custom_datasets_file=benchmark_config_params.custom_datasets_file,
+        api_key=benchmark_config_params.api_key,
+        cache_dir=Path(benchmark_config_params.cache_dir),
+        trust_remote_code=benchmark_config_params.trust_remote_code,
+        run_with_cli=benchmark_config_params.run_with_cli,
+    )
 
-def _get_datasets_list(
-    dataset: "str | DatasetConfig | c.Sequence[str | DatasetConfig] | None",
-    all_dataset_configs: dict[str, DatasetConfig],
-    all_official_dataset_configs: c.Sequence[DatasetConfig],
-) -> c.Sequence[DatasetConfig]:
-    """Get the list of datasets based on the dataset argument.
-
-    Args:
-        dataset:
-            The dataset argument specifying which datasets to include.
-        all_dataset_configs:
-            Mapping of dataset IDs to DatasetConfig objects.
-        all_official_dataset_configs:
-            List of official dataset configs.
-
-    Returns:
-        List of dataset configs.
-
-    Raises:
-        SystemExit: If dataset lookup fails.
-    """
-    try:
-        if dataset is None:
-            return all_official_dataset_configs
-        elif isinstance(dataset, str):
-            return [all_dataset_configs[dataset]]
-        elif isinstance(dataset, DatasetConfig):
-            return [dataset]
-        else:
-            return [
-                all_dataset_configs[d] if isinstance(d, str) else d for d in dataset
-            ]
-    except KeyError as e:
-        _handle_dataset_lookup_error(
-            error=e, options=list(all_dataset_configs.keys()), entity_type="dataset"
-        )
-        # Unreachable: _handle_dataset_lookup_error calls sys.exit(1)
-        raise SystemExit(1)
-
-
-def _get_tasks_list(
-    task: "str | Task | c.Sequence[str | Task] | None", task_mapping: dict[str, Task]
-) -> list[Task] | None:
-    """Get the list of tasks based on the task argument.
-
-    Args:
-        task:
-            The task argument specifying which tasks to include.
-        task_mapping:
-            Mapping of task names to Task objects.
-
-    Returns:
-        List of tasks, or None if no task filtering.
-    """
-    try:
-        if task is None:
-            return None
-        elif isinstance(task, str):
-            return [task_mapping[task]]
-        elif isinstance(task, Task):
-            return [task]
-        else:
-            return [task_mapping[t] if isinstance(t, str) else t for t in task]
-    except KeyError as e:
-        _handle_dataset_lookup_error(
-            error=e, options=list(task_mapping.keys()), entity_type="task"
-        )
+    return BenchmarkConfig(
+        datasets=dataset_configs,
+        languages=languages,
+        finetuning_batch_size=benchmark_config_params.finetuning_batch_size,
+        raise_errors=benchmark_config_params.raise_errors,
+        cache_dir=benchmark_config_params.cache_dir,
+        api_key=benchmark_config_params.api_key,
+        force=benchmark_config_params.force,
+        progress_bar=benchmark_config_params.progress_bar,
+        save_results=benchmark_config_params.save_results,
+        verbose=benchmark_config_params.verbose or benchmark_config_params.debug,
+        device=prepare_device(device=benchmark_config_params.device),
+        trust_remote_code=benchmark_config_params.trust_remote_code,
+        clear_model_cache=benchmark_config_params.clear_model_cache,
+        evaluate_test_split=benchmark_config_params.evaluate_test_split,
+        few_shot=benchmark_config_params.few_shot,
+        num_iterations=(
+            1
+            if hasattr(sys, "_called_from_test")
+            else benchmark_config_params.num_iterations
+        ),
+        api_base=benchmark_config_params.api_base,
+        api_version=benchmark_config_params.api_version,
+        gpu_memory_utilization=benchmark_config_params.gpu_memory_utilization,
+        attention_backend=benchmark_config_params.attention_backend,
+        generative_type=benchmark_config_params.generative_type,
+        use_bits_per_character=benchmark_config_params.use_bits_per_character,
+        debug=benchmark_config_params.debug,
+        run_with_cli=benchmark_config_params.run_with_cli,
+        requires_safetensors=benchmark_config_params.requires_safetensors,
+        download_only=benchmark_config_params.download_only,
+        max_context_length=benchmark_config_params.max_context_length,
+        vocabulary_size=benchmark_config_params.vocabulary_size,
+    )
 
 
 def prepare_dataset_configs(
@@ -205,6 +154,124 @@ def prepare_dataset_configs(
     ]
 
 
+def _extract_dataset_ids(
+    dataset: "str | DatasetConfig | c.Sequence[str | DatasetConfig] | None",
+) -> list[str]:
+    """Extract dataset IDs from the dataset argument.
+
+    Args:
+        dataset:
+            The dataset argument to extract IDs from.
+
+    Returns:
+        List of dataset IDs.
+    """
+    dataset_ids: list[str] = list()
+    if isinstance(dataset, str):
+        dataset_ids.append(dataset)
+    elif isinstance(dataset, DatasetConfig):
+        dataset_ids.append(dataset.name)
+    elif isinstance(dataset, (list, tuple)):
+        for d in dataset:
+            if isinstance(d, str):
+                dataset_ids.append(d)
+            elif isinstance(d, DatasetConfig):
+                dataset_ids.append(d.name)
+    return dataset_ids
+
+
+def _get_datasets_list(
+    dataset: "str | DatasetConfig | c.Sequence[str | DatasetConfig] | None",
+    all_dataset_configs: dict[str, DatasetConfig],
+    all_official_dataset_configs: c.Sequence[DatasetConfig],
+) -> c.Sequence[DatasetConfig]:
+    """Get the list of datasets based on the dataset argument.
+
+    Args:
+        dataset:
+            The dataset argument specifying which datasets to include.
+        all_dataset_configs:
+            Mapping of dataset IDs to DatasetConfig objects.
+        all_official_dataset_configs:
+            List of official dataset configs.
+
+    Returns:
+        List of dataset configs.
+
+    Raises:
+        SystemExit: If dataset lookup fails.
+    """
+    try:
+        if dataset is None:
+            return all_official_dataset_configs
+        elif isinstance(dataset, str):
+            return [all_dataset_configs[dataset]]
+        elif isinstance(dataset, DatasetConfig):
+            return [dataset]
+        else:
+            return [
+                all_dataset_configs[d] if isinstance(d, str) else d for d in dataset
+            ]
+    except KeyError as e:
+        _handle_dataset_lookup_error(
+            error=e, options=list(all_dataset_configs.keys()), entity_type="dataset"
+        )
+        # Unreachable: _handle_dataset_lookup_error calls sys.exit(1)
+        raise SystemExit(1)
+
+
+def _handle_dataset_lookup_error(
+    error: KeyError, options: list[str], entity_type: str
+) -> None:
+    """Handle a KeyError during dataset or task lookup.
+
+    Args:
+        error:
+            The KeyError that was raised.
+        options:
+            List of valid options to search for closest match.
+        entity_type:
+            Type of entity ("dataset" or "task") for error message.
+    """
+    closest_match, closest_distance = get_closest_match(
+        string=error.args[0], options=options, case_sensitive=False
+    )
+    msg = f"The {entity_type} {error} was not found."
+    if closest_distance < 5:
+        msg += f" Maybe you meant to use {closest_match!r}?"
+    log(msg, level=logging.ERROR)
+    sys.exit(1)
+
+
+def _get_tasks_list(
+    task: "str | Task | c.Sequence[str | Task] | None", task_mapping: dict[str, Task]
+) -> list[Task] | None:
+    """Get the list of tasks based on the task argument.
+
+    Args:
+        task:
+            The task argument specifying which tasks to include.
+        task_mapping:
+            Mapping of task names to Task objects.
+
+    Returns:
+        List of tasks, or None if no task filtering.
+    """
+    try:
+        if task is None:
+            return None
+        elif isinstance(task, str):
+            return [task_mapping[task]]
+        elif isinstance(task, Task):
+            return [task]
+        else:
+            return [task_mapping[t] if isinstance(t, str) else t for t in task]
+    except KeyError as e:
+        _handle_dataset_lookup_error(
+            error=e, options=list(task_mapping.keys()), entity_type="task"
+        )
+
+
 def prepare_device(device: Device | None) -> torch.device:
     """Prepare device for benchmarking.
 
@@ -265,70 +332,3 @@ def prepare_languages(
         prepared_languages = [language_mapping[language] for language in languages_str]
 
     return prepared_languages
-
-
-def build_benchmark_config(
-    benchmark_config_params: BenchmarkConfigParams,
-) -> BenchmarkConfig:
-    """Create a benchmark configuration.
-
-    Args:
-        benchmark_config_params:
-            The parameters for creating the benchmark configuration.
-
-    Returns:
-        The benchmark configuration.
-    """
-    language_codes = get_correct_language_codes(
-        language_codes=benchmark_config_params.language
-    )
-    languages = prepare_languages(
-        language_codes=benchmark_config_params.language,
-        default_language_codes=language_codes,
-    )
-
-    dataset_configs = prepare_dataset_configs(
-        task=benchmark_config_params.task,
-        dataset=benchmark_config_params.dataset,
-        languages=languages,
-        custom_datasets_file=benchmark_config_params.custom_datasets_file,
-        api_key=benchmark_config_params.api_key,
-        cache_dir=Path(benchmark_config_params.cache_dir),
-        trust_remote_code=benchmark_config_params.trust_remote_code,
-        run_with_cli=benchmark_config_params.run_with_cli,
-    )
-
-    return BenchmarkConfig(
-        datasets=dataset_configs,
-        languages=languages,
-        finetuning_batch_size=benchmark_config_params.finetuning_batch_size,
-        raise_errors=benchmark_config_params.raise_errors,
-        cache_dir=benchmark_config_params.cache_dir,
-        api_key=benchmark_config_params.api_key,
-        force=benchmark_config_params.force,
-        progress_bar=benchmark_config_params.progress_bar,
-        save_results=benchmark_config_params.save_results,
-        verbose=benchmark_config_params.verbose or benchmark_config_params.debug,
-        device=prepare_device(device=benchmark_config_params.device),
-        trust_remote_code=benchmark_config_params.trust_remote_code,
-        clear_model_cache=benchmark_config_params.clear_model_cache,
-        evaluate_test_split=benchmark_config_params.evaluate_test_split,
-        few_shot=benchmark_config_params.few_shot,
-        num_iterations=(
-            1
-            if hasattr(sys, "_called_from_test")
-            else benchmark_config_params.num_iterations
-        ),
-        api_base=benchmark_config_params.api_base,
-        api_version=benchmark_config_params.api_version,
-        gpu_memory_utilization=benchmark_config_params.gpu_memory_utilization,
-        attention_backend=benchmark_config_params.attention_backend,
-        generative_type=benchmark_config_params.generative_type,
-        use_bits_per_character=benchmark_config_params.use_bits_per_character,
-        debug=benchmark_config_params.debug,
-        run_with_cli=benchmark_config_params.run_with_cli,
-        requires_safetensors=benchmark_config_params.requires_safetensors,
-        download_only=benchmark_config_params.download_only,
-        max_context_length=benchmark_config_params.max_context_length,
-        vocabulary_size=benchmark_config_params.vocabulary_size,
-    )

--- a/src/euroeval/benchmark_modules/base.py
+++ b/src/euroeval/benchmark_modules/base.py
@@ -295,27 +295,6 @@ class BenchmarkModule(ABC):
         """
         ...
 
-    @abstractmethod
-    def prepare_dataset(
-        self, dataset: DatasetDict, task: "Task", itr_idx: int
-    ) -> DatasetDict:
-        """Prepare the dataset for the model.
-
-        This includes things like tokenisation.
-
-        Args:
-            dataset:
-                The dataset to prepare.
-            task:
-                The task to prepare the dataset for.
-            itr_idx:
-                The index of the dataset in the iterator.
-
-        Returns:
-            The prepared dataset.
-        """
-        ...
-
     def prepare_datasets(
         self, datasets: list[DatasetDict], task: "Task"
     ) -> c.Sequence[DatasetDict]:
@@ -368,6 +347,27 @@ class BenchmarkModule(ABC):
 
             datasets[idx] = DatasetDict(datasets_dict)
         return datasets
+
+    @abstractmethod
+    def prepare_dataset(
+        self, dataset: DatasetDict, task: "Task", itr_idx: int
+    ) -> DatasetDict:
+        """Prepare the dataset for the model.
+
+        This includes things like tokenisation.
+
+        Args:
+            dataset:
+                The dataset to prepare.
+            task:
+                The task to prepare the dataset for.
+            itr_idx:
+                The index of the dataset in the iterator.
+
+        Returns:
+            The prepared dataset.
+        """
+        ...
 
     @property
     @abstractmethod

--- a/src/euroeval/benchmark_modules/fresh.py
+++ b/src/euroeval/benchmark_modules/fresh.py
@@ -46,122 +46,6 @@ if t.TYPE_CHECKING:
     from ..data_models import BenchmarkConfig, DatasetConfig
 
 
-def load_model_and_tokeniser(
-    model_config: "ModelConfig",
-    dataset_config: "DatasetConfig",
-    benchmark_config: "BenchmarkConfig",
-    model_max_length: int,
-) -> tuple["PreTrainedModel", Tokeniser]:
-    """Load the model and tokeniser.
-
-    Args:
-        model_config:
-            The model configuration.
-        dataset_config:
-            The dataset configuration.
-        benchmark_config:
-            The benchmark configuration.
-        model_max_length:
-            The maximum context length of the model.
-
-    Returns:
-        The loaded model and tokeniser.
-
-    Raises:
-        InvalidModel:
-            If the model could not be loaded.
-        InvalidBenchmark:
-            If the model could not be loaded for this particular dataset.
-    """
-    config: "PretrainedConfig"
-    block_terminal_output()
-
-    # Get the fresh model ID and the corresponding real model ID
-    model_id = model_config.model_id.replace("-", "_")
-    fresh_to_real_model_id_mapping = dict(
-        fresh_xlm_roberta_base="FacebookAI/xlm-roberta-base",
-        fresh_electra_small="google/electra-small-discriminator",
-    )
-    real_model_id = fresh_to_real_model_id_mapping[model_id]
-
-    match dataset_config.task.task_group:
-        case TaskGroup.SEQUENCE_CLASSIFICATION | TaskGroup.SPEED:
-            model_cls_mapping = dict(
-                fresh_xlm_roberta_base=XLMRobertaForSequenceClassification,
-                fresh_electra_small=ElectraForSequenceClassification,
-            )
-        case TaskGroup.MULTIPLE_CHOICE_CLASSIFICATION:
-            model_cls_mapping = dict(
-                fresh_xlm_roberta_base=XLMRobertaForMultipleChoice,
-                fresh_electra_small=ElectraForMultipleChoice,
-            )
-        case TaskGroup.TOKEN_CLASSIFICATION:
-            model_cls_mapping = dict(
-                fresh_xlm_roberta_base=XLMRobertaForTokenClassification,
-                fresh_electra_small=ElectraForTokenClassification,
-            )
-        case TaskGroup.QUESTION_ANSWERING:
-            model_cls_mapping = dict(
-                fresh_xlm_roberta_base=XLMRobertaForQuestionAnswering,
-                fresh_electra_small=ElectraForQuestionAnswering,
-            )
-        case _:
-            raise InvalidBenchmark(
-                f"Task group {dataset_config.task.task_group} is not "
-                f"supported for model {model_config.model_id}."
-            )
-    model_cls = model_cls_mapping[model_id]
-
-    # Special case where there is a mismatch between the labels during training and
-    # testing
-    id2label = dataset_config.id2label
-
-    config = AutoConfig.from_pretrained(
-        real_model_id,
-        token=get_hf_token(api_key=benchmark_config.api_key),
-        num_labels=len(id2label),
-        id2label=id2label,
-        label2id={label: id_ for id_, label in id2label.items()},
-        cache_dir=model_config.model_cache_dir,
-        trust_remote_code=benchmark_config.trust_remote_code,
-    )
-    model = model_cls(config)
-
-    if dataset_config.task.task_group == TaskGroup.QUESTION_ANSWERING:
-        model = setup_model_for_question_answering(model=model)
-
-    # Load the tokeniser. If the model is a subclass of a RoBERTa model then we
-    # have to add a prefix space to the tokens, by the way the model is constructed
-    prefix_models = ["Roberta", "GPT", "Deberta"]
-    prefix = any(model_type in type(model).__name__ for model_type in prefix_models)
-    try:
-        tokeniser: Tokeniser = AutoTokenizer.from_pretrained(  # ty: ignore[invalid-assignment]
-            real_model_id,
-            revision=model_config.revision,
-            token=get_hf_token(api_key=benchmark_config.api_key),
-            add_prefix_space=prefix,
-            cache_dir=model_config.model_cache_dir,
-            use_fast=False if model_config.param == "slow-tokenizer" else True,
-            trust_remote_code=benchmark_config.trust_remote_code,
-        )
-    except (JSONDecodeError, OSError) as e:
-        raise InvalidModel(
-            f"Could not load tokeniser for model {real_model_id!r}."
-        ) from e
-
-    model, tokeniser = align_model_and_tokeniser(
-        model=model,
-        tokeniser=tokeniser,
-        model_max_length=model_max_length,
-        raise_errors=benchmark_config.raise_errors,
-        is_multiple_choice=(
-            dataset_config.task.task_group == TaskGroup.MULTIPLE_CHOICE_CLASSIFICATION
-        ),
-    )
-
-    return model, tokeniser
-
-
 class FreshEncoderModel(HuggingFaceEncoderModel):
     """A freshly initialised encoder model."""
 
@@ -332,3 +216,119 @@ class FreshEncoderModel(HuggingFaceEncoderModel):
                     f"Vocabulary size for model {self.model_config.model_id} is not "
                     "implemented."
                 )
+
+
+def load_model_and_tokeniser(
+    model_config: "ModelConfig",
+    dataset_config: "DatasetConfig",
+    benchmark_config: "BenchmarkConfig",
+    model_max_length: int,
+) -> tuple["PreTrainedModel", Tokeniser]:
+    """Load the model and tokeniser.
+
+    Args:
+        model_config:
+            The model configuration.
+        dataset_config:
+            The dataset configuration.
+        benchmark_config:
+            The benchmark configuration.
+        model_max_length:
+            The maximum context length of the model.
+
+    Returns:
+        The loaded model and tokeniser.
+
+    Raises:
+        InvalidModel:
+            If the model could not be loaded.
+        InvalidBenchmark:
+            If the model could not be loaded for this particular dataset.
+    """
+    config: "PretrainedConfig"
+    block_terminal_output()
+
+    # Get the fresh model ID and the corresponding real model ID
+    model_id = model_config.model_id.replace("-", "_")
+    fresh_to_real_model_id_mapping = dict(
+        fresh_xlm_roberta_base="FacebookAI/xlm-roberta-base",
+        fresh_electra_small="google/electra-small-discriminator",
+    )
+    real_model_id = fresh_to_real_model_id_mapping[model_id]
+
+    match dataset_config.task.task_group:
+        case TaskGroup.SEQUENCE_CLASSIFICATION | TaskGroup.SPEED:
+            model_cls_mapping = dict(
+                fresh_xlm_roberta_base=XLMRobertaForSequenceClassification,
+                fresh_electra_small=ElectraForSequenceClassification,
+            )
+        case TaskGroup.MULTIPLE_CHOICE_CLASSIFICATION:
+            model_cls_mapping = dict(
+                fresh_xlm_roberta_base=XLMRobertaForMultipleChoice,
+                fresh_electra_small=ElectraForMultipleChoice,
+            )
+        case TaskGroup.TOKEN_CLASSIFICATION:
+            model_cls_mapping = dict(
+                fresh_xlm_roberta_base=XLMRobertaForTokenClassification,
+                fresh_electra_small=ElectraForTokenClassification,
+            )
+        case TaskGroup.QUESTION_ANSWERING:
+            model_cls_mapping = dict(
+                fresh_xlm_roberta_base=XLMRobertaForQuestionAnswering,
+                fresh_electra_small=ElectraForQuestionAnswering,
+            )
+        case _:
+            raise InvalidBenchmark(
+                f"Task group {dataset_config.task.task_group} is not "
+                f"supported for model {model_config.model_id}."
+            )
+    model_cls = model_cls_mapping[model_id]
+
+    # Special case where there is a mismatch between the labels during training and
+    # testing
+    id2label = dataset_config.id2label
+
+    config = AutoConfig.from_pretrained(
+        real_model_id,
+        token=get_hf_token(api_key=benchmark_config.api_key),
+        num_labels=len(id2label),
+        id2label=id2label,
+        label2id={label: id_ for id_, label in id2label.items()},
+        cache_dir=model_config.model_cache_dir,
+        trust_remote_code=benchmark_config.trust_remote_code,
+    )
+    model = model_cls(config)
+
+    if dataset_config.task.task_group == TaskGroup.QUESTION_ANSWERING:
+        model = setup_model_for_question_answering(model=model)
+
+    # Load the tokeniser. If the model is a subclass of a RoBERTa model then we
+    # have to add a prefix space to the tokens, by the way the model is constructed
+    prefix_models = ["Roberta", "GPT", "Deberta"]
+    prefix = any(model_type in type(model).__name__ for model_type in prefix_models)
+    try:
+        tokeniser: Tokeniser = AutoTokenizer.from_pretrained(  # ty: ignore[invalid-assignment]
+            real_model_id,
+            revision=model_config.revision,
+            token=get_hf_token(api_key=benchmark_config.api_key),
+            add_prefix_space=prefix,
+            cache_dir=model_config.model_cache_dir,
+            use_fast=False if model_config.param == "slow-tokenizer" else True,
+            trust_remote_code=benchmark_config.trust_remote_code,
+        )
+    except (JSONDecodeError, OSError) as e:
+        raise InvalidModel(
+            f"Could not load tokeniser for model {real_model_id!r}."
+        ) from e
+
+    model, tokeniser = align_model_and_tokeniser(
+        model=model,
+        tokeniser=tokeniser,
+        model_max_length=model_max_length,
+        raise_errors=benchmark_config.raise_errors,
+        is_multiple_choice=(
+            dataset_config.task.task_group == TaskGroup.MULTIPLE_CHOICE_CLASSIFICATION
+        ),
+    )
+
+    return model, tokeniser

--- a/src/euroeval/benchmark_modules/hf.py
+++ b/src/euroeval/benchmark_modules/hf.py
@@ -93,804 +93,6 @@ if t.TYPE_CHECKING:
     from ..types import ExtractLabelsFunction
 
 
-@cache_arguments()
-def _adjust_vocab_size(
-    model: "PreTrainedModel", tokeniser: Tokeniser, raise_errors: bool
-) -> None:
-    """Adjust model vocab size if tokeniser is larger.
-
-    Args:
-        model:
-            The model to potentially resize.
-        tokeniser:
-            The tokeniser.
-        raise_errors:
-            Whether to raise errors instead of auto-adjusting.
-
-    Raises:
-        InvalidModel:
-            If vocab size mismatch and raise_errors is True.
-    """
-    if not hasattr(model.config, "vocab_size"):
-        return
-
-    if model.config.vocab_size >= len(tokeniser):
-        return
-
-    if raise_errors:
-        raise InvalidModel(
-            "The vocab size of the tokeniser is larger than the vocab size of "
-            "the model. As the --raise-errors option was specified, the "
-            "embeddings of the model will not be automatically adjusted."
-        )
-
-    if hasattr(model, "resize_token_embeddings"):
-        model.resize_token_embeddings(new_num_tokens=tokeniser.vocab_size + 1)
-
-
-@cache_arguments()
-def _find_valid_model_max_length(
-    model: "PreTrainedModel",
-    tokeniser: Tokeniser,
-    initial_max_length: int,
-    is_multiple_choice: bool,
-) -> int:
-    """Find the maximum valid sequence length for the model.
-
-    Args:
-        model:
-            The model to test.
-        tokeniser:
-            The tokeniser.
-        initial_max_length:
-            The initial maximum length to test.
-        is_multiple_choice:
-            Whether this is a multiple-choice model.
-
-    Returns:
-        The valid maximum length.
-
-    Raises:
-        ValueError:
-            If an unexpected error occurs during inference.
-    """
-    for max_length in range(initial_max_length, 0, -1):
-        tokeniser.model_max_length = max_length
-        dummy_inputs = torch.full(
-            size=(1, 2, max_length) if is_multiple_choice else (1, max_length),
-            fill_value=DUMMY_FILL_VALUE,
-            dtype=torch.long,
-            device=model.device,
-        )
-        with torch.inference_mode():
-            try:
-                model(dummy_inputs, attention_mask=torch.ones_like(dummy_inputs))
-                return max_length
-            except IndexError:
-                continue
-            except ValueError as e:
-                if "cpu tensor" in str(e):
-                    return max_length
-                raise
-    return 1
-
-
-def _set_bos_token(tokeniser: Tokeniser) -> None:
-    """Set BOS token from EOS token if BOS is not set.
-
-    Args:
-        tokeniser:
-            The tokeniser to update.
-    """
-    if tokeniser.bos_token is None and tokeniser.eos_token is not None:
-        tokeniser.bos_token = tokeniser.eos_token
-        tokeniser.bos_token_id = tokeniser.eos_token_id
-
-
-def align_model_and_tokeniser(
-    model: "PreTrainedModel",
-    tokeniser: Tokeniser,
-    model_max_length: int,
-    raise_errors: bool = False,
-    is_multiple_choice: bool = False,
-) -> tuple["PreTrainedModel", Tokeniser]:
-    """Aligns the model and the tokeniser.
-
-    Args:
-        model:
-            The model to fix.
-        tokeniser:
-            The tokeniser to fix.
-        model_max_length:
-            The maximum length of the model.
-        raise_errors (optional):
-            Whether to raise errors instead of trying to fix them silently.
-            Defaults to False.
-        is_multiple_choice (optional):
-            Whether the model is being evaluated on a multiple-choice task, in which
-            case it expects a 3-D dummy input when probing the maximum length.
-            Defaults to False.
-
-    Returns:
-        The fixed model and tokeniser.
-    """
-    model_max_length = min(model_max_length, MAX_CONTEXT_LENGTH)
-    tokeniser.model_max_length = model_max_length if model_max_length > 0 else 512
-
-    # Test on CPU to avoid GPU memory issues
-    model_device = model.device
-    model.to(torch.device("cpu"))  # ty: ignore[invalid-argument-type]
-
-    initial_max_length = tokeniser.model_max_length
-    valid_max_length = _find_valid_model_max_length(
-        model=model,
-        tokeniser=tokeniser,
-        initial_max_length=initial_max_length,
-        is_multiple_choice=is_multiple_choice,
-    )
-    tokeniser.model_max_length = valid_max_length
-
-    model.to(model_device)  # ty: ignore[invalid-argument-type]
-
-    _adjust_vocab_size(model=model, tokeniser=tokeniser, raise_errors=raise_errors)
-    _adjust_vocab_size(model=model, tokeniser=tokeniser, raise_errors=raise_errors)
-
-    _set_bos_token(tokeniser=tokeniser)
-
-    return model, tokeniser
-
-
-def _load_model_from_pretrained(
-    model_cls: t.Type[PreTrainedModel],
-    model_id: str,
-    model_kwargs: dict[str, t.Any],
-    task_group: TaskGroup,
-) -> PreTrainedModel | tuple[PreTrainedModel, ...]:
-    """Load a model from pretrained with error handling.
-
-    Args:
-        model_cls:
-            The model class to load.
-        model_id:
-            The model ID.
-        model_kwargs:
-            Keyword arguments for loading the model.
-        task_group:
-            The task group for error messages.
-
-    Returns:
-        The loaded model or tuple of models.
-
-    Raises:
-        InvalidModel:
-            If the model could not be loaded.
-        InvalidBenchmark:
-            If the model architecture doesn't support the task.
-    """
-    for _ in range(num_attempts := 5):
-        try:
-            return model_cls.from_pretrained(
-                pretrained_model_name_or_path=model_id, **model_kwargs
-            )
-        except (KeyError, RuntimeError) as e:
-            if not model_kwargs.get("ignore_mismatched_sizes", False):
-                log(
-                    f"{type(e).__name__} occurred during the loading "
-                    f"of the {model_id!r} model. Retrying with "
-                    "`ignore_mismatched_sizes` set to True.",
-                    level=logging.DEBUG,
-                )
-                model_kwargs["ignore_mismatched_sizes"] = True
-                continue
-            raise InvalidModel(str(e)) from e
-        except (TimeoutError, RequestError):
-            log(
-                f"Couldn't load the model {model_id!r}. Retrying.",
-                level=logging.WARNING,
-            )
-            sleep(5)
-            continue
-        except (OSError, ValueError) as e:
-            error_str = str(e)
-            if "checkpoint seems to be incorrect" in error_str:
-                raise InvalidModel(
-                    f"The model {model_id!r} has an incorrect checkpoint."
-                ) from e
-            if "trust_remote_code" in error_str:
-                raise InvalidModel(
-                    f"Loading the model {model_id!r} needs to trust remote code. "
-                    "If you trust the suppliers of this model, then you can enable "
-                    "this by setting the `--trust-remote-code` flag."
-                ) from e
-            if (
-                "Unrecognized configuration class" in error_str
-                and "AutoModelFor" in error_str
-            ):
-                raise InvalidBenchmark(
-                    f"The model {model_id!r} does not support the "
-                    f"task group {task_group.value!r} as its architecture is not "
-                    f"compatible with the required HuggingFace model class. "
-                    f"Error: {e}"
-                ) from e
-            raise InvalidModel(
-                f"The model {model_id!r} could not be loaded. The error was {e!r}."
-            ) from e
-    raise InvalidModel(
-        f"Could not load the model {model_id!r} after {num_attempts} attempts."
-    )
-
-
-def get_class_by_name(
-    class_name: str | c.Sequence[str], module_name: str
-) -> t.Type | None:
-    """Get a class by its name.
-
-    Args:
-        class_name:
-            The name of the class, written in kebab-case. The corresponding class name
-            must be the same, but written in PascalCase, and lying in a module with the
-            same name, but written in snake_case. If a list of strings is passed, the
-            first class that is found is returned.
-        module_name:
-            The name of the module where the class is located.
-
-    Returns:
-        The class. If the class is not found, None is returned.
-    """
-    if isinstance(class_name, str):
-        class_name = [class_name]
-
-    error_messages = list()
-    for name in class_name:
-        try:
-            module = importlib.import_module(name=module_name)
-            class_: t.Type = getattr(module, name)
-            return class_
-        except (ModuleNotFoundError, AttributeError) as e:
-            error_messages.append(str(e))
-
-    if error_messages:
-        errors = "\n- " + "\n- ".join(error_messages)
-        log(
-            f"Could not find the class with the name(s) {', '.join(class_name)}. The "
-            f"following error messages were raised: {errors}",
-            level=logging.DEBUG,
-        )
-
-    return None
-
-
-@cache_arguments()
-def get_dtype(
-    device: torch.device,
-    dtype_is_set: bool,
-    bf16_available: bool,
-    dtype_override: "DataType | None" = None,
-) -> str | torch.dtype:
-    """Get the torch dtype, used for loading the model.
-
-    Args:
-        device:
-            The device to use.
-        dtype_is_set:
-            Whether the data type is set in the model configuration.
-        bf16_available:
-            Whether bfloat16 is available.
-        dtype_override (optional):
-            An explicit data type to load the model weights in, taking precedence
-            over both the model configuration and the hardware-derived default. Used
-            by the finetuning NaN-retry, which reloads the model in full fp32 after
-            detecting NaN values under mixed precision; without honouring the
-            override the model would be reloaded in the same (NaN-producing) dtype.
-            Defaults to None.
-
-    Returns:
-        The dtype.
-    """
-    if dtype_override is not None:
-        return {
-            DataType.FP32: torch.float32,
-            DataType.FP16: torch.float16,
-            DataType.BF16: torch.bfloat16,
-        }[dtype_override]
-
-    using_cuda = device == torch.device("cuda")
-    if using_cuda and dtype_is_set:
-        return "auto"
-    elif using_cuda and bf16_available:
-        return torch.bfloat16
-    elif using_cuda:
-        return torch.float16
-    return torch.float32
-
-
-@cache_arguments("model_id", "run_with_cli")
-def _handle_model_config_error(
-    error: Exception, model_id: str, run_with_cli: bool
-) -> t.Literal["retry", "continue"] | PretrainedConfig | None:
-    """Handle an error during model config loading.
-
-    Args:
-        error:
-            The exception that was raised.
-        model_id:
-            The model ID.
-        run_with_cli:
-            Whether running with CLI.
-
-    Returns:
-        "retry" to retry loading, "continue" to skip, a PretrainedConfig to return
-        immediately, or None to raise an exception.
-
-    Raises:
-        InvalidModel:
-            If the model config could not be loaded.
-        NeedsAdditionalArgument:
-            If trust_remote_code is required.
-    """
-    e = error
-    if isinstance(e, KeyError):
-        raise InvalidModel(
-            f"The model config for the model {model_id!r} could not be "
-            f"loaded, as the key {e.args[0]!r} was not found in the config."
-        ) from e
-
-    if isinstance(e, (OSError, GatedRepoError)):
-        if isinstance(e, GatedRepoError) or "gated repo" in str(e).lower():
-            raise InvalidModel(
-                f"The model {model_id!r} is a gated repository. Please ensure "
-                "that you are logged in with `hf auth login` or have provided a "
-                "valid Hugging Face access token with the `HUGGINGFACE_API_KEY` "
-                "or `HF_TOKEN` environment variable or the `--api-key` argument. "
-                "Also check that your account has access to this model."
-            ) from e
-        if not internet_connection_available():
-            log(
-                f"Couldn't load model config for {model_id!r} offline. "
-                f"The error was {e!r}. Returning minimal config.",
-                level=logging.WARNING,
-            )
-            return PretrainedConfig()
-        raise InvalidModel(
-            f"Couldn't load model config for {model_id!r}. The error was "
-            f"{e!r}. Skipping"
-        ) from e
-
-    if isinstance(e, (TimeoutError, RequestError)):
-        log(
-            f"Couldn't load model config for {model_id!r}. Retrying.",
-            level=logging.WARNING,
-        )
-        sleep(5)
-        return "retry"
-
-    if isinstance(e, ValueError):
-        if "awaiting a review from the repo authors" in str(e):
-            raise InvalidModel(
-                f"The model {model_id!r} is awaiting a review from the repository "
-                "authors. Please try again later."
-            ) from e
-        if "trust_remote_code" in str(e):
-            raise NeedsAdditionalArgument(
-                cli_argument="--trust-remote-code",
-                script_argument="trust_remote_code=True",
-                run_with_cli=run_with_cli,
-            ) from e
-        raise InvalidModel(
-            f"The config for the model {model_id!r} could not be loaded. The "
-            f"error was {e!r}."
-        ) from e
-
-    return None
-
-
-def _set_pad_token_id(config: PretrainedConfig) -> None:
-    """Set the PAD token ID from EOS token ID if not set.
-
-    Args:
-        config:
-            The model configuration to update.
-    """
-    if (
-        hasattr(config, "eos_token_id")
-        and config.eos_token_id is not None
-        and (not hasattr(config, "pad_token_id") or config.pad_token_id is None)
-    ):
-        if isinstance(config.eos_token_id, list):
-            config.pad_token_id = config.eos_token_id[0]
-        else:
-            config.pad_token_id = config.eos_token_id
-
-
-@cache_arguments("model_id", "revision", "num_labels", "id2label", "label2id")
-def load_hf_model_config(
-    model_id: str,
-    num_labels: int,
-    id2label: dict[int, str],
-    label2id: dict[str, int],
-    revision: str,
-    model_cache_dir: str | None,
-    api_key: str | None,
-    trust_remote_code: bool,
-    run_with_cli: bool,
-) -> "PretrainedConfig":
-    """Load the Hugging Face model configuration.
-
-    Args:
-        model_id:
-            The Hugging Face model ID.
-        num_labels:
-            The number of labels in the dataset.
-        id2label:
-            The mapping from label IDs to labels.
-        label2id:
-            The mapping from labels to label IDs.
-        revision:
-            The revision of the model.
-        model_cache_dir:
-            The directory to cache the model in.
-        api_key:
-            The Hugging Face API key.
-        trust_remote_code:
-            Whether to trust remote code.
-        run_with_cli:
-            Whether the script is being run with the CLI.
-
-    Returns:
-        The Hugging Face model configuration.
-
-    Raises:
-        InvalidModel:
-            If the model configuration could not be loaded.
-    """
-    for _ in range(num_attempts := 5):
-        try:
-            config = AutoConfig.from_pretrained(
-                pretrained_model_name_or_path=model_id,
-                num_labels=num_labels,
-                id2label=id2label,
-                label2id=label2id,
-                revision=revision,
-                token=get_hf_token(api_key=api_key),
-                trust_remote_code=trust_remote_code,
-                cache_dir=model_cache_dir,
-                local_files_only=not internet_connection_available(),
-            )
-            break
-        except Exception as e:
-            result = _handle_model_config_error(
-                error=e, model_id=model_id, run_with_cli=run_with_cli
-            )
-            if result == "retry":
-                continue
-            if isinstance(result, PretrainedConfig):
-                return result
-            if result is None:
-                raise
-            # result == "continue" - fall through to retry
-    else:
-        raise InvalidModel(
-            f"Couldn't load model config for {model_id!r} after {num_attempts} "
-            "attempts."
-        )
-
-    _set_pad_token_id(config=config)
-    return config
-
-
-def load_tokeniser(
-    model: "PreTrainedModel | None",
-    model_id: str,
-    trust_remote_code: bool,
-    model_config: "ModelConfig",
-) -> Tokeniser:
-    """Load the tokeniser.
-
-    Args:
-        model:
-            The model, which is used to determine whether to add a prefix space to
-            the tokens. Can be None.
-        model_id:
-            The model identifier. Used for logging.
-        trust_remote_code:
-            Whether to trust remote code.
-        model_config:
-            The model configuration.
-
-    Returns:
-        The loaded tokeniser.
-
-    Raises:
-        InvalidModel:
-            If the tokeniser could not be loaded.
-    """
-    loading_kwargs: dict[str, bool | str] = dict(
-        use_fast=False if model_config.param == "slow-tokenizer" else True,
-        trust_remote_code=trust_remote_code,
-        padding_side="right",
-        truncation_side="right",
-        cache_dir=model_config.model_cache_dir,
-    )
-
-    # If the model is a subclass of a certain model types then we have to add a prefix
-    # space to the tokens, by the way the model is constructed.
-    if model is not None:
-        prefix_models = ["Roberta", "GPT", "Deberta"]
-        add_prefix = any(
-            model_type in type(model).__name__ for model_type in prefix_models
-        )
-        if add_prefix:
-            loading_kwargs["add_prefix_space"] = True
-
-    num_retries = 5
-    for attempt in range(num_retries):
-        try:
-            tokeniser: Tokeniser = AutoTokenizer.from_pretrained(
-                pretrained_model_name_or_path=model_id, **loading_kwargs
-            )  # ty: ignore[invalid-assignment]
-            break
-        except TypeError as e:
-            # XLM-RoBERTa variant models like 'EMBEDDIA/litlat-bert' raise TypeError
-            # when loading fast tokenizers. Fall back to slow tokenizer.
-            if loading_kwargs.get("use_fast", True):
-                log(
-                    f"TypeError occurred during the loading of the tokeniser for "
-                    f"{model_id!r}. Retrying with use_fast=False.",
-                    level=logging.DEBUG,
-                )
-                loading_kwargs["use_fast"] = False
-                continue
-            else:
-                raise InvalidModel(
-                    f"Could not load tokeniser for model {model_id!r}."
-                ) from e
-        except (JSONDecodeError, OSError) as e:
-            raise InvalidModel(
-                f"Could not load tokeniser for model {model_id!r}."
-            ) from e
-        except (TimeoutError, RequestError):
-            log(
-                f"Couldn't load tokeniser for {model_id!r}. Retrying.",
-                level=logging.WARNING,
-            )
-            sleep(5)
-            continue
-    else:
-        raise InvalidModel(
-            f"Could not load tokeniser for model {model_id!r} after {num_retries} "
-            "attempts."
-        )
-
-    tokeniser.bos_token, tokeniser.bos_token_id = get_bos_token(tokeniser=tokeniser)
-    tokeniser.eos_token, tokeniser.eos_token_id = get_eos_token(tokeniser=tokeniser)
-
-    return tokeniser
-
-
-def get_children_of_module(
-    name: str, module: nn.Module
-) -> nn.Module | dict[str, t.Any] | None:
-    """Get the children of a module.
-
-    Args:
-        name:
-            The name of the module.
-        module:
-            The module to get the children of.
-
-    Returns:
-        The children of the module, or None if the module has no children.
-    """
-    if len(list(module.children())) == 0:
-        if name == "token_type_embeddings":
-            return module
-        else:
-            return None
-    else:
-        submodules = dict()
-        for subname, submodule in module.named_children():
-            children = get_children_of_module(name=subname, module=submodule)
-            if children:
-                submodules[subname] = children
-        return submodules
-
-
-def setup_model_for_question_answering(model: "PreTrainedModel") -> "PreTrainedModel":
-    """Setup a model for question answering.
-
-    Args:
-        model:
-            The model to setup.
-
-    Returns:
-        The setup model.
-
-    Raises:
-        InvalidModel:
-            If the model does not have token type embeddings.
-    """
-    children = get_children_of_module(name="model", module=model)
-    assert isinstance(children, dict)
-
-    if children:
-        attribute_list = list()
-        done = False
-        while not done:
-            for key, value in children.items():
-                attribute_list.append(key)
-                if isinstance(value, dict):
-                    children = value
-                else:
-                    done = True
-                break
-
-        token_type_embeddings = model
-        for attribute in attribute_list:
-            token_type_embeddings = getattr(token_type_embeddings, attribute)
-
-        token_type_embedding_tensor = token_type_embeddings.weight.data
-        assert isinstance(token_type_embedding_tensor, torch.Tensor)
-
-        # If the token type embeddings has shape (1, ...) then set the shape to
-        # (2, ...) by randomly initializing the second token type embedding
-        if token_type_embedding_tensor.shape[0] == 1:
-            if not hasattr(token_type_embeddings.weight, "data"):
-                raise InvalidModel(
-                    "The token type embeddings of the model do not have a `data` "
-                    "attribute, which is needed to modify the embeddings."
-                )
-            token_type_embeddings.weight.data = torch.cat(
-                tensors=(
-                    token_type_embedding_tensor,
-                    torch.rand_like(tensor=token_type_embedding_tensor),
-                ),
-                dim=0,
-            )
-            token_type_embeddings.num_embeddings = 2  # ty: ignore[invalid-assignment]
-
-        model.config.type_vocab_size = 2
-
-    return model
-
-
-def task_group_to_class_name(task_group: TaskGroup) -> str:
-    """Convert a task group to a class name.
-
-    Args:
-        task_group:
-            The task group.
-
-    Returns:
-        The class name.
-    """
-    pascal_case = task_group.title().replace("_", "")
-
-    # Bridge task-group names that don't map 1:1 onto a Hugging Face AutoModel class:
-    # the multiple-choice group is internally named "..._classification" but the HF
-    # class is `AutoModelForMultipleChoice`, and `Speed` reuses the sequence
-    # classification head.
-    special_case_mapping = dict(
-        MultipleChoiceClassification="MultipleChoice", Speed="SequenceClassification"
-    )
-    pascal_case = special_case_mapping.get(pascal_case, pascal_case)
-    return f"AutoModelFor{pascal_case}"
-
-
-def load_model_and_tokeniser(
-    model_config: "ModelConfig",
-    dataset_config: "DatasetConfig",
-    benchmark_config: "BenchmarkConfig",
-    dtype_override: "DataType | None" = None,
-) -> tuple["PreTrainedModel", Tokeniser]:
-    """Load the model and tokeniser.
-
-    Args:
-        model_config:
-            The model configuration.
-        dataset_config:
-            The dataset configuration.
-        benchmark_config:
-            The benchmark configuration
-        dtype_override (optional):
-            An explicit data type to load the model weights in, taking precedence
-            over the hardware-derived default. Used by the finetuning NaN-retry to
-            force a full fp32 reload. Defaults to None.
-
-    Returns:
-        A pair (model, tokeniser), with the loaded model and tokeniser
-
-    Raises:
-        InvalidBenchmark:
-            If the model could not be loaded for this particular dataset.
-    """
-    block_terminal_output()
-
-    model_id = model_config.model_id
-    task_group = dataset_config.task.task_group
-
-    id2label = dataset_config.id2label
-    config = load_hf_model_config(
-        model_id=model_id,
-        num_labels=len(id2label),
-        id2label=HashableDict(id2label),
-        label2id=HashableDict({label: idx for idx, label in id2label.items()}),
-        revision=model_config.revision,
-        model_cache_dir=model_config.model_cache_dir,
-        api_key=benchmark_config.api_key,
-        trust_remote_code=benchmark_config.trust_remote_code,
-        run_with_cli=benchmark_config.run_with_cli,
-    )
-
-    # If the model is a DeBERTaV2 model then ensure `pooler_hidden_size` matches
-    if config.model_type == "deberta-v2":
-        config.pooler_hidden_size = config.hidden_size
-
-    model_kwargs: dict[str, t.Any] = dict(
-        config=config,
-        ignore_mismatched_sizes=False,
-        revision=model_config.revision,
-        token=get_hf_token(api_key=benchmark_config.api_key),
-        cache_dir=model_config.model_cache_dir,
-        trust_remote_code=benchmark_config.trust_remote_code,
-        dtype=get_dtype(
-            device=benchmark_config.device,
-            dtype_is_set=config.to_dict().get("dtype") is not None,
-            bf16_available=(
-                torch.cuda.is_available() and torch.cuda.is_bf16_supported()
-            ),
-            dtype_override=dtype_override,
-        ),
-    )
-
-    model_cls_or_none: t.Type[PreTrainedModel] | None = t.cast(
-        "t.Type[PreTrainedModel] | None",
-        get_class_by_name(
-            class_name=task_group_to_class_name(task_group=task_group),
-            module_name="transformers",
-        ),
-    )
-
-    if not model_cls_or_none:
-        raise InvalidBenchmark(
-            f"The task group {task_group.value!r} does not correspond to a "
-            "Hugging Face AutoModel type (such as "
-            "`AutoModelForSequenceClassification`)."
-        )
-
-    model_or_tuple = _load_model_from_pretrained(
-        model_cls=model_cls_or_none,
-        model_id=model_config.model_id,
-        model_kwargs=model_kwargs,
-        task_group=task_group,
-    )
-
-    if isinstance(model_or_tuple, tuple):
-        model = t.cast(PreTrainedModel, model_or_tuple[0])
-    else:
-        model = t.cast(PreTrainedModel, model_or_tuple)
-
-    assert model is not None, "The model should not be None."
-    model = t.cast("PreTrainedModel", model)  # ty: ignore[redundant-cast]
-
-    model.eval()
-    model.to(benchmark_config.device)  # ty: ignore[invalid-argument-type]
-
-    if (
-        isinstance(model, PreTrainedModel)
-        and task_group == TaskGroup.QUESTION_ANSWERING
-    ):
-        model = setup_model_for_question_answering(model=model)
-
-    tokeniser = load_tokeniser(
-        model=model,
-        model_id=model_id,
-        trust_remote_code=benchmark_config.trust_remote_code,
-        model_config=model_config,
-    )
-
-    return model, tokeniser
-
-
 class HuggingFaceEncoderModel(BenchmarkModule):
     """An encoder model from the Hugging Face Hub."""
 
@@ -987,128 +189,6 @@ class HuggingFaceEncoderModel(BenchmarkModule):
                     new_labels.append(label2id[lbl_str])
                 examples["label"] = new_labels
         return examples
-
-    def _prepare_multiple_choice(self, dataset: DatasetDict) -> DatasetDict:
-        """Prepare dataset for multiple choice classification.
-
-        Args:
-            dataset:
-                The dataset to prepare.
-
-        Returns:
-            The prepared dataset.
-        """
-        return DatasetDict(
-            {
-                split_name: split.map(
-                    partial(
-                        multiple_choice_classification.prepare_examples,
-                        tokeniser=self._tokeniser,
-                        num_choices=self.dataset_config.num_labels,
-                    ),
-                    batched=True,
-                    batch_size=10,
-                    remove_columns=split.column_names,
-                    load_from_cache_file=False,
-                    keep_in_memory=True,
-                )
-                for split_name, split in dataset.items()
-            }
-        )
-
-    def _prepare_question_answering(self, dataset: DatasetDict) -> DatasetDict:
-        """Prepare dataset for question answering.
-
-        Args:
-            dataset:
-                The dataset to prepare.
-
-        Returns:
-            The prepared dataset.
-        """
-        data_dict = dict()
-        test_columns = dataset["test"].column_names if "test" in dataset else []
-
-        for split_name in ["train", "val", "test"]:
-            if split_name not in dataset:
-                continue
-
-            split = dataset[split_name]
-            if split_name == "test":
-                prep_func = question_answering.prepare_test_examples
-            else:
-                prep_func = question_answering.prepare_train_examples
-
-            data_dict[split_name] = split.map(
-                partial(prep_func, tokeniser=self._tokeniser),
-                batched=True,
-                batch_size=10,
-                remove_columns=test_columns,
-                load_from_cache_file=False,
-                keep_in_memory=True,
-            )
-
-        result: DatasetDict = DatasetDict(data_dict)
-
-        # Restore columns hidden by Trainer (id, offset_mapping) for post-processing
-        for split_name, split in result.items():
-            result[split_name].set_format(
-                type=split.format["type"], columns=list(split.features.keys())
-            )
-
-        return result
-
-    def _prepare_sequence_classification(self, dataset: DatasetDict) -> DatasetDict:
-        """Prepare dataset for sequence classification.
-
-        Args:
-            dataset:
-                The dataset to prepare.
-
-        Returns:
-            The prepared dataset.
-        """
-        return dataset.map(
-            self._numericalise_labels, batched=True, load_from_cache_file=False
-        ).map(self._tokenise, batched=True, load_from_cache_file=False)
-
-    def _prepare_text_to_text(self, dataset: DatasetDict) -> DatasetDict:
-        """Prepare dataset for text-to-text tasks.
-
-        Args:
-            dataset:
-                The dataset to prepare.
-
-        Returns:
-            The prepared dataset.
-        """
-        return dataset.map(
-            self._tokenise,
-            batched=True,
-            load_from_cache_file=False,
-            keep_in_memory=True,
-        )
-
-    def _prepare_token_classification(self, dataset: DatasetDict) -> DatasetDict:
-        """Prepare dataset for token classification.
-
-        Args:
-            dataset:
-                The dataset to prepare.
-
-        Returns:
-            The prepared dataset.
-        """
-        return dataset.map(
-            partial(
-                token_classification.tokenize_and_align_labels,
-                tokeniser=self._tokeniser,
-                label2id=self._model.config.label2id,  # ty: ignore[invalid-argument-type]
-            ),
-            batched=True,
-            load_from_cache_file=False,
-            keep_in_memory=True,
-        )
 
     def _tokenise(self, examples: dict) -> "BatchEncoding":
         """Tokenise examples.
@@ -1357,6 +437,128 @@ class HuggingFaceEncoderModel(BenchmarkModule):
             case _:
                 raise NotImplementedError(f"Unsupported task group: {task.task_group}.")
 
+    def _prepare_multiple_choice(self, dataset: DatasetDict) -> DatasetDict:
+        """Prepare dataset for multiple choice classification.
+
+        Args:
+            dataset:
+                The dataset to prepare.
+
+        Returns:
+            The prepared dataset.
+        """
+        return DatasetDict(
+            {
+                split_name: split.map(
+                    partial(
+                        multiple_choice_classification.prepare_examples,
+                        tokeniser=self._tokeniser,
+                        num_choices=self.dataset_config.num_labels,
+                    ),
+                    batched=True,
+                    batch_size=10,
+                    remove_columns=split.column_names,
+                    load_from_cache_file=False,
+                    keep_in_memory=True,
+                )
+                for split_name, split in dataset.items()
+            }
+        )
+
+    def _prepare_question_answering(self, dataset: DatasetDict) -> DatasetDict:
+        """Prepare dataset for question answering.
+
+        Args:
+            dataset:
+                The dataset to prepare.
+
+        Returns:
+            The prepared dataset.
+        """
+        data_dict = dict()
+        test_columns = dataset["test"].column_names if "test" in dataset else []
+
+        for split_name in ["train", "val", "test"]:
+            if split_name not in dataset:
+                continue
+
+            split = dataset[split_name]
+            if split_name == "test":
+                prep_func = question_answering.prepare_test_examples
+            else:
+                prep_func = question_answering.prepare_train_examples
+
+            data_dict[split_name] = split.map(
+                partial(prep_func, tokeniser=self._tokeniser),
+                batched=True,
+                batch_size=10,
+                remove_columns=test_columns,
+                load_from_cache_file=False,
+                keep_in_memory=True,
+            )
+
+        result: DatasetDict = DatasetDict(data_dict)
+
+        # Restore columns hidden by Trainer (id, offset_mapping) for post-processing
+        for split_name, split in result.items():
+            result[split_name].set_format(
+                type=split.format["type"], columns=list(split.features.keys())
+            )
+
+        return result
+
+    def _prepare_sequence_classification(self, dataset: DatasetDict) -> DatasetDict:
+        """Prepare dataset for sequence classification.
+
+        Args:
+            dataset:
+                The dataset to prepare.
+
+        Returns:
+            The prepared dataset.
+        """
+        return dataset.map(
+            self._numericalise_labels, batched=True, load_from_cache_file=False
+        ).map(self._tokenise, batched=True, load_from_cache_file=False)
+
+    def _prepare_text_to_text(self, dataset: DatasetDict) -> DatasetDict:
+        """Prepare dataset for text-to-text tasks.
+
+        Args:
+            dataset:
+                The dataset to prepare.
+
+        Returns:
+            The prepared dataset.
+        """
+        return dataset.map(
+            self._tokenise,
+            batched=True,
+            load_from_cache_file=False,
+            keep_in_memory=True,
+        )
+
+    def _prepare_token_classification(self, dataset: DatasetDict) -> DatasetDict:
+        """Prepare dataset for token classification.
+
+        Args:
+            dataset:
+                The dataset to prepare.
+
+        Returns:
+            The prepared dataset.
+        """
+        return dataset.map(
+            partial(
+                token_classification.tokenize_and_align_labels,
+                tokeniser=self._tokeniser,
+                label2id=self._model.config.label2id,  # ty: ignore[invalid-argument-type]
+            ),
+            batched=True,
+            load_from_cache_file=False,
+            keep_in_memory=True,
+        )
+
     @property
     def trainer_class(self) -> t.Type["Trainer"]:
         """The Trainer class to use for finetuning.
@@ -1400,6 +602,897 @@ class HuggingFaceEncoderModel(BenchmarkModule):
         ):
             vocab_size = self._tokeniser.vocab_size
         return vocab_size
+
+
+def align_model_and_tokeniser(
+    model: "PreTrainedModel",
+    tokeniser: Tokeniser,
+    model_max_length: int,
+    raise_errors: bool = False,
+    is_multiple_choice: bool = False,
+) -> tuple["PreTrainedModel", Tokeniser]:
+    """Aligns the model and the tokeniser.
+
+    Args:
+        model:
+            The model to fix.
+        tokeniser:
+            The tokeniser to fix.
+        model_max_length:
+            The maximum length of the model.
+        raise_errors (optional):
+            Whether to raise errors instead of trying to fix them silently.
+            Defaults to False.
+        is_multiple_choice (optional):
+            Whether the model is being evaluated on a multiple-choice task, in which
+            case it expects a 3-D dummy input when probing the maximum length.
+            Defaults to False.
+
+    Returns:
+        The fixed model and tokeniser.
+    """
+    model_max_length = min(model_max_length, MAX_CONTEXT_LENGTH)
+    tokeniser.model_max_length = model_max_length if model_max_length > 0 else 512
+
+    # Test on CPU to avoid GPU memory issues
+    model_device = model.device
+    model.to(torch.device("cpu"))  # ty: ignore[invalid-argument-type]
+
+    initial_max_length = tokeniser.model_max_length
+    valid_max_length = _find_valid_model_max_length(
+        model=model,
+        tokeniser=tokeniser,
+        initial_max_length=initial_max_length,
+        is_multiple_choice=is_multiple_choice,
+    )
+    tokeniser.model_max_length = valid_max_length
+
+    model.to(model_device)  # ty: ignore[invalid-argument-type]
+
+    _adjust_vocab_size(model=model, tokeniser=tokeniser, raise_errors=raise_errors)
+    _adjust_vocab_size(model=model, tokeniser=tokeniser, raise_errors=raise_errors)
+
+    _set_bos_token(tokeniser=tokeniser)
+
+    return model, tokeniser
+
+
+@cache_arguments()
+def _adjust_vocab_size(
+    model: "PreTrainedModel", tokeniser: Tokeniser, raise_errors: bool
+) -> None:
+    """Adjust model vocab size if tokeniser is larger.
+
+    Args:
+        model:
+            The model to potentially resize.
+        tokeniser:
+            The tokeniser.
+        raise_errors:
+            Whether to raise errors instead of auto-adjusting.
+
+    Raises:
+        InvalidModel:
+            If vocab size mismatch and raise_errors is True.
+    """
+    if not hasattr(model.config, "vocab_size"):
+        return
+
+    if model.config.vocab_size >= len(tokeniser):
+        return
+
+    if raise_errors:
+        raise InvalidModel(
+            "The vocab size of the tokeniser is larger than the vocab size of "
+            "the model. As the --raise-errors option was specified, the "
+            "embeddings of the model will not be automatically adjusted."
+        )
+
+    if hasattr(model, "resize_token_embeddings"):
+        model.resize_token_embeddings(new_num_tokens=tokeniser.vocab_size + 1)
+
+
+@cache_arguments()
+def _find_valid_model_max_length(
+    model: "PreTrainedModel",
+    tokeniser: Tokeniser,
+    initial_max_length: int,
+    is_multiple_choice: bool,
+) -> int:
+    """Find the maximum valid sequence length for the model.
+
+    Args:
+        model:
+            The model to test.
+        tokeniser:
+            The tokeniser.
+        initial_max_length:
+            The initial maximum length to test.
+        is_multiple_choice:
+            Whether this is a multiple-choice model.
+
+    Returns:
+        The valid maximum length.
+
+    Raises:
+        ValueError:
+            If an unexpected error occurs during inference.
+    """
+    for max_length in range(initial_max_length, 0, -1):
+        tokeniser.model_max_length = max_length
+        dummy_inputs = torch.full(
+            size=(1, 2, max_length) if is_multiple_choice else (1, max_length),
+            fill_value=DUMMY_FILL_VALUE,
+            dtype=torch.long,
+            device=model.device,
+        )
+        with torch.inference_mode():
+            try:
+                model(dummy_inputs, attention_mask=torch.ones_like(dummy_inputs))
+                return max_length
+            except IndexError:
+                continue
+            except ValueError as e:
+                if "cpu tensor" in str(e):
+                    return max_length
+                raise
+    return 1
+
+
+def _set_bos_token(tokeniser: Tokeniser) -> None:
+    """Set BOS token from EOS token if BOS is not set.
+
+    Args:
+        tokeniser:
+            The tokeniser to update.
+    """
+    if tokeniser.bos_token is None and tokeniser.eos_token is not None:
+        tokeniser.bos_token = tokeniser.eos_token
+        tokeniser.bos_token_id = tokeniser.eos_token_id
+
+
+def load_model_and_tokeniser(
+    model_config: "ModelConfig",
+    dataset_config: "DatasetConfig",
+    benchmark_config: "BenchmarkConfig",
+    dtype_override: "DataType | None" = None,
+) -> tuple["PreTrainedModel", Tokeniser]:
+    """Load the model and tokeniser.
+
+    Args:
+        model_config:
+            The model configuration.
+        dataset_config:
+            The dataset configuration.
+        benchmark_config:
+            The benchmark configuration
+        dtype_override (optional):
+            An explicit data type to load the model weights in, taking precedence
+            over the hardware-derived default. Used by the finetuning NaN-retry to
+            force a full fp32 reload. Defaults to None.
+
+    Returns:
+        A pair (model, tokeniser), with the loaded model and tokeniser
+
+    Raises:
+        InvalidBenchmark:
+            If the model could not be loaded for this particular dataset.
+    """
+    block_terminal_output()
+
+    model_id = model_config.model_id
+    task_group = dataset_config.task.task_group
+
+    id2label = dataset_config.id2label
+    config = load_hf_model_config(
+        model_id=model_id,
+        num_labels=len(id2label),
+        id2label=HashableDict(id2label),
+        label2id=HashableDict({label: idx for idx, label in id2label.items()}),
+        revision=model_config.revision,
+        model_cache_dir=model_config.model_cache_dir,
+        api_key=benchmark_config.api_key,
+        trust_remote_code=benchmark_config.trust_remote_code,
+        run_with_cli=benchmark_config.run_with_cli,
+    )
+
+    # If the model is a DeBERTaV2 model then ensure `pooler_hidden_size` matches
+    if config.model_type == "deberta-v2":
+        config.pooler_hidden_size = config.hidden_size
+
+    model_kwargs: dict[str, t.Any] = dict(
+        config=config,
+        ignore_mismatched_sizes=False,
+        revision=model_config.revision,
+        token=get_hf_token(api_key=benchmark_config.api_key),
+        cache_dir=model_config.model_cache_dir,
+        trust_remote_code=benchmark_config.trust_remote_code,
+        dtype=get_dtype(
+            device=benchmark_config.device,
+            dtype_is_set=config.to_dict().get("dtype") is not None,
+            bf16_available=(
+                torch.cuda.is_available() and torch.cuda.is_bf16_supported()
+            ),
+            dtype_override=dtype_override,
+        ),
+    )
+
+    model_cls_or_none: t.Type[PreTrainedModel] | None = t.cast(
+        "t.Type[PreTrainedModel] | None",
+        get_class_by_name(
+            class_name=task_group_to_class_name(task_group=task_group),
+            module_name="transformers",
+        ),
+    )
+
+    if not model_cls_or_none:
+        raise InvalidBenchmark(
+            f"The task group {task_group.value!r} does not correspond to a "
+            "Hugging Face AutoModel type (such as "
+            "`AutoModelForSequenceClassification`)."
+        )
+
+    model_or_tuple = _load_model_from_pretrained(
+        model_cls=model_cls_or_none,
+        model_id=model_config.model_id,
+        model_kwargs=model_kwargs,
+        task_group=task_group,
+    )
+
+    if isinstance(model_or_tuple, tuple):
+        model = t.cast(PreTrainedModel, model_or_tuple[0])
+    else:
+        model = t.cast(PreTrainedModel, model_or_tuple)
+
+    assert model is not None, "The model should not be None."
+    model = t.cast("PreTrainedModel", model)  # ty: ignore[redundant-cast]
+
+    model.eval()
+    model.to(benchmark_config.device)  # ty: ignore[invalid-argument-type]
+
+    if (
+        isinstance(model, PreTrainedModel)
+        and task_group == TaskGroup.QUESTION_ANSWERING
+    ):
+        model = setup_model_for_question_answering(model=model)
+
+    tokeniser = load_tokeniser(
+        model=model,
+        model_id=model_id,
+        trust_remote_code=benchmark_config.trust_remote_code,
+        model_config=model_config,
+    )
+
+    return model, tokeniser
+
+
+def _load_model_from_pretrained(
+    model_cls: t.Type[PreTrainedModel],
+    model_id: str,
+    model_kwargs: dict[str, t.Any],
+    task_group: TaskGroup,
+) -> PreTrainedModel | tuple[PreTrainedModel, ...]:
+    """Load a model from pretrained with error handling.
+
+    Args:
+        model_cls:
+            The model class to load.
+        model_id:
+            The model ID.
+        model_kwargs:
+            Keyword arguments for loading the model.
+        task_group:
+            The task group for error messages.
+
+    Returns:
+        The loaded model or tuple of models.
+
+    Raises:
+        InvalidModel:
+            If the model could not be loaded.
+        InvalidBenchmark:
+            If the model architecture doesn't support the task.
+    """
+    for _ in range(num_attempts := 5):
+        try:
+            return model_cls.from_pretrained(
+                pretrained_model_name_or_path=model_id, **model_kwargs
+            )
+        except (KeyError, RuntimeError) as e:
+            if not model_kwargs.get("ignore_mismatched_sizes", False):
+                log(
+                    f"{type(e).__name__} occurred during the loading "
+                    f"of the {model_id!r} model. Retrying with "
+                    "`ignore_mismatched_sizes` set to True.",
+                    level=logging.DEBUG,
+                )
+                model_kwargs["ignore_mismatched_sizes"] = True
+                continue
+            raise InvalidModel(str(e)) from e
+        except (TimeoutError, RequestError):
+            log(
+                f"Couldn't load the model {model_id!r}. Retrying.",
+                level=logging.WARNING,
+            )
+            sleep(5)
+            continue
+        except (OSError, ValueError) as e:
+            error_str = str(e)
+            if "checkpoint seems to be incorrect" in error_str:
+                raise InvalidModel(
+                    f"The model {model_id!r} has an incorrect checkpoint."
+                ) from e
+            if "trust_remote_code" in error_str:
+                raise InvalidModel(
+                    f"Loading the model {model_id!r} needs to trust remote code. "
+                    "If you trust the suppliers of this model, then you can enable "
+                    "this by setting the `--trust-remote-code` flag."
+                ) from e
+            if (
+                "Unrecognized configuration class" in error_str
+                and "AutoModelFor" in error_str
+            ):
+                raise InvalidBenchmark(
+                    f"The model {model_id!r} does not support the "
+                    f"task group {task_group.value!r} as its architecture is not "
+                    f"compatible with the required HuggingFace model class. "
+                    f"Error: {e}"
+                ) from e
+            raise InvalidModel(
+                f"The model {model_id!r} could not be loaded. The error was {e!r}."
+            ) from e
+    raise InvalidModel(
+        f"Could not load the model {model_id!r} after {num_attempts} attempts."
+    )
+
+
+def get_class_by_name(
+    class_name: str | c.Sequence[str], module_name: str
+) -> t.Type | None:
+    """Get a class by its name.
+
+    Args:
+        class_name:
+            The name of the class, written in kebab-case. The corresponding class name
+            must be the same, but written in PascalCase, and lying in a module with the
+            same name, but written in snake_case. If a list of strings is passed, the
+            first class that is found is returned.
+        module_name:
+            The name of the module where the class is located.
+
+    Returns:
+        The class. If the class is not found, None is returned.
+    """
+    if isinstance(class_name, str):
+        class_name = [class_name]
+
+    error_messages = list()
+    for name in class_name:
+        try:
+            module = importlib.import_module(name=module_name)
+            class_: t.Type = getattr(module, name)
+            return class_
+        except (ModuleNotFoundError, AttributeError) as e:
+            error_messages.append(str(e))
+
+    if error_messages:
+        errors = "\n- " + "\n- ".join(error_messages)
+        log(
+            f"Could not find the class with the name(s) {', '.join(class_name)}. The "
+            f"following error messages were raised: {errors}",
+            level=logging.DEBUG,
+        )
+
+    return None
+
+
+@cache_arguments()
+def get_dtype(
+    device: torch.device,
+    dtype_is_set: bool,
+    bf16_available: bool,
+    dtype_override: "DataType | None" = None,
+) -> str | torch.dtype:
+    """Get the torch dtype, used for loading the model.
+
+    Args:
+        device:
+            The device to use.
+        dtype_is_set:
+            Whether the data type is set in the model configuration.
+        bf16_available:
+            Whether bfloat16 is available.
+        dtype_override (optional):
+            An explicit data type to load the model weights in, taking precedence
+            over both the model configuration and the hardware-derived default. Used
+            by the finetuning NaN-retry, which reloads the model in full fp32 after
+            detecting NaN values under mixed precision; without honouring the
+            override the model would be reloaded in the same (NaN-producing) dtype.
+            Defaults to None.
+
+    Returns:
+        The dtype.
+    """
+    if dtype_override is not None:
+        return {
+            DataType.FP32: torch.float32,
+            DataType.FP16: torch.float16,
+            DataType.BF16: torch.bfloat16,
+        }[dtype_override]
+
+    using_cuda = device == torch.device("cuda")
+    if using_cuda and dtype_is_set:
+        return "auto"
+    elif using_cuda and bf16_available:
+        return torch.bfloat16
+    elif using_cuda:
+        return torch.float16
+    return torch.float32
+
+
+@cache_arguments("model_id", "revision", "num_labels", "id2label", "label2id")
+def load_hf_model_config(
+    model_id: str,
+    num_labels: int,
+    id2label: dict[int, str],
+    label2id: dict[str, int],
+    revision: str,
+    model_cache_dir: str | None,
+    api_key: str | None,
+    trust_remote_code: bool,
+    run_with_cli: bool,
+) -> "PretrainedConfig":
+    """Load the Hugging Face model configuration.
+
+    Args:
+        model_id:
+            The Hugging Face model ID.
+        num_labels:
+            The number of labels in the dataset.
+        id2label:
+            The mapping from label IDs to labels.
+        label2id:
+            The mapping from labels to label IDs.
+        revision:
+            The revision of the model.
+        model_cache_dir:
+            The directory to cache the model in.
+        api_key:
+            The Hugging Face API key.
+        trust_remote_code:
+            Whether to trust remote code.
+        run_with_cli:
+            Whether the script is being run with the CLI.
+
+    Returns:
+        The Hugging Face model configuration.
+
+    Raises:
+        InvalidModel:
+            If the model configuration could not be loaded.
+    """
+    for _ in range(num_attempts := 5):
+        try:
+            config = AutoConfig.from_pretrained(
+                pretrained_model_name_or_path=model_id,
+                num_labels=num_labels,
+                id2label=id2label,
+                label2id=label2id,
+                revision=revision,
+                token=get_hf_token(api_key=api_key),
+                trust_remote_code=trust_remote_code,
+                cache_dir=model_cache_dir,
+                local_files_only=not internet_connection_available(),
+            )
+            break
+        except Exception as e:
+            result = _handle_model_config_error(
+                error=e, model_id=model_id, run_with_cli=run_with_cli
+            )
+            if result == "retry":
+                continue
+            if isinstance(result, PretrainedConfig):
+                return result
+            if result is None:
+                raise
+            # result == "continue" - fall through to retry
+    else:
+        raise InvalidModel(
+            f"Couldn't load model config for {model_id!r} after {num_attempts} "
+            "attempts."
+        )
+
+    _set_pad_token_id(config=config)
+    return config
+
+
+@cache_arguments("model_id", "run_with_cli")
+def _handle_model_config_error(
+    error: Exception, model_id: str, run_with_cli: bool
+) -> t.Literal["retry", "continue"] | PretrainedConfig | None:
+    """Handle an error during model config loading.
+
+    Args:
+        error:
+            The exception that was raised.
+        model_id:
+            The model ID.
+        run_with_cli:
+            Whether running with CLI.
+
+    Returns:
+        "retry" to retry loading, "continue" to skip, a PretrainedConfig to return
+        immediately, or None to raise an exception.
+
+    Raises:
+        InvalidModel:
+            If the model config could not be loaded.
+        NeedsAdditionalArgument:
+            If trust_remote_code is required.
+    """
+    e = error
+    if isinstance(e, KeyError):
+        raise InvalidModel(
+            f"The model config for the model {model_id!r} could not be "
+            f"loaded, as the key {e.args[0]!r} was not found in the config."
+        ) from e
+
+    if isinstance(e, (OSError, GatedRepoError)):
+        if isinstance(e, GatedRepoError) or "gated repo" in str(e).lower():
+            raise InvalidModel(
+                f"The model {model_id!r} is a gated repository. Please ensure "
+                "that you are logged in with `hf auth login` or have provided a "
+                "valid Hugging Face access token with the `HUGGINGFACE_API_KEY` "
+                "or `HF_TOKEN` environment variable or the `--api-key` argument. "
+                "Also check that your account has access to this model."
+            ) from e
+        if not internet_connection_available():
+            log(
+                f"Couldn't load model config for {model_id!r} offline. "
+                f"The error was {e!r}. Returning minimal config.",
+                level=logging.WARNING,
+            )
+            return PretrainedConfig()
+        raise InvalidModel(
+            f"Couldn't load model config for {model_id!r}. The error was "
+            f"{e!r}. Skipping"
+        ) from e
+
+    if isinstance(e, (TimeoutError, RequestError)):
+        log(
+            f"Couldn't load model config for {model_id!r}. Retrying.",
+            level=logging.WARNING,
+        )
+        sleep(5)
+        return "retry"
+
+    if isinstance(e, ValueError):
+        if "awaiting a review from the repo authors" in str(e):
+            raise InvalidModel(
+                f"The model {model_id!r} is awaiting a review from the repository "
+                "authors. Please try again later."
+            ) from e
+        if "trust_remote_code" in str(e):
+            raise NeedsAdditionalArgument(
+                cli_argument="--trust-remote-code",
+                script_argument="trust_remote_code=True",
+                run_with_cli=run_with_cli,
+            ) from e
+        raise InvalidModel(
+            f"The config for the model {model_id!r} could not be loaded. The "
+            f"error was {e!r}."
+        ) from e
+
+    return None
+
+
+def _set_pad_token_id(config: PretrainedConfig) -> None:
+    """Set the PAD token ID from EOS token ID if not set.
+
+    Args:
+        config:
+            The model configuration to update.
+    """
+    if (
+        hasattr(config, "eos_token_id")
+        and config.eos_token_id is not None
+        and (not hasattr(config, "pad_token_id") or config.pad_token_id is None)
+    ):
+        if isinstance(config.eos_token_id, list):
+            config.pad_token_id = config.eos_token_id[0]
+        else:
+            config.pad_token_id = config.eos_token_id
+
+
+def load_tokeniser(
+    model: "PreTrainedModel | None",
+    model_id: str,
+    trust_remote_code: bool,
+    model_config: "ModelConfig",
+) -> Tokeniser:
+    """Load the tokeniser.
+
+    Args:
+        model:
+            The model, which is used to determine whether to add a prefix space to
+            the tokens. Can be None.
+        model_id:
+            The model identifier. Used for logging.
+        trust_remote_code:
+            Whether to trust remote code.
+        model_config:
+            The model configuration.
+
+    Returns:
+        The loaded tokeniser.
+
+    Raises:
+        InvalidModel:
+            If the tokeniser could not be loaded.
+    """
+    loading_kwargs: dict[str, bool | str] = dict(
+        use_fast=False if model_config.param == "slow-tokenizer" else True,
+        trust_remote_code=trust_remote_code,
+        padding_side="right",
+        truncation_side="right",
+        cache_dir=model_config.model_cache_dir,
+    )
+
+    # If the model is a subclass of a certain model types then we have to add a prefix
+    # space to the tokens, by the way the model is constructed.
+    if model is not None:
+        prefix_models = ["Roberta", "GPT", "Deberta"]
+        add_prefix = any(
+            model_type in type(model).__name__ for model_type in prefix_models
+        )
+        if add_prefix:
+            loading_kwargs["add_prefix_space"] = True
+
+    num_retries = 5
+    for attempt in range(num_retries):
+        try:
+            tokeniser: Tokeniser = AutoTokenizer.from_pretrained(
+                pretrained_model_name_or_path=model_id, **loading_kwargs
+            )  # ty: ignore[invalid-assignment]
+            break
+        except TypeError as e:
+            # XLM-RoBERTa variant models like 'EMBEDDIA/litlat-bert' raise TypeError
+            # when loading fast tokenizers. Fall back to slow tokenizer.
+            if loading_kwargs.get("use_fast", True):
+                log(
+                    f"TypeError occurred during the loading of the tokeniser for "
+                    f"{model_id!r}. Retrying with use_fast=False.",
+                    level=logging.DEBUG,
+                )
+                loading_kwargs["use_fast"] = False
+                continue
+            else:
+                raise InvalidModel(
+                    f"Could not load tokeniser for model {model_id!r}."
+                ) from e
+        except (JSONDecodeError, OSError) as e:
+            raise InvalidModel(
+                f"Could not load tokeniser for model {model_id!r}."
+            ) from e
+        except (TimeoutError, RequestError):
+            log(
+                f"Couldn't load tokeniser for {model_id!r}. Retrying.",
+                level=logging.WARNING,
+            )
+            sleep(5)
+            continue
+    else:
+        raise InvalidModel(
+            f"Could not load tokeniser for model {model_id!r} after {num_retries} "
+            "attempts."
+        )
+
+    tokeniser.bos_token, tokeniser.bos_token_id = get_bos_token(tokeniser=tokeniser)
+    tokeniser.eos_token, tokeniser.eos_token_id = get_eos_token(tokeniser=tokeniser)
+
+    return tokeniser
+
+
+def setup_model_for_question_answering(model: "PreTrainedModel") -> "PreTrainedModel":
+    """Setup a model for question answering.
+
+    Args:
+        model:
+            The model to setup.
+
+    Returns:
+        The setup model.
+
+    Raises:
+        InvalidModel:
+            If the model does not have token type embeddings.
+    """
+    children = get_children_of_module(name="model", module=model)
+    assert isinstance(children, dict)
+
+    if children:
+        attribute_list = list()
+        done = False
+        while not done:
+            for key, value in children.items():
+                attribute_list.append(key)
+                if isinstance(value, dict):
+                    children = value
+                else:
+                    done = True
+                break
+
+        token_type_embeddings = model
+        for attribute in attribute_list:
+            token_type_embeddings = getattr(token_type_embeddings, attribute)
+
+        token_type_embedding_tensor = token_type_embeddings.weight.data
+        assert isinstance(token_type_embedding_tensor, torch.Tensor)
+
+        # If the token type embeddings has shape (1, ...) then set the shape to
+        # (2, ...) by randomly initializing the second token type embedding
+        if token_type_embedding_tensor.shape[0] == 1:
+            if not hasattr(token_type_embeddings.weight, "data"):
+                raise InvalidModel(
+                    "The token type embeddings of the model do not have a `data` "
+                    "attribute, which is needed to modify the embeddings."
+                )
+            token_type_embeddings.weight.data = torch.cat(
+                tensors=(
+                    token_type_embedding_tensor,
+                    torch.rand_like(tensor=token_type_embedding_tensor),
+                ),
+                dim=0,
+            )
+            token_type_embeddings.num_embeddings = 2  # ty: ignore[invalid-assignment]
+
+        model.config.type_vocab_size = 2
+
+    return model
+
+
+def get_children_of_module(
+    name: str, module: nn.Module
+) -> nn.Module | dict[str, t.Any] | None:
+    """Get the children of a module.
+
+    Args:
+        name:
+            The name of the module.
+        module:
+            The module to get the children of.
+
+    Returns:
+        The children of the module, or None if the module has no children.
+    """
+    if len(list(module.children())) == 0:
+        if name == "token_type_embeddings":
+            return module
+        else:
+            return None
+    else:
+        submodules = dict()
+        for subname, submodule in module.named_children():
+            children = get_children_of_module(name=subname, module=submodule)
+            if children:
+                submodules[subname] = children
+        return submodules
+
+
+def task_group_to_class_name(task_group: TaskGroup) -> str:
+    """Convert a task group to a class name.
+
+    Args:
+        task_group:
+            The task group.
+
+    Returns:
+        The class name.
+    """
+    pascal_case = task_group.title().replace("_", "")
+
+    # Bridge task-group names that don't map 1:1 onto a Hugging Face AutoModel class:
+    # the multiple-choice group is internally named "..._classification" but the HF
+    # class is `AutoModelForMultipleChoice`, and `Speed` reuses the sequence
+    # classification head.
+    special_case_mapping = dict(
+        MultipleChoiceClassification="MultipleChoice", Speed="SequenceClassification"
+    )
+    pascal_case = special_case_mapping.get(pascal_case, pascal_case)
+    return f"AutoModelFor{pascal_case}"
+
+
+def get_model_repo_info(
+    model_id: str,
+    revision: str,
+    api_key: str | None,
+    cache_dir: str,
+    trust_remote_code: bool,
+    requires_safetensors: bool,
+    run_with_cli: bool,
+) -> "HFModelInfo | None":
+    """Get the information about the model from the HF Hub or a local directory.
+
+    Args:
+        model_id:
+            The model ID.
+        revision:
+            The revision of the model.
+        api_key:
+            The Hugging Face API key.
+        cache_dir:
+            The directory to cache the model in.
+        trust_remote_code:
+            Whether to trust remote code.
+        requires_safetensors:
+            Whether the model requires safetensors.
+        run_with_cli:
+            Whether the script is being run with the CLI.
+
+    Returns:
+        The information about the model, or None if the model could not be found.
+    """
+    token = get_hf_token(api_key=api_key)
+    hf_api = HfApi(token=token)
+
+    # Try to get model info from local directory first
+    model_info: HfApiModelInfo | None = None
+    if Path(model_id).is_dir():
+        model_info = _get_local_model_info(model_id=model_id)
+        if model_info is None:
+            return None
+    elif not internet_connection_available():
+        model_info = HfApiModelInfo(id=model_id, tags=None, pipeline_tag=None)
+
+    # Fetch from HF Hub if not found locally
+    if model_info is None:
+        model_info = _fetch_model_info_from_hub(
+            hf_api=hf_api, model_id=model_id, revision=revision, token=token
+        )
+        if model_info is None:
+            return None
+
+    # Handle adapter models - get base model tags
+    tags = model_info.tags or list()
+    base_model_id: str | None = None
+    has_adapter_config = model_info.siblings is not None and any(
+        sibling.rfilename == "adapter_config.json" for sibling in model_info.siblings
+    )
+    if has_adapter_config:
+        tags, base_model_id = _get_tags_for_adapter_model(
+            model_id=model_id,
+            revision=revision,
+            model_info=model_info,
+            hf_api=hf_api,
+            token=token,
+        )
+
+    # Infer pipeline tag if not specified
+    pipeline_tag = model_info.pipeline_tag
+    if pipeline_tag is None:
+        pipeline_tag = _infer_pipeline_tag(
+            model_id=model_id,
+            revision=revision,
+            cache_dir=cache_dir,
+            api_key=api_key,
+            trust_remote_code=trust_remote_code,
+            run_with_cli=run_with_cli,
+            base_model_id=base_model_id,
+        )
+
+    # Check safetensors requirement
+    if requires_safetensors and not _check_safetensors_available(
+        hf_api=hf_api,
+        model_id=model_id,
+        revision=revision,
+        base_model_id=base_model_id,
+        run_with_cli=run_with_cli,
+    ):
+        return None
+
+    return HFModelInfo(
+        pipeline_tag=pipeline_tag, tags=tags, adapter_base_model_id=base_model_id
+    )
 
 
 def _check_safetensors_available(
@@ -1658,96 +1751,3 @@ def _infer_pipeline_tag(
     ):
         return "text-generation"
     return "fill-mask"
-
-
-def get_model_repo_info(
-    model_id: str,
-    revision: str,
-    api_key: str | None,
-    cache_dir: str,
-    trust_remote_code: bool,
-    requires_safetensors: bool,
-    run_with_cli: bool,
-) -> "HFModelInfo | None":
-    """Get the information about the model from the HF Hub or a local directory.
-
-    Args:
-        model_id:
-            The model ID.
-        revision:
-            The revision of the model.
-        api_key:
-            The Hugging Face API key.
-        cache_dir:
-            The directory to cache the model in.
-        trust_remote_code:
-            Whether to trust remote code.
-        requires_safetensors:
-            Whether the model requires safetensors.
-        run_with_cli:
-            Whether the script is being run with the CLI.
-
-    Returns:
-        The information about the model, or None if the model could not be found.
-    """
-    token = get_hf_token(api_key=api_key)
-    hf_api = HfApi(token=token)
-
-    # Try to get model info from local directory first
-    model_info: HfApiModelInfo | None = None
-    if Path(model_id).is_dir():
-        model_info = _get_local_model_info(model_id=model_id)
-        if model_info is None:
-            return None
-    elif not internet_connection_available():
-        model_info = HfApiModelInfo(id=model_id, tags=None, pipeline_tag=None)
-
-    # Fetch from HF Hub if not found locally
-    if model_info is None:
-        model_info = _fetch_model_info_from_hub(
-            hf_api=hf_api, model_id=model_id, revision=revision, token=token
-        )
-        if model_info is None:
-            return None
-
-    # Handle adapter models - get base model tags
-    tags = model_info.tags or list()
-    base_model_id: str | None = None
-    has_adapter_config = model_info.siblings is not None and any(
-        sibling.rfilename == "adapter_config.json" for sibling in model_info.siblings
-    )
-    if has_adapter_config:
-        tags, base_model_id = _get_tags_for_adapter_model(
-            model_id=model_id,
-            revision=revision,
-            model_info=model_info,
-            hf_api=hf_api,
-            token=token,
-        )
-
-    # Infer pipeline tag if not specified
-    pipeline_tag = model_info.pipeline_tag
-    if pipeline_tag is None:
-        pipeline_tag = _infer_pipeline_tag(
-            model_id=model_id,
-            revision=revision,
-            cache_dir=cache_dir,
-            api_key=api_key,
-            trust_remote_code=trust_remote_code,
-            run_with_cli=run_with_cli,
-            base_model_id=base_model_id,
-        )
-
-    # Check safetensors requirement
-    if requires_safetensors and not _check_safetensors_available(
-        hf_api=hf_api,
-        model_id=model_id,
-        revision=revision,
-        base_model_id=base_model_id,
-        run_with_cli=run_with_cli,
-    ):
-        return None
-
-    return HFModelInfo(
-        pipeline_tag=pipeline_tag, tags=tags, adapter_base_model_id=base_model_id
-    )

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -198,169 +198,6 @@ CUSTOM_INFERENCE_API_PREFIXES = [
 UNOFFICIAL_INFERENCE_API_PREFIXES = ["ordbogen/", "alx/"]
 
 
-def clean_model_id(model_id: str, benchmark_config: BenchmarkConfig) -> str:
-    """Clean a model ID.
-
-    This adds the default `openai/` prefix to the model ID if we're benchmarking a
-    custom API inference server and no prefix is used, just to make it more
-    convenient for the user.
-
-    Args:
-        model_id:
-            The model ID.
-        benchmark_config:
-            The benchmark configuration.
-
-    Returns:
-        The cleaned model ID.
-    """
-    new_model_id = deepcopy(model_id)
-
-    # Remove unofficial prefixes
-    for unofficial_prefix in UNOFFICIAL_INFERENCE_API_PREFIXES:
-        new_model_id = re.sub(
-            pattern=rf"^{re.escape(unofficial_prefix)}", repl="", string=new_model_id
-        )
-
-    if benchmark_config.api_base is not None and not any(
-        new_model_id.startswith(prefix) for prefix in CUSTOM_INFERENCE_API_PREFIXES
-    ):
-        if benchmark_config.generative_type == GenerativeType.BASE:
-            prefix = "text-completion-openai/"
-        else:
-            prefix = "openai/"
-        new_model_id = prefix + new_model_id
-
-    # When we want to evaluate an OpenAI model on a custom inference server, such as HF
-    # inference endpoints, LiteLLM gets confused since it's already using the `openai/`
-    # prefix. We thus have to add it twice, and this hack here is to ensure that we
-    # don't store the results with model ID `openai/openai/...`.
-    elif benchmark_config.api_base is not None and new_model_id.startswith("openai/"):
-        new_model_id = "openai/openai/" + re.sub(r"(openai/)*", "", new_model_id)
-
-    return new_model_id
-
-
-def set_up_benchmark_config_for_model(
-    benchmark_config: BenchmarkConfig, model_id: str
-) -> None:
-    """Set up the benchmark configuration for the model.
-
-    Args:
-        benchmark_config:
-            The benchmark configuration to set up.
-        model_id:
-            The model ID.
-    """
-    if model_id.startswith("ordbogen/"):
-        benchmark_config.api_key = os.getenv("ORDBOGEN_API_KEY")
-        benchmark_config.api_base = "https://api.ordbogen.ai/v1"
-    elif model_id.startswith("alx/"):
-        benchmark_config.api_key = os.getenv("ALX_API_KEY")
-        benchmark_config.api_base = "https://inference.alexandra.dk/v1"
-
-
-def try_download_ollama_model(model_id: str, progress_bar: bool) -> bool:
-    """Try to download an Ollama model.
-
-    Args:
-        model_id:
-            The model ID. If the model does not start with "ollama/" or "ollama_chat/"
-            then this function will return False.
-        progress_bar:
-            Whether to show a progress bar while downloading the model.
-
-    Returns:
-        Whether the model was downloaded successfully.
-
-    Raises:
-        InvalidModel:
-            If Ollama is not running or the model cannot be downloaded.
-    """
-    if not (model_id.startswith("ollama/") or model_id.startswith("ollama_chat/")):
-        return False
-
-    if model_id.startswith("ollama/"):
-        log_once(
-            "You're trying to benchmark a model with the old 'ollama/' prefix, which "
-            "probably results in bad performance, as it doesn't use the model's chat "
-            "template. If the model is not a chat model then just disregard this "
-            "warning, but if it is a chat model then please cancel this run and "
-            "use the 'ollama_chat/' prefix instead.",
-            level=logging.WARNING,
-        )
-
-    try:
-        downloaded_ollama_models: c.Sequence[str] = [
-            model_obj.model
-            for model_obj in ollama.list().models
-            if model_obj.model is not None
-        ]
-    except ConnectionError as e:
-        raise InvalidModel(
-            "Ollama does not seem to be running, so we cannot evaluate the model "
-            f"{model_id!r}. Please make sure that Ollama is running and try again."
-        ) from e
-
-    ollama_model_id = "/".join(model_id.split("/")[1:])
-    if ollama_model_id not in downloaded_ollama_models:
-        # Try fetching the model info
-        try:
-            response = ollama.pull(model=ollama_model_id, stream=True)
-        except ollama.ResponseError as e:
-            if "file does not exist" in str(e).lower():
-                # Check if the model exists if we prepend "hf.co/"
-                try:
-                    ollama_model_id_with_prefix = f"hf.co/{ollama_model_id}"
-                    model_id_with_prefix = (
-                        f"{model_id.split('/')[0]}/{ollama_model_id_with_prefix}"
-                    )
-                    ollama.pull(model=ollama_model_id_with_prefix, stream=True)
-                    log_once(
-                        f"The model {model_id!r} cannot be found on Ollama, but the "
-                        f"model {model_id_with_prefix} *was* found, so we would "
-                        "recommend you cancelling this run and trying the evaluation "
-                        "with that model ID instead.",
-                        level=logging.WARNING,
-                    )
-                    return False
-                except ollama.ResponseError as inner_e:
-                    if "file does not exist" in str(inner_e).lower():
-                        return False
-                    else:
-                        raise InvalidModel(
-                            f"Failed to download Ollama model {ollama_model_id}. "
-                            f"The error message was: {inner_e}"
-                        ) from inner_e
-            else:
-                raise InvalidModel(
-                    f"Failed to download Ollama model {ollama_model_id}. "
-                    f"The error message was: {e}"
-                ) from e
-
-        # Download the model
-        with get_pbar(
-            desc=f"Downloading {ollama_model_id}",
-            unit_scale=True,
-            unit="B",
-            disable=not progress_bar,
-        ) as pbar:
-            for status in response:
-                if status.total is not None:
-                    pbar.total = status.total
-                if status.completed is not None:
-                    pbar.update(status.completed - pbar.n)
-        return True
-
-    else:
-        log_once(
-            f"Ollama model {ollama_model_id!r} already downloaded, so skipping "
-            "download.",
-            level=logging.DEBUG,
-        )
-        return True
-
-
 class LiteLLMModel(BenchmarkModule):
     """A generative model from LiteLLM."""
 
@@ -451,6 +288,163 @@ class LiteLLMModel(BenchmarkModule):
             log_metadata=self.log_metadata,
         )
         self.buffer["max_concurrent_calls"] = 20
+
+    @property
+    def data_collator(self) -> c.Callable[[list[dict[str, t.Any]]], dict[str, t.Any]]:
+        """The data collator used to prepare samples during finetuning.
+
+        Returns:
+            The data collator.
+        """
+        raise NotImplementedError(
+            "The `data_collator` property has not been implemented for LiteLLM models."
+        )
+
+    @property
+    def extract_labels_from_generation(self) -> ExtractLabelsFunction:
+        """The function used to extract the labels from the generated output.
+
+        Returns:
+            The function used to extract the labels from the generated output.
+        """
+        return _extract_labels_from_generation_helper(
+            dataset_config=self.dataset_config,
+            model_config=self.model_config,
+            first_label_token_mapping=self.buffer["first_label_token_mapping"],
+        )
+
+    def generate(self, inputs: dict) -> GenerativeModelOutput:
+        """Generate outputs from the model.
+
+        Args:
+            inputs:
+                A batch of inputs to pass through the model.
+
+        Returns:
+            The generated model outputs.
+
+        Raises:
+            InvalidBenchmark:
+                If the inputs do not contain either 'messages' or 'text' keys.
+        """
+        model_inputs: c.Sequence[c.Sequence[litellm.AllMessageValues] | str]
+        if "messages" in inputs:
+            model_inputs = inputs["messages"]
+        elif "text" in inputs:
+            model_inputs = inputs["text"]
+        else:
+            raise InvalidBenchmark(
+                "The inputs must contain either 'messages' or 'text' keys."
+            )
+
+        # Get the mapping from labels to the first token in the label. We call this each
+        # time we generate a new dataset since the dataset config can change
+        self.buffer["first_label_token_mapping"] = get_first_label_token_mapping(
+            dataset_config=self.dataset_config,
+            model_config=self.model_config,
+            tokeniser=None,
+            generative_type=self.generative_type,
+            log_metadata=self.log_metadata,
+        )
+
+        all_responses: dict[int, "ModelResponse"] = {}
+        inputs_to_run: c.Sequence[
+            tuple[int, c.Sequence[litellm.AllMessageValues] | str]
+        ] = list(enumerate(model_inputs))
+        for attempt in range(num_attempts := 10):
+            if not inputs_to_run:
+                break
+
+            generation_kwargs = self.generation_kwargs or self.get_generation_kwargs(
+                dataset_config=self.dataset_config
+            )
+
+            batch_indices, batch_inputs = zip(*inputs_to_run)
+            successes, failures = safe_run(
+                self._generate_async(
+                    model_id=self.model_config.model_id,
+                    inputs=list(batch_inputs),
+                    max_concurrent_calls=self.buffer["max_concurrent_calls"],
+                    **generation_kwargs,
+                )
+            )
+
+            # Store the successful model outputs
+            for idx, response in successes:
+                orig_idx = batch_indices[idx]
+                all_responses[orig_idx] = response
+
+            # If all requests were successful, break
+            if not failures:
+                inputs_to_run = []
+                break
+
+            # Put the failed requests back in the queue to try again
+            inputs_to_run = [
+                (batch_indices[idx], model_inputs[batch_indices[idx]])
+                for idx, _ in failures
+            ]
+            log(
+                f"Attempt {attempt + 1:,}/{num_attempts:,}: retrying "
+                f"{len(inputs_to_run):,} failed message(s). Here is the first error: "
+                f"{failures[0][1]}.",
+                level=logging.DEBUG,
+            )
+
+            # Check if any errors are due to HTTP 429 (too many requests), in which case
+            # we reduce the number of concurrent calls
+            http_429_errors = [
+                idx
+                for idx, (_, error) in enumerate(failures)
+                if isinstance(error, RateLimitError)
+            ]
+            if http_429_errors and self.buffer["max_concurrent_calls"] > 1:
+                failures = [
+                    failures[i]
+                    for i in range(len(failures))
+                    if i not in http_429_errors
+                ]
+                self.buffer["max_concurrent_calls"] = max(
+                    1, self.buffer["max_concurrent_calls"] // 2
+                )
+                log(
+                    f"Reducing the maximum number of concurrent calls to "
+                    f"{self.buffer['max_concurrent_calls']:,} due to rate limiting.",
+                    level=logging.DEBUG,
+                )
+
+            # Attempt to handle the exceptions, to improve the chance of getting
+            # successful generations next time around
+            time_to_wait = 0
+            for _, error in failures:
+                generation_kwargs, wait_time = self._handle_exception(
+                    error=error, **generation_kwargs
+                )
+                time_to_wait = max(time_to_wait, wait_time)
+            if time_to_wait > 0:
+                log(
+                    f"Waiting {time_to_wait} second(s) before retrying...",
+                    level=logging.DEBUG,
+                )
+                sleep(time_to_wait)
+        else:
+            raise InvalidBenchmark(
+                message=f"Failed to generate text, after {num_attempts:,} attempts."
+            )
+
+        # Extract the generations from the model output
+        ordered_responses = [all_responses[i] for i in range(len(model_inputs))]
+        model_output = self._create_model_output(
+            model_responses=ordered_responses, model_id=self.model_config.model_id
+        )
+
+        if len(model_inputs) != len(model_output.sequences):
+            raise InvalidBenchmark(
+                f"Number of model inputs ({len(model_inputs):,}) does not match the "
+                f"number of model outputs ({len(model_output.sequences):,})."
+            )
+
+        return model_output
 
     @staticmethod
     def _create_model_output(
@@ -741,6 +735,57 @@ class LiteLLMModel(BenchmarkModule):
             pass  # Already closed
 
         return successes, failures
+
+    def _handle_exception(
+        self, error: Exception, **generation_kwargs
+    ) -> tuple[dict, int]:
+        """Handle an exception from the model.
+
+        Args:
+            error:
+                The exception to handle.
+            generation_kwargs:
+                The generation kwargs to pass to the model.
+
+        Returns:
+            A pair (generation_kwargs, retry_delay_seconds), where `generation_kwargs`
+            is the updated generation kwargs to pass to the model, and
+            `retry_delay_seconds` is the number of seconds to wait before retrying.
+
+        Raises:
+            InvalidBenchmark:
+                If the model's reasoning budget is not specified correctly.
+        """
+        error_msg = str(error).lower()
+        model_id = self.model_config.model_id
+
+        # Try parameter-specific handlers first
+        result = self._handle_parameter_error(
+            error=error,
+            error_msg=error_msg,
+            model_id=model_id,
+            generation_kwargs=generation_kwargs,
+        )
+        if result is not None:
+            return result
+
+        # Try service/retry handlers
+        result = self._handle_service_error(
+            error=error,
+            error_msg=error_msg,
+            model_id=model_id,
+            generation_kwargs=generation_kwargs,
+        )
+        if result is not None:
+            return result
+
+        # Try error-raising handlers
+        self._handle_fatal_error(error=error, error_msg=error_msg, model_id=model_id)
+
+        # Default: raise InvalidBenchmark
+        raise InvalidBenchmark(
+            f"Failed to generate text. The error message was: {error}"
+        ) from error
 
     def _handle_fatal_error(
         self, error: Exception, error_msg: str, model_id: str
@@ -1131,199 +1176,6 @@ class LiteLLMModel(BenchmarkModule):
 
         return None
 
-    def _handle_exception(
-        self, error: Exception, **generation_kwargs
-    ) -> tuple[dict, int]:
-        """Handle an exception from the model.
-
-        Args:
-            error:
-                The exception to handle.
-            generation_kwargs:
-                The generation kwargs to pass to the model.
-
-        Returns:
-            A pair (generation_kwargs, retry_delay_seconds), where `generation_kwargs`
-            is the updated generation kwargs to pass to the model, and
-            `retry_delay_seconds` is the number of seconds to wait before retrying.
-
-        Raises:
-            InvalidBenchmark:
-                If the model's reasoning budget is not specified correctly.
-        """
-        error_msg = str(error).lower()
-        model_id = self.model_config.model_id
-
-        # Try parameter-specific handlers first
-        result = self._handle_parameter_error(
-            error=error,
-            error_msg=error_msg,
-            model_id=model_id,
-            generation_kwargs=generation_kwargs,
-        )
-        if result is not None:
-            return result
-
-        # Try service/retry handlers
-        result = self._handle_service_error(
-            error=error,
-            error_msg=error_msg,
-            model_id=model_id,
-            generation_kwargs=generation_kwargs,
-        )
-        if result is not None:
-            return result
-
-        # Try error-raising handlers
-        self._handle_fatal_error(error=error, error_msg=error_msg, model_id=model_id)
-
-        # Default: raise InvalidBenchmark
-        raise InvalidBenchmark(
-            f"Failed to generate text. The error message was: {error}"
-        ) from error
-
-    def _setup_model_params(
-        self, generation_kwargs: dict[str, t.Any]
-    ) -> dict[str, t.Any]:
-        """Set up model-specific parameters.
-
-        Args:
-            generation_kwargs:
-                The generation kwargs to pass to the model.
-
-        Returns:
-            The updated generation kwargs with model-specific parameters configured.
-        """
-        if self.buffer["first_label_token_mapping"]:
-            generation_kwargs["logprobs"] = True
-            generation_kwargs["top_logprobs"] = MAX_LITELLM_LOGPROBS
-
-        param = self.model_config.param
-        if param == "thinking":
-            generation_kwargs["thinking"] = dict(
-                type="enabled", budget_tokens=REASONING_MAX_TOKENS - 1
-            )
-            log_once(
-                f"Enabling thinking mode for model {self.model_config.model_id!r}",
-                level=logging.DEBUG,
-            )
-        elif param == "no-thinking":
-            generation_kwargs["thinking"] = dict(budget_tokens=0)
-            log_once(
-                f"Disabling thinking mode for model {self.model_config.model_id!r}",
-                level=logging.DEBUG,
-            )
-        elif param in {"none", "minimal", "low", "medium", "high", "xhigh"}:
-            generation_kwargs["reasoning_effort"] = param
-            log_once(
-                f"Enabling reasoning effort {param!r} for model "
-                f"{self.model_config.model_id!r}",
-                level=logging.DEBUG,
-            )
-
-        return generation_kwargs
-
-    def _setup_response_format(
-        self, dataset_config: DatasetConfig, generation_kwargs: dict[str, t.Any]
-    ) -> dict[str, t.Any]:
-        """Set up response_format for structured generation.
-
-        Args:
-            dataset_config:
-                The dataset configuration.
-            generation_kwargs:
-                The generation kwargs to pass to the model.
-
-        Returns:
-            The updated generation kwargs with response_format configured.
-
-        Raises:
-            InvalidBenchmark:
-                If structured generation is required but not implemented for the task.
-        """
-        if dataset_config.task.structured_output_format is not None:
-            pydantic_class = dataset_config.task.structured_output_format
-            generation_kwargs["response_format"] = {
-                "type": "json_schema",
-                "json_schema": {
-                    "name": pydantic_class.__class__.__name__,
-                    "schema": pydantic_class.model_json_schema(),
-                },
-            }
-            log_once(
-                "Enabling structured generation for model "
-                f"{self.model_config.model_id!r} with response_format "
-                f"{pydantic_class.model_json_schema()}.",
-                level=logging.DEBUG,
-            )
-            return generation_kwargs
-
-        if self.benchmark_config.api_base is not None or supports_response_schema(
-            model=self.model_config.model_id
-        ):
-            if dataset_config.task.task_group == TaskGroup.TOKEN_CLASSIFICATION:
-                tag_names = list(dataset_config.prompt_label_mapping.values())
-                keys_and_their_types: dict[str, t.Any] = {
-                    tag_name: (conlist(str, max_length=5), ...)
-                    for tag_name in tag_names
-                }
-                pydantic_class = create_model("AnswerFormat", **keys_and_their_types)
-                generation_kwargs["response_format"] = pydantic_class
-                log_once(
-                    "Enabling structured generation for model "
-                    f"{self.model_config.model_id!r} with the JSON schema "
-                    f"{pydantic_class.model_json_schema()}",
-                    level=logging.DEBUG,
-                )
-                return generation_kwargs
-            elif dataset_config.task == LOGIC:
-                generation_kwargs["response_format"] = dict(type="json_object")
-                log_once(
-                    "Enabling structured generation for model "
-                    f"{self.model_config.model_id!r} with a generic JSON schema",
-                    level=logging.DEBUG,
-                )
-                return generation_kwargs
-            else:
-                raise InvalidBenchmark(
-                    "This task requires structured generation, but it has not "
-                    "been implemented for this task yet. Please open an issue "
-                    "at https://github.com/EuroEval/EuroEval/issues."
-                )
-
-        generation_kwargs["response_format"] = dict(type="json_object")
-        log_once(
-            "Enabling structured JSON generation for model "
-            f"{self.model_config.model_id!r} with no custom JSON schema, as "
-            "the model does not support schemas.",
-            level=logging.DEBUG,
-        )
-        return generation_kwargs
-
-    @property
-    def data_collator(self) -> c.Callable[[list[dict[str, t.Any]]], dict[str, t.Any]]:
-        """The data collator used to prepare samples during finetuning.
-
-        Returns:
-            The data collator.
-        """
-        raise NotImplementedError(
-            "The `data_collator` property has not been implemented for LiteLLM models."
-        )
-
-    @property
-    def extract_labels_from_generation(self) -> ExtractLabelsFunction:
-        """The function used to extract the labels from the generated output.
-
-        Returns:
-            The function used to extract the labels from the generated output.
-        """
-        return _extract_labels_from_generation_helper(
-            dataset_config=self.dataset_config,
-            model_config=self.model_config,
-            first_label_token_mapping=self.buffer["first_label_token_mapping"],
-        )
-
     def get_generation_kwargs(self, dataset_config: DatasetConfig) -> dict[str, t.Any]:
         """Get the generation arguments for the model.
 
@@ -1461,138 +1313,123 @@ class LiteLLMModel(BenchmarkModule):
 
         return generation_kwargs
 
-    def generate(self, inputs: dict) -> GenerativeModelOutput:
-        """Generate outputs from the model.
+    def _setup_model_params(
+        self, generation_kwargs: dict[str, t.Any]
+    ) -> dict[str, t.Any]:
+        """Set up model-specific parameters.
 
         Args:
-            inputs:
-                A batch of inputs to pass through the model.
+            generation_kwargs:
+                The generation kwargs to pass to the model.
 
         Returns:
-            The generated model outputs.
-
-        Raises:
-            InvalidBenchmark:
-                If the inputs do not contain either 'messages' or 'text' keys.
+            The updated generation kwargs with model-specific parameters configured.
         """
-        model_inputs: c.Sequence[c.Sequence[litellm.AllMessageValues] | str]
-        if "messages" in inputs:
-            model_inputs = inputs["messages"]
-        elif "text" in inputs:
-            model_inputs = inputs["text"]
-        else:
-            raise InvalidBenchmark(
-                "The inputs must contain either 'messages' or 'text' keys."
+        if self.buffer["first_label_token_mapping"]:
+            generation_kwargs["logprobs"] = True
+            generation_kwargs["top_logprobs"] = MAX_LITELLM_LOGPROBS
+
+        param = self.model_config.param
+        if param == "thinking":
+            generation_kwargs["thinking"] = dict(
+                type="enabled", budget_tokens=REASONING_MAX_TOKENS - 1
             )
-
-        # Get the mapping from labels to the first token in the label. We call this each
-        # time we generate a new dataset since the dataset config can change
-        self.buffer["first_label_token_mapping"] = get_first_label_token_mapping(
-            dataset_config=self.dataset_config,
-            model_config=self.model_config,
-            tokeniser=None,
-            generative_type=self.generative_type,
-            log_metadata=self.log_metadata,
-        )
-
-        all_responses: dict[int, "ModelResponse"] = {}
-        inputs_to_run: c.Sequence[
-            tuple[int, c.Sequence[litellm.AllMessageValues] | str]
-        ] = list(enumerate(model_inputs))
-        for attempt in range(num_attempts := 10):
-            if not inputs_to_run:
-                break
-
-            generation_kwargs = self.generation_kwargs or self.get_generation_kwargs(
-                dataset_config=self.dataset_config
+            log_once(
+                f"Enabling thinking mode for model {self.model_config.model_id!r}",
+                level=logging.DEBUG,
             )
-
-            batch_indices, batch_inputs = zip(*inputs_to_run)
-            successes, failures = safe_run(
-                self._generate_async(
-                    model_id=self.model_config.model_id,
-                    inputs=list(batch_inputs),
-                    max_concurrent_calls=self.buffer["max_concurrent_calls"],
-                    **generation_kwargs,
-                )
+        elif param == "no-thinking":
+            generation_kwargs["thinking"] = dict(budget_tokens=0)
+            log_once(
+                f"Disabling thinking mode for model {self.model_config.model_id!r}",
+                level=logging.DEBUG,
             )
-
-            # Store the successful model outputs
-            for idx, response in successes:
-                orig_idx = batch_indices[idx]
-                all_responses[orig_idx] = response
-
-            # If all requests were successful, break
-            if not failures:
-                inputs_to_run = []
-                break
-
-            # Put the failed requests back in the queue to try again
-            inputs_to_run = [
-                (batch_indices[idx], model_inputs[batch_indices[idx]])
-                for idx, _ in failures
-            ]
-            log(
-                f"Attempt {attempt + 1:,}/{num_attempts:,}: retrying "
-                f"{len(inputs_to_run):,} failed message(s). Here is the first error: "
-                f"{failures[0][1]}.",
+        elif param in {"none", "minimal", "low", "medium", "high", "xhigh"}:
+            generation_kwargs["reasoning_effort"] = param
+            log_once(
+                f"Enabling reasoning effort {param!r} for model "
+                f"{self.model_config.model_id!r}",
                 level=logging.DEBUG,
             )
 
-            # Check if any errors are due to HTTP 429 (too many requests), in which case
-            # we reduce the number of concurrent calls
-            http_429_errors = [
-                idx
-                for idx, (_, error) in enumerate(failures)
-                if isinstance(error, RateLimitError)
-            ]
-            if http_429_errors and self.buffer["max_concurrent_calls"] > 1:
-                failures = [
-                    failures[i]
-                    for i in range(len(failures))
-                    if i not in http_429_errors
-                ]
-                self.buffer["max_concurrent_calls"] = max(
-                    1, self.buffer["max_concurrent_calls"] // 2
-                )
-                log(
-                    f"Reducing the maximum number of concurrent calls to "
-                    f"{self.buffer['max_concurrent_calls']:,} due to rate limiting.",
-                    level=logging.DEBUG,
-                )
+        return generation_kwargs
 
-            # Attempt to handle the exceptions, to improve the chance of getting
-            # successful generations next time around
-            time_to_wait = 0
-            for _, error in failures:
-                generation_kwargs, wait_time = self._handle_exception(
-                    error=error, **generation_kwargs
-                )
-                time_to_wait = max(time_to_wait, wait_time)
-            if time_to_wait > 0:
-                log(
-                    f"Waiting {time_to_wait} second(s) before retrying...",
-                    level=logging.DEBUG,
-                )
-                sleep(time_to_wait)
-        else:
-            raise InvalidBenchmark(
-                message=f"Failed to generate text, after {num_attempts:,} attempts."
+    def _setup_response_format(
+        self, dataset_config: DatasetConfig, generation_kwargs: dict[str, t.Any]
+    ) -> dict[str, t.Any]:
+        """Set up response_format for structured generation.
+
+        Args:
+            dataset_config:
+                The dataset configuration.
+            generation_kwargs:
+                The generation kwargs to pass to the model.
+
+        Returns:
+            The updated generation kwargs with response_format configured.
+
+        Raises:
+            InvalidBenchmark:
+                If structured generation is required but not implemented for the task.
+        """
+        if dataset_config.task.structured_output_format is not None:
+            pydantic_class = dataset_config.task.structured_output_format
+            generation_kwargs["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": pydantic_class.__class__.__name__,
+                    "schema": pydantic_class.model_json_schema(),
+                },
+            }
+            log_once(
+                "Enabling structured generation for model "
+                f"{self.model_config.model_id!r} with response_format "
+                f"{pydantic_class.model_json_schema()}.",
+                level=logging.DEBUG,
             )
+            return generation_kwargs
 
-        # Extract the generations from the model output
-        ordered_responses = [all_responses[i] for i in range(len(model_inputs))]
-        model_output = self._create_model_output(
-            model_responses=ordered_responses, model_id=self.model_config.model_id
+        if self.benchmark_config.api_base is not None or supports_response_schema(
+            model=self.model_config.model_id
+        ):
+            if dataset_config.task.task_group == TaskGroup.TOKEN_CLASSIFICATION:
+                tag_names = list(dataset_config.prompt_label_mapping.values())
+                keys_and_their_types: dict[str, t.Any] = {
+                    tag_name: (conlist(str, max_length=5), ...)
+                    for tag_name in tag_names
+                }
+                pydantic_class = create_model("AnswerFormat", **keys_and_their_types)
+                generation_kwargs["response_format"] = pydantic_class
+                log_once(
+                    "Enabling structured generation for model "
+                    f"{self.model_config.model_id!r} with the JSON schema "
+                    f"{pydantic_class.model_json_schema()}",
+                    level=logging.DEBUG,
+                )
+                return generation_kwargs
+            elif dataset_config.task == LOGIC:
+                generation_kwargs["response_format"] = dict(type="json_object")
+                log_once(
+                    "Enabling structured generation for model "
+                    f"{self.model_config.model_id!r} with a generic JSON schema",
+                    level=logging.DEBUG,
+                )
+                return generation_kwargs
+            else:
+                raise InvalidBenchmark(
+                    "This task requires structured generation, but it has not "
+                    "been implemented for this task yet. Please open an issue "
+                    "at https://github.com/EuroEval/EuroEval/issues."
+                )
+
+        generation_kwargs["response_format"] = dict(type="json_object")
+        log_once(
+            "Enabling structured JSON generation for model "
+            f"{self.model_config.model_id!r} with no custom JSON schema, as "
+            "the model does not support schemas.",
+            level=logging.DEBUG,
         )
-
-        if len(model_inputs) != len(model_output.sequences):
-            raise InvalidBenchmark(
-                f"Number of model inputs ({len(model_inputs):,}) does not match the "
-                f"number of model outputs ({len(model_output.sequences):,})."
-            )
-
-        return model_output
+        return generation_kwargs
 
     @property
     def generative_type(self) -> GenerativeType | None:
@@ -1692,6 +1529,121 @@ class LiteLLMModel(BenchmarkModule):
             ),
             adapter_base_model_id=None,
         )
+
+    @cached_property
+    def model_max_length(self) -> int:
+        """The maximum length of the model.
+
+        Returns:
+            The maximum length of the model.
+        """
+        if self.benchmark_config.max_context_length is not None:
+            return self.benchmark_config.max_context_length
+        # Start by trying out the regex mapping, and use the value if it matches
+        for key, value in MODEL_MAX_LENGTH_MAPPING.items():
+            if re.fullmatch(pattern=key, string=self.model_config.model_id) is not None:
+                return value
+
+        # If it is an Ollama model then we can get the maximum length from the Ollama
+        # Python SDK
+        if self.is_ollama:
+            ollama_model_id = "/".join(self.model_config.model_id.split("/")[1:])
+            model_info = self._ollama_show.modelinfo
+            if model_info is not None:
+                context_length_keys = [
+                    key for key in model_info.keys() if "context_length" in key.lower()
+                ]
+                if context_length_keys:
+                    context_length = model_info[context_length_keys[0]]
+                    if context_length is not None:
+                        if self.log_metadata:
+                            log_once(
+                                f"Detected context length key "
+                                f"{context_length_keys[0]!r} for Ollama model "
+                                f"{ollama_model_id!r}",
+                                level=logging.DEBUG,
+                            )
+                        return int(context_length)
+                elif self.log_metadata:
+                    log_once(
+                        f"Tried to get the maximum length of the Ollama model "
+                        f"{ollama_model_id!r}, but could not find a context length. "
+                        f"The model info was {model_info}. Returning -1",
+                        level=logging.DEBUG,
+                    )
+
+        # If it is a model accessed through the Hugging Face inference API then we can
+        # get the maximum length from the Hugging Face model configuration from the
+        # Hugging Face Hub
+        if self.model_config.model_id.startswith("huggingface/"):
+            model_id = "/".join(self.model_config.model_id.split(sep="/")[-2:])
+            if HuggingFaceEncoderModel.model_exists(
+                model_id=model_id, benchmark_config=self.benchmark_config
+            ):
+                hf_config = load_hf_model_config(
+                    model_id=model_id,
+                    num_labels=self.dataset_config.num_labels,
+                    id2label=self.dataset_config.id2label,
+                    label2id=self.dataset_config.label2id,
+                    revision="main",
+                    model_cache_dir=self.model_config.model_cache_dir,
+                    api_key=self.benchmark_config.api_key,
+                    trust_remote_code=self.benchmark_config.trust_remote_code,
+                    run_with_cli=self.benchmark_config.run_with_cli,
+                )
+
+                tokeniser = load_tokeniser(
+                    model=None,
+                    model_id=model_id,
+                    trust_remote_code=self.benchmark_config.trust_remote_code,
+                    model_config=self.model_config,
+                )
+
+                all_max_lengths: list[int] = list()
+
+                # Add the registered max length of the tokeniser
+                if hasattr(
+                    tokeniser, "model_max_length"
+                ) and tokeniser.model_max_length < int(1e30):
+                    all_max_lengths.append(tokeniser.model_max_length)
+
+                # Add the max length derived from the model's input sizes
+                if hasattr(tokeniser, "max_model_input_sizes"):
+                    all_max_lengths.extend(
+                        [
+                            size
+                            for size in tokeniser.max_model_input_sizes.values()
+                            if size is not None
+                        ]
+                    )
+
+                # Add max length candidates from the model's configuration
+                candidate_config_max_lengths = [
+                    "max_position_embeddings",
+                    "max_sequence_length",
+                    "model_max_length",
+                    "sliding_window",
+                    "sliding_window_size",
+                    "n_positions",
+                ]
+                for candidate_config_max_length in candidate_config_max_lengths:
+                    if (
+                        hasattr(hf_config, candidate_config_max_length)
+                        and (value := getattr(hf_config, candidate_config_max_length))
+                        is not None
+                    ):
+                        all_max_lengths.append(value)
+
+                # To avoid models having artificially low max lengths, we remove any max
+                # lengths that are less than 128
+                all_max_lengths = [
+                    max_length for max_length in all_max_lengths if max_length >= 128
+                ]
+
+                if len(list(all_max_lengths)) > 0:
+                    return min(list(all_max_lengths))
+
+        return -1
 
     @classmethod
     def model_exists(
@@ -1815,121 +1767,6 @@ class LiteLLMModel(BenchmarkModule):
                 level=logging.ERROR,
             )
             return False
-
-    @cached_property
-    def model_max_length(self) -> int:
-        """The maximum length of the model.
-
-        Returns:
-            The maximum length of the model.
-        """
-        if self.benchmark_config.max_context_length is not None:
-            return self.benchmark_config.max_context_length
-        # Start by trying out the regex mapping, and use the value if it matches
-        for key, value in MODEL_MAX_LENGTH_MAPPING.items():
-            if re.fullmatch(pattern=key, string=self.model_config.model_id) is not None:
-                return value
-
-        # If it is an Ollama model then we can get the maximum length from the Ollama
-        # Python SDK
-        if self.is_ollama:
-            ollama_model_id = "/".join(self.model_config.model_id.split("/")[1:])
-            model_info = self._ollama_show.modelinfo
-            if model_info is not None:
-                context_length_keys = [
-                    key for key in model_info.keys() if "context_length" in key.lower()
-                ]
-                if context_length_keys:
-                    context_length = model_info[context_length_keys[0]]
-                    if context_length is not None:
-                        if self.log_metadata:
-                            log_once(
-                                f"Detected context length key "
-                                f"{context_length_keys[0]!r} for Ollama model "
-                                f"{ollama_model_id!r}",
-                                level=logging.DEBUG,
-                            )
-                        return int(context_length)
-                elif self.log_metadata:
-                    log_once(
-                        f"Tried to get the maximum length of the Ollama model "
-                        f"{ollama_model_id!r}, but could not find a context length. "
-                        f"The model info was {model_info}. Returning -1",
-                        level=logging.DEBUG,
-                    )
-
-        # If it is a model accessed through the Hugging Face inference API then we can
-        # get the maximum length from the Hugging Face model configuration from the
-        # Hugging Face Hub
-        if self.model_config.model_id.startswith("huggingface/"):
-            model_id = "/".join(self.model_config.model_id.split(sep="/")[-2:])
-            if HuggingFaceEncoderModel.model_exists(
-                model_id=model_id, benchmark_config=self.benchmark_config
-            ):
-                hf_config = load_hf_model_config(
-                    model_id=model_id,
-                    num_labels=self.dataset_config.num_labels,
-                    id2label=self.dataset_config.id2label,
-                    label2id=self.dataset_config.label2id,
-                    revision="main",
-                    model_cache_dir=self.model_config.model_cache_dir,
-                    api_key=self.benchmark_config.api_key,
-                    trust_remote_code=self.benchmark_config.trust_remote_code,
-                    run_with_cli=self.benchmark_config.run_with_cli,
-                )
-
-                tokeniser = load_tokeniser(
-                    model=None,
-                    model_id=model_id,
-                    trust_remote_code=self.benchmark_config.trust_remote_code,
-                    model_config=self.model_config,
-                )
-
-                all_max_lengths: list[int] = list()
-
-                # Add the registered max length of the tokeniser
-                if hasattr(
-                    tokeniser, "model_max_length"
-                ) and tokeniser.model_max_length < int(1e30):
-                    all_max_lengths.append(tokeniser.model_max_length)
-
-                # Add the max length derived from the model's input sizes
-                if hasattr(tokeniser, "max_model_input_sizes"):
-                    all_max_lengths.extend(
-                        [
-                            size
-                            for size in tokeniser.max_model_input_sizes.values()
-                            if size is not None
-                        ]
-                    )
-
-                # Add max length candidates from the model's configuration
-                candidate_config_max_lengths = [
-                    "max_position_embeddings",
-                    "max_sequence_length",
-                    "model_max_length",
-                    "sliding_window",
-                    "sliding_window_size",
-                    "n_positions",
-                ]
-                for candidate_config_max_length in candidate_config_max_lengths:
-                    if (
-                        hasattr(hf_config, candidate_config_max_length)
-                        and (value := getattr(hf_config, candidate_config_max_length))
-                        is not None
-                    ):
-                        all_max_lengths.append(value)
-
-                # To avoid models having artificially low max lengths, we remove any max
-                # lengths that are less than 128
-                all_max_lengths = [
-                    max_length for max_length in all_max_lengths if max_length >= 128
-                ]
-
-                if len(list(all_max_lengths)) > 0:
-                    return min(list(all_max_lengths))
-
-        return -1
 
     @cached_property
     def num_params(self) -> int:
@@ -2086,3 +1923,166 @@ class LiteLLMModel(BenchmarkModule):
                 return vocab_size
 
         return -1
+
+
+def clean_model_id(model_id: str, benchmark_config: BenchmarkConfig) -> str:
+    """Clean a model ID.
+
+    This adds the default `openai/` prefix to the model ID if we're benchmarking a
+    custom API inference server and no prefix is used, just to make it more
+    convenient for the user.
+
+    Args:
+        model_id:
+            The model ID.
+        benchmark_config:
+            The benchmark configuration.
+
+    Returns:
+        The cleaned model ID.
+    """
+    new_model_id = deepcopy(model_id)
+
+    # Remove unofficial prefixes
+    for unofficial_prefix in UNOFFICIAL_INFERENCE_API_PREFIXES:
+        new_model_id = re.sub(
+            pattern=rf"^{re.escape(unofficial_prefix)}", repl="", string=new_model_id
+        )
+
+    if benchmark_config.api_base is not None and not any(
+        new_model_id.startswith(prefix) for prefix in CUSTOM_INFERENCE_API_PREFIXES
+    ):
+        if benchmark_config.generative_type == GenerativeType.BASE:
+            prefix = "text-completion-openai/"
+        else:
+            prefix = "openai/"
+        new_model_id = prefix + new_model_id
+
+    # When we want to evaluate an OpenAI model on a custom inference server, such as HF
+    # inference endpoints, LiteLLM gets confused since it's already using the `openai/`
+    # prefix. We thus have to add it twice, and this hack here is to ensure that we
+    # don't store the results with model ID `openai/openai/...`.
+    elif benchmark_config.api_base is not None and new_model_id.startswith("openai/"):
+        new_model_id = "openai/openai/" + re.sub(r"(openai/)*", "", new_model_id)
+
+    return new_model_id
+
+
+def set_up_benchmark_config_for_model(
+    benchmark_config: BenchmarkConfig, model_id: str
+) -> None:
+    """Set up the benchmark configuration for the model.
+
+    Args:
+        benchmark_config:
+            The benchmark configuration to set up.
+        model_id:
+            The model ID.
+    """
+    if model_id.startswith("ordbogen/"):
+        benchmark_config.api_key = os.getenv("ORDBOGEN_API_KEY")
+        benchmark_config.api_base = "https://api.ordbogen.ai/v1"
+    elif model_id.startswith("alx/"):
+        benchmark_config.api_key = os.getenv("ALX_API_KEY")
+        benchmark_config.api_base = "https://inference.alexandra.dk/v1"
+
+
+def try_download_ollama_model(model_id: str, progress_bar: bool) -> bool:
+    """Try to download an Ollama model.
+
+    Args:
+        model_id:
+            The model ID. If the model does not start with "ollama/" or "ollama_chat/"
+            then this function will return False.
+        progress_bar:
+            Whether to show a progress bar while downloading the model.
+
+    Returns:
+        Whether the model was downloaded successfully.
+
+    Raises:
+        InvalidModel:
+            If Ollama is not running or the model cannot be downloaded.
+    """
+    if not (model_id.startswith("ollama/") or model_id.startswith("ollama_chat/")):
+        return False
+
+    if model_id.startswith("ollama/"):
+        log_once(
+            "You're trying to benchmark a model with the old 'ollama/' prefix, which "
+            "probably results in bad performance, as it doesn't use the model's chat "
+            "template. If the model is not a chat model then just disregard this "
+            "warning, but if it is a chat model then please cancel this run and "
+            "use the 'ollama_chat/' prefix instead.",
+            level=logging.WARNING,
+        )
+
+    try:
+        downloaded_ollama_models: c.Sequence[str] = [
+            model_obj.model
+            for model_obj in ollama.list().models
+            if model_obj.model is not None
+        ]
+    except ConnectionError as e:
+        raise InvalidModel(
+            "Ollama does not seem to be running, so we cannot evaluate the model "
+            f"{model_id!r}. Please make sure that Ollama is running and try again."
+        ) from e
+
+    ollama_model_id = "/".join(model_id.split("/")[1:])
+    if ollama_model_id not in downloaded_ollama_models:
+        # Try fetching the model info
+        try:
+            response = ollama.pull(model=ollama_model_id, stream=True)
+        except ollama.ResponseError as e:
+            if "file does not exist" in str(e).lower():
+                # Check if the model exists if we prepend "hf.co/"
+                try:
+                    ollama_model_id_with_prefix = f"hf.co/{ollama_model_id}"
+                    model_id_with_prefix = (
+                        f"{model_id.split('/')[0]}/{ollama_model_id_with_prefix}"
+                    )
+                    ollama.pull(model=ollama_model_id_with_prefix, stream=True)
+                    log_once(
+                        f"The model {model_id!r} cannot be found on Ollama, but the "
+                        f"model {model_id_with_prefix} *was* found, so we would "
+                        "recommend you cancelling this run and trying the evaluation "
+                        "with that model ID instead.",
+                        level=logging.WARNING,
+                    )
+                    return False
+                except ollama.ResponseError as inner_e:
+                    if "file does not exist" in str(inner_e).lower():
+                        return False
+                    else:
+                        raise InvalidModel(
+                            f"Failed to download Ollama model {ollama_model_id}. "
+                            f"The error message was: {inner_e}"
+                        ) from inner_e
+            else:
+                raise InvalidModel(
+                    f"Failed to download Ollama model {ollama_model_id}. "
+                    f"The error message was: {e}"
+                ) from e
+
+        # Download the model
+        with get_pbar(
+            desc=f"Downloading {ollama_model_id}",
+            unit_scale=True,
+            unit="B",
+            disable=not progress_bar,
+        ) as pbar:
+            for status in response:
+                if status.total is not None:
+                    pbar.total = status.total
+                if status.completed is not None:
+                    pbar.update(status.completed - pbar.n)
+        return True
+
+    else:
+        log_once(
+            f"Ollama model {ollama_model_id!r} already downloaded, so skipping "
+            "download.",
+            level=logging.DEBUG,
+        )
+        return True

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -122,6 +122,1211 @@ _ARCHITECTURE_ALIASES: dict[str, str] = {
 }
 
 
+class VLLMModel(HuggingFaceEncoderModel):
+    """A generative model using the vLLM inference framework."""
+
+    fresh_model = False
+    batching_preference = BatchingPreference.ALL_AT_ONCE
+    high_priority = True
+    allowed_params: dict[re.Pattern[str], list[str]] = {
+        re.compile(r".*"): ["thinking", "no-thinking", "slow-tokenizer"],
+        re.compile(r".*gpt-oss.*", flags=re.IGNORECASE): ["low", "medium", "high"],
+    }
+
+    def __init__(
+        self,
+        model_config: "ModelConfig",
+        dataset_config: "DatasetConfig",
+        benchmark_config: "BenchmarkConfig",
+        log_metadata: bool = True,
+    ) -> None:
+        """Initialise the vLLM model.
+
+        Args:
+            model_config:
+                The model configuration.
+            dataset_config:
+                The dataset configuration.
+            benchmark_config:
+                The benchmark configuration.
+            log_metadata:
+                Whether to log the model and dataset metadata.
+
+        Raises:
+            NeedsSystemDependency:
+                If the CUDA Toolkit is not installed on NVIDIA hardware.
+            NeedsExtraInstalled:
+                If the generative extra is not installed.
+            InvalidModel:
+                If the generative type was None for the model.
+        """
+        if importlib.util.find_spec("vllm") is None:
+            raise NeedsExtraInstalled(extra="generative")
+
+        if (
+            torch.cuda.is_available()
+            and torch.version.hip is None
+            and shutil.which("nvcc") is None
+        ):
+            raise NeedsSystemDependency(
+                dependency="nvcc",
+                instructions=(
+                    "Please install the CUDA Toolkit from "
+                    "https://developer.nvidia.com/cuda-downloads or ensure that NVCC "
+                    "is available in your PATH."
+                ),
+            )
+
+        raise_if_wrong_params(
+            model_config=model_config, allowed_params=self.allowed_params
+        )
+
+        # This is already set when calling `super().__init__`, but we need it to get
+        # the correct value from `self.generative_type`, so we set it here as well.
+        self.benchmark_config = benchmark_config
+        self.model_config = model_config
+
+        hf_model_config = load_hf_model_config(
+            model_id=model_config.adapter_base_model_id or model_config.model_id,
+            num_labels=0,
+            id2label=HashableDict(),
+            label2id=HashableDict(),
+            revision=(
+                model_config.revision
+                if model_config.adapter_base_model_id is None
+                else "main"
+            ),
+            model_cache_dir=model_config.model_cache_dir,
+            api_key=benchmark_config.api_key,
+            trust_remote_code=benchmark_config.trust_remote_code,
+            run_with_cli=benchmark_config.run_with_cli,
+        )
+        true_max_model_len = get_true_max_model_len(hf_model_config=hf_model_config)
+
+        tokeniser = load_tokeniser(
+            model_id=model_config.model_id,
+            revision=model_config.revision,
+            adapter_base_model_id=model_config.adapter_base_model_id,
+            trust_remote_code=benchmark_config.trust_remote_code,
+            model_max_length=true_max_model_len,
+            model_config=model_config,
+            hf_model_config=hf_model_config,
+            token=get_hf_token(api_key=benchmark_config.api_key),
+        )
+        self._tokeniser: Tokeniser = tokeniser
+
+        generative_type = self.generative_type
+        if generative_type is None:
+            raise InvalidModel(
+                f"Generative type for model {model_config.model_id!r} was None during "
+                "initialisation. Please report this issue at "
+                "https://github.com/EuroEval/EuroEval/issues/new."
+            )
+
+        with no_terminal_output(disable=benchmark_config.verbose):
+            model = load_model(
+                model_config=model_config,
+                benchmark_config=benchmark_config,
+                attention_backend=benchmark_config.attention_backend,
+                true_max_model_len=true_max_model_len,
+                generative_type=generative_type,
+                tokeniser=tokeniser,
+                hf_model_config=hf_model_config,
+            )
+        self._model: LLM = model
+
+        # We specify `HuggingFaceEncoderModel` here instead of `VLLMModel`, as we want
+        # to call the `__init__` method of the `BenchmarkModule` class.
+        super(HuggingFaceEncoderModel, self).__init__(
+            model_config=model_config,
+            dataset_config=dataset_config,
+            benchmark_config=benchmark_config,
+            log_metadata=log_metadata,
+        )
+
+        self.end_of_reasoning_token = get_end_of_reasoning_token(
+            model=self._model, tokeniser=self._tokeniser, model_config=model_config
+        )
+        self.end_of_chat_token_ids = get_end_of_chat_token_ids(
+            tokeniser=self._tokeniser, generative_type=self.generative_type
+        )
+        self.custom_stop_tokens = get_custom_stop_tokens(
+            model=self._model,
+            tokeniser=self._tokeniser,
+            model_id=model_config.model_id,
+            generative_type=self.generative_type,
+        )
+
+        self.buffer |= dict(
+            first_label_token_mapping=get_first_label_token_mapping(
+                dataset_config=self.dataset_config,
+                model_config=self.model_config,
+                tokeniser=self._tokeniser,
+                generative_type=self.generative_type,
+                log_metadata=self.log_metadata,
+            )
+        )
+        if self.model_config.adapter_base_model_id is not None:
+            if Path(self.model_config.model_id).exists():
+                adapter_path = self.model_config.model_id
+            else:
+                adapter_path = snapshot_download(
+                    repo_id=self.model_config.model_id,
+                    revision=self.model_config.revision,
+                    cache_dir=Path(self.model_config.model_cache_dir),
+                )
+            self.buffer["lora_request"] = LoRARequest(
+                lora_name="adapter", lora_int_id=1, lora_path=adapter_path
+            )
+
+    def __del__(self) -> None:
+        """Clean up the model and tokeniser."""
+        try:
+            if importlib.util.find_spec("vllm") is not None:
+                clear_vllm()
+        except ImportError:
+            pass
+        if hasattr(self, "_model"):
+            del self._model
+        if hasattr(self, "_tokeniser"):
+            del self._tokeniser
+
+    @property
+    def data_collator(self) -> c.Callable[[list[dict[str, t.Any]]], dict[str, t.Any]]:
+        """The data collator used to prepare samples during finetuning.
+
+        Returns:
+            The data collator.
+        """
+        raise NotImplementedError(
+            "The `data_collator` property has not been implemented for vLLM models."
+        )
+
+    @property
+    def extract_labels_from_generation(self) -> ExtractLabelsFunction:
+        """The function used to extract the labels from the generated output.
+
+        Returns:
+            The function used to extract the labels from the generated output.
+        """
+        return _extract_labels_from_generation_helper(
+            dataset_config=self.dataset_config,
+            model_config=self.model_config,
+            first_label_token_mapping=self.buffer["first_label_token_mapping"],
+        )
+
+    @property
+    def generative_type(self) -> GenerativeType | None:
+        """The generative type of the model.
+
+        Returns:
+            The generative type of the model, or None if it has not been set yet.
+        """
+        if self.benchmark_config.generative_type is not None:
+            type_ = self.benchmark_config.generative_type
+        elif self.model_config.param in {"thinking"}:
+            type_ = GenerativeType.REASONING
+        elif self.model_config.param in {"no-thinking"}:
+            type_ = GenerativeType.INSTRUCTION_TUNED
+        elif (
+            hasattr(self, "end_of_reasoning_token")
+            and self.end_of_reasoning_token is not None
+        ):
+            type_ = GenerativeType.REASONING
+        elif not hasattr(self, "_tokeniser"):
+            log_once(
+                "The generative type of the model has not been set yet as the "
+                "tokeniser has not been loaded.",
+                level=logging.DEBUG,
+            )
+            return None
+        elif (
+            has_chat_template(tokeniser=self._tokeniser)
+            or "instruct" in self.model_config.model_id.lower()
+        ):
+            type_ = GenerativeType.INSTRUCTION_TUNED
+        else:
+            type_ = GenerativeType.BASE
+        log_once(
+            f"Detected generative type {type_.name!r} for model "
+            f"{self.model_config.model_id!r}",
+            level=logging.DEBUG,
+        )
+        return type_
+
+    @classmethod
+    def get_model_config(
+        cls, model_id: str, benchmark_config: "BenchmarkConfig"
+    ) -> "ModelConfig":
+        """Fetch the model configuration.
+
+        Args:
+            model_id:
+                The model ID.
+            benchmark_config:
+                The benchmark configuration.
+
+        Returns:
+            The model configuration.
+
+        Raises:
+            InvalidModel:
+                If the model does not exist.
+        """
+        resolved_model_id, revision, model_info = _lookup_model_info(
+            model_id=model_id, benchmark_config=benchmark_config
+        )
+        if model_info is None:
+            raise InvalidModel(f"The model {model_id!r} could not be found.")
+
+        try:
+            generation_config = GenerationConfig.from_pretrained(
+                pretrained_model_name=resolved_model_id,
+                revision=revision,
+                cache_dir=benchmark_config.cache_dir,
+                token=benchmark_config.api_key,
+            )
+        except OSError:
+            generation_config = None
+
+        model_id_components = split_model_id(model_id=model_id)
+
+        return _build_model_config_helper(
+            model_id=resolved_model_id,
+            revision=revision,
+            param=model_id_components.param,
+            task=model_info.pipeline_tag,
+            model_info=model_info,
+            benchmark_config=benchmark_config,
+            inference_backend=InferenceBackend.VLLM,
+            model_type=ModelType.GENERATIVE,
+            adapter_base_model_id=model_info.adapter_base_model_id,
+            generation_config=generation_config,
+        )
+
+    @classmethod
+    def model_exists(
+        cls, model_id: str, benchmark_config: "BenchmarkConfig"
+    ) -> bool | NeedsExtraInstalled | NeedsEnvironmentVariable:
+        """Check if a model exists.
+
+        Args:
+            model_id:
+                The model ID.
+            benchmark_config:
+                The benchmark configuration.
+
+        Returns:
+            Whether the model exists, or an error describing why we cannot check
+            whether the model exists.
+        """
+        using_api = (
+            benchmark_config.api_base is not None
+            or benchmark_config.api_version is not None
+        )
+        if using_api:
+            return False
+
+        _, _, model_info = _lookup_model_info(
+            model_id=model_id, benchmark_config=benchmark_config
+        )
+        return (
+            model_info is not None
+            and model_info.pipeline_tag in GENERATIVE_PIPELINE_TAGS
+        )
+
+    def prepare_dataset(
+        self, dataset: "DatasetDict", task: "Task", itr_idx: int
+    ) -> "DatasetDict":
+        """Prepare the dataset for the model.
+
+        This includes things like tokenisation.
+
+        Args:
+            dataset:
+                The dataset to prepare.
+            task:
+                The task to prepare the dataset for.
+            itr_idx:
+                The index of the dataset in the iterator.
+
+        Returns:
+            The prepared dataset.
+        """
+        return _prepare_dataset_helper(
+            dataset=dataset,
+            task=task,
+            model_config=self.model_config,
+            dataset_config=self.dataset_config,
+            benchmark_config=self.benchmark_config,
+            generative_type=self.generative_type,
+            itr_idx=itr_idx,
+            always_populate_text_field=True,
+            tokeniser=self._tokeniser,
+        )
+
+    def score(self, inputs: dict) -> "GenerativeModelOutput":
+        """Compute BPC scores from prompt_logprobs.
+
+        Args:
+            inputs:
+                A batch of inputs with bpc_prompt column.
+
+        Returns:
+            Model output with BPC scores.
+        """
+        sampling_params = SamplingParams(
+            # BPC scoring only reads `prompt_logprobs`; no generation is needed, but
+            # vLLM requires `max_tokens >= 1`, so we generate a single throwaway token.
+            max_tokens=1,
+            prompt_logprobs=BPC_LOGPROBS,
+            logprobs=None,
+            temperature=GENERATION_KWARGS["temperature"],
+            top_p=GENERATION_KWARGS["top_p"],
+            top_k=int(GENERATION_KWARGS["top_k"]),
+            repetition_penalty=GENERATION_KWARGS["repetition_penalty"],
+            stop=[],  # Set in _run_vllm_core
+            structured_outputs=None,  # Set in _run_vllm_core
+        )
+        completions, raw_outputs = self._run_vllm_core(
+            inputs, "bpc_prompt", sampling_params
+        )
+
+        # Compute BPC scores
+        bpc_scores = compute_bpc_scores_for_vllm_outputs(
+            raw_outputs=raw_outputs, inputs=inputs, tokeniser=self._tokeniser
+        )
+        output = GenerativeModelOutput(sequences=completions)
+        if bpc_scores is not None:
+            output.bpc_scores = bpc_scores
+        return output
+
+    def _run_vllm_core(
+        self, inputs: dict, prompt_key: str, sampling_params: "SamplingParams"
+    ) -> tuple[list[str], list]:
+        """Run vLLM generation with given parameters.
+
+        Shared implementation used by both generate() and score().
+
+        Args:
+            inputs:
+                A batch of inputs to pass through the model.
+            prompt_key:
+                Key to extract prompts from inputs ("text" or "bpc_prompt").
+            sampling_params:
+                Sampling parameters for vLLM generation.
+
+        Returns:
+            Tuple of (completions, raw_outputs).
+
+        Raises:
+            InvalidBenchmark:
+                If generation fails or prompts are too long.
+        """
+        # Set up label token mapping first (required for most tasks)
+        self.buffer["first_label_token_mapping"] = get_first_label_token_mapping(
+            dataset_config=self.dataset_config,
+            model_config=self.model_config,
+            tokeniser=self._tokeniser,
+            generative_type=self.generative_type,
+            log_metadata=self.log_metadata,
+        )
+        if (
+            not self.buffer["first_label_token_mapping"]
+            and self.dataset_config.task.requires_logprobs
+        ):
+            raise InvalidBenchmark(
+                "The dataset requires logprobs, but we encountered an error when "
+                "trying to get the first token of each label in the dataset. You can "
+                "try running this benchmark with the --verbose flag or setting "
+                "FULL_LOG=1 to see what the error was. Skipping this evaluation."
+            )
+
+        # Set up structured outputs
+        structured_outputs = self._setup_structured_outputs(inputs)
+
+        # Set up generation kwargs and sampling params
+        generation_kwargs = self._setup_generation_kwargs()
+        stop_tokens = self._setup_stop_tokens()
+        sampling_params.stop = [t for t in stop_tokens if t]
+        sampling_params.structured_outputs = structured_outputs
+        sampling_params.temperature = generation_kwargs["temperature"]
+        sampling_params.top_p = generation_kwargs["top_p"]
+        sampling_params.top_k = int(generation_kwargs["top_k"])
+        sampling_params.repetition_penalty = generation_kwargs["repetition_penalty"]
+
+        # Set up logprobs if needed
+        if sampling_params.prompt_logprobs is None:
+            sampling_params.logprobs = (
+                MAX_VLLM_LOGPROBS if self.buffer["first_label_token_mapping"] else None
+            )
+
+        # Compute token budget and prepare prompts
+        max_context_length = min(self._tokeniser.model_max_length, MAX_CONTEXT_LENGTH)
+        max_tokens_per_prompt = self._apply_token_budget(
+            sampling_params, max_context_length
+        )
+        prompts = self._prepare_prompts(
+            inputs, prompt_key, max_tokens_per_prompt, sampling_params
+        )
+
+        # Generate and parse outputs
+        return self._generate_with_retries(prompts, sampling_params, max_context_length)
+
+    def _apply_token_budget(
+        self, sampling_params: "SamplingParams", max_context_length: int
+    ) -> int:
+        """Apply token budget and return max tokens per prompt.
+
+        Args:
+            sampling_params:
+                The sampling parameters.
+            max_context_length:
+                The maximum context length.
+
+        Returns:
+            The maximum number of tokens per prompt.
+        """
+        if sampling_params.prompt_logprobs is not None:
+            return max_context_length - sampling_params.max_tokens
+        generation_budget, max_tokens_per_prompt = compute_token_budget(
+            model_max_length=self._tokeniser.model_max_length,
+            max_generated_tokens=self.dataset_config.max_generated_tokens,
+        )
+        if generation_budget < self.dataset_config.max_generated_tokens:
+            log_once(
+                f"The model {self.model_config.model_id!r} has a context length of "
+                f"{max_context_length:,} tokens, which is too small to fit both "
+                "the prompt and the dataset's full generation budget of "
+                f"{self.dataset_config.max_generated_tokens:,} tokens. Reserving "
+                f"{generation_budget:,} tokens for generation when budgeting "
+                "prompt lengths instead.",
+                level=logging.WARNING,
+            )
+            if self.generative_type != GenerativeType.REASONING:
+                sampling_params.max_tokens = generation_budget
+        return max_tokens_per_prompt
+
+    def _generate_with_retries(
+        self,
+        prompts: list[str],
+        sampling_params: "SamplingParams",
+        max_context_length: int,
+    ) -> tuple[list[str], list]:
+        """Generate sequences with retry logic.
+
+        Args:
+            prompts:
+                The list of prompts to generate from.
+            sampling_params:
+                The sampling parameters.
+            max_context_length:
+                The maximum context length.
+
+        Returns:
+            A tuple of (completions, raw_outputs).
+
+        Raises:
+            InvalidBenchmark:
+                If generation fails after retries or outputs are invalid.
+        """
+        input_is_test = len(prompts) == 1 and len(set(prompts[0])) == 1
+        num_attempts = 3
+        truncation_attempts = 1
+        oom_messages = [
+            "out of memory",
+            "outofmemory",
+            "insufficient memory",
+            "command buffer execution failed",
+        ]
+
+        def check_oom(error: Exception) -> None:
+            if any(m in str(error).lower() for m in oom_messages):
+                raise InvalidModel(
+                    "vLLM ran out of device memory during generation. On "
+                    "shared-memory devices (e.g. Apple Metal) the default GPU memory "
+                    "utilization is often too high, since the reserved KV cache "
+                    "leaves no room for the per-step allocations. Re-run with a lower "
+                    "value, e.g. `--gpu-memory-utilization 0.3` (or lower). "
+                    f"Underlying error: {str(error)}"
+                ) from error
+
+        for _ in range(num_attempts):
+            try:
+                bos = str(self._tokeniser.bos_token or "x")
+                prompts = [p if p.strip() else bos for p in prompts]
+                raw_outputs = self._model.generate(  # ty: ignore[call-non-callable]
+                    prompts=prompts,
+                    sampling_params=sampling_params,
+                    use_tqdm=False if input_is_test else get_pbar,
+                    lora_request=self.buffer.get("lora_request"),
+                )
+                break
+            except TypeError as e:
+                log(
+                    f"Encountered error during vLLM generation: {str(e)}. Retrying...",
+                    level=logging.DEBUG,
+                )
+                sleep(1)
+            except (ValueError, RuntimeError) as e:
+                check_oom(e)
+                trunc_msgs = [
+                    r"prompt \(length [0-9]+\) is longer than the maximum model length",
+                    "Sampled token IDs exceed the max model length",
+                ]
+                if any(
+                    re.search(pat, str(e), flags=re.IGNORECASE) for pat in trunc_msgs
+                ):
+                    log(
+                        "Prompts are too long, so truncating them and trying again...",
+                        level=logging.WARNING,
+                    )
+                    log(f"The error message was: {str(e)}", level=logging.DEBUG)
+                    extra = 50 * truncation_attempts
+                    truncation_attempts += 1
+                    tok = self._tokeniser(
+                        text=prompts,
+                        truncation=True,
+                        max_length=max(
+                            max_context_length - sampling_params.max_tokens - extra, 0
+                        ),
+                    )
+                    prompts = _safe_batch_decode(
+                        self._tokeniser, tok.input_ids, skip_special_tokens=True
+                    )
+                else:
+                    raise InvalidBenchmark(
+                        f"An error occurred during vLLM generation: {str(e)}"
+                    ) from e
+            except Exception as e:
+                check_oom(e)
+                if type(e).__name__ == "EngineDeadError" or "RPC call" in str(e):
+                    raise InvalidBenchmark(
+                        "The vLLM engine died during generation, likely due to a "
+                        "worker RPC timeout. Consider raising "
+                        "`VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS` or reducing the "
+                        f"batch size. Underlying error: {str(e)}"
+                    ) from e
+                raise
+        else:
+            raise InvalidBenchmark(
+                f"Could not generate sequences after {num_attempts} attempts."
+            )
+        return self._filter_and_parse_outputs(
+            prompts=prompts, raw_outputs=raw_outputs, sampling_params=sampling_params
+        )
+
+    def _filter_and_parse_outputs(
+        self, prompts: list[str], raw_outputs: list, sampling_params: "SamplingParams"
+    ) -> tuple[list[str], list]:
+        """Filter extra outputs and parse completions.
+
+        Args:
+            prompts:
+                The list of prompts.
+            raw_outputs:
+                The raw model outputs.
+            sampling_params:
+                The sampling parameters.
+
+        Returns:
+            A tuple of (completions, raw_outputs).
+
+        Raises:
+            InvalidBenchmark:
+                If the prompts and outputs do not match.
+        """
+        extra = len(raw_outputs) - len(prompts)
+        if extra > 0:
+            raw_outputs = raw_outputs[extra:]
+            if not all(out.prompt == p for out, p in zip(raw_outputs, prompts)):
+                raise InvalidBenchmark(
+                    "The prompts and the model outputs do not match. "
+                    f"There were {extra!r} extra outputs."
+                )
+            log(
+                f"Filtered out {extra:,} extra outputs from the model, "
+                "which occured as we interupted the generation when we truncated "
+                "the prompts.",
+                level=logging.DEBUG,
+            )
+        return self._parse_completions(raw_outputs, sampling_params)
+
+    def _parse_completions(
+        self, raw_outputs: list, sampling_params: "SamplingParams"
+    ) -> tuple[list[str], list]:
+        """Parse raw outputs into completions.
+
+        Args:
+            raw_outputs:
+                The raw model outputs.
+            sampling_params:
+                The sampling parameters.
+
+        Returns:
+            A tuple of (completions, raw_outputs).
+
+        Raises:
+            InvalidBenchmark:
+                If the number of completions doesn't match the outputs.
+        """
+        if sampling_params.prompt_logprobs is not None:
+            return [""] * len(raw_outputs), raw_outputs
+        completion_ids = [list(out.outputs[0].token_ids) for out in raw_outputs]
+        completions = _safe_batch_decode(
+            self._tokeniser, completion_ids, skip_special_tokens=False
+        )
+        completions = self._remove_reasoning_content(completions)
+        completions = self._remove_stop_tokens(completions)
+        comp_ids = self._tokeniser(text=completions).input_ids
+        completions = _safe_batch_decode(
+            self._tokeniser, comp_ids, skip_special_tokens=True
+        )
+        if len(completions) != len(raw_outputs):
+            raise InvalidBenchmark(
+                f"Expected {len(raw_outputs):,} completions, "
+                f"but got {len(completions):,}."
+            )
+        return completions, raw_outputs
+
+    def _remove_reasoning_content(self, completions: list[str]) -> list[str]:
+        """Remove reasoning content from completions for reasoning models.
+
+        Args:
+            completions:
+                The list of completion strings.
+
+        Returns:
+            The completions with reasoning content removed.
+        """
+        if (
+            self.end_of_reasoning_token is None
+            or self.generative_type != GenerativeType.REASONING
+        ):
+            return completions
+        count = 0
+        for idx, comp in enumerate(completions):
+            if (
+                isinstance(self.end_of_reasoning_token, str)
+                and self.end_of_reasoning_token in comp
+            ):
+                completions[idx] = comp.split(self.end_of_reasoning_token)[-1]
+            elif isinstance(
+                self.end_of_reasoning_token, re.Pattern
+            ) and self.end_of_reasoning_token.search(comp):
+                completions[idx] = self.end_of_reasoning_token.split(comp)[-1]
+            else:
+                count += 1
+                completions[idx] = ""
+        if count > 0:
+            log_once(
+                f"The model {self.model_config.model_id!r} is a reasoning model, "
+                f"but the generated output did not contain the end of reasoning token "
+                f"({self.end_of_reasoning_token!r}) in {count:,}/{len(completions):,} "
+                "of the samples. Using an empty string for all these samples instead.",
+                level=logging.WARNING
+                if count / len(completions) > 0.5
+                else logging.DEBUG,
+            )
+        return completions
+
+    def _remove_stop_tokens(self, completions: list[str]) -> list[str]:
+        """Remove stop tokens from completions.
+
+        Args:
+            completions:
+                The list of completion strings.
+
+        Returns:
+            The completions with stop tokens removed.
+        """
+        stop_tokens = self._setup_stop_tokens()
+        pattern = re.compile("|".join(re.escape(t) for t in stop_tokens))
+        return [re.split(pattern=pattern, string=c)[0].strip() for c in completions]
+
+    def _setup_stop_tokens(self) -> list[str]:
+        """Set up stopping tokens for generation.
+
+        Returns:
+            A list of stop tokens for generation.
+        """
+        stop_tokens: list[str] = self.custom_stop_tokens.copy()
+        if self.generative_type == GenerativeType.BASE:
+            stop_tokens.append("\n\n")
+        if self._tokeniser.pad_token_id is not None:
+            assert isinstance(self._tokeniser.pad_token, str), (
+                f"The pad token for the model {self.model_config.model_id!r} "
+                f"is not a string, which is unexpected: {self._tokeniser.pad_token!r}."
+            )
+            stop_tokens.append(self._tokeniser.pad_token)
+        if self._tokeniser.eos_token_id is not None:
+            assert isinstance(self._tokeniser.eos_token, str), (
+                f"The EOS token for the model {self.model_config.model_id!r} "
+                f"is not a string, which is unexpected: {self._tokeniser.eos_token!r}."
+            )
+            stop_tokens.append(self._tokeniser.eos_token)
+            if self._tokeniser.pad_token_id is None:
+                self._tokeniser.pad_token_id = self._tokeniser.eos_token_id
+                self._tokeniser.pad_token = self._tokeniser.eos_token
+        if self.end_of_chat_token_ids is not None:
+            end_of_chat_token = self._tokeniser.decode(
+                list(self.end_of_chat_token_ids)
+            ).strip()
+            if end_of_chat_token:
+                stop_tokens.append(end_of_chat_token)
+        return stop_tokens
+
+    def generate(self, inputs: dict) -> "GenerativeModelOutput":
+        """Generate outputs from the model.
+
+        Args:
+            inputs:
+                A batch of inputs to pass through the model.
+
+        Returns:
+            The generated model outputs.
+        """
+        # Compute max_tokens based on model type
+        max_tokens: int = (
+            REASONING_MAX_TOKENS
+            if self.generative_type == GenerativeType.REASONING
+            else self.dataset_config.max_generated_tokens
+        )
+        sampling_params = SamplingParams(
+            max_tokens=max_tokens,
+            prompt_logprobs=None,
+            logprobs=None,  # Set in _run_vllm_core from first_label_token_mapping
+            temperature=GENERATION_KWARGS["temperature"],
+            top_p=GENERATION_KWARGS["top_p"],
+            top_k=int(GENERATION_KWARGS["top_k"]),
+            repetition_penalty=GENERATION_KWARGS["repetition_penalty"],
+            stop=[],  # Set in _run_vllm_core
+            structured_outputs=None,  # Set in _run_vllm_core
+        )
+        completions, raw_outputs = self._run_vllm_core(inputs, "text", sampling_params)
+
+        # Extract logprobs scores if available
+        if self.buffer["first_label_token_mapping"] and sampling_params.logprobs:
+            scores: c.Sequence[c.Sequence[c.Sequence[tuple[str, float]]]] = [
+                [
+                    [
+                        (obj.decoded_token or "", obj.logprob)
+                        for obj in token_logprobs_dict.values()
+                    ]
+                    for token_logprobs_dict in raw_output.outputs[0].logprobs or list()
+                ]
+                for raw_output in raw_outputs
+            ]
+            return GenerativeModelOutput(sequences=completions, scores=scores)
+        return GenerativeModelOutput(sequences=completions)
+
+    def _prepare_prompts(
+        self,
+        inputs: dict,
+        prompt_key: str,
+        max_tokens_per_prompt: int,
+        sampling_params: "SamplingParams",
+    ) -> list[str]:
+        """Prepare and truncate prompts.
+
+        Args:
+            inputs:
+                The input dictionary.
+            prompt_key:
+                The key for prompts in the inputs.
+            max_tokens_per_prompt:
+                Maximum tokens per prompt.
+            sampling_params:
+                The sampling parameters.
+
+        Returns:
+            A list of prepared and truncated prompts.
+        """
+        prompts: c.Sequence[str] = list(inputs[prompt_key])
+        prompts = self._clean_empty_prompts(prompts)
+        prompts = self._strip_prompts_if_needed(prompts)
+        prompts = self._truncate_prompts_if_needed(
+            prompts, max_tokens_per_prompt, sampling_params
+        )
+        return list(prompts)
+
+    def _clean_empty_prompts(self, prompts: c.Sequence[str]) -> list[str]:
+        """Replace empty prompts with BOS token.
+
+        Args:
+            prompts:
+                The sequence of prompts.
+
+        Returns:
+            A list of prompts with empty prompts replaced by BOS token.
+        """
+        if any(len(prompt.strip()) == 0 for prompt in prompts):
+            log("Found empty prompts, replacing with BOS token.", level=logging.DEBUG)
+            return [
+                prompt
+                if len(prompt.strip()) > 0
+                else str(self._tokeniser.bos_token or "x")
+                for prompt in prompts
+            ]
+        return list(prompts)
+
+    def _strip_prompts_if_needed(self, prompts: c.Sequence[str]) -> list[str]:
+        """Strip prompts if the model's tokeniser requires it.
+
+        Args:
+            prompts:
+                The sequence of prompts.
+
+        Returns:
+            A list of stripped prompts.
+        """
+        labels = list(self.dataset_config.prompt_label_mapping.values()) or [
+            "negative",
+            "positive",
+        ]
+        if self.generative_type == GenerativeType.BASE and should_prompts_be_stripped(
+            labels_to_be_generated=labels, tokeniser=self._tokeniser
+        ):
+            log_once(
+                f"Stripping prompts for model {self.model_config.model_id!r}.",
+                level=logging.DEBUG,
+            )
+            return [p.strip() for p in prompts]
+        return list(prompts)
+
+    def _truncate_prompts_if_needed(
+        self,
+        prompts: c.Sequence[str],
+        max_tokens_per_prompt: int,
+        sampling_params: "SamplingParams",
+    ) -> c.Sequence[str]:
+        """Truncate prompts if they exceed the token budget.
+
+        Args:
+            prompts:
+                The sequence of prompts.
+            max_tokens_per_prompt:
+                Maximum tokens per prompt.
+            sampling_params:
+                The sampling parameters.
+
+        Returns:
+            The truncated prompts.
+
+        Raises:
+            InvalidBenchmark:
+                If the model type is not set.
+        """
+        tokenized = self._tokeniser(text=prompts, max_length=max_tokens_per_prompt)
+        if all(len(ids) < max_tokens_per_prompt for ids in tokenized.input_ids):
+            log_once(
+                f"Truncation of prompts for model {self.model_config.model_id!r} is "
+                "not needed, so skipping truncation.",
+                level=logging.DEBUG,
+            )
+            return prompts
+        log(
+            f"Truncating prompts for the model {self.model_config.model_id!r} "
+            f"to a maximum of {max_tokens_per_prompt:,} tokens.",
+            level=logging.DEBUG,
+        )
+        if self.generative_type == GenerativeType.BASE:
+            return self._truncate_base_prompts(
+                prompts, max_tokens_per_prompt, sampling_params
+            )
+        if self.generative_type in (
+            GenerativeType.INSTRUCTION_TUNED,
+            GenerativeType.REASONING,
+        ):
+            return self._truncate_instruction_prompts(prompts, max_tokens_per_prompt)
+        raise InvalidBenchmark("The model type is not set!")
+
+    def _truncate_base_prompts(
+        self,
+        prompts: c.Sequence[str],
+        max_tokens_per_prompt: int,
+        sampling_params: "SamplingParams",
+    ) -> c.Sequence[str]:
+        """Truncate base model prompts from the left.
+
+        Args:
+            prompts:
+                The sequence of prompts.
+            max_tokens_per_prompt:
+                Maximum tokens per prompt.
+            sampling_params:
+                The sampling parameters.
+
+        Returns:
+            The truncated prompts.
+        """
+        original_side = self._tokeniser.truncation_side
+        if sampling_params.prompt_logprobs is not None:
+            self._tokeniser.truncation_side = "left"
+        try:
+            truncated = self._tokeniser(
+                text=prompts, max_length=max_tokens_per_prompt, truncation=True
+            )
+        finally:
+            self._tokeniser.truncation_side = original_side
+        return _safe_batch_decode(
+            self._tokeniser, truncated.input_ids, skip_special_tokens=True
+        )
+
+    def _truncate_instruction_prompts(
+        self, prompts: c.Sequence[str], max_tokens_per_prompt: int
+    ) -> c.Sequence[str]:
+        """Truncate instruction-tuned prompts by removing few-shot examples.
+
+        Args:
+            prompts:
+                The sequence of prompts.
+            max_tokens_per_prompt:
+                Maximum tokens per prompt.
+
+        Returns:
+            The truncated prompts.
+        """
+        assert self.end_of_chat_token_ids is not None
+        eoc_token = self._tokeniser.decode(list(self.end_of_chat_token_ids))
+        segments = [
+            (
+                p.replace(self._tokeniser.bos_token, "")
+                if self._tokeniser.bos_token
+                else p
+            ).split(eoc_token)
+            for p in prompts
+        ]
+        for remove_count in range(1, self.dataset_config.num_few_shot_examples + 1):
+            new_prompts = [eoc_token.join(seg[2 * remove_count :]) for seg in segments]
+            tok = self._tokeniser(text=new_prompts, max_length=max_tokens_per_prompt)
+            if all(len(ids) < max_tokens_per_prompt for ids in tok.input_ids):
+                return new_prompts
+        no_few_shot = [
+            eoc_token.join(seg[2 * self.dataset_config.num_few_shot_examples :])
+            for seg in segments
+        ]
+        log_once(
+            f"Could not fit the prompts for the model {self.model_config.model_id!r} "
+            f"within {max_tokens_per_prompt:,} tokens by removing few-shot examples, "
+            "so hard-truncating them instead.",
+            level=logging.WARNING,
+        )
+        truncated = self._tokeniser(
+            text=no_few_shot, max_length=max_tokens_per_prompt, truncation=True
+        )
+        return _safe_batch_decode(
+            self._tokeniser, truncated.input_ids, skip_special_tokens=True
+        )
+
+    def _setup_generation_kwargs(self) -> dict[str, t.Any]:
+        """Set up generation kwargs from model config.
+
+        Returns:
+            A dictionary of generation kwargs configured from the model.
+        """
+        generation_kwargs = GENERATION_KWARGS.copy()
+        if (generation_config := self.model_config.generation_config) is not None:
+            changed_params = generation_config.to_diff_dict()
+            for param_name in ["temperature", "top_p", "top_k", "repetition_penalty"]:
+                if param_name in changed_params:
+                    generation_kwargs[param_name] = changed_params[param_name]
+                    log_once(
+                        f"Using {param_name}={changed_params[param_name]} with the "
+                        f"model {self.model_config.model_id!r} as specified in its "
+                        "generation configuration.",
+                        level=logging.DEBUG,
+                    )
+        return generation_kwargs
+
+    def _setup_structured_outputs(
+        self, inputs: dict[str, t.Any]
+    ) -> "StructuredOutputsParams | None":
+        """Set up structured outputs parameters.
+
+        Args:
+            inputs:
+                The input dictionary for generation.
+
+        Returns:
+            StructuredOutputsParams if structured output is enabled, or None otherwise.
+        """
+        if (
+            self.dataset_config.task.uses_structured_output
+            or (self.dataset_config.task.uses_logprobs and self.dataset_config.labels)
+        ) and self.generative_type == GenerativeType.REASONING:
+            log_once(
+                "The dataset uses structured output, but we are not using it as the "
+                f"model {self.model_config.model_id!r} is a reasoning model.",
+                level=logging.DEBUG,
+            )
+            return None
+        if self.dataset_config.task.uses_structured_output:
+            return self._structured_output_for_task(inputs)
+        if (
+            self.dataset_config.task.uses_logprobs
+            and self.dataset_config.labels
+            and self.buffer.get("first_label_token_mapping", False)
+        ):
+            return self._structured_output_for_logprobs()
+        log_once(
+            "Not using structured generation as the dataset does not require it.",
+            level=logging.DEBUG,
+        )
+        return None
+
+    def _structured_output_for_logprobs(self) -> "StructuredOutputsParams":
+        """Handle structured output for logprobs-based tasks.
+
+        Returns:
+            StructuredOutputsParams for logprobs-based tasks.
+        """
+        choice_labels = [
+            self.dataset_config.prompt_label_mapping[label]
+            for label in self.dataset_config.labels
+        ]
+        if isinstance(self.buffer["first_label_token_mapping"], dict):
+            choice_labels = [
+                self.buffer["first_label_token_mapping"][label]
+                for label in choice_labels
+            ]
+        struct_output = StructuredOutputsParams(choice=choice_labels)
+        log_once(
+            f"Using structured generation with the choices: {struct_output.choice!r}.",
+            level=logging.DEBUG,
+        )
+        return struct_output
+
+    def _structured_output_for_task(
+        self, inputs: dict[str, t.Any]
+    ) -> "StructuredOutputsParams":
+        """Handle structured output for task-based generation.
+
+        Args:
+            inputs:
+                The input dictionary for generation.
+
+        Returns:
+            StructuredOutputsParams for the task.
+
+        Raises:
+            InvalidTask:
+                If the task requires structured output but doesn't define it.
+        """
+        if self.dataset_config.task.structured_output_format is not None:
+            return StructuredOutputsParams(
+                json=self.dataset_config.task.structured_output_format.model_json_schema()
+            )
+        if self.dataset_config.task.task_group == TaskGroup.TOKEN_CLASSIFICATION:
+            return self._so_token_classification()
+        if self.dataset_config.task == LOGIC:
+            return self._so_logic(inputs)
+        raise InvalidTask(
+            message=(
+                "Task set to use structured output, but it neither defines "
+                "an output structure nor is a token classification task "
+                "- at least one of these must be true."
+            )
+        )
+
+    def _so_logic(self, inputs: dict[str, t.Any]) -> "StructuredOutputsParams":
+        """Handle structured output for LOGIC tasks.
+
+        Args:
+            inputs:
+                The input dictionary for generation.
+
+        Returns:
+            StructuredOutputsParams for LOGIC tasks.
+        """
+        first_sample_raw = inputs["target_text"][0]
+        first_sample = (
+            json.loads(first_sample_raw)
+            if isinstance(first_sample_raw, str)
+            else first_sample_raw
+        )
+        object_keys = [k for k in first_sample.keys() if k.startswith("object_")]
+        n = len(object_keys)
+        k = len(first_sample[object_keys[0]]) if object_keys else 0
+        keys_and_their_types: dict[str, t.Any] = {
+            f"object_{i}": (list[str], ...) for i in range(1, n + 1)
+        }
+        answer_format_class = create_model("AnswerFormat", **keys_and_their_types)
+        schema = answer_format_class.model_json_schema()
+        log_once(
+            f"LOGIC task with {n} objects and {k} attributes per object. "
+            f"Using structured generation with the JSON schema: "
+            f"{json.dumps(schema, ensure_ascii=False)}",
+            level=logging.DEBUG,
+        )
+        return StructuredOutputsParams(json=schema)
+
+    def _so_token_classification(self) -> "StructuredOutputsParams":
+        """Handle structured output for token classification.
+
+        Returns:
+            StructuredOutputsParams for token classification.
+        """
+        tag_names = list(self.dataset_config.prompt_label_mapping.values())
+        keys_and_their_types: dict[str, t.Any] = {
+            tag_name: (conlist(str, max_length=5), ...) for tag_name in tag_names
+        }
+        answer_format_class = create_model("AnswerFormat", **keys_and_their_types)
+        schema = answer_format_class.model_json_schema()
+        log_once(
+            "Using structured generation with the JSON schema: "
+            f"{json.dumps(schema, ensure_ascii=False)}",
+            level=logging.DEBUG,
+        )
+        return StructuredOutputsParams(json=schema)
+
+    @property
+    def trainer_class(self) -> t.Type["Trainer"]:
+        """The Trainer class to use for finetuning.
+
+        Returns:
+            The Trainer class.
+        """
+        raise NotImplementedError(
+            "The `trainer_class` property has not been implemented for vLLM models."
+        )
+
+    def update_dataset_config(self, dataset_config: "DatasetConfig") -> t.Self:
+        """Update the dataset config registered in the benchmark module.
+
+        Args:
+            dataset_config:
+                The new dataset config.
+
+        Returns:
+            The benchmark module.
+
+        Raises:
+            InvalidBenchmark:
+                If the dataset requires logprobs, but we weren't able to update the
+                first label token mapping.
+        """
+        self.dataset_config = dataset_config
+        self.buffer["first_label_token_mapping"] = get_first_label_token_mapping(
+            dataset_config=self.dataset_config,
+            model_config=self.model_config,
+            tokeniser=self._tokeniser,
+            generative_type=self.generative_type,
+            log_metadata=self.log_metadata,
+        )
+        if (
+            not self.buffer["first_label_token_mapping"]
+            and self.dataset_config.task.requires_logprobs
+        ):
+            raise InvalidBenchmark(
+                "The dataset requires logprobs, but we encountered an error when "
+                "trying to get the first token of each label in the dataset. You can "
+                "try running this benchmark with the --verbose flag or setting "
+                "FULL_LOG=1 to see what the error was. Skipping this evaluation."
+            )
+        return self
+
+
 def _safe_batch_decode(
     tokeniser: Tokeniser, sequences: list[list[int]], skip_special_tokens: bool
 ) -> list[str]:
@@ -420,76 +1625,110 @@ def get_true_max_model_len(hf_model_config: "PretrainedConfig") -> int:
     return true_max_model_len
 
 
-def select_backend_and_parallelism(
-    force_single_gpu: bool = False,
-) -> tuple[str, int, int]:
-    """Determine the distributed backend and parallelism for vLLM.
+def load_model(
+    model_config: "ModelConfig",
+    benchmark_config: "BenchmarkConfig",
+    attention_backend: str | None,
+    generative_type: "GenerativeType",
+    true_max_model_len: int,
+    tokeniser: Tokeniser,
+    hf_model_config: "PretrainedConfig",
+) -> "LLM":
+    """Load the model.
 
     Args:
-        force_single_gpu:
-            If True, forces tensor parallelism to 1.
+        model_config:
+            The model configuration.
+        benchmark_config:
+            The benchmark configuration.
+        attention_backend:
+            The attention backend to use, or None to use the vLLM default.
+        generative_type:
+            The generative type of the model.
+        true_max_model_len:
+            The maximum context length of the model.
+        tokeniser:
+            The tokeniser associated with the model.
+        hf_model_config:
+            The Hugging Face model configuration.
 
     Returns:
-        Backend, tensor parallel size, and pipeline parallel size.
+        The loaded model.
     """
-    if not torch.cuda.is_available():
-        # Non-CUDA backends (e.g. Apple Metal, CPU) only ever expose a single device
-        # here, and their vLLM plugins don't support the multiprocessing executor —
-        # the Metal plugin rejects the worker's "mps" device. Use the in-process
-        # executor instead, which vLLM also selects by default for a single device.
-        #
-        # vLLM still initialises a gloo process group to talk to its engine-core
-        # subprocess, rendezvousing on the host's primary IP. On macOS that address is
-        # often unreachable from the host itself, so the rendezvous hangs indefinitely.
-        # Pin it to loopback (without clobbering an explicit user setting).
-        os.environ.setdefault("VLLM_HOST_IP", "127.0.0.1")
-        return "uni", 1, 1
+    model_id = model_config.adapter_base_model_id or model_config.model_id
+    revision = (
+        model_config.revision if model_config.adapter_base_model_id is None else "main"
+    )
 
-    # If forcing single GPU, skip multi-node setup entirely
-    if force_single_gpu:
-        return "mp", 1, 1
+    dtype, quantization = _determine_dtype(hf_model_config)
 
-    if not ray.is_initialized():
-        try:
-            ray.init(address="auto", ignore_reinit_error=True)
-        except Exception as e:
-            if "could not find any running ray instance" not in str(e).lower():
-                log_once(
-                    f"Ray initialisation failed with a {type(e)} exception: {e}",
-                    level=logging.DEBUG,
-                )
+    download_dir = (
+        str(Path(model_config.model_cache_dir) / "base_model")
+        if model_config.adapter_base_model_id is not None
+        else str(model_config.model_cache_dir)
+    )
 
-    is_ray = ray.is_initialized()
-    local_gpu_count = torch.cuda.device_count()
+    os.environ.setdefault(
+        "VLLM_CACHE_ROOT", str((Path(benchmark_config.cache_dir) / "vllm").resolve())
+    )
 
-    if is_ray:
-        resources = ray.cluster_resources()
-        total_gpus = int(resources.get("GPU", 0))
-    else:
-        total_gpus = local_gpu_count
+    vllm_params = get_vllm_tokenisation_params(
+        tokeniser=tokeniser, model_config=model_config
+    )
 
-    using_multiple_nodes = total_gpus > local_gpu_count
-    if is_ray and using_multiple_nodes:
-        distributed_executor_backend = "ray"
-        tensor_parallel_size = local_gpu_count if local_gpu_count > 0 else 1
-        pipeline_parallel_size = max(1, total_gpus // tensor_parallel_size)
-        log_once(
-            f"Detected a multi-node setup with {pipeline_parallel_size:,} nodes, each "
-            f"with {tensor_parallel_size:,} GPUs, so using `ray` as the "
-            "distributed backend.",
-            level=logging.DEBUG,
+    if hasattr(vllm.config, "attention") and attention_backend is not None:
+        vllm_params["attention_config"] = AttentionConfig(backend=attention_backend)  # ty: ignore[invalid-argument-type]
+
+    clear_vllm()
+
+    hf_overrides = _prepare_hf_overrides(
+        hf_model_config=hf_model_config, model_id=model_id
+    )
+
+    distributed_executor_backend, tensor_parallel_size, pipeline_parallel_size = (
+        select_backend_and_parallelism(force_single_gpu=False)
+    )
+
+    model_location = (
+        model_id
+        if internet_connection_available() or Path(model_id).is_dir()
+        else resolve_model_path(download_dir=download_dir)
+    )
+
+    max_model_len = min(
+        true_max_model_len,
+        MAX_CONTEXT_LENGTH + REASONING_MAX_TOKENS
+        if generative_type == GenerativeType.REASONING
+        else MAX_CONTEXT_LENGTH,
+    )
+
+    def _create_wrapped(force_single_gpu: bool = False) -> "LLM":
+        return _create_llm_instance(
+            model_location=model_location,
+            download_dir=download_dir,
+            benchmark_config=benchmark_config,
+            max_model_len=max_model_len,
+            revision=revision,
+            quantization=quantization,
+            dtype=dtype,
+            hf_overrides=hf_overrides,
+            vllm_params=vllm_params,
+            model_config=model_config,
+            force_single_gpu=force_single_gpu,
         )
-    else:
-        distributed_executor_backend = "mp"
-        tensor_parallel_size = local_gpu_count if local_gpu_count > 0 else 1
-        pipeline_parallel_size = 1
-        log_once(
-            f"Detected a single-node setup with {tensor_parallel_size:,} GPUs, "
-            "so using the multiprocessing distributed backend.",
-            level=logging.DEBUG,
+
+    try:
+        model = _create_wrapped(False)
+    except (RuntimeError, ValueError, OSError) as e:
+        model = _handle_model_load_error(
+            error=e,
+            model_id=model_id,
+            benchmark_config=benchmark_config,
+            create_llm_fn=_create_wrapped,
         )
 
-    return distributed_executor_backend, tensor_parallel_size, pipeline_parallel_size
+    model.config = hf_model_config
+    return model
 
 
 def _create_llm_instance(
@@ -567,6 +1806,78 @@ def _create_llm_instance(
     return LLM(**llm_kwargs)
 
 
+def select_backend_and_parallelism(
+    force_single_gpu: bool = False,
+) -> tuple[str, int, int]:
+    """Determine the distributed backend and parallelism for vLLM.
+
+    Args:
+        force_single_gpu:
+            If True, forces tensor parallelism to 1.
+
+    Returns:
+        Backend, tensor parallel size, and pipeline parallel size.
+    """
+    if not torch.cuda.is_available():
+        # Non-CUDA backends (e.g. Apple Metal, CPU) only ever expose a single device
+        # here, and their vLLM plugins don't support the multiprocessing executor —
+        # the Metal plugin rejects the worker's "mps" device. Use the in-process
+        # executor instead, which vLLM also selects by default for a single device.
+        #
+        # vLLM still initialises a gloo process group to talk to its engine-core
+        # subprocess, rendezvousing on the host's primary IP. On macOS that address is
+        # often unreachable from the host itself, so the rendezvous hangs indefinitely.
+        # Pin it to loopback (without clobbering an explicit user setting).
+        os.environ.setdefault("VLLM_HOST_IP", "127.0.0.1")
+        return "uni", 1, 1
+
+    # If forcing single GPU, skip multi-node setup entirely
+    if force_single_gpu:
+        return "mp", 1, 1
+
+    if not ray.is_initialized():
+        try:
+            ray.init(address="auto", ignore_reinit_error=True)
+        except Exception as e:
+            if "could not find any running ray instance" not in str(e).lower():
+                log_once(
+                    f"Ray initialisation failed with a {type(e)} exception: {e}",
+                    level=logging.DEBUG,
+                )
+
+    is_ray = ray.is_initialized()
+    local_gpu_count = torch.cuda.device_count()
+
+    if is_ray:
+        resources = ray.cluster_resources()
+        total_gpus = int(resources.get("GPU", 0))
+    else:
+        total_gpus = local_gpu_count
+
+    using_multiple_nodes = total_gpus > local_gpu_count
+    if is_ray and using_multiple_nodes:
+        distributed_executor_backend = "ray"
+        tensor_parallel_size = local_gpu_count if local_gpu_count > 0 else 1
+        pipeline_parallel_size = max(1, total_gpus // tensor_parallel_size)
+        log_once(
+            f"Detected a multi-node setup with {pipeline_parallel_size:,} nodes, each "
+            f"with {tensor_parallel_size:,} GPUs, so using `ray` as the "
+            "distributed backend.",
+            level=logging.DEBUG,
+        )
+    else:
+        distributed_executor_backend = "mp"
+        tensor_parallel_size = local_gpu_count if local_gpu_count > 0 else 1
+        pipeline_parallel_size = 1
+        log_once(
+            f"Detected a single-node setup with {tensor_parallel_size:,} GPUs, "
+            "so using the multiprocessing distributed backend.",
+            level=logging.DEBUG,
+        )
+
+    return distributed_executor_backend, tensor_parallel_size, pipeline_parallel_size
+
+
 def _determine_dtype(
     hf_model_config: "PretrainedConfig",
 ) -> tuple[str | torch.dtype, str | None]:
@@ -640,49 +1951,6 @@ def _determine_dtype(
         dtype = "auto"
 
     return dtype, quantization
-
-
-@contextlib.contextmanager
-def _skip_image_processor_context() -> c.Generator[None, None, None]:
-    """Suppress missing image processor errors during model loading.
-
-    Some models have multimodal architectures (e.g. Mistral3ForConditionalGeneration)
-    but are released without the preprocessor_config.json that transformers needs to
-    load the image processor.  Since EuroEval only does text inference, we can safely
-    return None for the image processor and let vLLM load the text backbone normally.
-
-    This context manager also sets environment flags to instruct vLLM to skip
-    multimodal initialisation.
-    """
-    original_func = AutoImageProcessor.from_pretrained.__func__
-
-    @classmethod  # type: ignore[misc]
-    def patched(
-        cls: type, pretrained_model_name_or_path: str, *args: object, **kwargs: object
-    ) -> object:
-        try:
-            return original_func(cls, pretrained_model_name_or_path, *args, **kwargs)  # ty: ignore[invalid-argument-type]
-        except OSError as e:
-            if "Can't load image processor" in str(
-                e
-            ) and "preprocessor_config.json" in str(e):
-                return None
-            raise
-
-    AutoImageProcessor.from_pretrained = patched  # ty: ignore[invalid-assignment]
-
-    # Set environment flags to tell vLLM to skip multimodal initialisation
-    original_mm_limit = os.environ.get("VLLM_LIMIT_MM_PER_PROMPT")
-    os.environ["VLLM_LIMIT_MM_PER_PROMPT"] = "0"
-
-    try:
-        yield
-    finally:
-        AutoImageProcessor.from_pretrained = classmethod(original_func)  # ty: ignore[invalid-assignment]
-        if original_mm_limit is not None:
-            os.environ["VLLM_LIMIT_MM_PER_PROMPT"] = original_mm_limit
-        else:
-            os.environ.pop("VLLM_LIMIT_MM_PER_PROMPT", None)
 
 
 def _handle_model_load_error(
@@ -811,6 +2079,88 @@ def _handle_model_load_error(
     ) from error
 
 
+@contextlib.contextmanager
+def _skip_image_processor_context() -> c.Generator[None, None, None]:
+    """Suppress missing image processor errors during model loading.
+
+    Some models have multimodal architectures (e.g. Mistral3ForConditionalGeneration)
+    but are released without the preprocessor_config.json that transformers needs to
+    load the image processor.  Since EuroEval only does text inference, we can safely
+    return None for the image processor and let vLLM load the text backbone normally.
+
+    This context manager also sets environment flags to instruct vLLM to skip
+    multimodal initialisation.
+    """
+    original_func = AutoImageProcessor.from_pretrained.__func__
+
+    @classmethod  # type: ignore[misc]
+    def patched(
+        cls: type, pretrained_model_name_or_path: str, *args: object, **kwargs: object
+    ) -> object:
+        try:
+            return original_func(cls, pretrained_model_name_or_path, *args, **kwargs)  # ty: ignore[invalid-argument-type]
+        except OSError as e:
+            if "Can't load image processor" in str(
+                e
+            ) and "preprocessor_config.json" in str(e):
+                return None
+            raise
+
+    AutoImageProcessor.from_pretrained = patched  # ty: ignore[invalid-assignment]
+
+    # Set environment flags to tell vLLM to skip multimodal initialisation
+    original_mm_limit = os.environ.get("VLLM_LIMIT_MM_PER_PROMPT")
+    os.environ["VLLM_LIMIT_MM_PER_PROMPT"] = "0"
+
+    try:
+        yield
+    finally:
+        AutoImageProcessor.from_pretrained = classmethod(original_func)  # ty: ignore[invalid-assignment]
+        if original_mm_limit is not None:
+            os.environ["VLLM_LIMIT_MM_PER_PROMPT"] = original_mm_limit
+        else:
+            os.environ.pop("VLLM_LIMIT_MM_PER_PROMPT", None)
+
+
+def _prepare_hf_overrides(
+    hf_model_config: "PretrainedConfig", model_id: str
+) -> dict[str, dict[str, str | int | float] | list[str]]:
+    """Prepare Hugging Face overrides for vLLM.
+
+    Args:
+        hf_model_config:
+            The Hugging Face model configuration.
+        model_id:
+            The model ID.
+
+    Returns:
+        Dictionary of HF overrides.
+    """
+    hf_overrides: dict[str, dict[str, str | int | float] | list[str]] = {}
+
+    if hf_model_config.architectures:
+        remapped = [
+            _ARCHITECTURE_ALIASES.get(arch, arch)
+            for arch in hf_model_config.architectures
+        ]
+        if remapped != hf_model_config.architectures:
+            log(
+                f"Remapping model architectures {hf_model_config.architectures} -> "
+                f"{remapped} for vLLM compatibility.",
+                level=logging.INFO,
+            )
+            hf_model_config.architectures = remapped
+            hf_overrides["architectures"] = remapped
+
+    rope_parameters_override = _get_rope_parameters_override(
+        model_id=model_id, hf_model_config=hf_model_config
+    )
+    if rope_parameters_override is not None:
+        hf_overrides["rope_parameters"] = rope_parameters_override
+
+    return hf_overrides
+
+
 def _get_rope_parameters_override(
     model_id: str, hf_model_config: "PretrainedConfig"
 ) -> dict[str, str | int | float] | None:
@@ -872,45 +2222,6 @@ def _get_rope_parameters_override(
     return rope_parameters
 
 
-def _prepare_hf_overrides(
-    hf_model_config: "PretrainedConfig", model_id: str
-) -> dict[str, dict[str, str | int | float] | list[str]]:
-    """Prepare Hugging Face overrides for vLLM.
-
-    Args:
-        hf_model_config:
-            The Hugging Face model configuration.
-        model_id:
-            The model ID.
-
-    Returns:
-        Dictionary of HF overrides.
-    """
-    hf_overrides: dict[str, dict[str, str | int | float] | list[str]] = {}
-
-    if hf_model_config.architectures:
-        remapped = [
-            _ARCHITECTURE_ALIASES.get(arch, arch)
-            for arch in hf_model_config.architectures
-        ]
-        if remapped != hf_model_config.architectures:
-            log(
-                f"Remapping model architectures {hf_model_config.architectures} -> "
-                f"{remapped} for vLLM compatibility.",
-                level=logging.INFO,
-            )
-            hf_model_config.architectures = remapped
-            hf_overrides["architectures"] = remapped
-
-    rope_parameters_override = _get_rope_parameters_override(
-        model_id=model_id, hf_model_config=hf_model_config
-    )
-    if rope_parameters_override is not None:
-        hf_overrides["rope_parameters"] = rope_parameters_override
-
-    return hf_overrides
-
-
 def get_vllm_tokenisation_params(
     tokeniser: Tokeniser, model_config: "ModelConfig"
 ) -> dict[str, t.Any]:
@@ -947,150 +2258,6 @@ def get_vllm_tokenisation_params(
         config_format=config_format,
         load_format=load_format,
     )
-
-
-def load_model(
-    model_config: "ModelConfig",
-    benchmark_config: "BenchmarkConfig",
-    attention_backend: str | None,
-    generative_type: "GenerativeType",
-    true_max_model_len: int,
-    tokeniser: Tokeniser,
-    hf_model_config: "PretrainedConfig",
-) -> "LLM":
-    """Load the model.
-
-    Args:
-        model_config:
-            The model configuration.
-        benchmark_config:
-            The benchmark configuration.
-        attention_backend:
-            The attention backend to use, or None to use the vLLM default.
-        generative_type:
-            The generative type of the model.
-        true_max_model_len:
-            The maximum context length of the model.
-        tokeniser:
-            The tokeniser associated with the model.
-        hf_model_config:
-            The Hugging Face model configuration.
-
-    Returns:
-        The loaded model.
-    """
-    model_id = model_config.adapter_base_model_id or model_config.model_id
-    revision = (
-        model_config.revision if model_config.adapter_base_model_id is None else "main"
-    )
-
-    dtype, quantization = _determine_dtype(hf_model_config)
-
-    download_dir = (
-        str(Path(model_config.model_cache_dir) / "base_model")
-        if model_config.adapter_base_model_id is not None
-        else str(model_config.model_cache_dir)
-    )
-
-    os.environ.setdefault(
-        "VLLM_CACHE_ROOT", str((Path(benchmark_config.cache_dir) / "vllm").resolve())
-    )
-
-    vllm_params = get_vllm_tokenisation_params(
-        tokeniser=tokeniser, model_config=model_config
-    )
-
-    if hasattr(vllm.config, "attention") and attention_backend is not None:
-        vllm_params["attention_config"] = AttentionConfig(backend=attention_backend)  # ty: ignore[invalid-argument-type]
-
-    clear_vllm()
-
-    hf_overrides = _prepare_hf_overrides(
-        hf_model_config=hf_model_config, model_id=model_id
-    )
-
-    distributed_executor_backend, tensor_parallel_size, pipeline_parallel_size = (
-        select_backend_and_parallelism(force_single_gpu=False)
-    )
-
-    model_location = (
-        model_id
-        if internet_connection_available() or Path(model_id).is_dir()
-        else resolve_model_path(download_dir=download_dir)
-    )
-
-    max_model_len = min(
-        true_max_model_len,
-        MAX_CONTEXT_LENGTH + REASONING_MAX_TOKENS
-        if generative_type == GenerativeType.REASONING
-        else MAX_CONTEXT_LENGTH,
-    )
-
-    def _create_wrapped(force_single_gpu: bool = False) -> "LLM":
-        return _create_llm_instance(
-            model_location=model_location,
-            download_dir=download_dir,
-            benchmark_config=benchmark_config,
-            max_model_len=max_model_len,
-            revision=revision,
-            quantization=quantization,
-            dtype=dtype,
-            hf_overrides=hf_overrides,
-            vllm_params=vllm_params,
-            model_config=model_config,
-            force_single_gpu=force_single_gpu,
-        )
-
-    try:
-        model = _create_wrapped(False)
-    except (RuntimeError, ValueError, OSError) as e:
-        model = _handle_model_load_error(
-            error=e,
-            model_id=model_id,
-            benchmark_config=benchmark_config,
-            create_llm_fn=_create_wrapped,
-        )
-
-    model.config = hf_model_config
-    return model
-
-
-def _is_mistral_tokeniser_model(
-    model_id: str, hf_model_config: "PretrainedConfig"
-) -> bool:
-    """Determine whether a model should use the Mistral common tokeniser.
-
-    Used as a fallback when ``AutoTokenizer.from_pretrained`` fails, to decide whether
-    to retry with ``MistralCommonTokenizer``. The decision is based on the model's
-    identity rather than the error message, since the error raised by
-    ``MistralCommonBackend.from_pretrained`` mentions "MistralCommonBackend", which
-    would otherwise match non-Mistral models whose tokeniser loading happens to fail.
-
-    Args:
-        model_id:
-            The model identifier.
-        hf_model_config:
-            The Hugging Face model configuration.
-
-    Returns:
-        Whether the model should be loaded with the Mistral common tokeniser.
-    """
-    # Base models do not use the mistral-common tokeniser, so we never fall back
-    # to it for them regardless of their model type or architectures. This
-    # includes IDs containing "base" and versioned base models like
-    # mistralai/Mistral-7B-v0.1 which lack a chat template. Instruction-tuned
-    # models are exempt from this check.
-    model_name = model_id.rsplit("/", 1)[-1].lower()
-    if "instruct" not in model_name and (
-        "base" in model_name or re.search(r"-v\d+\.\d+$", model_name)
-    ):
-        return False
-    if model_id.startswith("mistralai/"):
-        return True
-    if getattr(hf_model_config, "model_type", None) == "mistral":
-        return True
-    architectures = getattr(hf_model_config, "architectures", None) or []
-    return any("Mistral" in architecture for architecture in architectures)
 
 
 def load_tokeniser(
@@ -1216,1206 +2383,39 @@ def load_tokeniser(
     return tokeniser
 
 
-class VLLMModel(HuggingFaceEncoderModel):
-    """A generative model using the vLLM inference framework."""
-
-    fresh_model = False
-    batching_preference = BatchingPreference.ALL_AT_ONCE
-    high_priority = True
-    allowed_params: dict[re.Pattern[str], list[str]] = {
-        re.compile(r".*"): ["thinking", "no-thinking", "slow-tokenizer"],
-        re.compile(r".*gpt-oss.*", flags=re.IGNORECASE): ["low", "medium", "high"],
-    }
-
-    def __init__(
-        self,
-        model_config: "ModelConfig",
-        dataset_config: "DatasetConfig",
-        benchmark_config: "BenchmarkConfig",
-        log_metadata: bool = True,
-    ) -> None:
-        """Initialise the vLLM model.
-
-        Args:
-            model_config:
-                The model configuration.
-            dataset_config:
-                The dataset configuration.
-            benchmark_config:
-                The benchmark configuration.
-            log_metadata:
-                Whether to log the model and dataset metadata.
-
-        Raises:
-            NeedsSystemDependency:
-                If the CUDA Toolkit is not installed on NVIDIA hardware.
-            NeedsExtraInstalled:
-                If the generative extra is not installed.
-            InvalidModel:
-                If the generative type was None for the model.
-        """
-        if importlib.util.find_spec("vllm") is None:
-            raise NeedsExtraInstalled(extra="generative")
-
-        if (
-            torch.cuda.is_available()
-            and torch.version.hip is None
-            and shutil.which("nvcc") is None
-        ):
-            raise NeedsSystemDependency(
-                dependency="nvcc",
-                instructions=(
-                    "Please install the CUDA Toolkit from "
-                    "https://developer.nvidia.com/cuda-downloads or ensure that NVCC "
-                    "is available in your PATH."
-                ),
-            )
-
-        raise_if_wrong_params(
-            model_config=model_config, allowed_params=self.allowed_params
-        )
-
-        # This is already set when calling `super().__init__`, but we need it to get
-        # the correct value from `self.generative_type`, so we set it here as well.
-        self.benchmark_config = benchmark_config
-        self.model_config = model_config
-
-        hf_model_config = load_hf_model_config(
-            model_id=model_config.adapter_base_model_id or model_config.model_id,
-            num_labels=0,
-            id2label=HashableDict(),
-            label2id=HashableDict(),
-            revision=(
-                model_config.revision
-                if model_config.adapter_base_model_id is None
-                else "main"
-            ),
-            model_cache_dir=model_config.model_cache_dir,
-            api_key=benchmark_config.api_key,
-            trust_remote_code=benchmark_config.trust_remote_code,
-            run_with_cli=benchmark_config.run_with_cli,
-        )
-        true_max_model_len = get_true_max_model_len(hf_model_config=hf_model_config)
-
-        tokeniser = load_tokeniser(
-            model_id=model_config.model_id,
-            revision=model_config.revision,
-            adapter_base_model_id=model_config.adapter_base_model_id,
-            trust_remote_code=benchmark_config.trust_remote_code,
-            model_max_length=true_max_model_len,
-            model_config=model_config,
-            hf_model_config=hf_model_config,
-            token=get_hf_token(api_key=benchmark_config.api_key),
-        )
-        self._tokeniser: Tokeniser = tokeniser
-
-        generative_type = self.generative_type
-        if generative_type is None:
-            raise InvalidModel(
-                f"Generative type for model {model_config.model_id!r} was None during "
-                "initialisation. Please report this issue at "
-                "https://github.com/EuroEval/EuroEval/issues/new."
-            )
-
-        with no_terminal_output(disable=benchmark_config.verbose):
-            model = load_model(
-                model_config=model_config,
-                benchmark_config=benchmark_config,
-                attention_backend=benchmark_config.attention_backend,
-                true_max_model_len=true_max_model_len,
-                generative_type=generative_type,
-                tokeniser=tokeniser,
-                hf_model_config=hf_model_config,
-            )
-        self._model: LLM = model
-
-        # We specify `HuggingFaceEncoderModel` here instead of `VLLMModel`, as we want
-        # to call the `__init__` method of the `BenchmarkModule` class.
-        super(HuggingFaceEncoderModel, self).__init__(
-            model_config=model_config,
-            dataset_config=dataset_config,
-            benchmark_config=benchmark_config,
-            log_metadata=log_metadata,
-        )
-
-        self.end_of_reasoning_token = get_end_of_reasoning_token(
-            model=self._model, tokeniser=self._tokeniser, model_config=model_config
-        )
-        self.end_of_chat_token_ids = get_end_of_chat_token_ids(
-            tokeniser=self._tokeniser, generative_type=self.generative_type
-        )
-        self.custom_stop_tokens = get_custom_stop_tokens(
-            model=self._model,
-            tokeniser=self._tokeniser,
-            model_id=model_config.model_id,
-            generative_type=self.generative_type,
-        )
-
-        self.buffer |= dict(
-            first_label_token_mapping=get_first_label_token_mapping(
-                dataset_config=self.dataset_config,
-                model_config=self.model_config,
-                tokeniser=self._tokeniser,
-                generative_type=self.generative_type,
-                log_metadata=self.log_metadata,
-            )
-        )
-        if self.model_config.adapter_base_model_id is not None:
-            if Path(self.model_config.model_id).exists():
-                adapter_path = self.model_config.model_id
-            else:
-                adapter_path = snapshot_download(
-                    repo_id=self.model_config.model_id,
-                    revision=self.model_config.revision,
-                    cache_dir=Path(self.model_config.model_cache_dir),
-                )
-            self.buffer["lora_request"] = LoRARequest(
-                lora_name="adapter", lora_int_id=1, lora_path=adapter_path
-            )
-
-    def __del__(self) -> None:
-        """Clean up the model and tokeniser."""
-        try:
-            if importlib.util.find_spec("vllm") is not None:
-                clear_vllm()
-        except ImportError:
-            pass
-        if hasattr(self, "_model"):
-            del self._model
-        if hasattr(self, "_tokeniser"):
-            del self._tokeniser
-
-    def _apply_token_budget(
-        self, sampling_params: "SamplingParams", max_context_length: int
-    ) -> int:
-        """Apply token budget and return max tokens per prompt.
-
-        Args:
-            sampling_params:
-                The sampling parameters.
-            max_context_length:
-                The maximum context length.
-
-        Returns:
-            The maximum number of tokens per prompt.
-        """
-        if sampling_params.prompt_logprobs is not None:
-            return max_context_length - sampling_params.max_tokens
-        generation_budget, max_tokens_per_prompt = compute_token_budget(
-            model_max_length=self._tokeniser.model_max_length,
-            max_generated_tokens=self.dataset_config.max_generated_tokens,
-        )
-        if generation_budget < self.dataset_config.max_generated_tokens:
-            log_once(
-                f"The model {self.model_config.model_id!r} has a context length of "
-                f"{max_context_length:,} tokens, which is too small to fit both "
-                "the prompt and the dataset's full generation budget of "
-                f"{self.dataset_config.max_generated_tokens:,} tokens. Reserving "
-                f"{generation_budget:,} tokens for generation when budgeting "
-                "prompt lengths instead.",
-                level=logging.WARNING,
-            )
-            if self.generative_type != GenerativeType.REASONING:
-                sampling_params.max_tokens = generation_budget
-        return max_tokens_per_prompt
-
-    def _clean_empty_prompts(self, prompts: c.Sequence[str]) -> list[str]:
-        """Replace empty prompts with BOS token.
-
-        Args:
-            prompts:
-                The sequence of prompts.
-
-        Returns:
-            A list of prompts with empty prompts replaced by BOS token.
-        """
-        if any(len(prompt.strip()) == 0 for prompt in prompts):
-            log("Found empty prompts, replacing with BOS token.", level=logging.DEBUG)
-            return [
-                prompt
-                if len(prompt.strip()) > 0
-                else str(self._tokeniser.bos_token or "x")
-                for prompt in prompts
-            ]
-        return list(prompts)
-
-    def _remove_reasoning_content(self, completions: list[str]) -> list[str]:
-        """Remove reasoning content from completions for reasoning models.
-
-        Args:
-            completions:
-                The list of completion strings.
-
-        Returns:
-            The completions with reasoning content removed.
-        """
-        if (
-            self.end_of_reasoning_token is None
-            or self.generative_type != GenerativeType.REASONING
-        ):
-            return completions
-        count = 0
-        for idx, comp in enumerate(completions):
-            if (
-                isinstance(self.end_of_reasoning_token, str)
-                and self.end_of_reasoning_token in comp
-            ):
-                completions[idx] = comp.split(self.end_of_reasoning_token)[-1]
-            elif isinstance(
-                self.end_of_reasoning_token, re.Pattern
-            ) and self.end_of_reasoning_token.search(comp):
-                completions[idx] = self.end_of_reasoning_token.split(comp)[-1]
-            else:
-                count += 1
-                completions[idx] = ""
-        if count > 0:
-            log_once(
-                f"The model {self.model_config.model_id!r} is a reasoning model, "
-                f"but the generated output did not contain the end of reasoning token "
-                f"({self.end_of_reasoning_token!r}) in {count:,}/{len(completions):,} "
-                "of the samples. Using an empty string for all these samples instead.",
-                level=logging.WARNING
-                if count / len(completions) > 0.5
-                else logging.DEBUG,
-            )
-        return completions
-
-    def _setup_stop_tokens(self) -> list[str]:
-        """Set up stopping tokens for generation.
-
-        Returns:
-            A list of stop tokens for generation.
-        """
-        stop_tokens: list[str] = self.custom_stop_tokens.copy()
-        if self.generative_type == GenerativeType.BASE:
-            stop_tokens.append("\n\n")
-        if self._tokeniser.pad_token_id is not None:
-            assert isinstance(self._tokeniser.pad_token, str), (
-                f"The pad token for the model {self.model_config.model_id!r} "
-                f"is not a string, which is unexpected: {self._tokeniser.pad_token!r}."
-            )
-            stop_tokens.append(self._tokeniser.pad_token)
-        if self._tokeniser.eos_token_id is not None:
-            assert isinstance(self._tokeniser.eos_token, str), (
-                f"The EOS token for the model {self.model_config.model_id!r} "
-                f"is not a string, which is unexpected: {self._tokeniser.eos_token!r}."
-            )
-            stop_tokens.append(self._tokeniser.eos_token)
-            if self._tokeniser.pad_token_id is None:
-                self._tokeniser.pad_token_id = self._tokeniser.eos_token_id
-                self._tokeniser.pad_token = self._tokeniser.eos_token
-        if self.end_of_chat_token_ids is not None:
-            end_of_chat_token = self._tokeniser.decode(
-                list(self.end_of_chat_token_ids)
-            ).strip()
-            if end_of_chat_token:
-                stop_tokens.append(end_of_chat_token)
-        return stop_tokens
-
-    def _remove_stop_tokens(self, completions: list[str]) -> list[str]:
-        """Remove stop tokens from completions.
-
-        Args:
-            completions:
-                The list of completion strings.
-
-        Returns:
-            The completions with stop tokens removed.
-        """
-        stop_tokens = self._setup_stop_tokens()
-        pattern = re.compile("|".join(re.escape(t) for t in stop_tokens))
-        return [re.split(pattern=pattern, string=c)[0].strip() for c in completions]
-
-    def _parse_completions(
-        self, raw_outputs: list, sampling_params: "SamplingParams"
-    ) -> tuple[list[str], list]:
-        """Parse raw outputs into completions.
-
-        Args:
-            raw_outputs:
-                The raw model outputs.
-            sampling_params:
-                The sampling parameters.
-
-        Returns:
-            A tuple of (completions, raw_outputs).
-
-        Raises:
-            InvalidBenchmark:
-                If the number of completions doesn't match the outputs.
-        """
-        if sampling_params.prompt_logprobs is not None:
-            return [""] * len(raw_outputs), raw_outputs
-        completion_ids = [list(out.outputs[0].token_ids) for out in raw_outputs]
-        completions = _safe_batch_decode(
-            self._tokeniser, completion_ids, skip_special_tokens=False
-        )
-        completions = self._remove_reasoning_content(completions)
-        completions = self._remove_stop_tokens(completions)
-        comp_ids = self._tokeniser(text=completions).input_ids
-        completions = _safe_batch_decode(
-            self._tokeniser, comp_ids, skip_special_tokens=True
-        )
-        if len(completions) != len(raw_outputs):
-            raise InvalidBenchmark(
-                f"Expected {len(raw_outputs):,} completions, "
-                f"but got {len(completions):,}."
-            )
-        return completions, raw_outputs
-
-    def _filter_and_parse_outputs(
-        self, prompts: list[str], raw_outputs: list, sampling_params: "SamplingParams"
-    ) -> tuple[list[str], list]:
-        """Filter extra outputs and parse completions.
-
-        Args:
-            prompts:
-                The list of prompts.
-            raw_outputs:
-                The raw model outputs.
-            sampling_params:
-                The sampling parameters.
-
-        Returns:
-            A tuple of (completions, raw_outputs).
-
-        Raises:
-            InvalidBenchmark:
-                If the prompts and outputs do not match.
-        """
-        extra = len(raw_outputs) - len(prompts)
-        if extra > 0:
-            raw_outputs = raw_outputs[extra:]
-            if not all(out.prompt == p for out, p in zip(raw_outputs, prompts)):
-                raise InvalidBenchmark(
-                    "The prompts and the model outputs do not match. "
-                    f"There were {extra!r} extra outputs."
-                )
-            log(
-                f"Filtered out {extra:,} extra outputs from the model, "
-                "which occured as we interupted the generation when we truncated "
-                "the prompts.",
-                level=logging.DEBUG,
-            )
-        return self._parse_completions(raw_outputs, sampling_params)
-
-    def _strip_prompts_if_needed(self, prompts: c.Sequence[str]) -> list[str]:
-        """Strip prompts if the model's tokeniser requires it.
-
-        Args:
-            prompts:
-                The sequence of prompts.
-
-        Returns:
-            A list of stripped prompts.
-        """
-        labels = list(self.dataset_config.prompt_label_mapping.values()) or [
-            "negative",
-            "positive",
-        ]
-        if self.generative_type == GenerativeType.BASE and should_prompts_be_stripped(
-            labels_to_be_generated=labels, tokeniser=self._tokeniser
-        ):
-            log_once(
-                f"Stripping prompts for model {self.model_config.model_id!r}.",
-                level=logging.DEBUG,
-            )
-            return [p.strip() for p in prompts]
-        return list(prompts)
-
-    def _truncate_base_prompts(
-        self,
-        prompts: c.Sequence[str],
-        max_tokens_per_prompt: int,
-        sampling_params: "SamplingParams",
-    ) -> c.Sequence[str]:
-        """Truncate base model prompts from the left.
-
-        Args:
-            prompts:
-                The sequence of prompts.
-            max_tokens_per_prompt:
-                Maximum tokens per prompt.
-            sampling_params:
-                The sampling parameters.
-
-        Returns:
-            The truncated prompts.
-        """
-        original_side = self._tokeniser.truncation_side
-        if sampling_params.prompt_logprobs is not None:
-            self._tokeniser.truncation_side = "left"
-        try:
-            truncated = self._tokeniser(
-                text=prompts, max_length=max_tokens_per_prompt, truncation=True
-            )
-        finally:
-            self._tokeniser.truncation_side = original_side
-        return _safe_batch_decode(
-            self._tokeniser, truncated.input_ids, skip_special_tokens=True
-        )
-
-    def _truncate_instruction_prompts(
-        self, prompts: c.Sequence[str], max_tokens_per_prompt: int
-    ) -> c.Sequence[str]:
-        """Truncate instruction-tuned prompts by removing few-shot examples.
-
-        Args:
-            prompts:
-                The sequence of prompts.
-            max_tokens_per_prompt:
-                Maximum tokens per prompt.
-
-        Returns:
-            The truncated prompts.
-        """
-        assert self.end_of_chat_token_ids is not None
-        eoc_token = self._tokeniser.decode(list(self.end_of_chat_token_ids))
-        segments = [
-            (
-                p.replace(self._tokeniser.bos_token, "")
-                if self._tokeniser.bos_token
-                else p
-            ).split(eoc_token)
-            for p in prompts
-        ]
-        for remove_count in range(1, self.dataset_config.num_few_shot_examples + 1):
-            new_prompts = [eoc_token.join(seg[2 * remove_count :]) for seg in segments]
-            tok = self._tokeniser(text=new_prompts, max_length=max_tokens_per_prompt)
-            if all(len(ids) < max_tokens_per_prompt for ids in tok.input_ids):
-                return new_prompts
-        no_few_shot = [
-            eoc_token.join(seg[2 * self.dataset_config.num_few_shot_examples :])
-            for seg in segments
-        ]
-        log_once(
-            f"Could not fit the prompts for the model {self.model_config.model_id!r} "
-            f"within {max_tokens_per_prompt:,} tokens by removing few-shot examples, "
-            "so hard-truncating them instead.",
-            level=logging.WARNING,
-        )
-        truncated = self._tokeniser(
-            text=no_few_shot, max_length=max_tokens_per_prompt, truncation=True
-        )
-        return _safe_batch_decode(
-            self._tokeniser, truncated.input_ids, skip_special_tokens=True
-        )
-
-    def _truncate_prompts_if_needed(
-        self,
-        prompts: c.Sequence[str],
-        max_tokens_per_prompt: int,
-        sampling_params: "SamplingParams",
-    ) -> c.Sequence[str]:
-        """Truncate prompts if they exceed the token budget.
-
-        Args:
-            prompts:
-                The sequence of prompts.
-            max_tokens_per_prompt:
-                Maximum tokens per prompt.
-            sampling_params:
-                The sampling parameters.
-
-        Returns:
-            The truncated prompts.
-
-        Raises:
-            InvalidBenchmark:
-                If the model type is not set.
-        """
-        tokenized = self._tokeniser(text=prompts, max_length=max_tokens_per_prompt)
-        if all(len(ids) < max_tokens_per_prompt for ids in tokenized.input_ids):
-            log_once(
-                f"Truncation of prompts for model {self.model_config.model_id!r} is "
-                "not needed, so skipping truncation.",
-                level=logging.DEBUG,
-            )
-            return prompts
-        log(
-            f"Truncating prompts for the model {self.model_config.model_id!r} "
-            f"to a maximum of {max_tokens_per_prompt:,} tokens.",
-            level=logging.DEBUG,
-        )
-        if self.generative_type == GenerativeType.BASE:
-            return self._truncate_base_prompts(
-                prompts, max_tokens_per_prompt, sampling_params
-            )
-        if self.generative_type in (
-            GenerativeType.INSTRUCTION_TUNED,
-            GenerativeType.REASONING,
-        ):
-            return self._truncate_instruction_prompts(prompts, max_tokens_per_prompt)
-        raise InvalidBenchmark("The model type is not set!")
-
-    def _prepare_prompts(
-        self,
-        inputs: dict,
-        prompt_key: str,
-        max_tokens_per_prompt: int,
-        sampling_params: "SamplingParams",
-    ) -> list[str]:
-        """Prepare and truncate prompts.
-
-        Args:
-            inputs:
-                The input dictionary.
-            prompt_key:
-                The key for prompts in the inputs.
-            max_tokens_per_prompt:
-                Maximum tokens per prompt.
-            sampling_params:
-                The sampling parameters.
-
-        Returns:
-            A list of prepared and truncated prompts.
-        """
-        prompts: c.Sequence[str] = list(inputs[prompt_key])
-        prompts = self._clean_empty_prompts(prompts)
-        prompts = self._strip_prompts_if_needed(prompts)
-        prompts = self._truncate_prompts_if_needed(
-            prompts, max_tokens_per_prompt, sampling_params
-        )
-        return list(prompts)
-
-    def _setup_generation_kwargs(self) -> dict[str, t.Any]:
-        """Set up generation kwargs from model config.
-
-        Returns:
-            A dictionary of generation kwargs configured from the model.
-        """
-        generation_kwargs = GENERATION_KWARGS.copy()
-        if (generation_config := self.model_config.generation_config) is not None:
-            changed_params = generation_config.to_diff_dict()
-            for param_name in ["temperature", "top_p", "top_k", "repetition_penalty"]:
-                if param_name in changed_params:
-                    generation_kwargs[param_name] = changed_params[param_name]
-                    log_once(
-                        f"Using {param_name}={changed_params[param_name]} with the "
-                        f"model {self.model_config.model_id!r} as specified in its "
-                        "generation configuration.",
-                        level=logging.DEBUG,
-                    )
-        return generation_kwargs
-
-    def _structured_output_for_logprobs(self) -> "StructuredOutputsParams":
-        """Handle structured output for logprobs-based tasks.
-
-        Returns:
-            StructuredOutputsParams for logprobs-based tasks.
-        """
-        choice_labels = [
-            self.dataset_config.prompt_label_mapping[label]
-            for label in self.dataset_config.labels
-        ]
-        if isinstance(self.buffer["first_label_token_mapping"], dict):
-            choice_labels = [
-                self.buffer["first_label_token_mapping"][label]
-                for label in choice_labels
-            ]
-        struct_output = StructuredOutputsParams(choice=choice_labels)
-        log_once(
-            f"Using structured generation with the choices: {struct_output.choice!r}.",
-            level=logging.DEBUG,
-        )
-        return struct_output
-
-    def _so_logic(self, inputs: dict[str, t.Any]) -> "StructuredOutputsParams":
-        """Handle structured output for LOGIC tasks.
-
-        Args:
-            inputs:
-                The input dictionary for generation.
-
-        Returns:
-            StructuredOutputsParams for LOGIC tasks.
-        """
-        first_sample_raw = inputs["target_text"][0]
-        first_sample = (
-            json.loads(first_sample_raw)
-            if isinstance(first_sample_raw, str)
-            else first_sample_raw
-        )
-        object_keys = [k for k in first_sample.keys() if k.startswith("object_")]
-        n = len(object_keys)
-        k = len(first_sample[object_keys[0]]) if object_keys else 0
-        keys_and_their_types: dict[str, t.Any] = {
-            f"object_{i}": (list[str], ...) for i in range(1, n + 1)
-        }
-        answer_format_class = create_model("AnswerFormat", **keys_and_their_types)
-        schema = answer_format_class.model_json_schema()
-        log_once(
-            f"LOGIC task with {n} objects and {k} attributes per object. "
-            f"Using structured generation with the JSON schema: "
-            f"{json.dumps(schema, ensure_ascii=False)}",
-            level=logging.DEBUG,
-        )
-        return StructuredOutputsParams(json=schema)
-
-    def _so_token_classification(self) -> "StructuredOutputsParams":
-        """Handle structured output for token classification.
-
-        Returns:
-            StructuredOutputsParams for token classification.
-        """
-        tag_names = list(self.dataset_config.prompt_label_mapping.values())
-        keys_and_their_types: dict[str, t.Any] = {
-            tag_name: (conlist(str, max_length=5), ...) for tag_name in tag_names
-        }
-        answer_format_class = create_model("AnswerFormat", **keys_and_their_types)
-        schema = answer_format_class.model_json_schema()
-        log_once(
-            "Using structured generation with the JSON schema: "
-            f"{json.dumps(schema, ensure_ascii=False)}",
-            level=logging.DEBUG,
-        )
-        return StructuredOutputsParams(json=schema)
-
-    def _structured_output_for_task(
-        self, inputs: dict[str, t.Any]
-    ) -> "StructuredOutputsParams":
-        """Handle structured output for task-based generation.
-
-        Args:
-            inputs:
-                The input dictionary for generation.
-
-        Returns:
-            StructuredOutputsParams for the task.
-
-        Raises:
-            InvalidTask:
-                If the task requires structured output but doesn't define it.
-        """
-        if self.dataset_config.task.structured_output_format is not None:
-            return StructuredOutputsParams(
-                json=self.dataset_config.task.structured_output_format.model_json_schema()
-            )
-        if self.dataset_config.task.task_group == TaskGroup.TOKEN_CLASSIFICATION:
-            return self._so_token_classification()
-        if self.dataset_config.task == LOGIC:
-            return self._so_logic(inputs)
-        raise InvalidTask(
-            message=(
-                "Task set to use structured output, but it neither defines "
-                "an output structure nor is a token classification task "
-                "- at least one of these must be true."
-            )
-        )
-
-    def _setup_structured_outputs(
-        self, inputs: dict[str, t.Any]
-    ) -> "StructuredOutputsParams | None":
-        """Set up structured outputs parameters.
-
-        Args:
-            inputs:
-                The input dictionary for generation.
-
-        Returns:
-            StructuredOutputsParams if structured output is enabled, or None otherwise.
-        """
-        if (
-            self.dataset_config.task.uses_structured_output
-            or (self.dataset_config.task.uses_logprobs and self.dataset_config.labels)
-        ) and self.generative_type == GenerativeType.REASONING:
-            log_once(
-                "The dataset uses structured output, but we are not using it as the "
-                f"model {self.model_config.model_id!r} is a reasoning model.",
-                level=logging.DEBUG,
-            )
-            return None
-        if self.dataset_config.task.uses_structured_output:
-            return self._structured_output_for_task(inputs)
-        if (
-            self.dataset_config.task.uses_logprobs
-            and self.dataset_config.labels
-            and self.buffer.get("first_label_token_mapping", False)
-        ):
-            return self._structured_output_for_logprobs()
-        log_once(
-            "Not using structured generation as the dataset does not require it.",
-            level=logging.DEBUG,
-        )
-        return None
-
-    def _run_vllm_core(
-        self, inputs: dict, prompt_key: str, sampling_params: "SamplingParams"
-    ) -> tuple[list[str], list]:
-        """Run vLLM generation with given parameters.
-
-        Shared implementation used by both generate() and score().
-
-        Args:
-            inputs:
-                A batch of inputs to pass through the model.
-            prompt_key:
-                Key to extract prompts from inputs ("text" or "bpc_prompt").
-            sampling_params:
-                Sampling parameters for vLLM generation.
-
-        Returns:
-            Tuple of (completions, raw_outputs).
-
-        Raises:
-            InvalidBenchmark:
-                If generation fails or prompts are too long.
-        """
-        # Set up label token mapping first (required for most tasks)
-        self.buffer["first_label_token_mapping"] = get_first_label_token_mapping(
-            dataset_config=self.dataset_config,
-            model_config=self.model_config,
-            tokeniser=self._tokeniser,
-            generative_type=self.generative_type,
-            log_metadata=self.log_metadata,
-        )
-        if (
-            not self.buffer["first_label_token_mapping"]
-            and self.dataset_config.task.requires_logprobs
-        ):
-            raise InvalidBenchmark(
-                "The dataset requires logprobs, but we encountered an error when "
-                "trying to get the first token of each label in the dataset. You can "
-                "try running this benchmark with the --verbose flag or setting "
-                "FULL_LOG=1 to see what the error was. Skipping this evaluation."
-            )
-
-        # Set up structured outputs
-        structured_outputs = self._setup_structured_outputs(inputs)
-
-        # Set up generation kwargs and sampling params
-        generation_kwargs = self._setup_generation_kwargs()
-        stop_tokens = self._setup_stop_tokens()
-        sampling_params.stop = [t for t in stop_tokens if t]
-        sampling_params.structured_outputs = structured_outputs
-        sampling_params.temperature = generation_kwargs["temperature"]
-        sampling_params.top_p = generation_kwargs["top_p"]
-        sampling_params.top_k = int(generation_kwargs["top_k"])
-        sampling_params.repetition_penalty = generation_kwargs["repetition_penalty"]
-
-        # Set up logprobs if needed
-        if sampling_params.prompt_logprobs is None:
-            sampling_params.logprobs = (
-                MAX_VLLM_LOGPROBS if self.buffer["first_label_token_mapping"] else None
-            )
-
-        # Compute token budget and prepare prompts
-        max_context_length = min(self._tokeniser.model_max_length, MAX_CONTEXT_LENGTH)
-        max_tokens_per_prompt = self._apply_token_budget(
-            sampling_params, max_context_length
-        )
-        prompts = self._prepare_prompts(
-            inputs, prompt_key, max_tokens_per_prompt, sampling_params
-        )
-
-        # Generate and parse outputs
-        return self._generate_with_retries(prompts, sampling_params, max_context_length)
-
-    def generate(self, inputs: dict) -> "GenerativeModelOutput":
-        """Generate outputs from the model.
-
-        Args:
-            inputs:
-                A batch of inputs to pass through the model.
-
-        Returns:
-            The generated model outputs.
-        """
-        # Compute max_tokens based on model type
-        max_tokens: int = (
-            REASONING_MAX_TOKENS
-            if self.generative_type == GenerativeType.REASONING
-            else self.dataset_config.max_generated_tokens
-        )
-        sampling_params = SamplingParams(
-            max_tokens=max_tokens,
-            prompt_logprobs=None,
-            logprobs=None,  # Set in _run_vllm_core from first_label_token_mapping
-            temperature=GENERATION_KWARGS["temperature"],
-            top_p=GENERATION_KWARGS["top_p"],
-            top_k=int(GENERATION_KWARGS["top_k"]),
-            repetition_penalty=GENERATION_KWARGS["repetition_penalty"],
-            stop=[],  # Set in _run_vllm_core
-            structured_outputs=None,  # Set in _run_vllm_core
-        )
-        completions, raw_outputs = self._run_vllm_core(inputs, "text", sampling_params)
-
-        # Extract logprobs scores if available
-        if self.buffer["first_label_token_mapping"] and sampling_params.logprobs:
-            scores: c.Sequence[c.Sequence[c.Sequence[tuple[str, float]]]] = [
-                [
-                    [
-                        (obj.decoded_token or "", obj.logprob)
-                        for obj in token_logprobs_dict.values()
-                    ]
-                    for token_logprobs_dict in raw_output.outputs[0].logprobs or list()
-                ]
-                for raw_output in raw_outputs
-            ]
-            return GenerativeModelOutput(sequences=completions, scores=scores)
-        return GenerativeModelOutput(sequences=completions)
-
-    def _generate_with_retries(
-        self,
-        prompts: list[str],
-        sampling_params: "SamplingParams",
-        max_context_length: int,
-    ) -> tuple[list[str], list]:
-        """Generate sequences with retry logic.
-
-        Args:
-            prompts:
-                The list of prompts to generate from.
-            sampling_params:
-                The sampling parameters.
-            max_context_length:
-                The maximum context length.
-
-        Returns:
-            A tuple of (completions, raw_outputs).
-
-        Raises:
-            InvalidBenchmark:
-                If generation fails after retries or outputs are invalid.
-        """
-        input_is_test = len(prompts) == 1 and len(set(prompts[0])) == 1
-        num_attempts = 3
-        truncation_attempts = 1
-        oom_messages = [
-            "out of memory",
-            "outofmemory",
-            "insufficient memory",
-            "command buffer execution failed",
-        ]
-
-        def check_oom(error: Exception) -> None:
-            if any(m in str(error).lower() for m in oom_messages):
-                raise InvalidModel(
-                    "vLLM ran out of device memory during generation. On "
-                    "shared-memory devices (e.g. Apple Metal) the default GPU memory "
-                    "utilization is often too high, since the reserved KV cache "
-                    "leaves no room for the per-step allocations. Re-run with a lower "
-                    "value, e.g. `--gpu-memory-utilization 0.3` (or lower). "
-                    f"Underlying error: {str(error)}"
-                ) from error
-
-        for _ in range(num_attempts):
-            try:
-                bos = str(self._tokeniser.bos_token or "x")
-                prompts = [p if p.strip() else bos for p in prompts]
-                raw_outputs = self._model.generate(  # ty: ignore[call-non-callable]
-                    prompts=prompts,
-                    sampling_params=sampling_params,
-                    use_tqdm=False if input_is_test else get_pbar,
-                    lora_request=self.buffer.get("lora_request"),
-                )
-                break
-            except TypeError as e:
-                log(
-                    f"Encountered error during vLLM generation: {str(e)}. Retrying...",
-                    level=logging.DEBUG,
-                )
-                sleep(1)
-            except (ValueError, RuntimeError) as e:
-                check_oom(e)
-                trunc_msgs = [
-                    r"prompt \(length [0-9]+\) is longer than the maximum model length",
-                    "Sampled token IDs exceed the max model length",
-                ]
-                if any(
-                    re.search(pat, str(e), flags=re.IGNORECASE) for pat in trunc_msgs
-                ):
-                    log(
-                        "Prompts are too long, so truncating them and trying again...",
-                        level=logging.WARNING,
-                    )
-                    log(f"The error message was: {str(e)}", level=logging.DEBUG)
-                    extra = 50 * truncation_attempts
-                    truncation_attempts += 1
-                    tok = self._tokeniser(
-                        text=prompts,
-                        truncation=True,
-                        max_length=max(
-                            max_context_length - sampling_params.max_tokens - extra, 0
-                        ),
-                    )
-                    prompts = _safe_batch_decode(
-                        self._tokeniser, tok.input_ids, skip_special_tokens=True
-                    )
-                else:
-                    raise InvalidBenchmark(
-                        f"An error occurred during vLLM generation: {str(e)}"
-                    ) from e
-            except Exception as e:
-                check_oom(e)
-                if type(e).__name__ == "EngineDeadError" or "RPC call" in str(e):
-                    raise InvalidBenchmark(
-                        "The vLLM engine died during generation, likely due to a "
-                        "worker RPC timeout. Consider raising "
-                        "`VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS` or reducing the "
-                        f"batch size. Underlying error: {str(e)}"
-                    ) from e
-                raise
-        else:
-            raise InvalidBenchmark(
-                f"Could not generate sequences after {num_attempts} attempts."
-            )
-        return self._filter_and_parse_outputs(
-            prompts=prompts, raw_outputs=raw_outputs, sampling_params=sampling_params
-        )
-
-    @property
-    def data_collator(self) -> c.Callable[[list[dict[str, t.Any]]], dict[str, t.Any]]:
-        """The data collator used to prepare samples during finetuning.
-
-        Returns:
-            The data collator.
-        """
-        raise NotImplementedError(
-            "The `data_collator` property has not been implemented for vLLM models."
-        )
-
-    @property
-    def extract_labels_from_generation(self) -> ExtractLabelsFunction:
-        """The function used to extract the labels from the generated output.
-
-        Returns:
-            The function used to extract the labels from the generated output.
-        """
-        return _extract_labels_from_generation_helper(
-            dataset_config=self.dataset_config,
-            model_config=self.model_config,
-            first_label_token_mapping=self.buffer["first_label_token_mapping"],
-        )
-
-    @property
-    def generative_type(self) -> GenerativeType | None:
-        """The generative type of the model.
-
-        Returns:
-            The generative type of the model, or None if it has not been set yet.
-        """
-        if self.benchmark_config.generative_type is not None:
-            type_ = self.benchmark_config.generative_type
-        elif self.model_config.param in {"thinking"}:
-            type_ = GenerativeType.REASONING
-        elif self.model_config.param in {"no-thinking"}:
-            type_ = GenerativeType.INSTRUCTION_TUNED
-        elif (
-            hasattr(self, "end_of_reasoning_token")
-            and self.end_of_reasoning_token is not None
-        ):
-            type_ = GenerativeType.REASONING
-        elif not hasattr(self, "_tokeniser"):
-            log_once(
-                "The generative type of the model has not been set yet as the "
-                "tokeniser has not been loaded.",
-                level=logging.DEBUG,
-            )
-            return None
-        elif (
-            has_chat_template(tokeniser=self._tokeniser)
-            or "instruct" in self.model_config.model_id.lower()
-        ):
-            type_ = GenerativeType.INSTRUCTION_TUNED
-        else:
-            type_ = GenerativeType.BASE
-        log_once(
-            f"Detected generative type {type_.name!r} for model "
-            f"{self.model_config.model_id!r}",
-            level=logging.DEBUG,
-        )
-        return type_
-
-    @classmethod
-    def get_model_config(
-        cls, model_id: str, benchmark_config: "BenchmarkConfig"
-    ) -> "ModelConfig":
-        """Fetch the model configuration.
-
-        Args:
-            model_id:
-                The model ID.
-            benchmark_config:
-                The benchmark configuration.
-
-        Returns:
-            The model configuration.
-
-        Raises:
-            InvalidModel:
-                If the model does not exist.
-        """
-        resolved_model_id, revision, model_info = _lookup_model_info(
-            model_id=model_id, benchmark_config=benchmark_config
-        )
-        if model_info is None:
-            raise InvalidModel(f"The model {model_id!r} could not be found.")
-
-        try:
-            generation_config = GenerationConfig.from_pretrained(
-                pretrained_model_name=resolved_model_id,
-                revision=revision,
-                cache_dir=benchmark_config.cache_dir,
-                token=benchmark_config.api_key,
-            )
-        except OSError:
-            generation_config = None
-
-        model_id_components = split_model_id(model_id=model_id)
-
-        return _build_model_config_helper(
-            model_id=resolved_model_id,
-            revision=revision,
-            param=model_id_components.param,
-            task=model_info.pipeline_tag,
-            model_info=model_info,
-            benchmark_config=benchmark_config,
-            inference_backend=InferenceBackend.VLLM,
-            model_type=ModelType.GENERATIVE,
-            adapter_base_model_id=model_info.adapter_base_model_id,
-            generation_config=generation_config,
-        )
-
-    @classmethod
-    def model_exists(
-        cls, model_id: str, benchmark_config: "BenchmarkConfig"
-    ) -> bool | NeedsExtraInstalled | NeedsEnvironmentVariable:
-        """Check if a model exists.
-
-        Args:
-            model_id:
-                The model ID.
-            benchmark_config:
-                The benchmark configuration.
-
-        Returns:
-            Whether the model exists, or an error describing why we cannot check
-            whether the model exists.
-        """
-        using_api = (
-            benchmark_config.api_base is not None
-            or benchmark_config.api_version is not None
-        )
-        if using_api:
-            return False
-
-        _, _, model_info = _lookup_model_info(
-            model_id=model_id, benchmark_config=benchmark_config
-        )
-        return (
-            model_info is not None
-            and model_info.pipeline_tag in GENERATIVE_PIPELINE_TAGS
-        )
-
-    def prepare_dataset(
-        self, dataset: "DatasetDict", task: "Task", itr_idx: int
-    ) -> "DatasetDict":
-        """Prepare the dataset for the model.
-
-        This includes things like tokenisation.
-
-        Args:
-            dataset:
-                The dataset to prepare.
-            task:
-                The task to prepare the dataset for.
-            itr_idx:
-                The index of the dataset in the iterator.
-
-        Returns:
-            The prepared dataset.
-        """
-        return _prepare_dataset_helper(
-            dataset=dataset,
-            task=task,
-            model_config=self.model_config,
-            dataset_config=self.dataset_config,
-            benchmark_config=self.benchmark_config,
-            generative_type=self.generative_type,
-            itr_idx=itr_idx,
-            always_populate_text_field=True,
-            tokeniser=self._tokeniser,
-        )
-
-    def score(self, inputs: dict) -> "GenerativeModelOutput":
-        """Compute BPC scores from prompt_logprobs.
-
-        Args:
-            inputs:
-                A batch of inputs with bpc_prompt column.
-
-        Returns:
-            Model output with BPC scores.
-        """
-        sampling_params = SamplingParams(
-            # BPC scoring only reads `prompt_logprobs`; no generation is needed, but
-            # vLLM requires `max_tokens >= 1`, so we generate a single throwaway token.
-            max_tokens=1,
-            prompt_logprobs=BPC_LOGPROBS,
-            logprobs=None,
-            temperature=GENERATION_KWARGS["temperature"],
-            top_p=GENERATION_KWARGS["top_p"],
-            top_k=int(GENERATION_KWARGS["top_k"]),
-            repetition_penalty=GENERATION_KWARGS["repetition_penalty"],
-            stop=[],  # Set in _run_vllm_core
-            structured_outputs=None,  # Set in _run_vllm_core
-        )
-        completions, raw_outputs = self._run_vllm_core(
-            inputs, "bpc_prompt", sampling_params
-        )
-
-        # Compute BPC scores
-        bpc_scores = compute_bpc_scores_for_vllm_outputs(
-            raw_outputs=raw_outputs, inputs=inputs, tokeniser=self._tokeniser
-        )
-        output = GenerativeModelOutput(sequences=completions)
-        if bpc_scores is not None:
-            output.bpc_scores = bpc_scores
-        return output
-
-    @property
-    def trainer_class(self) -> t.Type["Trainer"]:
-        """The Trainer class to use for finetuning.
-
-        Returns:
-            The Trainer class.
-        """
-        raise NotImplementedError(
-            "The `trainer_class` property has not been implemented for vLLM models."
-        )
-
-    def update_dataset_config(self, dataset_config: "DatasetConfig") -> t.Self:
-        """Update the dataset config registered in the benchmark module.
-
-        Args:
-            dataset_config:
-                The new dataset config.
-
-        Returns:
-            The benchmark module.
-
-        Raises:
-            InvalidBenchmark:
-                If the dataset requires logprobs, but we weren't able to update the
-                first label token mapping.
-        """
-        self.dataset_config = dataset_config
-        self.buffer["first_label_token_mapping"] = get_first_label_token_mapping(
-            dataset_config=self.dataset_config,
-            model_config=self.model_config,
-            tokeniser=self._tokeniser,
-            generative_type=self.generative_type,
-            log_metadata=self.log_metadata,
-        )
-        if (
-            not self.buffer["first_label_token_mapping"]
-            and self.dataset_config.task.requires_logprobs
-        ):
-            raise InvalidBenchmark(
-                "The dataset requires logprobs, but we encountered an error when "
-                "trying to get the first token of each label in the dataset. You can "
-                "try running this benchmark with the --verbose flag or setting "
-                "FULL_LOG=1 to see what the error was. Skipping this evaluation."
-            )
-        return self
+def _is_mistral_tokeniser_model(
+    model_id: str, hf_model_config: "PretrainedConfig"
+) -> bool:
+    """Determine whether a model should use the Mistral common tokeniser.
+
+    Used as a fallback when ``AutoTokenizer.from_pretrained`` fails, to decide whether
+    to retry with ``MistralCommonTokenizer``. The decision is based on the model's
+    identity rather than the error message, since the error raised by
+    ``MistralCommonBackend.from_pretrained`` mentions "MistralCommonBackend", which
+    would otherwise match non-Mistral models whose tokeniser loading happens to fail.
+
+    Args:
+        model_id:
+            The model identifier.
+        hf_model_config:
+            The Hugging Face model configuration.
+
+    Returns:
+        Whether the model should be loaded with the Mistral common tokeniser.
+    """
+    # Base models do not use the mistral-common tokeniser, so we never fall back
+    # to it for them regardless of their model type or architectures. This
+    # includes IDs containing "base" and versioned base models like
+    # mistralai/Mistral-7B-v0.1 which lack a chat template. Instruction-tuned
+    # models are exempt from this check.
+    model_name = model_id.rsplit("/", 1)[-1].lower()
+    if "instruct" not in model_name and (
+        "base" in model_name or re.search(r"-v\d+\.\d+$", model_name)
+    ):
+        return False
+    if model_id.startswith("mistralai/"):
+        return True
+    if getattr(hf_model_config, "model_type", None) == "mistral":
+        return True
+    architectures = getattr(hf_model_config, "architectures", None) or []
+    return any("Mistral" in architecture for architecture in architectures)

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -37,131 +37,6 @@ if t.TYPE_CHECKING:
     from .data_models import BenchmarkConfig, DatasetConfig, ModelConfig, Task
 
 
-def clear_model_cache_fn(cache_dir: str) -> None:
-    """Clear the model cache.
-
-    Note that this will not remove the stored completions.
-
-    Args:
-        cache_dir:
-            The path to the cache directory.
-    """
-    model_cache_path = Path(cache_dir) / "model_cache"
-    model_cache_path.mkdir(parents=True, exist_ok=True)
-    for model_dir in model_cache_path.iterdir():
-        if model_dir.is_dir():
-            for sub_model_dir in model_dir.iterdir():
-                if sub_model_dir.is_dir():
-                    rmtree(sub_model_dir, ignore_errors=True)
-
-
-def get_record(
-    model_config: "ModelConfig",
-    dataset_config: "DatasetConfig",
-    benchmark_config: "BenchmarkConfig",
-    benchmark_results: c.Sequence[BenchmarkResult],
-) -> BenchmarkResult | None:
-    """Get the benchmark record for a given model and dataset.
-
-    Args:
-        model_config:
-            The configuration of the model we are evaluating.
-        dataset_config:
-            The configuration of the dataset we are evaluating on.
-        benchmark_config:
-            The general benchmark configuration.
-        benchmark_results:
-            The benchmark results.
-
-    Returns:
-        The benchmark record, or None if no such record exists.
-    """
-    for record in benchmark_results:
-        model_id_components = split_model_id(model_id=record.model)
-        same_model_id = model_id_components.model_id == model_config.model_id
-        same_revision = model_id_components.revision == model_config.revision
-        same_param = model_id_components.param == model_config.param
-        same_dataset = record.dataset == dataset_config.name
-        same_split = record.validation_split != benchmark_config.evaluate_test_split
-        same_num_shots = (
-            record.few_shot == benchmark_config.few_shot
-            or record.few_shot is None
-            or not record.generative
-            or dataset_config.task.requires_zero_shot
-        )
-        if (
-            same_model_id
-            and same_revision
-            and same_param
-            and same_dataset
-            and same_split
-            and same_num_shots
-        ):
-            return record
-    return None
-
-
-def initial_logging(
-    model_config: "ModelConfig",
-    dataset_config: "DatasetConfig",
-    benchmark_config: "BenchmarkConfig",
-    num_finished_benchmarks: int,
-    num_total_benchmarks: int,
-) -> None:
-    """Initial logging at the start of the benchmarking process.
-
-    Args:
-        model_config:
-            The configuration of the model we are evaluating.
-        dataset_config:
-            The configuration of the dataset we are evaluating on.
-        benchmark_config:
-            The general benchmark configuration.
-        num_finished_benchmarks:
-            The number of benchmarks that have already been finished.
-        num_total_benchmarks:
-            The total number of benchmarks to be run.
-    """
-    model_id = model_config.model_id
-    if model_config.revision and model_config.revision != "main":
-        model_id += f"@{model_config.revision}"
-    if model_config.param is not None:
-        model_id += f"#{model_config.param}"
-
-    split_type = "validation" if not benchmark_config.evaluate_test_split else "test"
-    if model_config.task in GENERATIVE_PIPELINE_TAGS:
-        if benchmark_config.few_shot:
-            eval_type = "Few-shot benchmarking"
-        else:
-            eval_type = "Zero-shot benchmarking"
-    else:
-        eval_type = "Benchmarking"
-
-    log_once(
-        f"\n{eval_type} {model_id} on the {split_type} split of "
-        f"{dataset_config.logging_string} ({num_finished_benchmarks + 1}/"
-        f"{num_total_benchmarks} benchmarks)...",
-        prefix=f"\n[{dt.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}]",
-        level=logging.INFO,
-    )
-
-    if dataset_config.unofficial:
-        log_once(
-            f"Note that the {dataset_config.name!r} dataset is unofficial, "
-            "meaning that the resulting evaluation will not be included in the "
-            "official leaderboard.",
-            level=logging.WARNING,
-        )
-
-    if benchmark_config.debug:
-        log_once(
-            "Running in debug mode. This will output additional information, as "
-            "well as store the model outputs in the current directory after each "
-            "batch. For this reason, evaluation will be slower.",
-            level=logging.WARNING,
-        )
-
-
 class Benchmarker:
     """Benchmarking all the language models.
 
@@ -373,6 +248,367 @@ class Benchmarker:
 
         self.results_path = Path.cwd() / "euroeval_benchmark_results.jsonl"
         adjust_logging_level(verbose=self.benchmark_config.verbose)
+
+    def benchmark(
+        self,
+        model: c.Sequence[str] | str,
+        task: "str | Task | c.Sequence[str | Task] | None" = None,
+        dataset: "str | DatasetConfig | c.Sequence[str | DatasetConfig] | None" = None,
+        progress_bar: bool | None = None,
+        save_results: bool | None = None,
+        language: str | c.Sequence[str] | None = None,
+        device: Device | None = None,
+        finetuning_batch_size: int | None = None,
+        raise_errors: bool | None = None,
+        cache_dir: str | None = None,
+        api_key: str | None = None,
+        api_base: str | None = None,
+        api_version: str | None = None,
+        trust_remote_code: bool | None = None,
+        clear_model_cache: bool | None = None,
+        evaluate_test_split: bool | None = None,
+        few_shot: bool | None = None,
+        num_iterations: int | None = None,
+        requires_safetensors: bool | None = None,
+        download_only: bool | None = None,
+        gpu_memory_utilization: float | None = None,
+        generative_type: GenerativeType | None = None,
+        use_bits_per_character: bool | None = None,
+        attention_backend: t.Literal[
+            *ATTENTION_BACKENDS  # ty: ignore[invalid-type-form]
+        ]
+        | None = None,
+        custom_datasets_file: Path | str | None = None,
+        force: bool | None = None,
+        verbose: bool | None = None,
+        debug: bool | None = None,
+        max_context_length: int | None = None,
+        vocabulary_size: int | None = None,
+    ) -> c.Sequence[BenchmarkResult]:
+        """Benchmarks models on datasets.
+
+        Args:
+            model:
+                The full Hugging Face Hub path(s) to the pretrained transformer model.
+                The specific model version to use can be added after the suffix '@':
+                "model@v1.0.0". It can be a branch name, a tag name, or a commit id,
+                and defaults to the latest version if not specified.
+            task:
+                The tasks benchmark the model(s) on. Mutually exclusive with `dataset`.
+                If both `task` and `dataset` are None then all datasets will be
+                benchmarked. Defaults to None.
+            dataset:
+                The datasets to benchmark on. Mutually exclusive with `task`. If both
+                `task` and `dataset` are None then all datasets will be benchmarked.
+                Defaults to None.
+            progress_bar:
+                Whether progress bars should be shown. Defaults to the value specified
+                when initialising the benchmarker.
+            save_results:
+                Whether to save the benchmark results to
+                'euroeval_benchmark_results.jsonl'. Defaults to the value specified
+                when initialising the benchmarker.
+            language:
+                The language codes of the languages to include, both for models and
+                datasets. Here 'no' means both Bokmål (nb) and Nynorsk (nn).
+                Set this to 'all' if all languages should be considered.
+                Defaults to the value specified when initialising the benchmarker.
+            device:
+                The device to use for benchmarking. Defaults to the value specified when
+                initialising the benchmarker.
+            finetuning_batch_size:
+                The batch size to use for finetuning. Defaults to the value specified
+                when initialising the benchmarker.
+            raise_errors:
+                Whether to raise errors instead of skipping the model evaluation.
+            cache_dir:
+                Directory to store cached models. Defaults to the value specified when
+                initialising the benchmarker.
+            api_key:
+                The API key to use for a given inference server. Defaults to the value
+                specified when initialising the benchmarker.
+            api_base:
+                The base URL for a given inference API. Only relevant if `model` refers
+                to a model on an inference API. Defaults to the value specified when
+                initialising the benchmarker.
+            api_version:
+                The version of the API to use. Defaults to the value specified when
+                initialising the benchmarker.
+            trust_remote_code:
+                Whether to trust remote code when loading models. Defaults to the value
+                specified when initialising the benchmarker.
+            clear_model_cache:
+                Whether to clear the model cache after benchmarking each model. Defaults
+                to the value specified when initialising the benchmarker.
+            evaluate_test_split:
+                Whether to evaluate the test split of the datasets. Defaults to the
+                value specified when initialising the benchmarker.
+            few_shot:
+                Whether to only evaluate the model using few-shot evaluation. Only
+                relevant if the model is generative. Defaults to the value specified
+                when initialising the benchmarker.
+            num_iterations:
+                The number of times each model should be evaluated. This is only meant
+                to be used for power users, and scores will not be allowed on the
+                leaderboards if this is changed. Defaults to the value specified when
+                initialising the benchmarker.
+            requires_safetensors:
+                Whether to only allow models that use the safetensors format. Defaults
+                to the value specified when initialising the benchmarker.
+            download_only:
+                Whether to only download the models without evaluating them. Defaults
+                to the value specified when initialising the benchmarker.
+            gpu_memory_utilization:
+                The GPU memory utilization to use for vLLM. Only relevant if the model
+                is generative. A larger value will result in faster evaluation, but at
+                the risk of running out of GPU memory. Only reduce this if you are
+                running out of GPU memory. Defaults to the value specified when
+                initialising the benchmarker.
+            generative_type:
+                The type of generative model to benchmark. Only relevant if the model is
+                generative. If not specified, then the type will be inferred based on
+                the tags of the model. Defaults to the value specified when initialising
+                the benchmarker.
+            use_bits_per_character:
+                Whether to compute bits-per-character (BPC) on the ground-truth answer.
+                For multiple-choice tasks, treats benchmark as text-to-text with bare
+                question → full answer text. Only supported for base decoder models.
+                Defaults to the value specified when initialising the benchmarker.
+            attention_backend:
+                The attention backend to use for vLLM. Only relevant if the model is
+                generative. Defaults to the value specified when initialising the
+                benchmarker.
+            custom_datasets_file:
+                Path to a Python file defining custom datasets. Defaults to the value
+                specified when initialising the benchmarker.
+            force:
+                Whether to force evaluations of models, even if they have been
+                benchmarked already. Defaults to the value specified when initialising
+                the benchmarker.
+            verbose:
+                Whether to output additional output. Defaults to the value specified
+                when initialising the benchmarker.
+            debug:
+                Whether to output debug information. Defaults to the value specified
+                when initialising the benchmarker.
+            max_context_length:
+                Override for the maximum context length of the model. If None, the
+                value will be inferred automatically from the model. Defaults to the
+                value specified when initialising the benchmarker.
+            vocabulary_size:
+                Override for the vocabulary size of the model. If None, the value will
+                be inferred automatically from the model. Defaults to the value
+                specified when initialising the benchmarker.
+
+        Returns:
+            A list of benchmark results.
+
+        Raises:
+            ValueError:
+                If both `task` and `dataset` are specified.
+            InvalidModel:
+                If we're offline benchmarking an adapter model, or if model loading
+                failed.
+        """
+        if task is not None and dataset is not None:
+            raise ValueError("Only one of `task` and `dataset` can be specified.")
+
+        # Determine verbose mode
+        is_verbose = (
+            verbose
+            if verbose is not None
+            else self.benchmark_config_default_params.verbose
+        )
+        if os.getenv("FULL_LOG", "0") == "1" or debug:
+            is_verbose = True
+
+        log_once(
+            "Started EuroEval run."
+            if is_verbose
+            else "Started EuroEval run. Run with `--verbose` for more information.",
+            level=logging.INFO,
+        )
+
+        # Announce BPC mode if active
+        is_bpc = (
+            use_bits_per_character
+            if use_bits_per_character is not None
+            else self.benchmark_config_default_params.use_bits_per_character
+        )
+        if is_bpc:
+            log_once(
+                "    ↳ Running in bits-per-character (BPC) mode: every dataset will be "
+                "scored by the bits-per-character of the ground-truth answer (lower is "
+                "better) instead of the usual task metrics.",
+                level=logging.INFO,
+            )
+
+        # Build benchmark config
+        benchmark_config = self._build_benchmark_config(
+            task=task,
+            dataset=dataset,
+            progress_bar=progress_bar,
+            save_results=save_results,
+            language=language,
+            device=device,
+            finetuning_batch_size=finetuning_batch_size,
+            raise_errors=raise_errors,
+            cache_dir=cache_dir,
+            api_key=api_key,
+            api_base=api_base,
+            api_version=api_version,
+            trust_remote_code=trust_remote_code,
+            clear_model_cache=clear_model_cache,
+            evaluate_test_split=evaluate_test_split,
+            few_shot=few_shot,
+            num_iterations=num_iterations,
+            requires_safetensors=requires_safetensors,
+            download_only=download_only,
+            gpu_memory_utilization=gpu_memory_utilization,
+            generative_type=generative_type,
+            use_bits_per_character=use_bits_per_character,
+            attention_backend=attention_backend,
+            custom_datasets_file=custom_datasets_file,
+            force=force,
+            verbose=verbose,
+            debug=debug,
+            max_context_length=max_context_length,
+            vocabulary_size=vocabulary_size,
+        )
+
+        adjust_logging_level(verbose=benchmark_config.verbose)
+
+        if benchmark_config.clear_model_cache:
+            clear_model_cache_fn(cache_dir=benchmark_config.cache_dir)
+
+        model_ids = self._prepare_model_ids(model_id=model)
+        dataset_configs = benchmark_config.datasets
+
+        # Fetch model configs and create mapping
+        model_configs = self._fetch_model_configs(model_ids, benchmark_config)
+        model_mapping = self._create_model_dataset_mapping(
+            model_configs, dataset_configs
+        )
+
+        # Filter out existing benchmarks
+        existing_results = self.benchmark_results
+        model_mapping, current_results = self._filter_existing_benchmarks(
+            model_mapping, benchmark_config, existing_results
+        )
+
+        total_benchmarks = sum(len(ds) for ds in model_mapping.values())
+        if total_benchmarks == 0:
+            log(
+                "No benchmarks to run, as all the selected models have already been "
+                "benchmarked on all the selected datasets.",
+                level=logging.INFO,
+            )
+            return current_results
+
+        num_finished = 0
+        num_skipped = 0
+        num_errored = 0
+
+        for model_config in model_configs:
+            if not model_mapping[model_config]:
+                log(
+                    f"Skipping model {model_config.model_id!r} because it has "
+                    "already been benchmarked on all valid datasets.",
+                    level=logging.DEBUG,
+                )
+                continue
+
+            self._check_adapter_requirements(model_config, benchmark_config)
+
+            loaded_model: "BenchmarkModule | None" = None
+            for dataset_config in model_mapping[model_config]:
+                params_to_revert = self._update_benchmark_config_for_dataset(
+                    dataset_config, benchmark_config
+                )
+
+                if benchmark_config.download_only:
+                    self._download(dataset_config, model_config, benchmark_config)
+                    num_finished += 1
+                    continue
+
+                # Load generative model if needed
+                if model_config.model_type == ModelType.GENERATIVE:
+                    if loaded_model is None:
+                        try:
+                            loaded_model = load_model(
+                                model_config=model_config,
+                                dataset_config=dataset_config,
+                                benchmark_config=benchmark_config,
+                            )
+                        except InvalidModel as e:
+                            if benchmark_config.raise_errors:
+                                raise e
+                            log(e.message, level=logging.ERROR)
+                            remaining = model_mapping[model_config][
+                                model_mapping[model_config].index(dataset_config) + 1 :
+                            ]
+                            num_errored += 1 + len(remaining)
+                            break
+
+                    if (
+                        loaded_model.generative_type
+                        not in dataset_config.allowed_generative_types
+                    ):
+                        log(
+                            f"Skipping the benchmark of model "
+                            f"{model_config.model_id!r} on dataset "
+                            f"{dataset_config.name!r} because the model has generative "
+                            f"type {loaded_model.generative_type} and the dataset "
+                            f"only allows {dataset_config.allowed_generative_types}.",
+                            level=logging.DEBUG,
+                        )
+                        num_skipped += 1
+                        continue
+
+                # Run benchmark and handle result
+                output_or_err = self._benchmark_single(
+                    model=loaded_model,
+                    model_config=model_config,
+                    dataset_config=dataset_config,
+                    benchmark_config=benchmark_config,
+                    num_finished_benchmarks=num_finished + num_skipped + num_errored,
+                    num_total_benchmarks=total_benchmarks,
+                )
+
+                num_finished, num_skipped, num_errored, should_break = (
+                    self._handle_benchmark_result(
+                        result_or_error=output_or_err,
+                        dataset_config=dataset_config,
+                        benchmark_config=benchmark_config,
+                        num_finished=num_finished,
+                        num_skipped=num_skipped,
+                        num_errored=num_errored,
+                        model_config=model_config,
+                        model_mapping=model_mapping,
+                        current_results=current_results,
+                    )
+                )
+                if should_break:
+                    break
+
+                # Revert config changes
+                for param, value in params_to_revert.items():
+                    setattr(benchmark_config, param, value)
+
+            del loaded_model
+            if benchmark_config.clear_model_cache:
+                clear_model_cache_fn(cache_dir=benchmark_config.cache_dir)
+
+        # Log summary
+        summary = self._generate_summary_message(num_finished, num_skipped, num_errored)
+        if summary:
+            log(summary, level=logging.INFO)
+
+        # Clean up process group
+        with contextlib.suppress(Exception):
+            destroy_process_group()
+
+        return current_results
 
     def _benchmark_single(
         self,
@@ -1043,367 +1279,6 @@ class Benchmarker:
             benchmark_config.few_shot = False
         return params_to_revert
 
-    def benchmark(
-        self,
-        model: c.Sequence[str] | str,
-        task: "str | Task | c.Sequence[str | Task] | None" = None,
-        dataset: "str | DatasetConfig | c.Sequence[str | DatasetConfig] | None" = None,
-        progress_bar: bool | None = None,
-        save_results: bool | None = None,
-        language: str | c.Sequence[str] | None = None,
-        device: Device | None = None,
-        finetuning_batch_size: int | None = None,
-        raise_errors: bool | None = None,
-        cache_dir: str | None = None,
-        api_key: str | None = None,
-        api_base: str | None = None,
-        api_version: str | None = None,
-        trust_remote_code: bool | None = None,
-        clear_model_cache: bool | None = None,
-        evaluate_test_split: bool | None = None,
-        few_shot: bool | None = None,
-        num_iterations: int | None = None,
-        requires_safetensors: bool | None = None,
-        download_only: bool | None = None,
-        gpu_memory_utilization: float | None = None,
-        generative_type: GenerativeType | None = None,
-        use_bits_per_character: bool | None = None,
-        attention_backend: t.Literal[
-            *ATTENTION_BACKENDS  # ty: ignore[invalid-type-form]
-        ]
-        | None = None,
-        custom_datasets_file: Path | str | None = None,
-        force: bool | None = None,
-        verbose: bool | None = None,
-        debug: bool | None = None,
-        max_context_length: int | None = None,
-        vocabulary_size: int | None = None,
-    ) -> c.Sequence[BenchmarkResult]:
-        """Benchmarks models on datasets.
-
-        Args:
-            model:
-                The full Hugging Face Hub path(s) to the pretrained transformer model.
-                The specific model version to use can be added after the suffix '@':
-                "model@v1.0.0". It can be a branch name, a tag name, or a commit id,
-                and defaults to the latest version if not specified.
-            task:
-                The tasks benchmark the model(s) on. Mutually exclusive with `dataset`.
-                If both `task` and `dataset` are None then all datasets will be
-                benchmarked. Defaults to None.
-            dataset:
-                The datasets to benchmark on. Mutually exclusive with `task`. If both
-                `task` and `dataset` are None then all datasets will be benchmarked.
-                Defaults to None.
-            progress_bar:
-                Whether progress bars should be shown. Defaults to the value specified
-                when initialising the benchmarker.
-            save_results:
-                Whether to save the benchmark results to
-                'euroeval_benchmark_results.jsonl'. Defaults to the value specified
-                when initialising the benchmarker.
-            language:
-                The language codes of the languages to include, both for models and
-                datasets. Here 'no' means both Bokmål (nb) and Nynorsk (nn).
-                Set this to 'all' if all languages should be considered.
-                Defaults to the value specified when initialising the benchmarker.
-            device:
-                The device to use for benchmarking. Defaults to the value specified when
-                initialising the benchmarker.
-            finetuning_batch_size:
-                The batch size to use for finetuning. Defaults to the value specified
-                when initialising the benchmarker.
-            raise_errors:
-                Whether to raise errors instead of skipping the model evaluation.
-            cache_dir:
-                Directory to store cached models. Defaults to the value specified when
-                initialising the benchmarker.
-            api_key:
-                The API key to use for a given inference server. Defaults to the value
-                specified when initialising the benchmarker.
-            api_base:
-                The base URL for a given inference API. Only relevant if `model` refers
-                to a model on an inference API. Defaults to the value specified when
-                initialising the benchmarker.
-            api_version:
-                The version of the API to use. Defaults to the value specified when
-                initialising the benchmarker.
-            trust_remote_code:
-                Whether to trust remote code when loading models. Defaults to the value
-                specified when initialising the benchmarker.
-            clear_model_cache:
-                Whether to clear the model cache after benchmarking each model. Defaults
-                to the value specified when initialising the benchmarker.
-            evaluate_test_split:
-                Whether to evaluate the test split of the datasets. Defaults to the
-                value specified when initialising the benchmarker.
-            few_shot:
-                Whether to only evaluate the model using few-shot evaluation. Only
-                relevant if the model is generative. Defaults to the value specified
-                when initialising the benchmarker.
-            num_iterations:
-                The number of times each model should be evaluated. This is only meant
-                to be used for power users, and scores will not be allowed on the
-                leaderboards if this is changed. Defaults to the value specified when
-                initialising the benchmarker.
-            requires_safetensors:
-                Whether to only allow models that use the safetensors format. Defaults
-                to the value specified when initialising the benchmarker.
-            download_only:
-                Whether to only download the models without evaluating them. Defaults
-                to the value specified when initialising the benchmarker.
-            gpu_memory_utilization:
-                The GPU memory utilization to use for vLLM. Only relevant if the model
-                is generative. A larger value will result in faster evaluation, but at
-                the risk of running out of GPU memory. Only reduce this if you are
-                running out of GPU memory. Defaults to the value specified when
-                initialising the benchmarker.
-            generative_type:
-                The type of generative model to benchmark. Only relevant if the model is
-                generative. If not specified, then the type will be inferred based on
-                the tags of the model. Defaults to the value specified when initialising
-                the benchmarker.
-            use_bits_per_character:
-                Whether to compute bits-per-character (BPC) on the ground-truth answer.
-                For multiple-choice tasks, treats benchmark as text-to-text with bare
-                question → full answer text. Only supported for base decoder models.
-                Defaults to the value specified when initialising the benchmarker.
-            attention_backend:
-                The attention backend to use for vLLM. Only relevant if the model is
-                generative. Defaults to the value specified when initialising the
-                benchmarker.
-            custom_datasets_file:
-                Path to a Python file defining custom datasets. Defaults to the value
-                specified when initialising the benchmarker.
-            force:
-                Whether to force evaluations of models, even if they have been
-                benchmarked already. Defaults to the value specified when initialising
-                the benchmarker.
-            verbose:
-                Whether to output additional output. Defaults to the value specified
-                when initialising the benchmarker.
-            debug:
-                Whether to output debug information. Defaults to the value specified
-                when initialising the benchmarker.
-            max_context_length:
-                Override for the maximum context length of the model. If None, the
-                value will be inferred automatically from the model. Defaults to the
-                value specified when initialising the benchmarker.
-            vocabulary_size:
-                Override for the vocabulary size of the model. If None, the value will
-                be inferred automatically from the model. Defaults to the value
-                specified when initialising the benchmarker.
-
-        Returns:
-            A list of benchmark results.
-
-        Raises:
-            ValueError:
-                If both `task` and `dataset` are specified.
-            InvalidModel:
-                If we're offline benchmarking an adapter model, or if model loading
-                failed.
-        """
-        if task is not None and dataset is not None:
-            raise ValueError("Only one of `task` and `dataset` can be specified.")
-
-        # Determine verbose mode
-        is_verbose = (
-            verbose
-            if verbose is not None
-            else self.benchmark_config_default_params.verbose
-        )
-        if os.getenv("FULL_LOG", "0") == "1" or debug:
-            is_verbose = True
-
-        log_once(
-            "Started EuroEval run."
-            if is_verbose
-            else "Started EuroEval run. Run with `--verbose` for more information.",
-            level=logging.INFO,
-        )
-
-        # Announce BPC mode if active
-        is_bpc = (
-            use_bits_per_character
-            if use_bits_per_character is not None
-            else self.benchmark_config_default_params.use_bits_per_character
-        )
-        if is_bpc:
-            log_once(
-                "    ↳ Running in bits-per-character (BPC) mode: every dataset will be "
-                "scored by the bits-per-character of the ground-truth answer (lower is "
-                "better) instead of the usual task metrics.",
-                level=logging.INFO,
-            )
-
-        # Build benchmark config
-        benchmark_config = self._build_benchmark_config(
-            task=task,
-            dataset=dataset,
-            progress_bar=progress_bar,
-            save_results=save_results,
-            language=language,
-            device=device,
-            finetuning_batch_size=finetuning_batch_size,
-            raise_errors=raise_errors,
-            cache_dir=cache_dir,
-            api_key=api_key,
-            api_base=api_base,
-            api_version=api_version,
-            trust_remote_code=trust_remote_code,
-            clear_model_cache=clear_model_cache,
-            evaluate_test_split=evaluate_test_split,
-            few_shot=few_shot,
-            num_iterations=num_iterations,
-            requires_safetensors=requires_safetensors,
-            download_only=download_only,
-            gpu_memory_utilization=gpu_memory_utilization,
-            generative_type=generative_type,
-            use_bits_per_character=use_bits_per_character,
-            attention_backend=attention_backend,
-            custom_datasets_file=custom_datasets_file,
-            force=force,
-            verbose=verbose,
-            debug=debug,
-            max_context_length=max_context_length,
-            vocabulary_size=vocabulary_size,
-        )
-
-        adjust_logging_level(verbose=benchmark_config.verbose)
-
-        if benchmark_config.clear_model_cache:
-            clear_model_cache_fn(cache_dir=benchmark_config.cache_dir)
-
-        model_ids = self._prepare_model_ids(model_id=model)
-        dataset_configs = benchmark_config.datasets
-
-        # Fetch model configs and create mapping
-        model_configs = self._fetch_model_configs(model_ids, benchmark_config)
-        model_mapping = self._create_model_dataset_mapping(
-            model_configs, dataset_configs
-        )
-
-        # Filter out existing benchmarks
-        existing_results = self.benchmark_results
-        model_mapping, current_results = self._filter_existing_benchmarks(
-            model_mapping, benchmark_config, existing_results
-        )
-
-        total_benchmarks = sum(len(ds) for ds in model_mapping.values())
-        if total_benchmarks == 0:
-            log(
-                "No benchmarks to run, as all the selected models have already been "
-                "benchmarked on all the selected datasets.",
-                level=logging.INFO,
-            )
-            return current_results
-
-        num_finished = 0
-        num_skipped = 0
-        num_errored = 0
-
-        for model_config in model_configs:
-            if not model_mapping[model_config]:
-                log(
-                    f"Skipping model {model_config.model_id!r} because it has "
-                    "already been benchmarked on all valid datasets.",
-                    level=logging.DEBUG,
-                )
-                continue
-
-            self._check_adapter_requirements(model_config, benchmark_config)
-
-            loaded_model: "BenchmarkModule | None" = None
-            for dataset_config in model_mapping[model_config]:
-                params_to_revert = self._update_benchmark_config_for_dataset(
-                    dataset_config, benchmark_config
-                )
-
-                if benchmark_config.download_only:
-                    self._download(dataset_config, model_config, benchmark_config)
-                    num_finished += 1
-                    continue
-
-                # Load generative model if needed
-                if model_config.model_type == ModelType.GENERATIVE:
-                    if loaded_model is None:
-                        try:
-                            loaded_model = load_model(
-                                model_config=model_config,
-                                dataset_config=dataset_config,
-                                benchmark_config=benchmark_config,
-                            )
-                        except InvalidModel as e:
-                            if benchmark_config.raise_errors:
-                                raise e
-                            log(e.message, level=logging.ERROR)
-                            remaining = model_mapping[model_config][
-                                model_mapping[model_config].index(dataset_config) + 1 :
-                            ]
-                            num_errored += 1 + len(remaining)
-                            break
-
-                    if (
-                        loaded_model.generative_type
-                        not in dataset_config.allowed_generative_types
-                    ):
-                        log(
-                            f"Skipping the benchmark of model "
-                            f"{model_config.model_id!r} on dataset "
-                            f"{dataset_config.name!r} because the model has generative "
-                            f"type {loaded_model.generative_type} and the dataset "
-                            f"only allows {dataset_config.allowed_generative_types}.",
-                            level=logging.DEBUG,
-                        )
-                        num_skipped += 1
-                        continue
-
-                # Run benchmark and handle result
-                output_or_err = self._benchmark_single(
-                    model=loaded_model,
-                    model_config=model_config,
-                    dataset_config=dataset_config,
-                    benchmark_config=benchmark_config,
-                    num_finished_benchmarks=num_finished + num_skipped + num_errored,
-                    num_total_benchmarks=total_benchmarks,
-                )
-
-                num_finished, num_skipped, num_errored, should_break = (
-                    self._handle_benchmark_result(
-                        result_or_error=output_or_err,
-                        dataset_config=dataset_config,
-                        benchmark_config=benchmark_config,
-                        num_finished=num_finished,
-                        num_skipped=num_skipped,
-                        num_errored=num_errored,
-                        model_config=model_config,
-                        model_mapping=model_mapping,
-                        current_results=current_results,
-                    )
-                )
-                if should_break:
-                    break
-
-                # Revert config changes
-                for param, value in params_to_revert.items():
-                    setattr(benchmark_config, param, value)
-
-            del loaded_model
-            if benchmark_config.clear_model_cache:
-                clear_model_cache_fn(cache_dir=benchmark_config.cache_dir)
-
-        # Log summary
-        summary = self._generate_summary_message(num_finished, num_skipped, num_errored)
-        if summary:
-            log(summary, level=logging.INFO)
-
-        # Clean up process group
-        with contextlib.suppress(Exception):
-            destroy_process_group()
-
-        return current_results
-
     @property
     def benchmark_results(self) -> c.Sequence[BenchmarkResult]:
         """The benchmark results.
@@ -1412,3 +1287,128 @@ class Benchmarker:
             A list of benchmark results.
         """
         return BenchmarkResult.from_jsonl(self.results_path)
+
+
+def clear_model_cache_fn(cache_dir: str) -> None:
+    """Clear the model cache.
+
+    Note that this will not remove the stored completions.
+
+    Args:
+        cache_dir:
+            The path to the cache directory.
+    """
+    model_cache_path = Path(cache_dir) / "model_cache"
+    model_cache_path.mkdir(parents=True, exist_ok=True)
+    for model_dir in model_cache_path.iterdir():
+        if model_dir.is_dir():
+            for sub_model_dir in model_dir.iterdir():
+                if sub_model_dir.is_dir():
+                    rmtree(sub_model_dir, ignore_errors=True)
+
+
+def get_record(
+    model_config: "ModelConfig",
+    dataset_config: "DatasetConfig",
+    benchmark_config: "BenchmarkConfig",
+    benchmark_results: c.Sequence[BenchmarkResult],
+) -> BenchmarkResult | None:
+    """Get the benchmark record for a given model and dataset.
+
+    Args:
+        model_config:
+            The configuration of the model we are evaluating.
+        dataset_config:
+            The configuration of the dataset we are evaluating on.
+        benchmark_config:
+            The general benchmark configuration.
+        benchmark_results:
+            The benchmark results.
+
+    Returns:
+        The benchmark record, or None if no such record exists.
+    """
+    for record in benchmark_results:
+        model_id_components = split_model_id(model_id=record.model)
+        same_model_id = model_id_components.model_id == model_config.model_id
+        same_revision = model_id_components.revision == model_config.revision
+        same_param = model_id_components.param == model_config.param
+        same_dataset = record.dataset == dataset_config.name
+        same_split = record.validation_split != benchmark_config.evaluate_test_split
+        same_num_shots = (
+            record.few_shot == benchmark_config.few_shot
+            or record.few_shot is None
+            or not record.generative
+            or dataset_config.task.requires_zero_shot
+        )
+        if (
+            same_model_id
+            and same_revision
+            and same_param
+            and same_dataset
+            and same_split
+            and same_num_shots
+        ):
+            return record
+    return None
+
+
+def initial_logging(
+    model_config: "ModelConfig",
+    dataset_config: "DatasetConfig",
+    benchmark_config: "BenchmarkConfig",
+    num_finished_benchmarks: int,
+    num_total_benchmarks: int,
+) -> None:
+    """Initial logging at the start of the benchmarking process.
+
+    Args:
+        model_config:
+            The configuration of the model we are evaluating.
+        dataset_config:
+            The configuration of the dataset we are evaluating on.
+        benchmark_config:
+            The general benchmark configuration.
+        num_finished_benchmarks:
+            The number of benchmarks that have already been finished.
+        num_total_benchmarks:
+            The total number of benchmarks to be run.
+    """
+    model_id = model_config.model_id
+    if model_config.revision and model_config.revision != "main":
+        model_id += f"@{model_config.revision}"
+    if model_config.param is not None:
+        model_id += f"#{model_config.param}"
+
+    split_type = "validation" if not benchmark_config.evaluate_test_split else "test"
+    if model_config.task in GENERATIVE_PIPELINE_TAGS:
+        if benchmark_config.few_shot:
+            eval_type = "Few-shot benchmarking"
+        else:
+            eval_type = "Zero-shot benchmarking"
+    else:
+        eval_type = "Benchmarking"
+
+    log_once(
+        f"\n{eval_type} {model_id} on the {split_type} split of "
+        f"{dataset_config.logging_string} ({num_finished_benchmarks + 1}/"
+        f"{num_total_benchmarks} benchmarks)...",
+        prefix=f"\n[{dt.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}]",
+        level=logging.INFO,
+    )
+
+    if dataset_config.unofficial:
+        log_once(
+            f"Note that the {dataset_config.name!r} dataset is unofficial, "
+            "meaning that the resulting evaluation will not be included in the "
+            "official leaderboard.",
+            level=logging.WARNING,
+        )
+
+    if benchmark_config.debug:
+        log_once(
+            "Running in debug mode. This will output additional information, as "
+            "well as store the model outputs in the current directory after each "
+            "batch. For this reason, evaluation will be slower.",
+            level=logging.WARNING,
+        )

--- a/src/euroeval/bpc_scoring.py
+++ b/src/euroeval/bpc_scoring.py
@@ -17,6 +17,68 @@ from .logging_utils import log_once
 from .types import Tokeniser
 
 
+def compute_bpc_scores_for_vllm_outputs(
+    raw_outputs: c.Sequence["RequestOutput"], inputs: dict, tokeniser: Tokeniser
+) -> list[float] | None:
+    """Compute BPC scores from vLLM outputs.
+
+    High-level wrapper that reads the pre-computed gold answer texts and computes BPC
+    scores.
+
+    Args:
+        raw_outputs: Raw outputs from vLLM with prompt_logprobs.
+        inputs:
+            Model inputs containing the ``bpc_prompt``, ``bpc_answer_start``,
+            ``bpc_answer_text`` and ``bpc_answer_char_count`` columns produced during
+            dataset preparation.
+        tokeniser: Tokeniser for tokenisation.
+
+    Returns:
+        BPC scores, or None if there are no answer texts to score.
+
+    Raises:
+        InvalidModel:
+            If the active vLLM backend does not return per-token prompt logprobs,
+            which are mandatory for BPC scoring (e.g. the Apple Metal plugin).
+    """
+    # The gold answer texts are derived once during dataset preparation and carried in
+    # the `bpc_answer_text` column, guaranteeing they match the answers appended to
+    # `bpc_prompt`. An absent column or all-empty texts means the task group has no
+    # scoreable answer, so BPC is skipped.
+    answer_texts = inputs.get("bpc_answer_text")
+    if not answer_texts or all(answer == "" for answer in answer_texts):
+        return None
+
+    # Per-token prompt logprobs are mandatory for BPC. Some vLLM backends (notably the
+    # Apple Metal plugin `vllm_metal`) do not compute them and return an empty or
+    # degenerate structure (e.g. a single placeholder entry for a multi-token prompt),
+    # so detect that and fail fast with clear guidance instead of silently reporting
+    # infinite scores.
+    backend_provides_prompt_logprobs = all(
+        raw_output.prompt_logprobs is not None
+        and raw_output.prompt_token_ids is not None
+        and len(raw_output.prompt_logprobs) >= len(raw_output.prompt_token_ids)
+        for raw_output in raw_outputs
+    )
+    if not backend_provides_prompt_logprobs:
+        raise InvalidModel(
+            "Bits-per-character (BPC) scoring requires per-token prompt logprobs, but "
+            "the active vLLM backend did not return them. This is a known limitation "
+            "of the Apple Metal plugin (`vllm_metal`), which does not compute prompt "
+            "logprobs; BPC scoring is currently only supported on the CUDA vLLM "
+            "backend."
+        )
+
+    return compute_bpc_scores(
+        raw_outputs=raw_outputs,
+        prompts=inputs["bpc_prompt"],
+        answer_texts=answer_texts,
+        answer_start_indices=inputs["bpc_answer_start"],
+        tokeniser=tokeniser,
+        answer_char_counts=inputs.get("bpc_answer_char_count"),
+    )
+
+
 def compute_bpc_scores(
     raw_outputs: c.Sequence["RequestOutput"],
     prompts: c.Sequence[str],
@@ -144,65 +206,3 @@ def compute_bpc_scores(
         bpc_scores.append(bpc)
 
     return bpc_scores
-
-
-def compute_bpc_scores_for_vllm_outputs(
-    raw_outputs: c.Sequence["RequestOutput"], inputs: dict, tokeniser: Tokeniser
-) -> list[float] | None:
-    """Compute BPC scores from vLLM outputs.
-
-    High-level wrapper that reads the pre-computed gold answer texts and computes BPC
-    scores.
-
-    Args:
-        raw_outputs: Raw outputs from vLLM with prompt_logprobs.
-        inputs:
-            Model inputs containing the ``bpc_prompt``, ``bpc_answer_start``,
-            ``bpc_answer_text`` and ``bpc_answer_char_count`` columns produced during
-            dataset preparation.
-        tokeniser: Tokeniser for tokenisation.
-
-    Returns:
-        BPC scores, or None if there are no answer texts to score.
-
-    Raises:
-        InvalidModel:
-            If the active vLLM backend does not return per-token prompt logprobs,
-            which are mandatory for BPC scoring (e.g. the Apple Metal plugin).
-    """
-    # The gold answer texts are derived once during dataset preparation and carried in
-    # the `bpc_answer_text` column, guaranteeing they match the answers appended to
-    # `bpc_prompt`. An absent column or all-empty texts means the task group has no
-    # scoreable answer, so BPC is skipped.
-    answer_texts = inputs.get("bpc_answer_text")
-    if not answer_texts or all(answer == "" for answer in answer_texts):
-        return None
-
-    # Per-token prompt logprobs are mandatory for BPC. Some vLLM backends (notably the
-    # Apple Metal plugin `vllm_metal`) do not compute them and return an empty or
-    # degenerate structure (e.g. a single placeholder entry for a multi-token prompt),
-    # so detect that and fail fast with clear guidance instead of silently reporting
-    # infinite scores.
-    backend_provides_prompt_logprobs = all(
-        raw_output.prompt_logprobs is not None
-        and raw_output.prompt_token_ids is not None
-        and len(raw_output.prompt_logprobs) >= len(raw_output.prompt_token_ids)
-        for raw_output in raw_outputs
-    )
-    if not backend_provides_prompt_logprobs:
-        raise InvalidModel(
-            "Bits-per-character (BPC) scoring requires per-token prompt logprobs, but "
-            "the active vLLM backend did not return them. This is a known limitation "
-            "of the Apple Metal plugin (`vllm_metal`), which does not compute prompt "
-            "logprobs; BPC scoring is currently only supported on the CUDA vLLM "
-            "backend."
-        )
-
-    return compute_bpc_scores(
-        raw_outputs=raw_outputs,
-        prompts=inputs["bpc_prompt"],
-        answer_texts=answer_texts,
-        answer_start_indices=inputs["bpc_answer_start"],
-        tokeniser=tokeniser,
-        answer_char_counts=inputs.get("bpc_answer_char_count"),
-    )

--- a/src/euroeval/custom_dataset_configs.py
+++ b/src/euroeval/custom_dataset_configs.py
@@ -21,42 +21,66 @@ from .utils import get_hf_token
 from .yaml_config import load_yaml_config
 
 
-def load_custom_datasets_module(custom_datasets_file: Path) -> ModuleType | None:
-    """Load the custom datasets module if it exists.
+def try_get_dataset_config_from_repo(
+    dataset_id: str,
+    api_key: str | None,
+    cache_dir: Path,
+    trust_remote_code: bool,
+    run_with_cli: bool,
+) -> DatasetConfig | None:
+    """Try to get a dataset config from a Hugging Face dataset repository.
+
+    The function first looks for a YAML config file (`eval.yaml`) which can be
+    loaded without executing any remote code. If no YAML file is present the
+    function falls back to `euroeval_config.py`, which requires
+    `trust_remote_code=True`.
 
     Args:
-        custom_datasets_file:
-            The path to the custom datasets module.
+        dataset_id:
+            The ID of the dataset to get the config for.
+        api_key:
+            The Hugging Face API key to use to check if the repositories have
+            custom dataset configs.
+        cache_dir:
+            The directory to store the cache in.
+        trust_remote_code:
+            Whether to trust remote code. Only required when loading a Python
+            config (`euroeval_config.py`). YAML configs never require this flag.
+        run_with_cli:
+            Whether the code is being run with the CLI.
 
     Returns:
-        The custom datasets module, or None if it does not exist.
+        The dataset config if it exists, otherwise None.
     """
-    if custom_datasets_file.is_file():
-        spec = importlib.util.spec_from_file_location(
-            name="custom_datasets_module", location=str(custom_datasets_file.resolve())
-        )
-        if spec is None:
+    token = get_hf_token(api_key=api_key)
+    hf_api = HfApi(token=token)
+    if not _repo_exists(hf_api=hf_api, dataset_id=dataset_id):
+        return None
+
+    repo_files = _list_repo_files(hf_api=hf_api, dataset_id=dataset_id, revision="main")
+
+    if "eval.yaml" in repo_files:
+        try:
+            yaml_config = load_yaml_config(
+                hf_api=hf_api, dataset_id=dataset_id, cache_dir=cache_dir
+            )
+            if yaml_config is not None:
+                return yaml_config
+        except Exception as e:
             log_once(
-                message=(
-                    "Could not load the spec for the custom datasets file from "
-                    f"{custom_datasets_file.resolve()}."
-                ),
+                f"Failed to load eval.yaml from dataset repository {dataset_id}. "
+                f"The error was '{e}'. Trying the Python config instead, if it "
+                "exists.",
                 level=logging.ERROR,
             )
-            return None
-        module = importlib.util.module_from_spec(spec=spec)
-        if spec.loader is None:
-            log_once(
-                message=(
-                    "Could not load the module for the custom datasets file from "
-                    f"{custom_datasets_file.resolve()}."
-                ),
-                level=logging.ERROR,
-            )
-            return None
-        spec.loader.exec_module(module)
-        return module
-    return None
+
+    return load_python_config(
+        hf_api=hf_api,
+        dataset_id=dataset_id,
+        cache_dir=cache_dir,
+        trust_remote_code=trust_remote_code,
+        run_with_cli=run_with_cli,
+    )
 
 
 def load_python_config(
@@ -179,63 +203,39 @@ def load_python_config(
     return repo_dataset_config
 
 
-def try_get_dataset_config_from_repo(
-    dataset_id: str,
-    api_key: str | None,
-    cache_dir: Path,
-    trust_remote_code: bool,
-    run_with_cli: bool,
-) -> DatasetConfig | None:
-    """Try to get a dataset config from a Hugging Face dataset repository.
-
-    The function first looks for a YAML config file (`eval.yaml`) which can be
-    loaded without executing any remote code. If no YAML file is present the
-    function falls back to `euroeval_config.py`, which requires
-    `trust_remote_code=True`.
+def load_custom_datasets_module(custom_datasets_file: Path) -> ModuleType | None:
+    """Load the custom datasets module if it exists.
 
     Args:
-        dataset_id:
-            The ID of the dataset to get the config for.
-        api_key:
-            The Hugging Face API key to use to check if the repositories have
-            custom dataset configs.
-        cache_dir:
-            The directory to store the cache in.
-        trust_remote_code:
-            Whether to trust remote code. Only required when loading a Python
-            config (`euroeval_config.py`). YAML configs never require this flag.
-        run_with_cli:
-            Whether the code is being run with the CLI.
+        custom_datasets_file:
+            The path to the custom datasets module.
 
     Returns:
-        The dataset config if it exists, otherwise None.
+        The custom datasets module, or None if it does not exist.
     """
-    token = get_hf_token(api_key=api_key)
-    hf_api = HfApi(token=token)
-    if not _repo_exists(hf_api=hf_api, dataset_id=dataset_id):
-        return None
-
-    repo_files = _list_repo_files(hf_api=hf_api, dataset_id=dataset_id, revision="main")
-
-    if "eval.yaml" in repo_files:
-        try:
-            yaml_config = load_yaml_config(
-                hf_api=hf_api, dataset_id=dataset_id, cache_dir=cache_dir
-            )
-            if yaml_config is not None:
-                return yaml_config
-        except Exception as e:
+    if custom_datasets_file.is_file():
+        spec = importlib.util.spec_from_file_location(
+            name="custom_datasets_module", location=str(custom_datasets_file.resolve())
+        )
+        if spec is None:
             log_once(
-                f"Failed to load eval.yaml from dataset repository {dataset_id}. "
-                f"The error was '{e}'. Trying the Python config instead, if it "
-                "exists.",
+                message=(
+                    "Could not load the spec for the custom datasets file from "
+                    f"{custom_datasets_file.resolve()}."
+                ),
                 level=logging.ERROR,
             )
-
-    return load_python_config(
-        hf_api=hf_api,
-        dataset_id=dataset_id,
-        cache_dir=cache_dir,
-        trust_remote_code=trust_remote_code,
-        run_with_cli=run_with_cli,
-    )
+            return None
+        module = importlib.util.module_from_spec(spec=spec)
+        if spec.loader is None:
+            log_once(
+                message=(
+                    "Could not load the module for the custom datasets file from "
+                    f"{custom_datasets_file.resolve()}."
+                ),
+                level=logging.ERROR,
+            )
+            return None
+        spec.loader.exec_module(module)
+        return module
+    return None

--- a/src/euroeval/data_loading.py
+++ b/src/euroeval/data_loading.py
@@ -23,6 +23,92 @@ if t.TYPE_CHECKING:
     from .data_models import BenchmarkConfig, DatasetConfig
 
 
+def load_data(
+    rng: Generator, dataset_config: "DatasetConfig", benchmark_config: "BenchmarkConfig"
+) -> list["DatasetDict"]:
+    """Load the raw bootstrapped datasets.
+
+    Args:
+        rng:
+            The random number generator to use.
+        dataset_config:
+            The configuration for the dataset.
+        benchmark_config:
+            The configuration for the benchmark.
+
+    Returns:
+        A list of bootstrapped datasets, one for each iteration.
+    """
+    dataset = load_raw_data(
+        dataset_config=dataset_config,
+        cache_dir=benchmark_config.cache_dir,
+        api_key=benchmark_config.api_key,
+    )
+
+    # Apply custom preprocessing function if configured
+    if dataset_config.preprocessing_func is not None:
+        dataset = dataset_config.preprocessing_func(dataset)
+
+    # Always add an index column to the dataset, so that we can easily identify which
+    # example is which when we're bootstrapping
+    for split_name, split in dataset.items():
+        if "index" not in split.features:
+            split = split.add_column(name="index", column=range(len(split)))
+            assert isinstance(split, Dataset), (
+                f"Expected a Dataset object after adding an index column, but got "
+                f"{type(split)}."
+            )
+            dataset[split_name] = split
+
+    if (
+        not benchmark_config.evaluate_test_split
+        and dataset_config.val_split is not None
+    ):
+        dataset["test"] = dataset["val"]
+
+    splits = [split for split in ["train", "val", "test"] if split in dataset]
+
+    # Remove empty examples from the datasets
+    for text_feature in ["tokens", "text"]:
+        for split in splits:
+            if text_feature in dataset[split].features:
+                dataset = dataset.filter(lambda x: len(x[text_feature]) > 0)
+
+    # If we are testing then truncate the test set, unless we need the full set for
+    # evaluation
+    if hasattr(sys, "_called_from_test") and dataset_config.task != EUROPEAN_VALUES:
+        # Truncate test set to one sample for testing
+        dataset["test"] = dataset["test"].select(range(1))
+
+    # Bootstrap the splits, if applicable
+    if dataset_config.bootstrap_samples:
+        bootstrapped_splits: dict[str, c.Sequence["Dataset"]] = dict()
+        for split in splits:
+            bootstrap_indices = rng.integers(
+                0,
+                len(dataset[split]),
+                size=(benchmark_config.num_iterations, len(dataset[split])),
+            )
+            bootstrapped_splits[split] = [
+                dataset[split].select(bootstrap_indices[idx])
+                for idx in range(benchmark_config.num_iterations)
+            ]
+        datasets = [
+            DatasetDict(
+                {
+                    split: bootstrapped_splits[split][idx]
+                    for split in ["train", "val", "test"]
+                    if split in bootstrapped_splits
+                }
+            )
+            for idx in range(benchmark_config.num_iterations)
+        ]
+    else:
+        datasets = [dataset] * benchmark_config.num_iterations
+
+    return datasets
+
+
 def load_raw_data(
     dataset_config: "DatasetConfig", cache_dir: str, api_key: str | None
 ) -> "DatasetDict":
@@ -167,89 +253,3 @@ def load_raw_data(
     )
 
     return dataset
-
-
-def load_data(
-    rng: Generator, dataset_config: "DatasetConfig", benchmark_config: "BenchmarkConfig"
-) -> list["DatasetDict"]:
-    """Load the raw bootstrapped datasets.
-
-    Args:
-        rng:
-            The random number generator to use.
-        dataset_config:
-            The configuration for the dataset.
-        benchmark_config:
-            The configuration for the benchmark.
-
-    Returns:
-        A list of bootstrapped datasets, one for each iteration.
-    """
-    dataset = load_raw_data(
-        dataset_config=dataset_config,
-        cache_dir=benchmark_config.cache_dir,
-        api_key=benchmark_config.api_key,
-    )
-
-    # Apply custom preprocessing function if configured
-    if dataset_config.preprocessing_func is not None:
-        dataset = dataset_config.preprocessing_func(dataset)
-
-    # Always add an index column to the dataset, so that we can easily identify which
-    # example is which when we're bootstrapping
-    for split_name, split in dataset.items():
-        if "index" not in split.features:
-            split = split.add_column(name="index", column=range(len(split)))
-            assert isinstance(split, Dataset), (
-                f"Expected a Dataset object after adding an index column, but got "
-                f"{type(split)}."
-            )
-            dataset[split_name] = split
-
-    if (
-        not benchmark_config.evaluate_test_split
-        and dataset_config.val_split is not None
-    ):
-        dataset["test"] = dataset["val"]
-
-    splits = [split for split in ["train", "val", "test"] if split in dataset]
-
-    # Remove empty examples from the datasets
-    for text_feature in ["tokens", "text"]:
-        for split in splits:
-            if text_feature in dataset[split].features:
-                dataset = dataset.filter(lambda x: len(x[text_feature]) > 0)
-
-    # If we are testing then truncate the test set, unless we need the full set for
-    # evaluation
-    if hasattr(sys, "_called_from_test") and dataset_config.task != EUROPEAN_VALUES:
-        # Truncate test set to one sample for testing
-        dataset["test"] = dataset["test"].select(range(1))
-
-    # Bootstrap the splits, if applicable
-    if dataset_config.bootstrap_samples:
-        bootstrapped_splits: dict[str, c.Sequence["Dataset"]] = dict()
-        for split in splits:
-            bootstrap_indices = rng.integers(
-                0,
-                len(dataset[split]),
-                size=(benchmark_config.num_iterations, len(dataset[split])),
-            )
-            bootstrapped_splits[split] = [
-                dataset[split].select(bootstrap_indices[idx])
-                for idx in range(benchmark_config.num_iterations)
-            ]
-        datasets = [
-            DatasetDict(
-                {
-                    split: bootstrapped_splits[split][idx]
-                    for split in ["train", "val", "test"]
-                    if split in bootstrapped_splits
-                }
-            )
-            for idx in range(benchmark_config.num_iterations)
-        ]
-    else:
-        datasets = [dataset] * benchmark_config.num_iterations
-
-    return datasets

--- a/src/euroeval/data_models.py
+++ b/src/euroeval/data_models.py
@@ -126,20 +126,6 @@ class BenchmarkResult(pydantic.BaseModel):
     open: bool | None = None
     trained_from_scratch: bool | None = None
 
-    def to_eee_dict(self) -> dict[str, object]:
-        """Convert this benchmark result to the Every Eval Ever (EEE) format.
-
-        Produces a dictionary conforming to the Every Eval Ever JSON schema v0.2.1
-        (https://github.com/evaleval/every_eval_ever/blob/main/eval.schema.json).
-        The resulting dict can be written directly to
-        `euroeval_benchmark_results.jsonl` and later reconstructed without loss
-        via `from_eee_dict` (or `from_dict`).
-
-        Returns:
-            A dictionary matching the EEE JSON schema v0.2.1.
-        """
-        return benchmark_result_to_eee_dict(result=self)
-
     def append_to_results(self, results_path: Path) -> None:
         """Append the benchmark result to the results file.
 
@@ -161,23 +147,40 @@ class BenchmarkResult(pydantic.BaseModel):
         with results_path.open("a") as f:
             f.write(("\n" if needs_sep else "") + json_str + "\n")
 
-    @classmethod
-    def from_eee_dict(cls, config: dict[str, object]) -> "BenchmarkResult":
-        """Create a BenchmarkResult from an Every Eval Ever format dictionary.
+    def to_eee_dict(self) -> dict[str, object]:
+        """Convert this benchmark result to the Every Eval Ever (EEE) format.
 
-        Reconstructs a full `BenchmarkResult` from a dictionary conforming to the
-        Every Eval Ever (EEE) JSON schema v0.2.1.  The method is the inverse of
-        `to_eee_dict` and enables lossless round-trips via `from_dict`.
-
-        Args:
-            config:
-                A dictionary conforming to the EEE JSON schema v0.2.1, as produced
-                by `to_eee_dict`.
+        Produces a dictionary conforming to the Every Eval Ever JSON schema v0.2.1
+        (https://github.com/evaleval/every_eval_ever/blob/main/eval.schema.json).
+        The resulting dict can be written directly to
+        `euroeval_benchmark_results.jsonl` and later reconstructed without loss
+        via `from_eee_dict` (or `from_dict`).
 
         Returns:
-            The reconstructed benchmark result.
+            A dictionary matching the EEE JSON schema v0.2.1.
         """
-        return benchmark_result_from_eee_dict(config=config)
+        return benchmark_result_to_eee_dict(result=self)
+
+    @classmethod
+    def from_jsonl(cls, results_path: Path) -> list["BenchmarkResult"]:
+        """Load benchmark results from a JSONL file.
+
+        Parses a JSONL file with robust handling of blank lines and concatenated
+        JSON objects (`}{`). Returns an empty list if the file does not exist.
+
+        Args:
+            results_path:
+                The path to the JSONL file containing benchmark results.
+
+        Returns:
+            A list of BenchmarkResult instances.
+        """
+        if not results_path.exists():
+            return []
+
+        lines = results_path.read_text(encoding="utf-8").splitlines()
+        records = parse_jsonl_lines(lines=lines, source=str(results_path), strict=False)
+        return [cls.from_dict(record) for record in records]
 
     @classmethod
     def from_dict(cls, config: dict[str, object]) -> "BenchmarkResult":
@@ -253,25 +256,22 @@ class BenchmarkResult(pydantic.BaseModel):
         return cls(**config)  # ty: ignore[invalid-argument-type]
 
     @classmethod
-    def from_jsonl(cls, results_path: Path) -> list["BenchmarkResult"]:
-        """Load benchmark results from a JSONL file.
+    def from_eee_dict(cls, config: dict[str, object]) -> "BenchmarkResult":
+        """Create a BenchmarkResult from an Every Eval Ever format dictionary.
 
-        Parses a JSONL file with robust handling of blank lines and concatenated
-        JSON objects (`}{`). Returns an empty list if the file does not exist.
+        Reconstructs a full `BenchmarkResult` from a dictionary conforming to the
+        Every Eval Ever (EEE) JSON schema v0.2.1.  The method is the inverse of
+        `to_eee_dict` and enables lossless round-trips via `from_dict`.
 
         Args:
-            results_path:
-                The path to the JSONL file containing benchmark results.
+            config:
+                A dictionary conforming to the EEE JSON schema v0.2.1, as produced
+                by `to_eee_dict`.
 
         Returns:
-            A list of BenchmarkResult instances.
+            The reconstructed benchmark result.
         """
-        if not results_path.exists():
-            return []
-
-        lines = results_path.read_text(encoding="utf-8").splitlines()
-        records = parse_jsonl_lines(lines=lines, source=str(results_path), strict=False)
-        return [cls.from_dict(record) for record in records]
+        return benchmark_result_from_eee_dict(config=config)
 
 
 class HashableDict(dict[t.Any, t.Any]):

--- a/src/euroeval/eee_utils.py
+++ b/src/euroeval/eee_utils.py
@@ -13,38 +13,6 @@ if t.TYPE_CHECKING:
     from .data_models import BenchmarkResult
 
 
-def parse_optional_bool(value: str | bool | None) -> bool | None:
-    """Parse a string-encoded or bool optional boolean value.
-
-    Args:
-        value:
-            The value to parse. `None` maps to `None`; bool values are
-            returned as-is; string values are compared case-insensitively
-            to `"true"`.
-
-    Returns:
-        `None` if value is `None`, otherwise a boolean.
-    """
-    if value is None:
-        return None
-    if isinstance(value, bool):
-        return value
-    return value.lower() == "true"
-
-
-def parse_optional_str(value: str | None) -> str | None:
-    """Parse a string-encoded optional string value.
-
-    Args:
-        value:
-            The string to parse.  `None` maps to `None`.
-
-    Returns:
-        `None` if value is `None`, otherwise the original string.
-    """
-    return None if value is None else value
-
-
 def benchmark_result_from_eee_dict(config: dict) -> "BenchmarkResult":
     """Create a BenchmarkResult from an Every Eval Ever format dictionary.
 
@@ -161,6 +129,38 @@ def benchmark_result_from_eee_dict(config: dict) -> "BenchmarkResult":
         open=open,
         trained_from_scratch=trained_from_scratch,
     )
+
+
+def parse_optional_bool(value: str | bool | None) -> bool | None:
+    """Parse a string-encoded or bool optional boolean value.
+
+    Args:
+        value:
+            The value to parse. `None` maps to `None`; bool values are
+            returned as-is; string values are compared case-insensitively
+            to `"true"`.
+
+    Returns:
+        `None` if value is `None`, otherwise a boolean.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    return value.lower() == "true"
+
+
+def parse_optional_str(value: str | None) -> str | None:
+    """Parse a string-encoded optional string value.
+
+    Args:
+        value:
+            The string to parse.  `None` maps to `None`.
+
+    Returns:
+        `None` if value is `None`, otherwise the original string.
+    """
+    return None if value is None else value
 
 
 def benchmark_result_to_eee_dict(result: "BenchmarkResult") -> dict:

--- a/src/euroeval/finetuning.py
+++ b/src/euroeval/finetuning.py
@@ -29,6 +29,147 @@ if t.TYPE_CHECKING:
     from .data_models import BenchmarkConfig, DatasetConfig, ModelConfig
 
 
+def finetune(
+    model: "BenchmarkModule | None",
+    datasets: c.Sequence["DatasetDict"],
+    model_config: "ModelConfig",
+    dataset_config: "DatasetConfig",
+    benchmark_config: "BenchmarkConfig",
+) -> c.Sequence[dict[str, float]]:
+    """Evaluate a model on a dataset through finetuning.
+
+    Args:
+        model:
+            The model to evaluate.
+        datasets:
+            The datasets to use for training and evaluation.
+        model_config:
+            The configuration of the model.
+        dataset_config:
+            The dataset configuration.
+        benchmark_config:
+            The benchmark configuration.
+
+    Returns:
+        A list of dicts containing the scores for each metric for each iteration.
+
+    Raises:
+        InvalidBenchmark:
+            If the benchmark could not be completed.
+    """
+    # Set the data type to use for the model weights
+    using_cuda = benchmark_config.device == torch.device("cuda")
+    if using_cuda and torch.cuda.is_bf16_supported():
+        dtype = DataType.BF16
+    elif using_cuda:
+        dtype = DataType.FP16
+    else:
+        dtype = DataType.FP32
+
+    bs: int = benchmark_config.finetuning_batch_size
+    scores: list[dict[str, float]] = list()
+    model_already_initialized = False
+    # None means "load in the hardware-derived default dtype"; set to FP32 by the
+    # NaN-retry below so the model is actually *reloaded* in fp32 rather than just
+    # having mixed-precision autocast disabled while the weights stay in bf16/fp16.
+    dtype_override: DataType | None = None
+    for idx in get_pbar(
+        iterable=range(benchmark_config.num_iterations),
+        desc="Benchmarking",
+        disable=not benchmark_config.progress_bar,
+    ):
+        # Set variable that tracks whether we need to initialize new models in
+        # the single iteration call
+        model_already_initialized = idx == 0
+
+        # Run a loop here to deal with automatic reduction of batch size
+        for _ in range(num_attempts := 10):
+            # Clear GPU memory
+            if not model_already_initialized:
+                try:
+                    del model
+                except UnboundLocalError:
+                    pass
+                clear_memory()
+
+            try:
+                # Re-block terminal output, as it gets unblocked by the `transformers`
+                # package before training
+                block_terminal_output()
+
+                training_args = get_training_args(
+                    benchmark_config=benchmark_config,
+                    model_config=model_config,
+                    iteration_idx=idx,
+                    dtype=dtype,
+                    batch_size=bs,
+                )
+
+                itr_scores = finetune_single_iteration(
+                    model=model if model_already_initialized else None,
+                    dataset=datasets[idx],
+                    training_args=training_args,
+                    model_config=model_config,
+                    dataset_config=dataset_config,
+                    benchmark_config=benchmark_config,
+                    dtype_override=dtype_override,
+                )
+
+                scores.append(itr_scores)
+                log(
+                    f"Test scores for iteration {idx}: {itr_scores}",
+                    level=logging.DEBUG,
+                )
+
+                break
+
+            # NaN values can appear in the model output when using mixed precision, as
+            # the hidden states get overflowed. In this case we try to disable mixed
+            # precision and try again.
+            except NaNValueInModelOutput as e:
+                if dtype != DataType.FP32:
+                    dtype = DataType.FP32
+                    dtype_override = DataType.FP32
+                    model_already_initialized = False
+                    log(
+                        "NaN value detected in model outputs while using mixed "
+                        "precision. Retrying with full fp32 precision.",
+                        level=logging.DEBUG,
+                    )
+                else:
+                    raise InvalidBenchmark(
+                        "NaN value detected in model outputs, even with mixed "
+                        "precision disabled."
+                    ) from e
+
+            except Exception as e:
+                if "CUDA" not in str(e) and "out of memory" not in str(e):
+                    raise InvalidBenchmark(str(e)) from e
+
+                if bs <= 1:
+                    msg = "Could not benchmark the model, even with a batch size of 1!"
+                    if "MPS" in str(e):
+                        msg += (
+                            " As you are using MPS, you can try running the evaluation "
+                            "with the `PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0` "
+                            "environment variable set, as this removes the upper bound "
+                            "on the memory usage."
+                        )
+                    raise InvalidBenchmark(msg) from e
+
+                model_already_initialized = False
+
+                bs //= 2
+                log(f"Reduced batch size to {bs}", level=logging.DEBUG)
+
+        else:
+            raise InvalidBenchmark(
+                f"Could not benchmark the model after {num_attempts} attempts!"
+            )
+
+    return scores
+
+
 def finetune_single_iteration(
     model: "BenchmarkModule | None",
     dataset: "DatasetDict",
@@ -209,147 +350,6 @@ def get_training_args(
         training_args._n_gpu = 1
 
     return training_args
-
-
-def finetune(
-    model: "BenchmarkModule | None",
-    datasets: c.Sequence["DatasetDict"],
-    model_config: "ModelConfig",
-    dataset_config: "DatasetConfig",
-    benchmark_config: "BenchmarkConfig",
-) -> c.Sequence[dict[str, float]]:
-    """Evaluate a model on a dataset through finetuning.
-
-    Args:
-        model:
-            The model to evaluate.
-        datasets:
-            The datasets to use for training and evaluation.
-        model_config:
-            The configuration of the model.
-        dataset_config:
-            The dataset configuration.
-        benchmark_config:
-            The benchmark configuration.
-
-    Returns:
-        A list of dicts containing the scores for each metric for each iteration.
-
-    Raises:
-        InvalidBenchmark:
-            If the benchmark could not be completed.
-    """
-    # Set the data type to use for the model weights
-    using_cuda = benchmark_config.device == torch.device("cuda")
-    if using_cuda and torch.cuda.is_bf16_supported():
-        dtype = DataType.BF16
-    elif using_cuda:
-        dtype = DataType.FP16
-    else:
-        dtype = DataType.FP32
-
-    bs: int = benchmark_config.finetuning_batch_size
-    scores: list[dict[str, float]] = list()
-    model_already_initialized = False
-    # None means "load in the hardware-derived default dtype"; set to FP32 by the
-    # NaN-retry below so the model is actually *reloaded* in fp32 rather than just
-    # having mixed-precision autocast disabled while the weights stay in bf16/fp16.
-    dtype_override: DataType | None = None
-    for idx in get_pbar(
-        iterable=range(benchmark_config.num_iterations),
-        desc="Benchmarking",
-        disable=not benchmark_config.progress_bar,
-    ):
-        # Set variable that tracks whether we need to initialize new models in
-        # the single iteration call
-        model_already_initialized = idx == 0
-
-        # Run a loop here to deal with automatic reduction of batch size
-        for _ in range(num_attempts := 10):
-            # Clear GPU memory
-            if not model_already_initialized:
-                try:
-                    del model
-                except UnboundLocalError:
-                    pass
-                clear_memory()
-
-            try:
-                # Re-block terminal output, as it gets unblocked by the `transformers`
-                # package before training
-                block_terminal_output()
-
-                training_args = get_training_args(
-                    benchmark_config=benchmark_config,
-                    model_config=model_config,
-                    iteration_idx=idx,
-                    dtype=dtype,
-                    batch_size=bs,
-                )
-
-                itr_scores = finetune_single_iteration(
-                    model=model if model_already_initialized else None,
-                    dataset=datasets[idx],
-                    training_args=training_args,
-                    model_config=model_config,
-                    dataset_config=dataset_config,
-                    benchmark_config=benchmark_config,
-                    dtype_override=dtype_override,
-                )
-
-                scores.append(itr_scores)
-                log(
-                    f"Test scores for iteration {idx}: {itr_scores}",
-                    level=logging.DEBUG,
-                )
-
-                break
-
-            # NaN values can appear in the model output when using mixed precision, as
-            # the hidden states get overflowed. In this case we try to disable mixed
-            # precision and try again.
-            except NaNValueInModelOutput as e:
-                if dtype != DataType.FP32:
-                    dtype = DataType.FP32
-                    dtype_override = DataType.FP32
-                    model_already_initialized = False
-                    log(
-                        "NaN value detected in model outputs while using mixed "
-                        "precision. Retrying with full fp32 precision.",
-                        level=logging.DEBUG,
-                    )
-                else:
-                    raise InvalidBenchmark(
-                        "NaN value detected in model outputs, even with mixed "
-                        "precision disabled."
-                    ) from e
-
-            except Exception as e:
-                if "CUDA" not in str(e) and "out of memory" not in str(e):
-                    raise InvalidBenchmark(str(e)) from e
-
-                if bs <= 1:
-                    msg = "Could not benchmark the model, even with a batch size of 1!"
-                    if "MPS" in str(e):
-                        msg += (
-                            " As you are using MPS, you can try running the evaluation "
-                            "with the `PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0` "
-                            "environment variable set, as this removes the upper bound "
-                            "on the memory usage."
-                        )
-                    raise InvalidBenchmark(msg) from e
-
-                model_already_initialized = False
-
-                bs //= 2
-                log(f"Reduced batch size to {bs}", level=logging.DEBUG)
-
-        else:
-            raise InvalidBenchmark(
-                f"Could not benchmark the model after {num_attempts} attempts!"
-            )
-
-    return scores
 
 
 def remove_extra_tensors_from_logits(

--- a/src/euroeval/generation.py
+++ b/src/euroeval/generation.py
@@ -33,39 +33,6 @@ if t.TYPE_CHECKING:
     from .types import FailedInstance, IterationScores
 
 
-def _labels_match(predicted: object, gold: object) -> bool:
-    """Check whether a predicted label (or label sequence) matches the gold one.
-
-    The comparison is case-insensitive, and for token-classification label
-    sequences it is an exact element-wise match. For sequence classification this
-    mirrors the task metric exactly. For token classification the metric is
-    span-based F1 rather than element-wise equality, but failed instances there
-    only arise when JSON parsing fails entirely (so the prediction defaults to all
-    "o"); exact-match then correctly treats an all-"o" prediction against an
-    all-"o" gold as not a failure, which is the intended behaviour.
-
-    Args:
-        predicted:
-            The model's predicted label, or its list of per-token labels.
-        gold:
-            The gold label, or its list of per-token labels.
-
-    Returns:
-        Whether the prediction matches the gold label.
-    """
-    if isinstance(predicted, str) and isinstance(gold, str):
-        return predicted.lower() == gold.lower()
-    if isinstance(predicted, list) and isinstance(gold, list):
-        predicted_norm = [
-            label.lower() if isinstance(label, str) else label for label in predicted
-        ]
-        gold_norm = [
-            label.lower() if isinstance(label, str) else label for label in gold
-        ]
-        return predicted_norm == gold_norm
-    return predicted == gold
-
-
 def _compute_final_scores(
     benchmark_config: "BenchmarkConfig",
     dataset: Dataset,
@@ -137,6 +104,39 @@ def _compute_final_scores(
             benchmark_config=benchmark_config,
         )
         return {**metrics_scores, "failed_instances": failed_instances}
+
+
+def _labels_match(predicted: object, gold: object) -> bool:
+    """Check whether a predicted label (or label sequence) matches the gold one.
+
+    The comparison is case-insensitive, and for token-classification label
+    sequences it is an exact element-wise match. For sequence classification this
+    mirrors the task metric exactly. For token classification the metric is
+    span-based F1 rather than element-wise equality, but failed instances there
+    only arise when JSON parsing fails entirely (so the prediction defaults to all
+    "o"); exact-match then correctly treats an all-"o" prediction against an
+    all-"o" gold as not a failure, which is the intended behaviour.
+
+    Args:
+        predicted:
+            The model's predicted label, or its list of per-token labels.
+        gold:
+            The gold label, or its list of per-token labels.
+
+    Returns:
+        Whether the prediction matches the gold label.
+    """
+    if isinstance(predicted, str) and isinstance(gold, str):
+        return predicted.lower() == gold.lower()
+    if isinstance(predicted, list) and isinstance(gold, list):
+        predicted_norm = [
+            label.lower() if isinstance(label, str) else label for label in predicted
+        ]
+        gold_norm = [
+            label.lower() if isinstance(label, str) else label for label in gold
+        ]
+        return predicted_norm == gold_norm
+    return predicted == gold
 
 
 def _extract_ground_truth(
@@ -221,6 +221,92 @@ def _get_iteration_iterator(
             f"The batching preference {batching_preference!r} is "
             "currently not supported."
         )
+
+
+def _process_batch(
+    batch: dict[str, t.Any],
+    model: "BenchmarkModule",
+    benchmark_config: "BenchmarkConfig",
+    dataset_config: "DatasetConfig",
+    all_preds: list[str],
+    all_predicted_labels: list[object],
+    all_bpc_scores: list[float],
+    failed_instances: list["FailedInstance"],
+    cache: ModelCache,
+) -> None:
+    """Process a single batch and update accumulators.
+
+    Args:
+        batch:
+            The batch to process.
+        model:
+            The model to use for generation.
+        benchmark_config:
+            The benchmark configuration.
+        dataset_config:
+            The dataset configuration.
+        all_preds:
+            Accumulator for extracted labels.
+        all_predicted_labels:
+            Accumulator for predicted labels.
+        all_bpc_scores:
+            Accumulator for BPC scores.
+        failed_instances:
+            Accumulator for failed instances.
+        cache:
+            The model output cache.
+    """
+    # Ensure batch is in list format
+    single_sample_batch = ("text" in batch and isinstance(batch["text"], str)) or (
+        "messages" in batch and isinstance(batch["messages"][0], dict)
+    )
+    if single_sample_batch:
+        batch = {key: [value] for key, value in batch.items()}
+
+    # Use score() for BPC, generate() for standard generation
+    if benchmark_config.use_bits_per_character:
+        model_output = model.score(inputs=batch)  # type: ignore[attr-defined]
+    else:
+        model_output = model.generate(inputs=batch)
+
+    # In BPC mode we score via prompt_logprobs only
+    if not benchmark_config.use_bits_per_character:
+        extracted_labels = model.extract_labels_from_generation(
+            input_batch=batch, model_output=model_output
+        )
+        if pred2extracted := dataset_config.prompt_label_mapping:
+            extracted_to_predicted = {
+                extracted: predicted for predicted, extracted in pred2extracted.items()
+            }
+            model_output.predicted_labels = [
+                extracted_to_predicted.get(label, label).lower()
+                if isinstance(label, str)
+                else [extracted_to_predicted.get(lbl, lbl).lower() for lbl in label]
+                for label in extracted_labels
+            ]
+        else:
+            model_output.predicted_labels = extracted_labels
+        offset = len(all_preds)
+        for failed_instance in model_output.failed_instances:
+            failed_instance["sample_index"] += offset
+        all_preds.extend(extracted_labels)
+        all_predicted_labels.extend(model_output.predicted_labels or [])
+
+    failed_instances.extend(model_output.failed_instances)
+
+    # Extended logging in debug mode
+    if benchmark_config.debug:
+        debug_log(batch=batch, model_output=model_output, dataset_config=dataset_config)
+
+    cache.add_to_cache(model_inputs=batch, model_output=model_output)
+
+    # Collect BPC scores
+    if benchmark_config.use_bits_per_character and model_output.bpc_scores:
+        all_bpc_scores.extend(model_output.bpc_scores)
+
+    # Save cache often in debug mode
+    if benchmark_config.debug:
+        cache.save()
 
 
 def debug_log(
@@ -332,171 +418,6 @@ def debug_log(
         )
 
 
-def _process_cached_dataset(
-    cached_dataset: Dataset,
-    model: "BenchmarkModule",
-    benchmark_config: "BenchmarkConfig",
-    dataset_config: "DatasetConfig",
-    cache: ModelCache,
-    all_preds: list[str],
-    all_predicted_labels: list[object],
-    all_bpc_scores: list[float],
-    failed_instances: list["FailedInstance"],
-) -> None:
-    """Process cached dataset and update accumulators.
-
-    Args:
-        cached_dataset:
-            The cached dataset to process.
-        model:
-            The model for label extraction.
-        benchmark_config:
-            The benchmark configuration.
-        dataset_config:
-            The dataset configuration.
-        cache:
-            The model output cache.
-        all_preds:
-            Accumulator for extracted labels.
-        all_predicted_labels:
-            Accumulator for predicted labels.
-        all_bpc_scores:
-            Accumulator for BPC scores.
-        failed_instances:
-            Accumulator for failed instances.
-    """
-    model_output = load_cached_model_outputs(cached_dataset=cached_dataset, cache=cache)
-    if not benchmark_config.use_bits_per_character:
-        extracted_labels = model.extract_labels_from_generation(
-            input_batch=cached_dataset[:], model_output=model_output
-        )
-        if model_output.predicted_labels is None:
-            if pred2extracted := dataset_config.prompt_label_mapping:
-                extracted_to_predicted = {
-                    extracted: predicted
-                    for predicted, extracted in pred2extracted.items()
-                }
-                model_output.predicted_labels = [
-                    extracted_to_predicted.get(label, label).lower()
-                    if isinstance(label, str)
-                    else [extracted_to_predicted.get(lbl, lbl).lower() for lbl in label]
-                    for label in extracted_labels
-                ]
-            else:
-                model_output.predicted_labels = extracted_labels
-        offset = len(all_preds)
-        for failed_instance in model_output.failed_instances:
-            failed_instance["sample_index"] += offset
-        all_preds.extend(extracted_labels)
-        all_predicted_labels.extend(model_output.predicted_labels or [])
-
-    failed_instances.extend(model_output.failed_instances)
-
-    if benchmark_config.use_bits_per_character and model_output.bpc_scores:
-        all_bpc_scores.extend(model_output.bpc_scores)
-
-
-def generate_single_iteration(
-    dataset: "Dataset",
-    model: "BenchmarkModule",
-    dataset_config: "DatasetConfig",
-    benchmark_config: "BenchmarkConfig",
-    cache: ModelCache,
-) -> "IterationScores":
-    """Evaluate a model on a dataset in a single iteration through generation.
-
-    Args:
-        dataset:
-            The dataset to evaluate on.
-        model:
-            The model to evaluate.
-        dataset_config:
-            The configuration of the dataset.
-        benchmark_config:
-            The configuration of the benchmark.
-        cache:
-            The model output cache.
-
-    Returns:
-        A dictionary of scores with a 'failed_instances' key.
-    """
-    cache.load()
-
-    # Split dataset into cached and non-cached parts
-    if dataset_config.bootstrap_samples:
-        cached_dataset, non_cached_dataset = split_dataset_into_cached_and_non_cached(
-            dataset=dataset, cache=cache
-        )
-    else:
-        cached_dataset = Dataset.from_dict({})
-        non_cached_dataset = dataset
-
-    all_preds: list[str] = []
-    all_predicted_labels: list[object] = []
-    all_bpc_scores: list[float] = []
-    failed_instances: list["FailedInstance"] = []
-
-    # Process non-cached dataset
-    if len(non_cached_dataset) > 0:
-        itr = _get_iteration_iterator(
-            dataset=non_cached_dataset,
-            batching_preference=model.batching_preference,
-            progress_bar=benchmark_config.progress_bar,
-        )
-
-        for batch in itr:
-            assert isinstance(batch, dict), (
-                f"Expected a dictionary but got {type(batch)}."
-            )
-            _process_batch(
-                batch=batch,
-                model=model,
-                benchmark_config=benchmark_config,
-                dataset_config=dataset_config,
-                all_preds=all_preds,
-                all_predicted_labels=all_predicted_labels,
-                all_bpc_scores=all_bpc_scores,
-                failed_instances=failed_instances,
-                cache=cache,
-            )
-
-        if isinstance(itr, tqdm):
-            itr.close()
-        cache.save()
-
-    # Process cached dataset
-    if len(cached_dataset) > 0:
-        _process_cached_dataset(
-            cached_dataset=cached_dataset,
-            model=model,
-            benchmark_config=benchmark_config,
-            dataset_config=dataset_config,
-            cache=cache,
-            all_preds=all_preds,
-            all_predicted_labels=all_predicted_labels,
-            all_bpc_scores=all_bpc_scores,
-            failed_instances=failed_instances,
-        )
-
-    # Extract ground truth labels
-    ground_truth = _extract_ground_truth(
-        non_cached_dataset=non_cached_dataset, cached_dataset=cached_dataset
-    )
-
-    # Compute and return final scores
-    return _compute_final_scores(
-        benchmark_config=benchmark_config,
-        dataset=dataset,
-        dataset_config=dataset_config,
-        model=model,
-        all_bpc_scores=all_bpc_scores,
-        all_preds=all_preds,
-        all_predicted_labels=all_predicted_labels,
-        ground_truth=ground_truth,
-        failed_instances=failed_instances,
-    )
-
-
 def generate(
     model: "BenchmarkModule",
     datasets: c.Sequence["DatasetDict"],
@@ -604,28 +525,131 @@ def generate(
     return scores
 
 
-def _process_batch(
-    batch: dict[str, t.Any],
+def generate_single_iteration(
+    dataset: "Dataset",
+    model: "BenchmarkModule",
+    dataset_config: "DatasetConfig",
+    benchmark_config: "BenchmarkConfig",
+    cache: ModelCache,
+) -> "IterationScores":
+    """Evaluate a model on a dataset in a single iteration through generation.
+
+    Args:
+        dataset:
+            The dataset to evaluate on.
+        model:
+            The model to evaluate.
+        dataset_config:
+            The configuration of the dataset.
+        benchmark_config:
+            The configuration of the benchmark.
+        cache:
+            The model output cache.
+
+    Returns:
+        A dictionary of scores with a 'failed_instances' key.
+    """
+    cache.load()
+
+    # Split dataset into cached and non-cached parts
+    if dataset_config.bootstrap_samples:
+        cached_dataset, non_cached_dataset = split_dataset_into_cached_and_non_cached(
+            dataset=dataset, cache=cache
+        )
+    else:
+        cached_dataset = Dataset.from_dict({})
+        non_cached_dataset = dataset
+
+    all_preds: list[str] = []
+    all_predicted_labels: list[object] = []
+    all_bpc_scores: list[float] = []
+    failed_instances: list["FailedInstance"] = []
+
+    # Process non-cached dataset
+    if len(non_cached_dataset) > 0:
+        itr = _get_iteration_iterator(
+            dataset=non_cached_dataset,
+            batching_preference=model.batching_preference,
+            progress_bar=benchmark_config.progress_bar,
+        )
+
+        for batch in itr:
+            assert isinstance(batch, dict), (
+                f"Expected a dictionary but got {type(batch)}."
+            )
+            _process_batch(
+                batch=batch,
+                model=model,
+                benchmark_config=benchmark_config,
+                dataset_config=dataset_config,
+                all_preds=all_preds,
+                all_predicted_labels=all_predicted_labels,
+                all_bpc_scores=all_bpc_scores,
+                failed_instances=failed_instances,
+                cache=cache,
+            )
+
+        if isinstance(itr, tqdm):
+            itr.close()
+        cache.save()
+
+    # Process cached dataset
+    if len(cached_dataset) > 0:
+        _process_cached_dataset(
+            cached_dataset=cached_dataset,
+            model=model,
+            benchmark_config=benchmark_config,
+            dataset_config=dataset_config,
+            cache=cache,
+            all_preds=all_preds,
+            all_predicted_labels=all_predicted_labels,
+            all_bpc_scores=all_bpc_scores,
+            failed_instances=failed_instances,
+        )
+
+    # Extract ground truth labels
+    ground_truth = _extract_ground_truth(
+        non_cached_dataset=non_cached_dataset, cached_dataset=cached_dataset
+    )
+
+    # Compute and return final scores
+    return _compute_final_scores(
+        benchmark_config=benchmark_config,
+        dataset=dataset,
+        dataset_config=dataset_config,
+        model=model,
+        all_bpc_scores=all_bpc_scores,
+        all_preds=all_preds,
+        all_predicted_labels=all_predicted_labels,
+        ground_truth=ground_truth,
+        failed_instances=failed_instances,
+    )
+
+
+def _process_cached_dataset(
+    cached_dataset: Dataset,
     model: "BenchmarkModule",
     benchmark_config: "BenchmarkConfig",
     dataset_config: "DatasetConfig",
+    cache: ModelCache,
     all_preds: list[str],
     all_predicted_labels: list[object],
     all_bpc_scores: list[float],
     failed_instances: list["FailedInstance"],
-    cache: ModelCache,
 ) -> None:
-    """Process a single batch and update accumulators.
+    """Process cached dataset and update accumulators.
 
     Args:
-        batch:
-            The batch to process.
+        cached_dataset:
+            The cached dataset to process.
         model:
-            The model to use for generation.
+            The model for label extraction.
         benchmark_config:
             The benchmark configuration.
         dataset_config:
             The dataset configuration.
+        cache:
+            The model output cache.
         all_preds:
             Accumulator for extracted labels.
         all_predicted_labels:
@@ -634,39 +658,26 @@ def _process_batch(
             Accumulator for BPC scores.
         failed_instances:
             Accumulator for failed instances.
-        cache:
-            The model output cache.
     """
-    # Ensure batch is in list format
-    single_sample_batch = ("text" in batch and isinstance(batch["text"], str)) or (
-        "messages" in batch and isinstance(batch["messages"][0], dict)
-    )
-    if single_sample_batch:
-        batch = {key: [value] for key, value in batch.items()}
-
-    # Use score() for BPC, generate() for standard generation
-    if benchmark_config.use_bits_per_character:
-        model_output = model.score(inputs=batch)  # type: ignore[attr-defined]
-    else:
-        model_output = model.generate(inputs=batch)
-
-    # In BPC mode we score via prompt_logprobs only
+    model_output = load_cached_model_outputs(cached_dataset=cached_dataset, cache=cache)
     if not benchmark_config.use_bits_per_character:
         extracted_labels = model.extract_labels_from_generation(
-            input_batch=batch, model_output=model_output
+            input_batch=cached_dataset[:], model_output=model_output
         )
-        if pred2extracted := dataset_config.prompt_label_mapping:
-            extracted_to_predicted = {
-                extracted: predicted for predicted, extracted in pred2extracted.items()
-            }
-            model_output.predicted_labels = [
-                extracted_to_predicted.get(label, label).lower()
-                if isinstance(label, str)
-                else [extracted_to_predicted.get(lbl, lbl).lower() for lbl in label]
-                for label in extracted_labels
-            ]
-        else:
-            model_output.predicted_labels = extracted_labels
+        if model_output.predicted_labels is None:
+            if pred2extracted := dataset_config.prompt_label_mapping:
+                extracted_to_predicted = {
+                    extracted: predicted
+                    for predicted, extracted in pred2extracted.items()
+                }
+                model_output.predicted_labels = [
+                    extracted_to_predicted.get(label, label).lower()
+                    if isinstance(label, str)
+                    else [extracted_to_predicted.get(lbl, lbl).lower() for lbl in label]
+                    for label in extracted_labels
+                ]
+            else:
+                model_output.predicted_labels = extracted_labels
         offset = len(all_preds)
         for failed_instance in model_output.failed_instances:
             failed_instance["sample_index"] += offset
@@ -675,16 +686,5 @@ def _process_batch(
 
     failed_instances.extend(model_output.failed_instances)
 
-    # Extended logging in debug mode
-    if benchmark_config.debug:
-        debug_log(batch=batch, model_output=model_output, dataset_config=dataset_config)
-
-    cache.add_to_cache(model_inputs=batch, model_output=model_output)
-
-    # Collect BPC scores
     if benchmark_config.use_bits_per_character and model_output.bpc_scores:
         all_bpc_scores.extend(model_output.bpc_scores)
-
-    # Save cache often in debug mode
-    if benchmark_config.debug:
-        cache.save()

--- a/src/euroeval/generation_utils.py
+++ b/src/euroeval/generation_utils.py
@@ -30,6 +30,119 @@ if t.TYPE_CHECKING:
     from .data_models import BenchmarkConfig, DatasetConfig, ModelConfig
 
 
+def apply_prompt(
+    examples: dict[str, t.Any],
+    few_shot_examples: c.Sequence[dict[str, t.Any]],
+    model_config: "ModelConfig",
+    dataset_config: "DatasetConfig",
+    generative_type: GenerativeType | None,
+    always_populate_text_field: bool,
+    tokeniser: "PreTrainedTokenizer | None",
+    use_bits_per_character: bool = False,
+) -> dict[str, t.Any]:
+    """Apply prompt template to an example, potentially with few-shot examples.
+
+    Args:
+        examples:
+            The examples to apply the few-shot examples to.
+        few_shot_examples:
+            The few-shot examples to apply.
+        model_config:
+            The model configuration.
+        dataset_config:
+            The dataset configuration.
+        generative_type:
+            The generative type of the model.
+        always_populate_text_field:
+            Whether to always populate the 'text' field in the examples, as opposed to
+            the 'messages' field.
+        tokeniser:
+            The tokeniser to use for the model. If None, the tokeniser is not used.
+        use_bits_per_character:
+            Whether to use bits-per-character (BPC) scoring. For multiple-choice tasks,
+            treats benchmark as text-to-text with bare question → full answer text.
+            Defaults to False.
+
+    Returns:
+        The example with the few-shot examples applied.
+
+    Raises:
+        ValueError:
+            If the `tokeniser` argument is not provided when the model is instruction
+            tuned and when we are not just returning the raw messages.
+    """
+    # Sanity check
+    is_instruction_tuned = generative_type in {
+        GenerativeType.INSTRUCTION_TUNED,
+        GenerativeType.REASONING,
+    }
+    if is_instruction_tuned and always_populate_text_field and tokeniser is None:
+        raise ValueError(
+            "The `tokeniser` argument must be provided when the model is instruction "
+            "tuned and when we are not just returning the raw messages."
+        )
+
+    create_prompt = _create_prompt_creator(dataset_config, generative_type)
+
+    # Add bare inputs for BPC on MCQ tasks
+    if (
+        use_bits_per_character
+        and dataset_config.task.task_group == TaskGroup.MULTIPLE_CHOICE_CLASSIFICATION
+        and "raw_choices" not in examples
+    ):
+        _add_bare_inputs_for_bpc(examples, list(few_shot_examples))
+
+    sections_builder = _get_sections_builder(
+        task_group=dataset_config.task.task_group,
+        dataset_config=dataset_config,
+        use_bits_per_character=use_bits_per_character,
+    )
+    few_shot_sections, new_sections = sections_builder(
+        list(few_shot_examples), examples, create_prompt
+    )
+
+    # Build outputs based on model type
+    if is_instruction_tuned and always_populate_text_field:
+        assert tokeniser is not None
+    if is_instruction_tuned:
+        outputs = _build_instruction_tuned_outputs(
+            few_shot_sections=few_shot_sections,
+            new_sections=new_sections,
+            model_config=model_config,
+            dataset_config=dataset_config,
+            generative_type=generative_type,
+            tokeniser=tokeniser,
+            always_populate_text_field=always_populate_text_field,
+        )
+        examples.update(outputs)
+    else:
+        outputs = _build_standard_outputs(
+            few_shot_sections=few_shot_sections,
+            new_sections=new_sections,
+            dataset_config=dataset_config,
+        )
+        examples.update(outputs)
+
+    # Always add the final prompts without few-shot examples, too, for analysis
+    examples["prompt"] = [new_prompt for new_prompt, _ in new_sections]
+
+    # Create bpc_prompt column for BPC scoring when requested
+    if use_bits_per_character:
+        assert tokeniser is not None, (
+            "tokeniser must be provided when use_bits_per_character=True"
+        )
+        num_examples = len(new_sections)
+        bpc_data = _build_bpc_outputs(
+            dataset_config=dataset_config,
+            examples=examples,
+            tokeniser=tokeniser,
+            num_examples=num_examples,
+        )
+        examples.update(bpc_data)
+
+    return examples
+
+
 def _add_bare_inputs_for_bpc(
     examples: dict[str, t.Any], few_shot_examples: list[dict[str, t.Any]]
 ) -> None:
@@ -47,6 +160,55 @@ def _add_bare_inputs_for_bpc(
             fs_bare, fs_choices = parse_bare_question_and_choices(fs_example["text"])
             fs_example["bare_input"] = fs_bare
             fs_example["raw_choices"] = fs_choices
+
+
+def _build_bpc_outputs(
+    dataset_config: "DatasetConfig",
+    examples: dict[str, t.Any],
+    tokeniser: "PreTrainedTokenizer",
+    num_examples: int,
+) -> dict[str, t.Any]:
+    """Build BPC prompt and answer_start columns.
+
+    Args:
+        dataset_config:
+            The dataset configuration.
+        examples:
+            The examples to evaluate.
+        tokeniser:
+            The tokeniser.
+        num_examples:
+            The number of examples.
+
+    Returns:
+        A dictionary of BPC outputs.
+    """
+    labels_for_spacing = list(dataset_config.prompt_label_mapping.values()) or [
+        "negative",
+        "positive",
+    ]
+    strip_bpc_prompt = should_prompts_be_stripped(
+        labels_to_be_generated=labels_for_spacing, tokeniser=tokeniser
+    )
+
+    full_prompts: list[str] = [str(text) for text in examples["text"]]
+
+    answers = _extract_bpc_answers(
+        task_group=dataset_config.task.task_group,
+        examples=examples,
+        dataset_config=dataset_config,
+        num_examples=num_examples,
+    )
+
+    bpc_data = _build_bpc_columns(
+        task_group=dataset_config.task.task_group,
+        full_prompts=full_prompts,
+        answers=answers,
+        tokeniser=tokeniser,
+        strip_bpc_prompt=strip_bpc_prompt,
+        num_examples=num_examples,
+    )
+    return bpc_data
 
 
 def _build_bpc_columns(
@@ -185,107 +347,6 @@ def _extract_bpc_answers(
         return None
 
 
-def _build_bpc_outputs(
-    dataset_config: "DatasetConfig",
-    examples: dict[str, t.Any],
-    tokeniser: "PreTrainedTokenizer",
-    num_examples: int,
-) -> dict[str, t.Any]:
-    """Build BPC prompt and answer_start columns.
-
-    Args:
-        dataset_config:
-            The dataset configuration.
-        examples:
-            The examples to evaluate.
-        tokeniser:
-            The tokeniser.
-        num_examples:
-            The number of examples.
-
-    Returns:
-        A dictionary of BPC outputs.
-    """
-    labels_for_spacing = list(dataset_config.prompt_label_mapping.values()) or [
-        "negative",
-        "positive",
-    ]
-    strip_bpc_prompt = should_prompts_be_stripped(
-        labels_to_be_generated=labels_for_spacing, tokeniser=tokeniser
-    )
-
-    full_prompts: list[str] = [str(text) for text in examples["text"]]
-
-    answers = _extract_bpc_answers(
-        task_group=dataset_config.task.task_group,
-        examples=examples,
-        dataset_config=dataset_config,
-        num_examples=num_examples,
-    )
-
-    bpc_data = _build_bpc_columns(
-        task_group=dataset_config.task.task_group,
-        full_prompts=full_prompts,
-        answers=answers,
-        tokeniser=tokeniser,
-        strip_bpc_prompt=strip_bpc_prompt,
-        num_examples=num_examples,
-    )
-    return bpc_data
-
-
-def _build_chat_template_kwargs(model_config: "ModelConfig") -> dict[str, t.Any]:
-    """Build chat template kwargs for reasoning effort.
-
-    Args:
-        model_config:
-            The model configuration.
-
-    Returns:
-        A dictionary of chat template kwargs.
-    """
-    if model_config.param in {"low", "medium", "high"}:
-        log_once(f"Set reasoning mode to {model_config.param!r}.", level=logging.DEBUG)
-        return {"reasoning_effort": model_config.param}
-    return {}
-
-
-def _select_chat_template(
-    tokeniser: "PreTrainedTokenizer",
-    dataset_config: "DatasetConfig",
-    model_config: "ModelConfig",
-) -> str | None:
-    """Select chat template matching dataset language if available.
-
-    Args:
-        tokeniser:
-            The tokeniser.
-        dataset_config:
-            The dataset configuration.
-        model_config:
-            The model configuration.
-
-    Returns:
-        The chat template, or None if no matching template is found.
-    """
-    if not (
-        hasattr(tokeniser, "chat_template")
-        and isinstance(tokeniser.chat_template, dict)
-    ):
-        return None
-
-    language_codes = [language.code for language in dataset_config.languages]
-    for name, candidate_template in tokeniser.chat_template.items():
-        if name.lower() in language_codes:
-            log_once(
-                f"Using the {name!r} chat template for the tokeniser for "
-                f"model {model_config.model_id!r}.",
-                level=logging.DEBUG,
-            )
-            return candidate_template
-    return None
-
-
 def _build_instruction_tuned_outputs(
     few_shot_sections: list[tuple[str, str]],
     new_sections: list[tuple[str, str]],
@@ -349,6 +410,207 @@ def _build_instruction_tuned_outputs(
         outputs["messages"] = messages_list
 
     return outputs
+
+
+def _build_chat_template_kwargs(model_config: "ModelConfig") -> dict[str, t.Any]:
+    """Build chat template kwargs for reasoning effort.
+
+    Args:
+        model_config:
+            The model configuration.
+
+    Returns:
+        A dictionary of chat template kwargs.
+    """
+    if model_config.param in {"low", "medium", "high"}:
+        log_once(f"Set reasoning mode to {model_config.param!r}.", level=logging.DEBUG)
+        return {"reasoning_effort": model_config.param}
+    return {}
+
+
+def _select_chat_template(
+    tokeniser: "PreTrainedTokenizer",
+    dataset_config: "DatasetConfig",
+    model_config: "ModelConfig",
+) -> str | None:
+    """Select chat template matching dataset language if available.
+
+    Args:
+        tokeniser:
+            The tokeniser.
+        dataset_config:
+            The dataset configuration.
+        model_config:
+            The model configuration.
+
+    Returns:
+        The chat template, or None if no matching template is found.
+    """
+    if not (
+        hasattr(tokeniser, "chat_template")
+        and isinstance(tokeniser.chat_template, dict)
+    ):
+        return None
+
+    language_codes = [language.code for language in dataset_config.languages]
+    for name, candidate_template in tokeniser.chat_template.items():
+        if name.lower() in language_codes:
+            log_once(
+                f"Using the {name!r} chat template for the tokeniser for "
+                f"model {model_config.model_id!r}.",
+                level=logging.DEBUG,
+            )
+            return candidate_template
+    return None
+
+
+def _build_standard_outputs(
+    few_shot_sections: list[tuple[str, str]],
+    new_sections: list[tuple[str, str]],
+    dataset_config: "DatasetConfig",
+) -> dict[str, t.Any]:
+    """Build outputs for non-instruction-tuned models.
+
+    Args:
+        few_shot_sections:
+            The few-shot sections.
+        new_sections:
+            The new sections.
+        dataset_config:
+            The dataset configuration.
+
+    Returns:
+        A dictionary of outputs.
+    """
+    prompt_prefix = ""
+    if dataset_config.prompt_prefix:
+        labels_str = dataset_config.get_labels_str()
+        prompt_prefix = (
+            dataset_config.prompt_prefix.format(labels_str=labels_str) + "\n\n"
+        )
+
+    few_shot_prompt = "\n\n".join([prompt for prompt, _ in few_shot_sections])
+    if few_shot_prompt:
+        few_shot_prompt += "\n\n"
+
+    return {
+        "text": [
+            prompt_prefix + few_shot_prompt + new_prompt
+            for new_prompt, _ in new_sections
+        ]
+    }
+
+
+def _create_prompt_creator(
+    dataset_config: "DatasetConfig", generative_type: GenerativeType | None
+) -> c.Callable[..., tuple[str, str]]:
+    """Create a function that builds prompts from keyword arguments.
+
+    Args:
+        dataset_config:
+            The dataset configuration.
+        generative_type:
+            The generative type of the model.
+
+    Returns:
+        A function that builds prompts from keyword arguments.
+    """
+
+    def create_prompt(**kwargs: str) -> tuple[str, str]:
+        """Create a prompt from the given keyword arguments.
+
+        Args:
+            kwargs:
+                The keyword arguments to use in the prompt.
+
+        Returns:
+            A pair (prompt, label), where "label" is an empty string if the model is
+            not instruction tuned (as in this case it is included in the prompt).
+        """
+        label_key = "label" if "label" in kwargs else "target_text"
+        label = kwargs.pop(label_key)
+        assert label is not None, (
+            f"Found a None label for the prompt: {kwargs}. This should not happen."
+        )
+        label_mapping = dataset_config.prompt_label_mapping
+        label = label_mapping.get(label, label)
+        if generative_type in {
+            GenerativeType.INSTRUCTION_TUNED,
+            GenerativeType.REASONING,
+        }:
+            prompt = dataset_config.instruction_prompt.format(**kwargs)
+            return prompt, label
+        else:
+            kwargs[label_key] = label
+            return dataset_config.prompt_template.format(**kwargs), ""
+
+    return create_prompt
+
+
+def _get_sections_builder(
+    task_group: TaskGroup, dataset_config: "DatasetConfig", use_bits_per_character: bool
+) -> c.Callable[
+    [list[dict[str, t.Any]], dict[str, t.Any], c.Callable],
+    tuple[list[tuple[str, str]], list[tuple[str, str]]],
+]:
+    """Get a function that builds few-shot and new sections for a task group.
+
+    Args:
+        task_group:
+            The task group to build sections for.
+        dataset_config:
+            The dataset configuration.
+        use_bits_per_character:
+            Whether to use bits-per-character scoring.
+
+    Returns:
+        A function that takes few_shot_examples, examples, and create_prompt,
+        and returns (few_shot_sections, new_sections).
+    """
+    if task_group == TaskGroup.SEQUENCE_CLASSIFICATION:
+        return lambda few_shot_examples, examples, create_prompt: (
+            _build_sequence_classification_sections(
+                few_shot_examples=few_shot_examples,
+                examples=examples,
+                create_prompt=create_prompt,
+                dataset_config=dataset_config,
+            )
+        )
+    elif task_group == TaskGroup.MULTIPLE_CHOICE_CLASSIFICATION:
+        return lambda few_shot_examples, examples, create_prompt: _build_mcq_sections(
+            few_shot_examples=few_shot_examples,
+            examples=examples,
+            create_prompt=create_prompt,
+            dataset_config=dataset_config,
+            use_bits_per_character=use_bits_per_character,
+        )
+    elif task_group == TaskGroup.TEXT_TO_TEXT:
+        return lambda few_shot_examples, examples, create_prompt: (
+            _build_text_to_text_sections(
+                few_shot_examples=few_shot_examples,
+                examples=examples,
+                create_prompt=create_prompt,
+            )
+        )
+    elif task_group == TaskGroup.TOKEN_CLASSIFICATION:
+        return lambda few_shot_examples, examples, create_prompt: (
+            _build_token_classification_sections(
+                few_shot_examples=few_shot_examples,
+                examples=examples,
+                create_prompt=create_prompt,
+                dataset_config=dataset_config,
+            )
+        )
+    elif task_group == TaskGroup.QUESTION_ANSWERING:
+        return lambda few_shot_examples, examples, create_prompt: (
+            _build_question_answering_sections(
+                few_shot_examples=few_shot_examples,
+                examples=examples,
+                create_prompt=create_prompt,
+            )
+        )
+    else:
+        raise NotImplementedError(f"Unsupported task group: {task_group}.")
 
 
 def _build_mcq_sections(
@@ -498,43 +760,6 @@ def _build_sequence_classification_sections(
     return few_shot_sections, new_sections
 
 
-def _build_standard_outputs(
-    few_shot_sections: list[tuple[str, str]],
-    new_sections: list[tuple[str, str]],
-    dataset_config: "DatasetConfig",
-) -> dict[str, t.Any]:
-    """Build outputs for non-instruction-tuned models.
-
-    Args:
-        few_shot_sections:
-            The few-shot sections.
-        new_sections:
-            The new sections.
-        dataset_config:
-            The dataset configuration.
-
-    Returns:
-        A dictionary of outputs.
-    """
-    prompt_prefix = ""
-    if dataset_config.prompt_prefix:
-        labels_str = dataset_config.get_labels_str()
-        prompt_prefix = (
-            dataset_config.prompt_prefix.format(labels_str=labels_str) + "\n\n"
-        )
-
-    few_shot_prompt = "\n\n".join([prompt for prompt, _ in few_shot_sections])
-    if few_shot_prompt:
-        few_shot_prompt += "\n\n"
-
-    return {
-        "text": [
-            prompt_prefix + few_shot_prompt + new_prompt
-            for new_prompt, _ in new_sections
-        ]
-    }
-
-
 def _build_text_to_text_sections(
     few_shot_examples: list[dict[str, t.Any]],
     examples: dict[str, t.Any],
@@ -612,50 +837,97 @@ def _build_token_classification_sections(
     return few_shot_sections, new_sections
 
 
-def _create_prompt_creator(
-    dataset_config: "DatasetConfig", generative_type: GenerativeType | None
-) -> c.Callable[..., tuple[str, str]]:
-    """Create a function that builds prompts from keyword arguments.
+def extract_few_shot_examples(
+    dataset: "DatasetDict",
+    dataset_config: "DatasetConfig",
+    benchmark_config: "BenchmarkConfig",
+    itr_idx: int,
+) -> c.Sequence[dict[str, t.Any]]:
+    """Extract few-shot examples from a dataset.
+
+    This will always extract the examples from the training split.
+
+    We ensure that the few-shot examples are unique by picking them one at a time.
 
     Args:
+        dataset:
+            The dataset to extract the few-shot examples from.
         dataset_config:
             The dataset configuration.
-        generative_type:
-            The generative type of the model.
+        benchmark_config:
+            The benchmark configuration.
+        itr_idx:
+            The index of the dataset in the iterator.
 
     Returns:
-        A function that builds prompts from keyword arguments.
+        The few-shot examples.
     """
-
-    def create_prompt(**kwargs: str) -> tuple[str, str]:
-        """Create a prompt from the given keyword arguments.
-
-        Args:
-            kwargs:
-                The keyword arguments to use in the prompt.
-
-        Returns:
-            A pair (prompt, label), where "label" is an empty string if the model is
-            not instruction tuned (as in this case it is included in the prompt).
-        """
-        label_key = "label" if "label" in kwargs else "target_text"
-        label = kwargs.pop(label_key)
-        assert label is not None, (
-            f"Found a None label for the prompt: {kwargs}. This should not happen."
+    if "train" not in dataset:
+        log_once(
+            "There is no training split in the dataset, so we cannot extract any "
+            "few-shot examples, even though you requested few-shot evaluation (it's "
+            "the default). We will therefore evaluate the model zero-shot.",
+            level=logging.DEBUG,
         )
-        label_mapping = dataset_config.prompt_label_mapping
-        label = label_mapping.get(label, label)
-        if generative_type in {
-            GenerativeType.INSTRUCTION_TUNED,
-            GenerativeType.REASONING,
-        }:
-            prompt = dataset_config.instruction_prompt.format(**kwargs)
-            return prompt, label
-        else:
-            kwargs[label_key] = label
-            return dataset_config.prompt_template.format(**kwargs), ""
+        return list()
 
-    return create_prompt
+    if dataset_config.task.requires_zero_shot and benchmark_config.few_shot:
+        msg = (
+            "This task only allows zero-shot evaluation, so even though you have "
+            "requested few-shot evaluation "
+        )
+        if benchmark_config.run_with_cli:
+            msg += "(by not setting the --zero-shot flag), "
+        else:
+            msg += "(by setting the default `few_shot=True` argument), "
+        msg += "we will run the evaluation in zero-shot mode."
+        benchmark_config.few_shot = False
+        log_once(msg, level=logging.DEBUG)
+        return []
+
+    random_seed = 4242 + itr_idx
+    num_few_shots = dataset_config.num_few_shot_examples
+    shuffled_train = dataset["train"].shuffle(seed=random_seed)
+    assert isinstance(shuffled_train, Dataset), (
+        f"Expected `shuffled_train` to be a Dataset, but got {type(shuffled_train)} "
+        "instead."
+    )
+
+    few_shot_examples: list[dict[str, t.Any]]
+    match dataset_config.task.task_group:
+        case (
+            TaskGroup.SEQUENCE_CLASSIFICATION | TaskGroup.MULTIPLE_CHOICE_CLASSIFICATION
+        ):
+            few_shot_examples = _extract_classification_examples(
+                shuffled_train=shuffled_train,
+                num_few_shots=num_few_shots,
+                dataset_config=dataset_config,
+                random_seed=random_seed,
+            )
+        case TaskGroup.TEXT_TO_TEXT:
+            few_shot_examples = _extract_text_to_text_examples(
+                shuffled_train=shuffled_train, num_few_shots=num_few_shots
+            )
+        case TaskGroup.TOKEN_CLASSIFICATION:
+            few_shot_examples = _extract_token_classification_examples(
+                shuffled_train=shuffled_train,
+                num_few_shots=num_few_shots,
+                dataset_config=dataset_config,
+            )
+        case TaskGroup.QUESTION_ANSWERING:
+            few_shot_examples = _extract_question_answering_examples(
+                shuffled_train=shuffled_train,
+                num_few_shots=num_few_shots,
+                random_seed=random_seed,
+            )
+        case _:
+            raise NotImplementedError(
+                f"Unsupported task group: {dataset_config.task.task_group}."
+            )
+
+    random.seed(random_seed)
+    random.shuffle(few_shot_examples)
+    return few_shot_examples
 
 
 def _extract_classification_examples(
@@ -858,278 +1130,6 @@ def _extract_token_classification_examples(
         shuffled_train = shuffled_train.filter(
             lambda x: x["tokens"] != example["tokens"]
         )
-    return few_shot_examples
-
-
-def _get_sections_builder(
-    task_group: TaskGroup, dataset_config: "DatasetConfig", use_bits_per_character: bool
-) -> c.Callable[
-    [list[dict[str, t.Any]], dict[str, t.Any], c.Callable],
-    tuple[list[tuple[str, str]], list[tuple[str, str]]],
-]:
-    """Get a function that builds few-shot and new sections for a task group.
-
-    Args:
-        task_group:
-            The task group to build sections for.
-        dataset_config:
-            The dataset configuration.
-        use_bits_per_character:
-            Whether to use bits-per-character scoring.
-
-    Returns:
-        A function that takes few_shot_examples, examples, and create_prompt,
-        and returns (few_shot_sections, new_sections).
-    """
-    if task_group == TaskGroup.SEQUENCE_CLASSIFICATION:
-        return lambda few_shot_examples, examples, create_prompt: (
-            _build_sequence_classification_sections(
-                few_shot_examples=few_shot_examples,
-                examples=examples,
-                create_prompt=create_prompt,
-                dataset_config=dataset_config,
-            )
-        )
-    elif task_group == TaskGroup.MULTIPLE_CHOICE_CLASSIFICATION:
-        return lambda few_shot_examples, examples, create_prompt: _build_mcq_sections(
-            few_shot_examples=few_shot_examples,
-            examples=examples,
-            create_prompt=create_prompt,
-            dataset_config=dataset_config,
-            use_bits_per_character=use_bits_per_character,
-        )
-    elif task_group == TaskGroup.TEXT_TO_TEXT:
-        return lambda few_shot_examples, examples, create_prompt: (
-            _build_text_to_text_sections(
-                few_shot_examples=few_shot_examples,
-                examples=examples,
-                create_prompt=create_prompt,
-            )
-        )
-    elif task_group == TaskGroup.TOKEN_CLASSIFICATION:
-        return lambda few_shot_examples, examples, create_prompt: (
-            _build_token_classification_sections(
-                few_shot_examples=few_shot_examples,
-                examples=examples,
-                create_prompt=create_prompt,
-                dataset_config=dataset_config,
-            )
-        )
-    elif task_group == TaskGroup.QUESTION_ANSWERING:
-        return lambda few_shot_examples, examples, create_prompt: (
-            _build_question_answering_sections(
-                few_shot_examples=few_shot_examples,
-                examples=examples,
-                create_prompt=create_prompt,
-            )
-        )
-    else:
-        raise NotImplementedError(f"Unsupported task group: {task_group}.")
-
-
-def apply_prompt(
-    examples: dict[str, t.Any],
-    few_shot_examples: c.Sequence[dict[str, t.Any]],
-    model_config: "ModelConfig",
-    dataset_config: "DatasetConfig",
-    generative_type: GenerativeType | None,
-    always_populate_text_field: bool,
-    tokeniser: "PreTrainedTokenizer | None",
-    use_bits_per_character: bool = False,
-) -> dict[str, t.Any]:
-    """Apply prompt template to an example, potentially with few-shot examples.
-
-    Args:
-        examples:
-            The examples to apply the few-shot examples to.
-        few_shot_examples:
-            The few-shot examples to apply.
-        model_config:
-            The model configuration.
-        dataset_config:
-            The dataset configuration.
-        generative_type:
-            The generative type of the model.
-        always_populate_text_field:
-            Whether to always populate the 'text' field in the examples, as opposed to
-            the 'messages' field.
-        tokeniser:
-            The tokeniser to use for the model. If None, the tokeniser is not used.
-        use_bits_per_character:
-            Whether to use bits-per-character (BPC) scoring. For multiple-choice tasks,
-            treats benchmark as text-to-text with bare question → full answer text.
-            Defaults to False.
-
-    Returns:
-        The example with the few-shot examples applied.
-
-    Raises:
-        ValueError:
-            If the `tokeniser` argument is not provided when the model is instruction
-            tuned and when we are not just returning the raw messages.
-    """
-    # Sanity check
-    is_instruction_tuned = generative_type in {
-        GenerativeType.INSTRUCTION_TUNED,
-        GenerativeType.REASONING,
-    }
-    if is_instruction_tuned and always_populate_text_field and tokeniser is None:
-        raise ValueError(
-            "The `tokeniser` argument must be provided when the model is instruction "
-            "tuned and when we are not just returning the raw messages."
-        )
-
-    create_prompt = _create_prompt_creator(dataset_config, generative_type)
-
-    # Add bare inputs for BPC on MCQ tasks
-    if (
-        use_bits_per_character
-        and dataset_config.task.task_group == TaskGroup.MULTIPLE_CHOICE_CLASSIFICATION
-        and "raw_choices" not in examples
-    ):
-        _add_bare_inputs_for_bpc(examples, list(few_shot_examples))
-
-    sections_builder = _get_sections_builder(
-        task_group=dataset_config.task.task_group,
-        dataset_config=dataset_config,
-        use_bits_per_character=use_bits_per_character,
-    )
-    few_shot_sections, new_sections = sections_builder(
-        list(few_shot_examples), examples, create_prompt
-    )
-
-    # Build outputs based on model type
-    if is_instruction_tuned and always_populate_text_field:
-        assert tokeniser is not None
-    if is_instruction_tuned:
-        outputs = _build_instruction_tuned_outputs(
-            few_shot_sections=few_shot_sections,
-            new_sections=new_sections,
-            model_config=model_config,
-            dataset_config=dataset_config,
-            generative_type=generative_type,
-            tokeniser=tokeniser,
-            always_populate_text_field=always_populate_text_field,
-        )
-        examples.update(outputs)
-    else:
-        outputs = _build_standard_outputs(
-            few_shot_sections=few_shot_sections,
-            new_sections=new_sections,
-            dataset_config=dataset_config,
-        )
-        examples.update(outputs)
-
-    # Always add the final prompts without few-shot examples, too, for analysis
-    examples["prompt"] = [new_prompt for new_prompt, _ in new_sections]
-
-    # Create bpc_prompt column for BPC scoring when requested
-    if use_bits_per_character:
-        assert tokeniser is not None, (
-            "tokeniser must be provided when use_bits_per_character=True"
-        )
-        num_examples = len(new_sections)
-        bpc_data = _build_bpc_outputs(
-            dataset_config=dataset_config,
-            examples=examples,
-            tokeniser=tokeniser,
-            num_examples=num_examples,
-        )
-        examples.update(bpc_data)
-
-    return examples
-
-
-def extract_few_shot_examples(
-    dataset: "DatasetDict",
-    dataset_config: "DatasetConfig",
-    benchmark_config: "BenchmarkConfig",
-    itr_idx: int,
-) -> c.Sequence[dict[str, t.Any]]:
-    """Extract few-shot examples from a dataset.
-
-    This will always extract the examples from the training split.
-
-    We ensure that the few-shot examples are unique by picking them one at a time.
-
-    Args:
-        dataset:
-            The dataset to extract the few-shot examples from.
-        dataset_config:
-            The dataset configuration.
-        benchmark_config:
-            The benchmark configuration.
-        itr_idx:
-            The index of the dataset in the iterator.
-
-    Returns:
-        The few-shot examples.
-    """
-    if "train" not in dataset:
-        log_once(
-            "There is no training split in the dataset, so we cannot extract any "
-            "few-shot examples, even though you requested few-shot evaluation (it's "
-            "the default). We will therefore evaluate the model zero-shot.",
-            level=logging.DEBUG,
-        )
-        return list()
-
-    if dataset_config.task.requires_zero_shot and benchmark_config.few_shot:
-        msg = (
-            "This task only allows zero-shot evaluation, so even though you have "
-            "requested few-shot evaluation "
-        )
-        if benchmark_config.run_with_cli:
-            msg += "(by not setting the --zero-shot flag), "
-        else:
-            msg += "(by setting the default `few_shot=True` argument), "
-        msg += "we will run the evaluation in zero-shot mode."
-        benchmark_config.few_shot = False
-        log_once(msg, level=logging.DEBUG)
-        return []
-
-    random_seed = 4242 + itr_idx
-    num_few_shots = dataset_config.num_few_shot_examples
-    shuffled_train = dataset["train"].shuffle(seed=random_seed)
-    assert isinstance(shuffled_train, Dataset), (
-        f"Expected `shuffled_train` to be a Dataset, but got {type(shuffled_train)} "
-        "instead."
-    )
-
-    few_shot_examples: list[dict[str, t.Any]]
-    match dataset_config.task.task_group:
-        case (
-            TaskGroup.SEQUENCE_CLASSIFICATION | TaskGroup.MULTIPLE_CHOICE_CLASSIFICATION
-        ):
-            few_shot_examples = _extract_classification_examples(
-                shuffled_train=shuffled_train,
-                num_few_shots=num_few_shots,
-                dataset_config=dataset_config,
-                random_seed=random_seed,
-            )
-        case TaskGroup.TEXT_TO_TEXT:
-            few_shot_examples = _extract_text_to_text_examples(
-                shuffled_train=shuffled_train, num_few_shots=num_few_shots
-            )
-        case TaskGroup.TOKEN_CLASSIFICATION:
-            few_shot_examples = _extract_token_classification_examples(
-                shuffled_train=shuffled_train,
-                num_few_shots=num_few_shots,
-                dataset_config=dataset_config,
-            )
-        case TaskGroup.QUESTION_ANSWERING:
-            few_shot_examples = _extract_question_answering_examples(
-                shuffled_train=shuffled_train,
-                num_few_shots=num_few_shots,
-                random_seed=random_seed,
-            )
-        case _:
-            raise NotImplementedError(
-                f"Unsupported task group: {dataset_config.task.task_group}."
-            )
-
-    random.seed(random_seed)
-    random.shuffle(few_shot_examples)
     return few_shot_examples
 
 

--- a/src/euroeval/languages.py
+++ b/src/euroeval/languages.py
@@ -75,15 +75,6 @@ class Language:
         self._or_separator = value
 
 
-def get_all_languages() -> dict[str, Language]:
-    """Get a list of all the languages.
-
-    Returns:
-        A mapping between language codes and their configurations.
-    """
-    return {cfg.code: cfg for cfg in globals().values() if isinstance(cfg, Language)}
-
-
 def get_correct_language_codes(
     language_codes: str | c.Sequence[str],
 ) -> c.Sequence[str]:
@@ -117,6 +108,15 @@ def get_correct_language_codes(
         languages = list(set(languages) | {"no"})
 
     return languages
+
+
+def get_all_languages() -> dict[str, Language]:
+    """Get a list of all the languages.
+
+    Returns:
+        A mapping between language codes and their configurations.
+    """
+    return {cfg.code: cfg for cfg in globals().values() if isinstance(cfg, Language)}
 
 
 ABKHAZIAN: Language = Language(

--- a/src/euroeval/logging_utils.py
+++ b/src/euroeval/logging_utils.py
@@ -137,6 +137,100 @@ def get_pbar(*tqdm_args, **tqdm_kwargs) -> tqdm:
     return tqdm(*tqdm_args, **tqdm_kwargs)
 
 
+class no_terminal_output:
+    """Context manager that suppresses all terminal output."""
+
+    def __init__(self, disable: bool = False) -> None:
+        """Initialise the context manager.
+
+        Args:
+            disable:
+                If True, this context manager does nothing.
+        """
+        self.disable = disable
+        self.devnull_file: TextIOWrapper | None = None
+        self._original_stdout_fd: int | None = None
+        self._original_stderr_fd: int | None = None
+
+    def __enter__(self) -> None:
+        """Suppress all terminal output."""
+        if self.disable:
+            return
+
+        try:
+            # Save original FDs by duplicating them
+            self._original_stdout_fd = os.dup(sys.stdout.fileno())
+            self._original_stderr_fd = os.dup(sys.stderr.fileno())
+
+            # Open /dev/null
+            self.devnull_file = open(os.devnull, "w")
+
+            # Redirect stdout/stderr to /dev/null
+            os.dup2(self.devnull_file.fileno(), sys.stdout.fileno())
+            os.dup2(self.devnull_file.fileno(), sys.stderr.fileno())
+
+        except OSError:
+            self._log_windows_warning()
+            # If setup fails, clean up any resources we might have acquired
+            self.__exit__(None, None, None)
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Re-enable terminal output."""
+        if self.disable:
+            return
+
+        # Restore stdout/stderr from our saved FDs
+        try:
+            if self._original_stdout_fd is not None:
+                os.dup2(self._original_stdout_fd, sys.stdout.fileno())
+            if self._original_stderr_fd is not None:
+                os.dup2(self._original_stderr_fd, sys.stderr.fileno())
+        except OSError:
+            self._log_windows_warning()
+        finally:
+            # Close the duplicated FDs we created
+            if self._original_stdout_fd is not None:
+                os.close(self._original_stdout_fd)
+            if self._original_stderr_fd is not None:
+                os.close(self._original_stderr_fd)
+
+            # Close the /dev/null file
+            if self.devnull_file is not None:
+                self.devnull_file.close()
+
+    def _log_windows_warning(self) -> None:
+        """Log a warning about Windows not supporting blocking terminal output."""
+        log_once(
+            "Your operating system (probably Windows) does not support blocking "
+            "terminal output, so expect more messy output - sorry!",
+            level=logging.WARNING,
+        )
+
+
+@cache_arguments("message")
+def log_once(message: str, level: int, prefix: str = "") -> None:
+    """Log a message once.
+
+    This is ensured by caching the "message" argument and only logging it the first time
+    this function is called with that message.
+
+    Args:
+        message:
+            The message to log.
+        level:
+            The logging level. Defaults to logging.INFO.
+        prefix:
+            A prefix to add to the message, which is not considered when determining if
+            the message has been logged before.
+    """
+    log(message=prefix + message, level=level)
+
+
 def log(message: str, level: int, colour: str | None = None) -> None:
     """Log a message.
 
@@ -179,97 +273,3 @@ def log(message: str, level: int, colour: str | None = None) -> None:
             logger.critical(message)
         case _:
             raise ValueError(f"Invalid logging level: {level}")
-
-
-@cache_arguments("message")
-def log_once(message: str, level: int, prefix: str = "") -> None:
-    """Log a message once.
-
-    This is ensured by caching the "message" argument and only logging it the first time
-    this function is called with that message.
-
-    Args:
-        message:
-            The message to log.
-        level:
-            The logging level. Defaults to logging.INFO.
-        prefix:
-            A prefix to add to the message, which is not considered when determining if
-            the message has been logged before.
-    """
-    log(message=prefix + message, level=level)
-
-
-class no_terminal_output:
-    """Context manager that suppresses all terminal output."""
-
-    def __init__(self, disable: bool = False) -> None:
-        """Initialise the context manager.
-
-        Args:
-            disable:
-                If True, this context manager does nothing.
-        """
-        self.disable = disable
-        self.devnull_file: TextIOWrapper | None = None
-        self._original_stdout_fd: int | None = None
-        self._original_stderr_fd: int | None = None
-
-    def _log_windows_warning(self) -> None:
-        """Log a warning about Windows not supporting blocking terminal output."""
-        log_once(
-            "Your operating system (probably Windows) does not support blocking "
-            "terminal output, so expect more messy output - sorry!",
-            level=logging.WARNING,
-        )
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> None:
-        """Re-enable terminal output."""
-        if self.disable:
-            return
-
-        # Restore stdout/stderr from our saved FDs
-        try:
-            if self._original_stdout_fd is not None:
-                os.dup2(self._original_stdout_fd, sys.stdout.fileno())
-            if self._original_stderr_fd is not None:
-                os.dup2(self._original_stderr_fd, sys.stderr.fileno())
-        except OSError:
-            self._log_windows_warning()
-        finally:
-            # Close the duplicated FDs we created
-            if self._original_stdout_fd is not None:
-                os.close(self._original_stdout_fd)
-            if self._original_stderr_fd is not None:
-                os.close(self._original_stderr_fd)
-
-            # Close the /dev/null file
-            if self.devnull_file is not None:
-                self.devnull_file.close()
-
-    def __enter__(self) -> None:
-        """Suppress all terminal output."""
-        if self.disable:
-            return
-
-        try:
-            # Save original FDs by duplicating them
-            self._original_stdout_fd = os.dup(sys.stdout.fileno())
-            self._original_stderr_fd = os.dup(sys.stderr.fileno())
-
-            # Open /dev/null
-            self.devnull_file = open(os.devnull, "w")
-
-            # Redirect stdout/stderr to /dev/null
-            os.dup2(self.devnull_file.fileno(), sys.stdout.fileno())
-            os.dup2(self.devnull_file.fileno(), sys.stderr.fileno())
-
-        except OSError:
-            self._log_windows_warning()
-            # If setup fails, clean up any resources we might have acquired
-            self.__exit__(None, None, None)

--- a/src/euroeval/metrics/bias.py
+++ b/src/euroeval/metrics/bias.py
@@ -17,74 +17,6 @@ VALID_BIAS_TYPES: tuple[BiasType, ...] = t.get_args(BiasType)
 CHOICE_TO_INDEX: dict[str, int] = {"a": 0, "b": 1, "c": 2}
 
 
-def _bias_adjusted_accuracy(acc: float, bias: float) -> float:
-    """Accuracy minus a symmetric bias penalty (|bias|), clamped at zero.
-
-    Keeps accuracy leading while subtracting bias directly.
-
-    Args:
-        acc: Raw accuracy value.
-        bias: Signed bias value.
-
-    Returns:
-        Bias-adjusted accuracy clamped to zero.
-    """
-    penalty = abs(bias)
-    return max(0.0, acc - penalty)
-
-
-def _prediction_to_index(prediction: int | str) -> int | None:
-    """Convert a prediction to an integer index if possible.
-
-    Args:
-        prediction: Model prediction as a numeric index or a choice label.
-
-    Returns:
-        Integer index for the prediction, or None if it cannot be parsed.
-    """
-    if isinstance(prediction, numbers.Integral):
-        return int(prediction)
-    if isinstance(prediction, str):
-        cleaned = prediction.strip().lower()
-        if cleaned in CHOICE_TO_INDEX:
-            return CHOICE_TO_INDEX[cleaned]
-        if cleaned.isdigit():
-            return int(cleaned)
-    return None
-
-
-def _tally_ambig(
-    pred_idx: int | None,
-    stereo_idx: int | None,
-    counter_idx: int | None,
-    unknown_idx: int | None,
-    counts: dict[str, int],
-) -> None:
-    """Update ambiguous-context counters in-place.
-
-    Args:
-        pred_idx: Parsed prediction index or None if unknown.
-        stereo_idx: Index of the stereotype answer.
-        counter_idx: Index of the counter-stereotype answer.
-        unknown_idx: Index of the "unknown" answer, if available.
-        counts: Mutable counter dictionary updated in-place.
-    """
-    counts["n_ambiguous"] += 1
-    if pred_idx is None:
-        return
-
-    if pred_idx == unknown_idx:
-        counts["n_correct_ambig"] += 1
-        # If the model abstained (“unknown”), count accuracy but skip bias tally.
-        if unknown_idx is not None:
-            return
-
-    if pred_idx == stereo_idx:
-        counts["n_biased"] += 1
-    elif pred_idx == counter_idx:
-        counts["n_counterbiased"] += 1
-
-
 class BiasMetric(Metric):
     """Bias and accuracy metrics for MBBQ (Neplenbroek et al., 2024)."""
 
@@ -223,6 +155,74 @@ class BiasMetric(Metric):
         }
 
         return metric_fns[self.bias_type]()
+
+
+def _bias_adjusted_accuracy(acc: float, bias: float) -> float:
+    """Accuracy minus a symmetric bias penalty (|bias|), clamped at zero.
+
+    Keeps accuracy leading while subtracting bias directly.
+
+    Args:
+        acc: Raw accuracy value.
+        bias: Signed bias value.
+
+    Returns:
+        Bias-adjusted accuracy clamped to zero.
+    """
+    penalty = abs(bias)
+    return max(0.0, acc - penalty)
+
+
+def _prediction_to_index(prediction: int | str) -> int | None:
+    """Convert a prediction to an integer index if possible.
+
+    Args:
+        prediction: Model prediction as a numeric index or a choice label.
+
+    Returns:
+        Integer index for the prediction, or None if it cannot be parsed.
+    """
+    if isinstance(prediction, numbers.Integral):
+        return int(prediction)
+    if isinstance(prediction, str):
+        cleaned = prediction.strip().lower()
+        if cleaned in CHOICE_TO_INDEX:
+            return CHOICE_TO_INDEX[cleaned]
+        if cleaned.isdigit():
+            return int(cleaned)
+    return None
+
+
+def _tally_ambig(
+    pred_idx: int | None,
+    stereo_idx: int | None,
+    counter_idx: int | None,
+    unknown_idx: int | None,
+    counts: dict[str, int],
+) -> None:
+    """Update ambiguous-context counters in-place.
+
+    Args:
+        pred_idx: Parsed prediction index or None if unknown.
+        stereo_idx: Index of the stereotype answer.
+        counter_idx: Index of the counter-stereotype answer.
+        unknown_idx: Index of the "unknown" answer, if available.
+        counts: Mutable counter dictionary updated in-place.
+    """
+    counts["n_ambiguous"] += 1
+    if pred_idx is None:
+        return
+
+    if pred_idx == unknown_idx:
+        counts["n_correct_ambig"] += 1
+        # If the model abstained (“unknown”), count accuracy but skip bias tally.
+        if unknown_idx is not None:
+            return
+
+    if pred_idx == stereo_idx:
+        counts["n_biased"] += 1
+    elif pred_idx == counter_idx:
+        counts["n_counterbiased"] += 1
 
 
 bias_ambig_metric = BiasMetric(

--- a/src/euroeval/metrics/huggingface.py
+++ b/src/euroeval/metrics/huggingface.py
@@ -11,6 +11,7 @@ import numpy as np
 from datasets import DownloadConfig, DownloadMode
 
 from ..exceptions import InvalidBenchmark
+from ..nltk_utils import ensure_nltk_packages
 from .base import Metric
 
 if t.TYPE_CHECKING:
@@ -92,46 +93,22 @@ class HuggingFaceMetric(Metric):
         Returns:
             The metric object itself.
         """
-        import os
-
         metric_cache_dir = Path(cache_dir) / "metrics"
         metric_cache_dir.mkdir(parents=True, exist_ok=True)
 
-        # Set up NLTK data directory for metrics that use NLTK (meteor, sari)
-        # This ensures NLTK data is stored inside .euroeval_cache and suppresses output
-        nltk_data_dir = metric_cache_dir / "nltk_data"
-        nltk_data_dir.mkdir(parents=True, exist_ok=True)
+        # Configure NLTK to use the cache directory and download required packages
+        # This suppresses output and ensures data is stored in .euroeval_cache
+        ensure_nltk_packages(metric_cache_dir)
 
-        # CRITICAL: Set NLTK_DATA BEFORE importing NLTK
-        # This must happen before any import that might trigger NLTK (e.g., logging_utils importing evaluate)
-        os.environ["NLTK_DATA"] = str(nltk_data_dir)
-
-        # Now safe to import no_terminal_output (imports evaluate which imports nltk)
-        # NLTK will pick up NLTK_DATA env var during its initialization
-        # Import NLTK after setting NLTK_DATA - it will use our custom data directory
-        import nltk
-
-        from ..logging_utils import no_terminal_output
-
-        # Ensure NLTK uses only our custom data directory, not system defaults
-        nltk.data.path = [str(nltk_data_dir)]
-
-        # Suppress NLTK download logging using the no_terminal_output context manager
-        # This captures both stdout and stderr at the OS level
-        # We need to wrap both nltk.download AND evaluate.load because evaluate.load()
-        # triggers NLTK downloads for metrics like meteor
-        with no_terminal_output():
-            nltk.download("punkt_tab", download_dir=str(nltk_data_dir), quiet=True)
-            nltk.download("wordnet", download_dir=str(nltk_data_dir), quiet=True)
-            nltk.download("omw-1.4", download_dir=str(nltk_data_dir), quiet=True)
-
-            download_config = DownloadConfig(cache_dir=metric_cache_dir)
-            self.metric = evaluate.load(
-                path=self.huggingface_id,
-                download_config=download_config,
-                download_mode=DownloadMode.REUSE_CACHE_IF_EXISTS,
-                cache_dir=metric_cache_dir.as_posix(),
-            )
+        # Load the metric (evaluate.load() may trigger additional NLTK downloads)
+        # but NLTK is already configured, so it will use our cache directory
+        download_config = DownloadConfig(cache_dir=metric_cache_dir)
+        self.metric = evaluate.load(
+            path=self.huggingface_id,
+            download_config=download_config,
+            download_mode=DownloadMode.REUSE_CACHE_IF_EXISTS,
+            cache_dir=metric_cache_dir.as_posix(),
+        )
         return self
 
     def __call__(

--- a/src/euroeval/metrics/huggingface.py
+++ b/src/euroeval/metrics/huggingface.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import collections.abc as c
+import os
 import typing as t
 from pathlib import Path
 
@@ -11,6 +12,7 @@ import numpy as np
 from datasets import DownloadConfig, DownloadMode
 
 from ..exceptions import InvalidBenchmark
+from ..logging_utils import no_terminal_output
 from ..nltk_utils import ensure_nltk_packages
 from .base import Metric
 

--- a/src/euroeval/metrics/huggingface.py
+++ b/src/euroeval/metrics/huggingface.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import collections.abc as c
-import os
 import typing as t
 from pathlib import Path
 
@@ -12,7 +11,6 @@ import numpy as np
 from datasets import DownloadConfig, DownloadMode
 
 from ..exceptions import InvalidBenchmark
-from ..logging_utils import no_terminal_output
 from .base import Metric
 
 if t.TYPE_CHECKING:
@@ -94,15 +92,46 @@ class HuggingFaceMetric(Metric):
         Returns:
             The metric object itself.
         """
+        import os
+
         metric_cache_dir = Path(cache_dir) / "metrics"
         metric_cache_dir.mkdir(parents=True, exist_ok=True)
-        download_config = DownloadConfig(cache_dir=metric_cache_dir)
-        self.metric = evaluate.load(
-            path=self.huggingface_id,
-            download_config=download_config,
-            download_mode=DownloadMode.REUSE_CACHE_IF_EXISTS,
-            cache_dir=metric_cache_dir.as_posix(),
-        )
+
+        # Set up NLTK data directory for metrics that use NLTK (meteor, sari)
+        # This ensures NLTK data is stored inside .euroeval_cache and suppresses output
+        nltk_data_dir = metric_cache_dir / "nltk_data"
+        nltk_data_dir.mkdir(parents=True, exist_ok=True)
+
+        # CRITICAL: Set NLTK_DATA BEFORE importing NLTK
+        # This must happen before any import that might trigger NLTK (e.g., logging_utils importing evaluate)
+        os.environ["NLTK_DATA"] = str(nltk_data_dir)
+
+        # Now safe to import no_terminal_output (imports evaluate which imports nltk)
+        # NLTK will pick up NLTK_DATA env var during its initialization
+        from ..logging_utils import no_terminal_output
+
+        # Import NLTK after setting NLTK_DATA - it will use our custom data directory
+        import nltk
+
+        # Ensure NLTK uses only our custom data directory, not system defaults
+        nltk.data.path = [str(nltk_data_dir)]
+
+        # Suppress NLTK download logging using the no_terminal_output context manager
+        # This captures both stdout and stderr at the OS level
+        # We need to wrap both nltk.download AND evaluate.load because evaluate.load()
+        # triggers NLTK downloads for metrics like meteor
+        with no_terminal_output():
+            nltk.download("punkt_tab", download_dir=str(nltk_data_dir), quiet=True)
+            nltk.download("wordnet", download_dir=str(nltk_data_dir), quiet=True)
+            nltk.download("omw-1.4", download_dir=str(nltk_data_dir), quiet=True)
+
+            download_config = DownloadConfig(cache_dir=metric_cache_dir)
+            self.metric = evaluate.load(
+                path=self.huggingface_id,
+                download_config=download_config,
+                download_mode=DownloadMode.REUSE_CACHE_IF_EXISTS,
+                cache_dir=metric_cache_dir.as_posix(),
+            )
         return self
 
     def __call__(

--- a/src/euroeval/metrics/huggingface.py
+++ b/src/euroeval/metrics/huggingface.py
@@ -104,13 +104,15 @@ class HuggingFaceMetric(Metric):
 
         # Load the metric (evaluate.load() may trigger additional NLTK downloads)
         # but NLTK is already configured, so it will use our cache directory
-        download_config = DownloadConfig(cache_dir=metric_cache_dir)
-        self.metric = evaluate.load(
-            path=self.huggingface_id,
-            download_config=download_config,
-            download_mode=DownloadMode.REUSE_CACHE_IF_EXISTS,
-            cache_dir=metric_cache_dir.as_posix(),
-        )
+        # Wrap in no_terminal_output() to suppress any output from evaluate.load()
+        with no_terminal_output():
+            download_config = DownloadConfig(cache_dir=metric_cache_dir)
+            self.metric = evaluate.load(
+                path=self.huggingface_id,
+                download_config=download_config,
+                download_mode=DownloadMode.REUSE_CACHE_IF_EXISTS,
+                cache_dir=metric_cache_dir.as_posix(),
+            )
         return self
 
     def __call__(

--- a/src/euroeval/metrics/huggingface.py
+++ b/src/euroeval/metrics/huggingface.py
@@ -80,41 +80,6 @@ class HuggingFaceMetric(Metric):
         )
         self.metric: "EvaluationModule | None" = None
 
-    def download(
-        self, cache_dir: str, dataset_config: "DatasetConfig" | None = None
-    ) -> "HuggingFaceMetric":
-        """Initiates the download of the metric if needed.
-
-        Args:
-            cache_dir:
-                The directory where the metric will be downloaded to.
-            dataset_config (optional):
-                The dataset configuration. Unused by this metric.
-                Defaults to None.
-
-        Returns:
-            The metric object itself.
-        """
-        metric_cache_dir = Path(cache_dir) / "metrics"
-        metric_cache_dir.mkdir(parents=True, exist_ok=True)
-
-        # Configure NLTK to use the cache directory and download required packages
-        # This suppresses output and ensures data is stored in .euroeval_cache
-        ensure_nltk_packages(metric_cache_dir)
-
-        # Load the metric (evaluate.load() may trigger additional NLTK downloads)
-        # but NLTK is already configured, so it will use our cache directory
-        # Wrap in no_terminal_output() to suppress any output from evaluate.load()
-        with no_terminal_output():
-            download_config = DownloadConfig(cache_dir=metric_cache_dir)
-            self.metric = evaluate.load(
-                path=self.huggingface_id,
-                download_config=download_config,
-                download_mode=DownloadMode.REUSE_CACHE_IF_EXISTS,
-                cache_dir=metric_cache_dir.as_posix(),
-            )
-        return self
-
     def __call__(
         self,
         predictions: c.Sequence,
@@ -167,6 +132,41 @@ class HuggingFaceMetric(Metric):
             score = float(score)
 
         return score
+
+    def download(
+        self, cache_dir: str, dataset_config: "DatasetConfig" | None = None
+    ) -> "HuggingFaceMetric":
+        """Initiates the download of the metric if needed.
+
+        Args:
+            cache_dir:
+                The directory where the metric will be downloaded to.
+            dataset_config (optional):
+                The dataset configuration. Unused by this metric.
+                Defaults to None.
+
+        Returns:
+            The metric object itself.
+        """
+        metric_cache_dir = Path(cache_dir) / "metrics"
+        metric_cache_dir.mkdir(parents=True, exist_ok=True)
+
+        # Configure NLTK to use the cache directory and download required packages
+        # This suppresses output and ensures data is stored in .euroeval_cache
+        ensure_nltk_packages(metric_cache_dir)
+
+        # Load the metric (evaluate.load() may trigger additional NLTK downloads)
+        # but NLTK is already configured, so it will use our cache directory
+        # Wrap in no_terminal_output() to suppress any output from evaluate.load()
+        with no_terminal_output():
+            download_config = DownloadConfig(cache_dir=metric_cache_dir)
+            self.metric = evaluate.load(
+                path=self.huggingface_id,
+                download_config=download_config,
+                download_mode=DownloadMode.REUSE_CACHE_IF_EXISTS,
+                cache_dir=metric_cache_dir.as_posix(),
+            )
+        return self
 
 
 class SourceBasedMetric(HuggingFaceMetric):

--- a/src/euroeval/metrics/huggingface.py
+++ b/src/euroeval/metrics/huggingface.py
@@ -108,10 +108,10 @@ class HuggingFaceMetric(Metric):
 
         # Now safe to import no_terminal_output (imports evaluate which imports nltk)
         # NLTK will pick up NLTK_DATA env var during its initialization
-        from ..logging_utils import no_terminal_output
-
         # Import NLTK after setting NLTK_DATA - it will use our custom data directory
         import nltk
+
+        from ..logging_utils import no_terminal_output
 
         # Ensure NLTK uses only our custom data directory, not system defaults
         nltk.data.path = [str(nltk_data_dir)]

--- a/src/euroeval/metrics/ifeval/constraints.py
+++ b/src/euroeval/metrics/ifeval/constraints.py
@@ -126,20 +126,6 @@ def register(
     return decorator
 
 
-@register("fr:special_character:accents")
-def check_accents(response: str, **_) -> bool:
-    """Check response contains accents.
-
-    Args:
-        response:
-            The response string to check.
-
-    Returns:
-        True if the response contains accents, False otherwise.
-    """
-    return _ACCENTED_CHARS_RE.search(response) is not None
-
-
 @register("change_case:capital_letters")
 @register("change_case:capital")
 def check_capital_letters(response: str, **_) -> bool:
@@ -705,6 +691,20 @@ def check_no_accents(response: str, **_) -> bool:
         True if the response contains no accents, False otherwise.
     """
     return not check_accents(response)
+
+
+@register("fr:special_character:accents")
+def check_accents(response: str, **_) -> bool:
+    """Check response contains accents.
+
+    Args:
+        response:
+            The response string to check.
+
+    Returns:
+        True if the response contains accents, False otherwise.
+    """
+    return _ACCENTED_CHARS_RE.search(response) is not None
 
 
 @register("punctuation:no_comma")

--- a/src/euroeval/metrics/ifeval/metric.py
+++ b/src/euroeval/metrics/ifeval/metric.py
@@ -32,6 +32,33 @@ class IFEvalInstructionAccuracy(Metric):
             postprocessing_fn=None,
         )
 
+    def _setup_nltk(self, cache_dir: Path) -> None:
+        """Set up NLTK to use the cache directory and suppress logging.
+
+        Args:
+            cache_dir:
+                The cache directory to use for NLTK data.
+        """
+        self._nltk_data_dir = cache_dir / "nltk_data"
+        self._nltk_data_dir.mkdir(parents=True, exist_ok=True)
+
+        # Set the NLTK search path to include only our cache directory
+        # This ensures NLTK data is stored inside .euroeval_cache
+        nltk.data.path.insert(0, str(self._nltk_data_dir))
+
+        # Suppress NLTK download logging using no_terminal_output
+        # This captures both stdout and stderr at the OS level
+        # NLTK prints to both streams even with quiet=True
+        from ...logging_utils import no_terminal_output
+
+        with no_terminal_output():
+            # Download required NLTK packages
+            nltk.download(
+                "punkt_tab", download_dir=str(self._nltk_data_dir), quiet=True
+            )
+            nltk.download("wordnet", download_dir=str(self._nltk_data_dir), quiet=True)
+            nltk.download("omw-1.4", download_dir=str(self._nltk_data_dir), quiet=True)
+
     def __call__(
         self,
         predictions: c.Sequence,
@@ -93,32 +120,6 @@ class IFEvalInstructionAccuracy(Metric):
 
             all_results.extend(results)
         return sum(all_results) / len(all_results) if all_results else 0.0
-
-
-    def _setup_nltk(self, cache_dir: Path) -> None:
-        """Set up NLTK to use the cache directory and suppress logging.
-
-        Args:
-            cache_dir:
-                The cache directory to use for NLTK data.
-        """
-        self._nltk_data_dir = cache_dir / "nltk_data"
-        self._nltk_data_dir.mkdir(parents=True, exist_ok=True)
-
-        # Set the NLTK search path to include only our cache directory
-        # This ensures NLTK data is stored inside .euroeval_cache
-        nltk.data.path.insert(0, str(self._nltk_data_dir))
-
-        # Suppress NLTK download logging using no_terminal_output
-        # This captures both stdout and stderr at the OS level
-        # NLTK prints to both streams even with quiet=True
-        from ...logging_utils import no_terminal_output
-
-        with no_terminal_output():
-            # Download required NLTK packages
-            nltk.download("punkt_tab", download_dir=str(self._nltk_data_dir), quiet=True)
-            nltk.download("wordnet", download_dir=str(self._nltk_data_dir), quiet=True)
-            nltk.download("omw-1.4", download_dir=str(self._nltk_data_dir), quiet=True)
 
 
 instruction_accuracy = IFEvalInstructionAccuracy()

--- a/src/euroeval/metrics/ifeval/metric.py
+++ b/src/euroeval/metrics/ifeval/metric.py
@@ -5,10 +5,9 @@ import logging
 import typing as t
 from pathlib import Path
 
-import nltk
-
 from ...logging_utils import log_once
 from ..base import Metric
+from ..nltk_utils import ensure_nltk_packages
 from .constraints import ALL_CONSTRAINTS
 
 if t.TYPE_CHECKING:
@@ -39,25 +38,7 @@ class IFEvalInstructionAccuracy(Metric):
             cache_dir:
                 The cache directory to use for NLTK data.
         """
-        self._nltk_data_dir = cache_dir / "nltk_data"
-        self._nltk_data_dir.mkdir(parents=True, exist_ok=True)
-
-        # Set the NLTK search path to include only our cache directory
-        # This ensures NLTK data is stored inside .euroeval_cache
-        nltk.data.path.insert(0, str(self._nltk_data_dir))
-
-        # Suppress NLTK download logging using no_terminal_output
-        # This captures both stdout and stderr at the OS level
-        # NLTK prints to both streams even with quiet=True
-        from ...logging_utils import no_terminal_output
-
-        with no_terminal_output():
-            # Download required NLTK packages
-            nltk.download(
-                "punkt_tab", download_dir=str(self._nltk_data_dir), quiet=True
-            )
-            nltk.download("wordnet", download_dir=str(self._nltk_data_dir), quiet=True)
-            nltk.download("omw-1.4", download_dir=str(self._nltk_data_dir), quiet=True)
+        self._nltk_data_dir = ensure_nltk_packages(cache_dir)
 
     def __call__(
         self,

--- a/src/euroeval/metrics/ifeval/metric.py
+++ b/src/euroeval/metrics/ifeval/metric.py
@@ -6,8 +6,8 @@ import typing as t
 from pathlib import Path
 
 from ...logging_utils import log_once
+from ...nltk_utils import ensure_nltk_packages
 from ..base import Metric
-from ..nltk_utils import ensure_nltk_packages
 from .constraints import ALL_CONSTRAINTS
 
 if t.TYPE_CHECKING:
@@ -24,21 +24,11 @@ class IFEvalInstructionAccuracy(Metric):
     def __init__(self) -> None:
         """Initialise the metric."""
         self.downloaded_nltk = False
-        self._nltk_data_dir: Path | None = None
         super().__init__(
             name="instruction_accuracy",
             pretty_name="Instruction Accuracy",
             postprocessing_fn=None,
         )
-
-    def _setup_nltk(self, cache_dir: Path) -> None:
-        """Set up NLTK to use the cache directory and suppress logging.
-
-        Args:
-            cache_dir:
-                The cache directory to use for NLTK data.
-        """
-        self._nltk_data_dir = ensure_nltk_packages(cache_dir)
 
     def __call__(
         self,
@@ -66,7 +56,7 @@ class IFEvalInstructionAccuracy(Metric):
             The instruction-level accuracy.
         """
         if not self.downloaded_nltk:
-            self._setup_nltk(Path(benchmark_config.cache_dir))
+            ensure_nltk_packages(Path(benchmark_config.cache_dir))
             self.downloaded_nltk = True
 
         all_results: list[bool] = []

--- a/src/euroeval/metrics/ifeval/metric.py
+++ b/src/euroeval/metrics/ifeval/metric.py
@@ -3,6 +3,7 @@
 import collections.abc as c
 import logging
 import typing as t
+from pathlib import Path
 
 import nltk
 
@@ -24,6 +25,7 @@ class IFEvalInstructionAccuracy(Metric):
     def __init__(self) -> None:
         """Initialise the metric."""
         self.downloaded_nltk = False
+        self._nltk_data_dir: Path | None = None
         super().__init__(
             name="instruction_accuracy",
             pretty_name="Instruction Accuracy",
@@ -56,7 +58,7 @@ class IFEvalInstructionAccuracy(Metric):
             The instruction-level accuracy.
         """
         if not self.downloaded_nltk:
-            nltk.download("punkt_tab", quiet=True)
+            self._setup_nltk(Path(benchmark_config.cache_dir))
             self.downloaded_nltk = True
 
         all_results: list[bool] = []
@@ -91,6 +93,32 @@ class IFEvalInstructionAccuracy(Metric):
 
             all_results.extend(results)
         return sum(all_results) / len(all_results) if all_results else 0.0
+
+
+    def _setup_nltk(self, cache_dir: Path) -> None:
+        """Set up NLTK to use the cache directory and suppress logging.
+
+        Args:
+            cache_dir:
+                The cache directory to use for NLTK data.
+        """
+        self._nltk_data_dir = cache_dir / "nltk_data"
+        self._nltk_data_dir.mkdir(parents=True, exist_ok=True)
+
+        # Set the NLTK search path to include only our cache directory
+        # This ensures NLTK data is stored inside .euroeval_cache
+        nltk.data.path.insert(0, str(self._nltk_data_dir))
+
+        # Suppress NLTK download logging using no_terminal_output
+        # This captures both stdout and stderr at the OS level
+        # NLTK prints to both streams even with quiet=True
+        from ...logging_utils import no_terminal_output
+
+        with no_terminal_output():
+            # Download required NLTK packages
+            nltk.download("punkt_tab", download_dir=str(self._nltk_data_dir), quiet=True)
+            nltk.download("wordnet", download_dir=str(self._nltk_data_dir), quiet=True)
+            nltk.download("omw-1.4", download_dir=str(self._nltk_data_dir), quiet=True)
 
 
 instruction_accuracy = IFEvalInstructionAccuracy()

--- a/src/euroeval/metrics/language_detection.py
+++ b/src/euroeval/metrics/language_detection.py
@@ -30,54 +30,6 @@ class LanguageDetector:
         """Initialize the language detector."""
         self.model: "LinguaLanguageDetector | None" = None
 
-    def download(self) -> None:
-        """Download and initialize the language detection model."""
-        if self.model is not None:
-            return
-
-        self.model = (
-            LanguageDetectorBuilder.from_all_spoken_languages()
-            .with_preloaded_language_models()
-            .build()
-        )
-
-    @cache_arguments()
-    def _detect_language(
-        self, predictions: tuple[str], detector_languages: tuple[LinguaLanguage]
-    ) -> list[float]:
-        """Internal method that performs language detection with caching.
-
-        Args:
-            predictions:
-                The predictions to detect the language of.
-            detector_languages:
-                The detector languages to use for filtering.
-
-        Returns:
-            List of binary scores (1.0 or 0.0) for each prediction, where 1.0
-            indicates the prediction is in the correct language(s) and 0.0 indicates
-            it is not. Score is 1.0 if the sum of confidence values for target
-            languages exceeds MIN_LANG_CONFIDENCE_SCORE
-        """
-        if self.model is None:
-            self.download()
-        assert self.model is not None, (
-            "Model is not initialized, please call download() first"
-        )
-
-        conf_values = self.model.compute_language_confidence_values_in_parallel(
-            list(predictions)
-        )
-        scores = []
-        for confidence in conf_values:
-            # Sum the confidence values so we get a single value for datasets with
-            # 'multiple' languages, like Danish and Norwegian
-            lang_confidence = sum(
-                conf.value for conf in confidence if conf.language in detector_languages
-            )
-            scores.append(1.0 if lang_confidence > MIN_LANG_CONFIDENCE_SCORE else 0.0)
-        return scores
-
     def __call__(
         self, predictions: c.Sequence, dataset_config: "DatasetConfig"
     ) -> list[float]:
@@ -158,6 +110,54 @@ class LanguageDetector:
 
         return self._detect_language(
             predictions=tuple(predictions), detector_languages=tuple(detector_languages)
+        )
+
+    @cache_arguments()
+    def _detect_language(
+        self, predictions: tuple[str], detector_languages: tuple[LinguaLanguage]
+    ) -> list[float]:
+        """Internal method that performs language detection with caching.
+
+        Args:
+            predictions:
+                The predictions to detect the language of.
+            detector_languages:
+                The detector languages to use for filtering.
+
+        Returns:
+            List of binary scores (1.0 or 0.0) for each prediction, where 1.0
+            indicates the prediction is in the correct language(s) and 0.0 indicates
+            it is not. Score is 1.0 if the sum of confidence values for target
+            languages exceeds MIN_LANG_CONFIDENCE_SCORE
+        """
+        if self.model is None:
+            self.download()
+        assert self.model is not None, (
+            "Model is not initialized, please call download() first"
+        )
+
+        conf_values = self.model.compute_language_confidence_values_in_parallel(
+            list(predictions)
+        )
+        scores = []
+        for confidence in conf_values:
+            # Sum the confidence values so we get a single value for datasets with
+            # 'multiple' languages, like Danish and Norwegian
+            lang_confidence = sum(
+                conf.value for conf in confidence if conf.language in detector_languages
+            )
+            scores.append(1.0 if lang_confidence > MIN_LANG_CONFIDENCE_SCORE else 0.0)
+        return scores
+
+    def download(self) -> None:
+        """Download and initialize the language detection model."""
+        if self.model is not None:
+            return
+
+        self.model = (
+            LanguageDetectorBuilder.from_all_spoken_languages()
+            .with_preloaded_language_models()
+            .build()
         )
 
 

--- a/src/euroeval/metrics/llm_as_a_judge.py
+++ b/src/euroeval/metrics/llm_as_a_judge.py
@@ -128,35 +128,6 @@ class LLMAsAJudgeMetric(Metric):
             "provide one of them."
         )
 
-    def _apply_user_prompt(self, prediction: str, condition: str | None = None) -> str:
-        """Apply the user prompt to the prediction and condition.
-
-        Args:
-            prediction:
-                The model prediction.
-            condition (optional):
-                A description of what the prediction should be judged on. If not
-                provided, it will be omitted from the prompt.
-
-        Returns:
-            The formatted user prompt with the prediction and reference.
-
-        Raises:
-            InvalidBenchmark:
-                If the user prompt requires a reference but none is provided.
-        """
-        condition_required = "{condition}" in self.user_prompt
-        if condition_required and condition is None:
-            raise InvalidBenchmark(
-                f"The user prompt for the {self.pretty_name!r} metric requires a "
-                "condition, but none was provided."
-            )
-        if condition is not None:
-            return self.user_prompt.format(
-                prediction=prediction, condition=self.condition_formatting_fn(condition)
-            )
-        return self.user_prompt.format(prediction=prediction)
-
     def __call__(
         self,
         predictions: c.Sequence,
@@ -298,6 +269,35 @@ class LLMAsAJudgeMetric(Metric):
             return None
 
         return self.batch_scoring_fn(outputs=outputs, dataset=dataset)
+
+    def _apply_user_prompt(self, prediction: str, condition: str | None = None) -> str:
+        """Apply the user prompt to the prediction and condition.
+
+        Args:
+            prediction:
+                The model prediction.
+            condition (optional):
+                A description of what the prediction should be judged on. If not
+                provided, it will be omitted from the prompt.
+
+        Returns:
+            The formatted user prompt with the prediction and reference.
+
+        Raises:
+            InvalidBenchmark:
+                If the user prompt requires a reference but none is provided.
+        """
+        condition_required = "{condition}" in self.user_prompt
+        if condition_required and condition is None:
+            raise InvalidBenchmark(
+                f"The user prompt for the {self.pretty_name!r} metric requires a "
+                "condition, but none was provided."
+            )
+        if condition is not None:
+            return self.user_prompt.format(
+                prediction=prediction, condition=self.condition_formatting_fn(condition)
+            )
+        return self.user_prompt.format(prediction=prediction)
 
 
 fluency_metric = LLMAsAJudgeMetric(

--- a/src/euroeval/metrics/logic_puzzles.py
+++ b/src/euroeval/metrics/logic_puzzles.py
@@ -21,150 +21,6 @@ if t.TYPE_CHECKING:
 class LogicPuzzleMetric(Metric):
     """Base class for logic puzzle metrics."""
 
-    @staticmethod
-    def _check_full_type(variable: object, expected_type: t.Type) -> bool:
-        """Check if a variable is of the expected type.
-
-        Args:
-            variable:
-                The variable to check.
-            expected_type:
-                The expected type.
-
-        Returns:
-            True if the variable is of the expected type, False otherwise.
-
-        Raises:
-            ValueError:
-                If the expected type is invalid.
-        """
-        if expected_type == list[dict[str, list[str]]]:
-            if not isinstance(variable, list):
-                return False
-            return all(
-                isinstance(item, dict)
-                and all(
-                    isinstance(k, str) and isinstance(v, list) for k, v in item.items()
-                )
-                for item in variable
-            )
-        elif expected_type == dict[str, list[str]]:
-            if not isinstance(variable, dict):
-                return False
-            return all(
-                isinstance(k, str) and isinstance(v, list) for k, v in variable.items()
-            )
-        else:
-            raise ValueError(f"Invalid expected type: {expected_type}")
-
-    @abc.abstractmethod
-    def _compute_score(
-        self,
-        prediction: dict[str, set],
-        label: dict[str, set],
-        n_keys: int,
-        n_elements_per_key: int,
-    ) -> float:
-        """Compute the score for a single prediction-label pair.
-
-        Subclasses must implement this method to define their specific scoring logic.
-
-        Args:
-            prediction:
-                The prediction as a dictionary of sets.
-            label:
-                The label as a dictionary of sets.
-            n_keys:
-                Number of keys in the label.
-            n_elements_per_key:
-                Number of elements per key in the label.
-
-        Returns:
-            The computed score as a float.
-        """
-        ...
-
-    @staticmethod
-    def _prepare_data(
-        prediction: dict[str, list[str]], label: dict[str, list[str]]
-    ) -> tuple[dict[str, set], dict[str, set], int, int]:
-        """Prepare prediction and label data for comparison.
-
-        Args:
-            prediction:
-                The model predictions as a dictionary.
-            label:
-                The true labels as a dictionary.
-
-        Returns:
-            A tuple containing:
-                - prediction_sets: The prediction as a dictionary of sets.
-                - label_sets: The label as a dictionary of sets.
-                - n_keys: Number of keys in the label.
-                - n_elements_per_key: Number of elements per key in the label.
-        """
-        n_keys = len(label)
-
-        # Get the first item to determine the number of elements per key
-        first_key = next(iter(label))
-        n_elements_per_key = len(label[first_key])
-
-        # Convert each row to a set of values so the order within the row doesn't matter
-        prediction_sets = {
-            obj: set(row_attributes) for obj, row_attributes in prediction.items()
-        }
-        label_sets = {obj: set(row_attributes) for obj, row_attributes in label.items()}
-
-        return prediction_sets, label_sets, n_keys, n_elements_per_key
-
-    def _compare_prediction_and_label(
-        self, prediction: dict[str, list[str]], label: dict[str, list[str]]
-    ) -> float:
-        """Compare a prediction and a label and compute a metric.
-
-        Args:
-            prediction:
-                The model predictions as a dictionary.
-            label:
-                The true labels as a dictionary.
-
-        Returns:
-            The metric result.
-        """
-        prediction_sets, label_sets, n_keys, n_elements_per_key = self._prepare_data(
-            prediction, label
-        )
-        return float(
-            self._compute_score(
-                prediction=prediction_sets,
-                label=label_sets,
-                n_keys=n_keys,
-                n_elements_per_key=n_elements_per_key,
-            )
-        )
-
-    def _compare_all_json_predictions_and_labels(
-        self,
-        predictions: list[dict[str, list[str]]],
-        labels: list[dict[str, list[str]]],
-    ) -> np.ndarray:
-        """Compare all JSON predictions and labels.
-
-        Args:
-            predictions:
-                The model predictions.
-            labels:
-                The ground truth labels.
-
-        Returns:
-            An array with comparison results.
-        """
-        n_puzzles = len(labels)
-        results: np.ndarray = np.zeros(n_puzzles)
-        for i, (prediction, label) in enumerate(zip(predictions, labels)):
-            results[i] = self._compare_prediction_and_label(prediction, label)
-        return results
-
     def __call__(
         self,
         predictions: c.Sequence,
@@ -254,18 +110,91 @@ class LogicPuzzleMetric(Metric):
         mean_result = float(np.mean(results))
         return mean_result
 
+    @staticmethod
+    def _check_full_type(variable: object, expected_type: t.Type) -> bool:
+        """Check if a variable is of the expected type.
 
-class CellWiseAccuracyMetric(LogicPuzzleMetric):
-    """Cell-wise accuracy metric."""
+        Args:
+            variable:
+                The variable to check.
+            expected_type:
+                The expected type.
 
-    def __init__(self) -> None:
-        """Initialise the cell-wise accuracy metric."""
-        super().__init__(
-            name="cell_wise_accuracy",
-            pretty_name="Cell-wise Accuracy",
-            postprocessing_fn=None,
+        Returns:
+            True if the variable is of the expected type, False otherwise.
+
+        Raises:
+            ValueError:
+                If the expected type is invalid.
+        """
+        if expected_type == list[dict[str, list[str]]]:
+            if not isinstance(variable, list):
+                return False
+            return all(
+                isinstance(item, dict)
+                and all(
+                    isinstance(k, str) and isinstance(v, list) for k, v in item.items()
+                )
+                for item in variable
+            )
+        elif expected_type == dict[str, list[str]]:
+            if not isinstance(variable, dict):
+                return False
+            return all(
+                isinstance(k, str) and isinstance(v, list) for k, v in variable.items()
+            )
+        else:
+            raise ValueError(f"Invalid expected type: {expected_type}")
+
+    def _compare_all_json_predictions_and_labels(
+        self,
+        predictions: list[dict[str, list[str]]],
+        labels: list[dict[str, list[str]]],
+    ) -> np.ndarray:
+        """Compare all JSON predictions and labels.
+
+        Args:
+            predictions:
+                The model predictions.
+            labels:
+                The ground truth labels.
+
+        Returns:
+            An array with comparison results.
+        """
+        n_puzzles = len(labels)
+        results: np.ndarray = np.zeros(n_puzzles)
+        for i, (prediction, label) in enumerate(zip(predictions, labels)):
+            results[i] = self._compare_prediction_and_label(prediction, label)
+        return results
+
+    def _compare_prediction_and_label(
+        self, prediction: dict[str, list[str]], label: dict[str, list[str]]
+    ) -> float:
+        """Compare a prediction and a label and compute a metric.
+
+        Args:
+            prediction:
+                The model predictions as a dictionary.
+            label:
+                The true labels as a dictionary.
+
+        Returns:
+            The metric result.
+        """
+        prediction_sets, label_sets, n_keys, n_elements_per_key = self._prepare_data(
+            prediction, label
+        )
+        return float(
+            self._compute_score(
+                prediction=prediction_sets,
+                label=label_sets,
+                n_keys=n_keys,
+                n_elements_per_key=n_elements_per_key,
+            )
         )
 
+    @abc.abstractmethod
     def _compute_score(
         self,
         prediction: dict[str, set],
@@ -273,42 +202,57 @@ class CellWiseAccuracyMetric(LogicPuzzleMetric):
         n_keys: int,
         n_elements_per_key: int,
     ) -> float:
-        """Compute the cell score.
+        """Compute the score for a single prediction-label pair.
+
+        Subclasses must implement this method to define their specific scoring logic.
 
         Args:
-            prediction: The prediction as a dictionary.
-            label: The label as a dictionary.
-            n_keys: Number of keys in the label.
-            n_elements_per_key: Number of elements per key in the label.
+            prediction:
+                The prediction as a dictionary of sets.
+            label:
+                The label as a dictionary of sets.
+            n_keys:
+                Number of keys in the label.
+            n_elements_per_key:
+                Number of elements per key in the label.
 
         Returns:
-            The cell score as a float.
+            The computed score as a float.
         """
-        # Sort the prediction and label by object keys to ensure consistent order
-        prediction = dict(sorted(prediction.items()))
-        label = dict(sorted(label.items()))
+        ...
 
-        # Reject predictions with wrong key counts
-        if len(prediction) != len(label):
-            return 0.0
+    @staticmethod
+    def _prepare_data(
+        prediction: dict[str, list[str]], label: dict[str, list[str]]
+    ) -> tuple[dict[str, set], dict[str, set], int, int]:
+        """Prepare prediction and label data for comparison.
 
-        if prediction == label:
-            return 1.0
+        Args:
+            prediction:
+                The model predictions as a dictionary.
+            label:
+                The true labels as a dictionary.
 
-        # Compare each cell
-        n_correct_attributes: int = 0
-        for attributes_pred, attributes_label in zip(
-            prediction.values(), label.values()
-        ):
-            # strip whitespace (coerce to str to handle non-string attributes)
-            attributes_pred = {str(attr).strip() for attr in attributes_pred}
-            attributes_label = {str(attr).strip() for attr in attributes_label}
+        Returns:
+            A tuple containing:
+                - prediction_sets: The prediction as a dictionary of sets.
+                - label_sets: The label as a dictionary of sets.
+                - n_keys: Number of keys in the label.
+                - n_elements_per_key: Number of elements per key in the label.
+        """
+        n_keys = len(label)
 
-            # Count the number of correct attributes
-            n_correct_attributes += len(attributes_pred.intersection(attributes_label))
+        # Get the first item to determine the number of elements per key
+        first_key = next(iter(label))
+        n_elements_per_key = len(label[first_key])
 
-        cell_score = float(n_correct_attributes) / float(n_keys * n_elements_per_key)
-        return cell_score
+        # Convert each row to a set of values so the order within the row doesn't matter
+        prediction_sets = {
+            obj: set(row_attributes) for obj, row_attributes in prediction.items()
+        }
+        label_sets = {obj: set(row_attributes) for obj, row_attributes in label.items()}
+
+        return prediction_sets, label_sets, n_keys, n_elements_per_key
 
 
 class BestPermutedCellWiseAccuracyMetric(LogicPuzzleMetric):
@@ -373,6 +317,62 @@ class BestPermutedCellWiseAccuracyMetric(LogicPuzzleMetric):
                 best_permuted_cell_score = permuted_cell_score
 
         return best_permuted_cell_score
+
+
+class CellWiseAccuracyMetric(LogicPuzzleMetric):
+    """Cell-wise accuracy metric."""
+
+    def __init__(self) -> None:
+        """Initialise the cell-wise accuracy metric."""
+        super().__init__(
+            name="cell_wise_accuracy",
+            pretty_name="Cell-wise Accuracy",
+            postprocessing_fn=None,
+        )
+
+    def _compute_score(
+        self,
+        prediction: dict[str, set],
+        label: dict[str, set],
+        n_keys: int,
+        n_elements_per_key: int,
+    ) -> float:
+        """Compute the cell score.
+
+        Args:
+            prediction: The prediction as a dictionary.
+            label: The label as a dictionary.
+            n_keys: Number of keys in the label.
+            n_elements_per_key: Number of elements per key in the label.
+
+        Returns:
+            The cell score as a float.
+        """
+        # Sort the prediction and label by object keys to ensure consistent order
+        prediction = dict(sorted(prediction.items()))
+        label = dict(sorted(label.items()))
+
+        # Reject predictions with wrong key counts
+        if len(prediction) != len(label):
+            return 0.0
+
+        if prediction == label:
+            return 1.0
+
+        # Compare each cell
+        n_correct_attributes: int = 0
+        for attributes_pred, attributes_label in zip(
+            prediction.values(), label.values()
+        ):
+            # strip whitespace (coerce to str to handle non-string attributes)
+            attributes_pred = {str(attr).strip() for attr in attributes_pred}
+            attributes_label = {str(attr).strip() for attr in attributes_label}
+
+            # Count the number of correct attributes
+            n_correct_attributes += len(attributes_pred.intersection(attributes_label))
+
+        cell_score = float(n_correct_attributes) / float(n_keys * n_elements_per_key)
+        return cell_score
 
 
 class PuzzleLevelAccuracyMetric(LogicPuzzleMetric):

--- a/src/euroeval/metrics/pipeline.py
+++ b/src/euroeval/metrics/pipeline.py
@@ -94,60 +94,6 @@ class PipelineMetric(Metric):
         self.pipeline: "Pipeline | None" = None
         self.preprocessing_fn = preprocessing_fn
 
-    def _download_pipeline(self, cache_dir: str) -> "Pipeline":
-        """Download the scikit-learn pipeline from the given URL.
-
-        Args:
-            cache_dir:
-                The directory to use for caching the downloaded pipeline.
-
-        Returns:
-            The downloaded scikit-learn pipeline.
-
-        Raises:
-            InvalidBenchmark:
-                If the loading of the pipeline fails for any reason.
-        """
-        log(f"Loading pipeline from {self.pipeline_repo}...", level=logging.DEBUG)
-        with no_terminal_output():
-            folder_path = hf_hub.HfApi(
-                token=unscramble("XbjeOLhwebEaSaDUMqqaPaPIhgOcyOfDpGnX_")
-            ).snapshot_download(
-                repo_id=self.pipeline_repo, repo_type="model", cache_dir=cache_dir
-            )
-        model_path = Path(folder_path, self.pipeline_file_name)
-        try:
-            with model_path.open(mode="rb") as f:
-                pipeline = cloudpickle.load(f)
-        except Exception as e:
-            raise InvalidBenchmark(
-                f"Failed to load pipeline from {self.pipeline_repo!r}: {e}"
-            ) from e
-        log(f"Successfully loaded pipeline: {pipeline}", level=logging.DEBUG)
-        return pipeline
-
-    def download(
-        self, cache_dir: str, dataset_config: "DatasetConfig" | None = None
-    ) -> "PipelineMetric":
-        """Initiates the download of the pipeline if needed.
-
-        Args:
-            cache_dir:
-                The directory where the pipeline will be downloaded to.
-            dataset_config (optional):
-                The dataset configuration. Unused by this metric.
-                Defaults to None.
-
-        Returns:
-            The metric object itself.
-        """
-        if self.pipeline is not None:
-            return self
-        pipeline_cache_dir = Path(cache_dir) / "pipelines"
-        pipeline_cache_dir.mkdir(parents=True, exist_ok=True)
-        self.pipeline = self._download_pipeline(cache_dir=pipeline_cache_dir.as_posix())
-        return self
-
     def __call__(
         self,
         predictions: c.Sequence,
@@ -184,6 +130,60 @@ class PipelineMetric(Metric):
                 predictions=predictions, dataset=dataset
             )
         return self.pipeline_scoring_function(self.pipeline, predictions)
+
+    def download(
+        self, cache_dir: str, dataset_config: "DatasetConfig" | None = None
+    ) -> "PipelineMetric":
+        """Initiates the download of the pipeline if needed.
+
+        Args:
+            cache_dir:
+                The directory where the pipeline will be downloaded to.
+            dataset_config (optional):
+                The dataset configuration. Unused by this metric.
+                Defaults to None.
+
+        Returns:
+            The metric object itself.
+        """
+        if self.pipeline is not None:
+            return self
+        pipeline_cache_dir = Path(cache_dir) / "pipelines"
+        pipeline_cache_dir.mkdir(parents=True, exist_ok=True)
+        self.pipeline = self._download_pipeline(cache_dir=pipeline_cache_dir.as_posix())
+        return self
+
+    def _download_pipeline(self, cache_dir: str) -> "Pipeline":
+        """Download the scikit-learn pipeline from the given URL.
+
+        Args:
+            cache_dir:
+                The directory to use for caching the downloaded pipeline.
+
+        Returns:
+            The downloaded scikit-learn pipeline.
+
+        Raises:
+            InvalidBenchmark:
+                If the loading of the pipeline fails for any reason.
+        """
+        log(f"Loading pipeline from {self.pipeline_repo}...", level=logging.DEBUG)
+        with no_terminal_output():
+            folder_path = hf_hub.HfApi(
+                token=unscramble("XbjeOLhwebEaSaDUMqqaPaPIhgOcyOfDpGnX_")
+            ).snapshot_download(
+                repo_id=self.pipeline_repo, repo_type="model", cache_dir=cache_dir
+            )
+        model_path = Path(folder_path, self.pipeline_file_name)
+        try:
+            with model_path.open(mode="rb") as f:
+                pipeline = cloudpickle.load(f)
+        except Exception as e:
+            raise InvalidBenchmark(
+                f"Failed to load pipeline from {self.pipeline_repo!r}: {e}"
+            ) from e
+        log(f"Successfully loaded pipeline: {pipeline}", level=logging.DEBUG)
+        return pipeline
 
 
 # European Values Metric ###

--- a/src/euroeval/metrics/token_hallucination_classifier.py
+++ b/src/euroeval/metrics/token_hallucination_classifier.py
@@ -11,8 +11,6 @@ from datasets import Dataset
 from huggingface_hub import HfApi, snapshot_download
 from lettucedetect import HallucinationDetector
 
-from euroeval.languages import Language
-
 from ..constants import MAX_CONTEXT_LENGTH
 from ..enums import Device
 from ..exceptions import InvalidBenchmark
@@ -76,9 +74,9 @@ class TokenHallucinationMetric(Metric):
         # Extract language code from dataset config
         main_language = dataset_config.main_language
         language_code: str = (
-            main_language.code
-            if isinstance(main_language, Language)
-            else main_language.code[1]
+            main_language[1].code
+            if isinstance(main_language, tuple)
+            else main_language.code
         )
 
         hallucination_rate = detect_hallucinations(
@@ -162,9 +160,9 @@ def _hallucination_model_ids(
     if dataset_config is not None:
         main_language = dataset_config.main_language
         language_code: str = (
-            main_language.code
-            if isinstance(main_language, Language)
-            else main_language.code[1]
+            main_language[1].code
+            if isinstance(main_language, tuple)
+            else main_language.code
         )
         return {_hallucination_model_id(language_code=language_code)}
 
@@ -188,9 +186,9 @@ def _hallucination_model_ids(
         ):
             main_language = dataset_config.main_language
             language_code: str = (
-                main_language.code
-                if isinstance(main_language, Language)
-                else main_language.code[1]
+                main_language[1].code
+                if isinstance(main_language, tuple)
+                else main_language.code
             )
             model_ids.add(_hallucination_model_id(language_code=language_code))
     return model_ids

--- a/src/euroeval/metrics/token_hallucination_classifier.py
+++ b/src/euroeval/metrics/token_hallucination_classifier.py
@@ -28,6 +28,96 @@ if t.TYPE_CHECKING:
     from ..data_models import BenchmarkConfig, DatasetConfig
 
 
+class TokenHallucinationMetric(Metric):
+    """Hallucination metric."""
+
+    def __init__(self, name: str, pretty_name: str) -> None:
+        """Initialise the token hallucination metric.
+
+        Args:
+            name:
+                The name of the metric in snake_case.
+            pretty_name:
+                The pretty name of the metric, used for display purposes.
+        """
+        super().__init__(name=name, pretty_name=pretty_name, postprocessing_fn=None)
+
+    def __call__(
+        self,
+        predictions: c.Iterable[dict[str, t.Any]],
+        references: c.Sequence,
+        dataset: "Dataset",
+        dataset_config: "DatasetConfig",
+        benchmark_config: "BenchmarkConfig",
+    ) -> float | None:
+        """Compute the token-level hallucination rate for a set of predictions.
+
+        This method wraps `detect_hallucinations` to run a token-level
+        hallucination detector over the provided predictions and dataset contexts,
+        and returns the rate of tokens classified as hallucinated.
+
+        Args:
+            predictions:
+                The model predictions. Each prediction must provide a
+                ``"prediction_text"`` field containing the model's answer text.
+            references:
+                The ground truth references. Unused by this metric, but accepted
+                for API consistency with the base ``Metric`` interface.
+            dataset:
+                The dataset used for evaluation.
+            dataset_config:
+                The dataset configuration.
+            benchmark_config:
+                The benchmark configuration, used to determine the compute device.
+
+        Returns:
+            The hallucination rate (hallucinated_tokens/total_tokens).
+        """
+        # Extract language code from dataset config
+        main_language = dataset_config.main_language
+        language_code: str = (
+            main_language.code
+            if isinstance(main_language, Language)
+            else main_language.code[1]
+        )
+
+        hallucination_rate = detect_hallucinations(
+            dataset=dataset,
+            predictions=predictions,
+            model=_hallucination_model_id(language_code=language_code),
+            device=Device(benchmark_config.device.type),
+            cache_dir=benchmark_config.cache_dir,
+        )
+        return hallucination_rate
+
+    def download(
+        self, cache_dir: str, dataset_config: "DatasetConfig" | None = None
+    ) -> "TokenHallucinationMetric":
+        """Pre-download hallucination detection models.
+
+        The hallucination detection model is language-specific. When a dataset
+        configuration is provided, only the model(s) for the relevant language(s)
+        are downloaded. Otherwise, all hallucination detection models referenced
+        by built-in dataset configurations are fetched for offline benchmarking.
+
+        Args:
+            cache_dir:
+                The directory where the models will be downloaded to.
+            dataset_config (optional):
+                The dataset configuration, used to filter which hallucination
+                detection models to download based on language. When None, all
+                models are downloaded. Defaults to None.
+
+        Returns:
+            The metric object itself.
+        """
+        for model_id in _hallucination_model_ids(
+            cache_dir=cache_dir, dataset_config=dataset_config
+        ):
+            snapshot_download(repo_id=model_id, repo_type="model", cache_dir=cache_dir)
+        return self
+
+
 def _hallucination_model_id(language_code: str) -> str:
     """Build the hallucination detection model ID for a dataset.
 
@@ -104,33 +194,6 @@ def _hallucination_model_ids(
             )
             model_ids.add(_hallucination_model_id(language_code=language_code))
     return model_ids
-
-
-def _answer_too_long(
-    answer: str, tokenizer: "PreTrainedTokenizerBase", max_length: int
-) -> bool:
-    """Check whether an answer alone exceeds the detector's token budget.
-
-    The hallucination detector tokenises the prompt and answer together with
-    ``truncation="only_first"``, which only truncates the prompt. If the answer
-    alone leaves no room for the prompt (e.g. for reasoning models that emit long
-    answers), the tokeniser raises a truncation error. Such samples are skipped.
-
-    Args:
-        answer:
-            The predicted answer text to check.
-        tokenizer:
-            The detector's tokeniser, used to count tokens.
-        max_length:
-            The detector's maximum input sequence length.
-
-    Returns:
-        Whether the answer is too long to be evaluated alongside a prompt.
-    """
-    answer_token_count = len(tokenizer(answer, add_special_tokens=False)["input_ids"])
-    # Reserve room for special tokens ([CLS], two [SEP]) and at least one prompt
-    # token, matching the detector's ``truncation="only_first"`` requirement.
-    return answer_token_count >= max_length - 4
 
 
 def detect_hallucinations(
@@ -225,94 +288,31 @@ def detect_hallucinations(
     return hallucination_rate
 
 
-class TokenHallucinationMetric(Metric):
-    """Hallucination metric."""
+def _answer_too_long(
+    answer: str, tokenizer: "PreTrainedTokenizerBase", max_length: int
+) -> bool:
+    """Check whether an answer alone exceeds the detector's token budget.
 
-    def __init__(self, name: str, pretty_name: str) -> None:
-        """Initialise the token hallucination metric.
+    The hallucination detector tokenises the prompt and answer together with
+    ``truncation="only_first"``, which only truncates the prompt. If the answer
+    alone leaves no room for the prompt (e.g. for reasoning models that emit long
+    answers), the tokeniser raises a truncation error. Such samples are skipped.
 
-        Args:
-            name:
-                The name of the metric in snake_case.
-            pretty_name:
-                The pretty name of the metric, used for display purposes.
-        """
-        super().__init__(name=name, pretty_name=pretty_name, postprocessing_fn=None)
+    Args:
+        answer:
+            The predicted answer text to check.
+        tokenizer:
+            The detector's tokeniser, used to count tokens.
+        max_length:
+            The detector's maximum input sequence length.
 
-    def __call__(
-        self,
-        predictions: c.Iterable[dict[str, t.Any]],
-        references: c.Sequence,
-        dataset: "Dataset",
-        dataset_config: "DatasetConfig",
-        benchmark_config: "BenchmarkConfig",
-    ) -> float | None:
-        """Compute the token-level hallucination rate for a set of predictions.
-
-        This method wraps `detect_hallucinations` to run a token-level
-        hallucination detector over the provided predictions and dataset contexts,
-        and returns the rate of tokens classified as hallucinated.
-
-        Args:
-            predictions:
-                The model predictions. Each prediction must provide a
-                ``"prediction_text"`` field containing the model's answer text.
-            references:
-                The ground truth references. Unused by this metric, but accepted
-                for API consistency with the base ``Metric`` interface.
-            dataset:
-                The dataset used for evaluation.
-            dataset_config:
-                The dataset configuration.
-            benchmark_config:
-                The benchmark configuration, used to determine the compute device.
-
-        Returns:
-            The hallucination rate (hallucinated_tokens/total_tokens).
-        """
-        # Extract language code from dataset config
-        main_language = dataset_config.main_language
-        language_code: str = (
-            main_language.code
-            if isinstance(main_language, Language)
-            else main_language.code[1]
-        )
-
-        hallucination_rate = detect_hallucinations(
-            dataset=dataset,
-            predictions=predictions,
-            model=_hallucination_model_id(language_code=language_code),
-            device=Device(benchmark_config.device.type),
-            cache_dir=benchmark_config.cache_dir,
-        )
-        return hallucination_rate
-
-    def download(
-        self, cache_dir: str, dataset_config: "DatasetConfig" | None = None
-    ) -> "TokenHallucinationMetric":
-        """Pre-download hallucination detection models.
-
-        The hallucination detection model is language-specific. When a dataset
-        configuration is provided, only the model(s) for the relevant language(s)
-        are downloaded. Otherwise, all hallucination detection models referenced
-        by built-in dataset configurations are fetched for offline benchmarking.
-
-        Args:
-            cache_dir:
-                The directory where the models will be downloaded to.
-            dataset_config (optional):
-                The dataset configuration, used to filter which hallucination
-                detection models to download based on language. When None, all
-                models are downloaded. Defaults to None.
-
-        Returns:
-            The metric object itself.
-        """
-        for model_id in _hallucination_model_ids(
-            cache_dir=cache_dir, dataset_config=dataset_config
-        ):
-            snapshot_download(repo_id=model_id, repo_type="model", cache_dir=cache_dir)
-        return self
+    Returns:
+        Whether the answer is too long to be evaluated alongside a prompt.
+    """
+    answer_token_count = len(tokenizer(answer, add_special_tokens=False)["input_ids"])
+    # Reserve room for special tokens ([CLS], two [SEP]) and at least one prompt
+    # token, matching the detector's ``truncation="only_first"`` requirement.
+    return answer_token_count >= max_length - 4
 
 
 hallucination_metric = TokenHallucinationMetric(

--- a/src/euroeval/metrics/token_hallucination_classifier.py
+++ b/src/euroeval/metrics/token_hallucination_classifier.py
@@ -270,10 +270,18 @@ class TokenHallucinationMetric(Metric):
         Returns:
             The hallucination rate (hallucinated_tokens/total_tokens).
         """
+        # Extract language code from dataset config
+        main_language = dataset_config.main_language
+        language_code: str = (
+            main_language.code
+            if isinstance(main_language, Language)
+            else main_language.code[1]
+        )
+
         hallucination_rate = detect_hallucinations(
             dataset=dataset,
             predictions=predictions,
-            model=_hallucination_model_id(dataset_config=dataset_config),
+            model=_hallucination_model_id(language_code=language_code),
             device=Device(benchmark_config.device.type),
             cache_dir=benchmark_config.cache_dir,
         )

--- a/src/euroeval/metrics/tool_calling.py
+++ b/src/euroeval/metrics/tool_calling.py
@@ -15,6 +15,48 @@ if t.TYPE_CHECKING:
 from ..metrics.base import Metric
 
 
+class ToolCallingAccuracy(Metric):
+    """Metric for tool calling."""
+
+    def __call__(
+        self,
+        predictions: c.Sequence,
+        references: c.Sequence,
+        dataset: "Dataset",
+        dataset_config: "DatasetConfig",
+        benchmark_config: "BenchmarkConfig",
+    ) -> float | None:
+        """Calculate tool calling accuracy.
+
+        Args:
+            predictions:
+                Predicted "labels" - meaning tool calls in this context.
+            references:
+                Ground truth data - NB: format is different from predictions,
+                since ground truth contains lists of possible outputs rather than
+                a single 'truth'.
+            dataset:
+                Dataset - used for tool information like required arguments.
+            dataset_config:
+                Part of interface - not used here.
+            benchmark_config:
+                Part of interface - not used here.
+
+        Returns:
+            The score (accuracy).
+            Returns None if any of predictions, references or dataset["function"]
+            sequences are empty - meaning a score could not be calculated.
+        """
+        function_descriptions = [json.loads(f) for f in dataset["function"]]
+        results = []
+        for x in zip(predictions, references, function_descriptions):
+            results.append(_evaluate_function_toolcall_response(*x))
+        if not results:
+            return None
+        else:
+            return sum(results) / len(results)
+
+
 def _evaluate_function_toolcall_response(
     pred_calls_str: str, ref_calls_str: str, descriptions: list[dict]
 ) -> bool:
@@ -111,48 +153,6 @@ def _evaluate_function_toolcall_response(
             if key not in pred_args or pred_args[key] not in values:
                 return False
     return True
-
-
-class ToolCallingAccuracy(Metric):
-    """Metric for tool calling."""
-
-    def __call__(
-        self,
-        predictions: c.Sequence,
-        references: c.Sequence,
-        dataset: "Dataset",
-        dataset_config: "DatasetConfig",
-        benchmark_config: "BenchmarkConfig",
-    ) -> float | None:
-        """Calculate tool calling accuracy.
-
-        Args:
-            predictions:
-                Predicted "labels" - meaning tool calls in this context.
-            references:
-                Ground truth data - NB: format is different from predictions,
-                since ground truth contains lists of possible outputs rather than
-                a single 'truth'.
-            dataset:
-                Dataset - used for tool information like required arguments.
-            dataset_config:
-                Part of interface - not used here.
-            benchmark_config:
-                Part of interface - not used here.
-
-        Returns:
-            The score (accuracy).
-            Returns None if any of predictions, references or dataset["function"]
-            sequences are empty - meaning a score could not be calculated.
-        """
-        function_descriptions = [json.loads(f) for f in dataset["function"]]
-        results = []
-        for x in zip(predictions, references, function_descriptions):
-            results.append(_evaluate_function_toolcall_response(*x))
-        if not results:
-            return None
-        else:
-            return sum(results) / len(results)
 
 
 tool_calling_accuracy = ToolCallingAccuracy(

--- a/src/euroeval/model_cache.py
+++ b/src/euroeval/model_cache.py
@@ -76,18 +76,6 @@ class ModelCache:
         self.indent_json_when_saving = indent_json_when_saving
         self.cache: dict[str, SingleGenerativeModelOutput] = dict()
 
-    def _hash_key(self, key: str | c.Sequence[dict[str, str]]) -> str:
-        """Hash the key to use as an index in the cache.
-
-        Args:
-            key:
-                The key to hash.
-
-        Returns:
-            The hashed key.
-        """
-        return hashlib.md5(string=str(key).encode()).hexdigest()
-
     def __contains__(self, key: str | c.Sequence[dict[str, str]]) -> bool:
         """Check if a key is in the cache.
 
@@ -100,6 +88,18 @@ class ModelCache:
         """
         hashed_key = self._hash_key(key=key)
         return hashed_key in self.cache
+
+    def _hash_key(self, key: str | c.Sequence[dict[str, str]]) -> str:
+        """Hash the key to use as an index in the cache.
+
+        Args:
+            key:
+                The key to hash.
+
+        Returns:
+            The hashed key.
+        """
+        return hashlib.md5(string=str(key).encode()).hexdigest()
 
     def __getitem__(
         self, key: str | c.Sequence[dict[str, str]]

--- a/src/euroeval/nltk_utils.py
+++ b/src/euroeval/nltk_utils.py
@@ -5,6 +5,11 @@ from pathlib import Path
 
 from .logging_utils import no_terminal_output
 
+# Auto-configure NLTK cache on module import (top of call hierarchy)
+# This ensures any code using NLTK after importing euroeval gets correct paths
+_euroeval_cache_dir = Path(__file__).parent.parent / ".euroeval_cache"
+setup_nltk_data_dir(_euroeval_cache_dir)
+
 
 def download_nltk_packages(
     nltk_data_dir: Path, packages: list[str] | None = None
@@ -27,6 +32,28 @@ def download_nltk_packages(
     with no_terminal_output():
         for package in packages:
             nltk.download(package, download_dir=str(nltk_data_dir), quiet=True)
+
+
+def ensure_nltk_packages(
+    cache_dir: str | Path, packages: list[str] | None = None
+) -> Path:
+    """Configure NLTK and download required packages.
+
+    This is the main entry point - call this before using any NLTK functionality.
+
+    Args:
+        cache_dir:
+            The cache directory where NLTK data will be stored.
+        packages:
+            List of NLTK package names to download. If None, downloads the default
+            packages: punkt_tab, wordnet, omw-1.4.
+
+    Returns:
+        The path to the NLTK data directory.
+    """
+    nltk_data_dir = setup_nltk_data_dir(cache_dir)
+    download_nltk_packages(nltk_data_dir, packages)
+    return nltk_data_dir
 
 
 def setup_nltk_data_dir(cache_dir: str | Path) -> Path:
@@ -53,26 +80,4 @@ def setup_nltk_data_dir(cache_dir: str | Path) -> Path:
     # Override NLTK's search path to use only our cache directory
     nltk.data.path = [str(nltk_data_dir)]
 
-    return nltk_data_dir
-
-
-def ensure_nltk_packages(
-    cache_dir: str | Path, packages: list[str] | None = None
-) -> Path:
-    """Configure NLTK and download required packages.
-
-    This is the main entry point - call this before using any NLTK functionality.
-
-    Args:
-        cache_dir:
-            The cache directory where NLTK data will be stored.
-        packages:
-            List of NLTK package names to download. If None, downloads the default
-            packages: punkt_tab, wordnet, omw-1.4.
-
-    Returns:
-        The path to the NLTK data directory.
-    """
-    nltk_data_dir = setup_nltk_data_dir(cache_dir)
-    download_nltk_packages(nltk_data_dir, packages)
     return nltk_data_dir

--- a/src/euroeval/nltk_utils.py
+++ b/src/euroeval/nltk_utils.py
@@ -3,6 +3,10 @@
 import os
 from pathlib import Path
 
+import nltk
+
+from .logging_utils import no_terminal_output
+
 
 def download_nltk_packages(
     nltk_data_dir: Path, packages: list[str] | None = None
@@ -16,10 +20,6 @@ def download_nltk_packages(
             List of NLTK package names to download. If None, downloads the default
             packages: punkt_tab, wordnet, omw-1.4.
     """
-    import nltk
-
-    from .logging_utils import no_terminal_output
-
     if packages is None:
         packages = ["punkt_tab", "wordnet", "omw-1.4"]
 
@@ -42,8 +42,6 @@ def setup_nltk_data_dir(cache_dir: str | Path) -> Path:
     Returns:
         The path to the NLTK data directory.
     """
-    import nltk
-
     nltk_data_dir = Path(cache_dir) / "nltk_data"
     nltk_data_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/euroeval/nltk_utils.py
+++ b/src/euroeval/nltk_utils.py
@@ -6,6 +6,28 @@ from pathlib import Path
 from .logging_utils import no_terminal_output
 
 
+def ensure_nltk_packages(
+    cache_dir: str | Path, packages: list[str] | None = None
+) -> Path:
+    """Configure NLTK and download required packages.
+
+    This is the main entry point - call this before using any NLTK functionality.
+
+    Args:
+        cache_dir:
+            The cache directory where NLTK data will be stored.
+        packages:
+            List of NLTK package names to download. If None, downloads the default
+            packages: punkt_tab, wordnet, omw-1.4.
+
+    Returns:
+        The path to the NLTK data directory.
+    """
+    nltk_data_dir = setup_nltk_data_dir(cache_dir)
+    download_nltk_packages(nltk_data_dir, packages)
+    return nltk_data_dir
+
+
 def download_nltk_packages(
     nltk_data_dir: Path, packages: list[str] | None = None
 ) -> None:
@@ -53,26 +75,4 @@ def setup_nltk_data_dir(cache_dir: str | Path) -> Path:
     # Override NLTK's search path to use only our cache directory
     nltk.data.path = [str(nltk_data_dir)]
 
-    return nltk_data_dir
-
-
-def ensure_nltk_packages(
-    cache_dir: str | Path, packages: list[str] | None = None
-) -> Path:
-    """Configure NLTK and download required packages.
-
-    This is the main entry point - call this before using any NLTK functionality.
-
-    Args:
-        cache_dir:
-            The cache directory where NLTK data will be stored.
-        packages:
-            List of NLTK package names to download. If None, downloads the default
-            packages: punkt_tab, wordnet, omw-1.4.
-
-    Returns:
-        The path to the NLTK data directory.
-    """
-    nltk_data_dir = setup_nltk_data_dir(cache_dir)
-    download_nltk_packages(nltk_data_dir, packages)
     return nltk_data_dir

--- a/src/euroeval/nltk_utils.py
+++ b/src/euroeval/nltk_utils.py
@@ -1,0 +1,78 @@
+"""Utility functions for NLTK configuration and downloads."""
+
+import os
+from pathlib import Path
+
+
+def download_nltk_packages(
+    nltk_data_dir: Path, packages: list[str] | None = None
+) -> None:
+    """Download NLTK packages to a custom directory with suppressed output.
+
+    Args:
+        nltk_data_dir:
+            The directory where NLTK data will be stored.
+        packages:
+            List of NLTK package names to download. If None, downloads the default
+            packages: punkt_tab, wordnet, omw-1.4.
+    """
+    import nltk
+
+    from .logging_utils import no_terminal_output
+
+    if packages is None:
+        packages = ["punkt_tab", "wordnet", "omw-1.4"]
+
+    # Suppress all NLTK output during download
+    with no_terminal_output():
+        for package in packages:
+            nltk.download(package, download_dir=str(nltk_data_dir), quiet=True)
+
+
+def setup_nltk_data_dir(cache_dir: str | Path) -> Path:
+    """Configure NLTK to use a custom data directory and return the path.
+
+    This ensures NLTK data is stored inside .euroeval_cache and not in the
+    home directory. Should be called early in the initialization chain.
+
+    Args:
+        cache_dir:
+            The cache directory where NLTK data will be stored.
+
+    Returns:
+        The path to the NLTK data directory.
+    """
+    import nltk
+
+    nltk_data_dir = Path(cache_dir) / "nltk_data"
+    nltk_data_dir.mkdir(parents=True, exist_ok=True)
+
+    # Set NLTK_DATA before any NLTK operations
+    os.environ["NLTK_DATA"] = str(nltk_data_dir)
+
+    # Override NLTK's search path to use only our cache directory
+    nltk.data.path = [str(nltk_data_dir)]
+
+    return nltk_data_dir
+
+
+def ensure_nltk_packages(
+    cache_dir: str | Path, packages: list[str] | None = None
+) -> Path:
+    """Configure NLTK and download required packages.
+
+    This is the main entry point - call this before using any NLTK functionality.
+
+    Args:
+        cache_dir:
+            The cache directory where NLTK data will be stored.
+        packages:
+            List of NLTK package names to download. If None, downloads the default
+            packages: punkt_tab, wordnet, omw-1.4.
+
+    Returns:
+        The path to the NLTK data directory.
+    """
+    nltk_data_dir = setup_nltk_data_dir(cache_dir)
+    download_nltk_packages(nltk_data_dir, packages)
+    return nltk_data_dir

--- a/src/euroeval/nltk_utils.py
+++ b/src/euroeval/nltk_utils.py
@@ -3,8 +3,6 @@
 import os
 from pathlib import Path
 
-import nltk
-
 from .logging_utils import no_terminal_output
 
 
@@ -20,6 +18,8 @@ def download_nltk_packages(
             List of NLTK package names to download. If None, downloads the default
             packages: punkt_tab, wordnet, omw-1.4.
     """
+    import nltk  # noqa: PLC0415 (import inside function intentional - defers NLTK init)
+
     if packages is None:
         packages = ["punkt_tab", "wordnet", "omw-1.4"]
 
@@ -42,6 +42,8 @@ def setup_nltk_data_dir(cache_dir: str | Path) -> Path:
     Returns:
         The path to the NLTK data directory.
     """
+    import nltk  # noqa: PLC0415 (import inside function intentional - defers NLTK init)
+
     nltk_data_dir = Path(cache_dir) / "nltk_data"
     nltk_data_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/euroeval/nltk_utils.py
+++ b/src/euroeval/nltk_utils.py
@@ -5,11 +5,6 @@ from pathlib import Path
 
 from .logging_utils import no_terminal_output
 
-# Auto-configure NLTK cache on module import (top of call hierarchy)
-# This ensures any code using NLTK after importing euroeval gets correct paths
-_euroeval_cache_dir = Path(__file__).parent.parent / ".euroeval_cache"
-setup_nltk_data_dir(_euroeval_cache_dir)
-
 
 def download_nltk_packages(
     nltk_data_dir: Path, packages: list[str] | None = None
@@ -32,28 +27,6 @@ def download_nltk_packages(
     with no_terminal_output():
         for package in packages:
             nltk.download(package, download_dir=str(nltk_data_dir), quiet=True)
-
-
-def ensure_nltk_packages(
-    cache_dir: str | Path, packages: list[str] | None = None
-) -> Path:
-    """Configure NLTK and download required packages.
-
-    This is the main entry point - call this before using any NLTK functionality.
-
-    Args:
-        cache_dir:
-            The cache directory where NLTK data will be stored.
-        packages:
-            List of NLTK package names to download. If None, downloads the default
-            packages: punkt_tab, wordnet, omw-1.4.
-
-    Returns:
-        The path to the NLTK data directory.
-    """
-    nltk_data_dir = setup_nltk_data_dir(cache_dir)
-    download_nltk_packages(nltk_data_dir, packages)
-    return nltk_data_dir
 
 
 def setup_nltk_data_dir(cache_dir: str | Path) -> Path:
@@ -80,4 +53,26 @@ def setup_nltk_data_dir(cache_dir: str | Path) -> Path:
     # Override NLTK's search path to use only our cache directory
     nltk.data.path = [str(nltk_data_dir)]
 
+    return nltk_data_dir
+
+
+def ensure_nltk_packages(
+    cache_dir: str | Path, packages: list[str] | None = None
+) -> Path:
+    """Configure NLTK and download required packages.
+
+    This is the main entry point - call this before using any NLTK functionality.
+
+    Args:
+        cache_dir:
+            The cache directory where NLTK data will be stored.
+        packages:
+            List of NLTK package names to download. If None, downloads the default
+            packages: punkt_tab, wordnet, omw-1.4.
+
+    Returns:
+        The path to the NLTK data directory.
+    """
+    nltk_data_dir = setup_nltk_data_dir(cache_dir)
+    download_nltk_packages(nltk_data_dir, packages)
     return nltk_data_dir

--- a/src/euroeval/preprocessing.py
+++ b/src/euroeval/preprocessing.py
@@ -46,6 +46,116 @@ def _fix_mc_label_column(
     return example
 
 
+def build_preprocessing_func(
+    dataset_name: str,
+    task_group: "TaskGroup",
+    input_column: str,
+    target_column: str | None,
+    choices_column: "str | list[str] | None",
+    choices_label: str,
+) -> "c.Callable[[DatasetDict], DatasetDict]":
+    """Build a preprocessing function from column mapping arguments.
+
+    The returned function renames or merges columns in a DatasetDict to match the
+    framework's standard column names:
+
+    - If ``input_column`` differs from ``"text"`` (without ``choices_column``), it is
+      renamed to ``"text"``.
+    - If ``choices_column`` is given, ``input_column`` and ``choices_column`` are merged
+      into a single ``"text"`` column formatted as::
+
+          <input_text>
+          <choices_label>:
+          a. <choice_0>
+          b. <choice_1>
+          ...
+
+    - If ``target_column`` is given, it is renamed to the task-group standard:
+      ``"labels"`` for token classification, ``"target_text"`` for text-to-text, and
+      ``"label"`` for everything else.
+
+    Args:
+        dataset_name:
+            The name of the dataset, used in error messages.
+        task_group:
+            The task group, used to determine the standard target column name.
+        input_column:
+            Column to rename to ``"text"``. When combined with ``choices_column``, the
+            two are merged into a formatted ``"text"`` column instead. Defaults to
+            ``"text"`` (no rename).
+        target_column:
+            Column to rename to the task-appropriate standard target column name.
+        choices_column:
+            Either the name of a single column containing a list of answer-choice
+            strings, or a list of column names each containing a single answer-choice
+            string, to merge with the input column.
+        choices_label:
+            The language-specific label for the choices section (e.g. ``"Choices"``).
+
+    Returns:
+        A callable that accepts a ``DatasetDict`` and returns a preprocessed
+        ``DatasetDict``.
+    """
+    std_target = _get_standard_target_column(task_group, target_column)
+
+    # Normalize choices_column to a list for uniform handling
+    choices_cols: list[str] | None
+    if isinstance(choices_column, list):
+        choices_cols = choices_column
+    elif choices_column is not None:
+        choices_cols = [choices_column]
+    else:
+        choices_cols = None
+
+    def preprocessing_func(dataset: "DatasetDict") -> "DatasetDict":
+        """Apply column mapping and merging to all splits in the dataset.
+
+        Validates that configured columns exist in all splits before processing, then
+        renames or merges columns according to the configuration passed to
+        :func:`build_preprocessing_func`.
+
+        Args:
+            dataset:
+                The dataset to preprocess.
+
+        Returns:
+            The preprocessed dataset with columns renamed or merged as configured.
+        """
+        _validate_columns(
+            dataset=dataset,
+            dataset_name=dataset_name,
+            input_column=input_column,
+            choices_cols=choices_cols,
+            target_column=target_column,
+        )
+
+        for split_name, split in dataset.items():
+            if choices_cols is not None:
+                assert choices_column is not None
+                split = _handle_choices_columns(
+                    split=split,
+                    input_column=input_column,
+                    choices_column=choices_column,
+                    choices_cols=choices_cols,
+                    choices_label=choices_label,
+                    target_column=target_column,
+                )
+            elif input_column != "text":
+                if "text" in split.column_names:
+                    split = split.remove_columns(["text"])
+                split = split.rename_column(input_column, "text")
+
+            split = _handle_target_column_rename(
+                split=split, std_target=std_target, target_column=target_column
+            )
+
+            dataset[split_name] = split
+
+        return dataset
+
+    return preprocessing_func
+
+
 def _get_standard_target_column(
     task_group: TaskGroup, target_column: str | None
 ) -> str | None:
@@ -204,116 +314,6 @@ def _validate_columns(
                 f"{target_column!r}, but this column was not found in all splits "
                 f"for the dataset {dataset_name!r}."
             )
-
-
-def build_preprocessing_func(
-    dataset_name: str,
-    task_group: "TaskGroup",
-    input_column: str,
-    target_column: str | None,
-    choices_column: "str | list[str] | None",
-    choices_label: str,
-) -> "c.Callable[[DatasetDict], DatasetDict]":
-    """Build a preprocessing function from column mapping arguments.
-
-    The returned function renames or merges columns in a DatasetDict to match the
-    framework's standard column names:
-
-    - If ``input_column`` differs from ``"text"`` (without ``choices_column``), it is
-      renamed to ``"text"``.
-    - If ``choices_column`` is given, ``input_column`` and ``choices_column`` are merged
-      into a single ``"text"`` column formatted as::
-
-          <input_text>
-          <choices_label>:
-          a. <choice_0>
-          b. <choice_1>
-          ...
-
-    - If ``target_column`` is given, it is renamed to the task-group standard:
-      ``"labels"`` for token classification, ``"target_text"`` for text-to-text, and
-      ``"label"`` for everything else.
-
-    Args:
-        dataset_name:
-            The name of the dataset, used in error messages.
-        task_group:
-            The task group, used to determine the standard target column name.
-        input_column:
-            Column to rename to ``"text"``. When combined with ``choices_column``, the
-            two are merged into a formatted ``"text"`` column instead. Defaults to
-            ``"text"`` (no rename).
-        target_column:
-            Column to rename to the task-appropriate standard target column name.
-        choices_column:
-            Either the name of a single column containing a list of answer-choice
-            strings, or a list of column names each containing a single answer-choice
-            string, to merge with the input column.
-        choices_label:
-            The language-specific label for the choices section (e.g. ``"Choices"``).
-
-    Returns:
-        A callable that accepts a ``DatasetDict`` and returns a preprocessed
-        ``DatasetDict``.
-    """
-    std_target = _get_standard_target_column(task_group, target_column)
-
-    # Normalize choices_column to a list for uniform handling
-    choices_cols: list[str] | None
-    if isinstance(choices_column, list):
-        choices_cols = choices_column
-    elif choices_column is not None:
-        choices_cols = [choices_column]
-    else:
-        choices_cols = None
-
-    def preprocessing_func(dataset: "DatasetDict") -> "DatasetDict":
-        """Apply column mapping and merging to all splits in the dataset.
-
-        Validates that configured columns exist in all splits before processing, then
-        renames or merges columns according to the configuration passed to
-        :func:`build_preprocessing_func`.
-
-        Args:
-            dataset:
-                The dataset to preprocess.
-
-        Returns:
-            The preprocessed dataset with columns renamed or merged as configured.
-        """
-        _validate_columns(
-            dataset=dataset,
-            dataset_name=dataset_name,
-            input_column=input_column,
-            choices_cols=choices_cols,
-            target_column=target_column,
-        )
-
-        for split_name, split in dataset.items():
-            if choices_cols is not None:
-                assert choices_column is not None
-                split = _handle_choices_columns(
-                    split=split,
-                    input_column=input_column,
-                    choices_column=choices_column,
-                    choices_cols=choices_cols,
-                    choices_label=choices_label,
-                    target_column=target_column,
-                )
-            elif input_column != "text":
-                if "text" in split.column_names:
-                    split = split.remove_columns(["text"])
-                split = split.rename_column(input_column, "text")
-
-            split = _handle_target_column_rename(
-                split=split, std_target=std_target, target_column=target_column
-            )
-
-            dataset[split_name] = split
-
-        return dataset
-
-    return preprocessing_func
 
 
 def merge_input_and_choices(

--- a/src/euroeval/scores.py
+++ b/src/euroeval/scores.py
@@ -14,44 +14,6 @@ if t.TYPE_CHECKING:
     from .types import IterationScores, ScoreDict
 
 
-def aggregate_scores(
-    scores: c.Sequence["IterationScores"], metric: "Metric"
-) -> tuple[float, float]:
-    """Helper function to compute the mean with confidence intervals.
-
-    Args:
-        scores:
-            Dictionary with the names of the metrics as keys, of the form
-            "<split>_<metric_name>", such as "val_f1", and values the metric values.
-        metric:
-            The metric, which is used to collect the correct metric from `scores`.
-
-    Returns:
-        A pair of floats, containing the score and the radius of its 95% confidence
-        interval.
-    """
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-
-        test_scores: list[float] = [
-            v
-            for dct in scores
-            for v in [
-                dct[metric.name] if metric.name in dct else dct[f"test_{metric.name}"]
-            ]
-            if isinstance(v, float)
-        ]
-        test_score = np.mean(test_scores).item()
-
-        if len(test_scores) > 1:
-            sample_std = np.std(test_scores, ddof=1)
-            test_se = (sample_std / np.sqrt(len(test_scores))).item()
-        else:
-            test_se = np.nan
-
-        return (test_score, 1.96 * test_se)
-
-
 def log_scores(
     dataset_name: str,
     metrics: c.Sequence["Metric"],
@@ -110,3 +72,41 @@ def log_scores(
     log("\n".join(all_log_strs), level=logging.INFO)
 
     return dict(raw=scores, total=total_dict)
+
+
+def aggregate_scores(
+    scores: c.Sequence["IterationScores"], metric: "Metric"
+) -> tuple[float, float]:
+    """Helper function to compute the mean with confidence intervals.
+
+    Args:
+        scores:
+            Dictionary with the names of the metrics as keys, of the form
+            "<split>_<metric_name>", such as "val_f1", and values the metric values.
+        metric:
+            The metric, which is used to collect the correct metric from `scores`.
+
+    Returns:
+        A pair of floats, containing the score and the radius of its 95% confidence
+        interval.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+
+        test_scores: list[float] = [
+            v
+            for dct in scores
+            for v in [
+                dct[metric.name] if metric.name in dct else dct[f"test_{metric.name}"]
+            ]
+            if isinstance(v, float)
+        ]
+        test_score = np.mean(test_scores).item()
+
+        if len(test_scores) > 1:
+            sample_std = np.std(test_scores, ddof=1)
+            test_se = (sample_std / np.sqrt(len(test_scores))).item()
+        else:
+            test_se = np.nan
+
+        return (test_score, 1.96 * test_se)

--- a/src/euroeval/speed_benchmark.py
+++ b/src/euroeval/speed_benchmark.py
@@ -17,6 +17,33 @@ if t.TYPE_CHECKING:
     from .data_models import BenchmarkConfig
 
 
+def benchmark_speed(
+    model: "BenchmarkModule", benchmark_config: "BenchmarkConfig"
+) -> c.Sequence[dict[str, float]]:
+    """Benchmark model inference speed.
+
+    Args:
+        model:
+            Model to use.
+        benchmark_config:
+            Configuration for the benchmark.
+
+    Returns:
+        Dictionary of scores.
+    """
+    scores: list[dict[str, float]] = list()
+    for idx in get_pbar(
+        iterable=range(benchmark_config.num_iterations),
+        desc="Benchmarking",
+        disable=not benchmark_config.progress_bar,
+    ):
+        itr_scores = benchmark_speed_single_iteration(model=model, itr_idx=idx)
+        clear_memory()
+        scores.append(itr_scores)
+        log(f"Scores for iteration {idx}: {itr_scores}", level=logging.DEBUG)
+    return scores
+
+
 def benchmark_speed_single_iteration(
     model: "BenchmarkModule", itr_idx: int
 ) -> dict[str, float]:
@@ -100,30 +127,3 @@ def benchmark_speed_single_iteration(
     return dict(
         test_speed=gpt2_tokens_per_second, test_speed_short=gpt2_tokens_per_second_short
     )
-
-
-def benchmark_speed(
-    model: "BenchmarkModule", benchmark_config: "BenchmarkConfig"
-) -> c.Sequence[dict[str, float]]:
-    """Benchmark model inference speed.
-
-    Args:
-        model:
-            Model to use.
-        benchmark_config:
-            Configuration for the benchmark.
-
-    Returns:
-        Dictionary of scores.
-    """
-    scores: list[dict[str, float]] = list()
-    for idx in get_pbar(
-        iterable=range(benchmark_config.num_iterations),
-        desc="Benchmarking",
-        disable=not benchmark_config.progress_bar,
-    ):
-        itr_scores = benchmark_speed_single_iteration(model=model, itr_idx=idx)
-        clear_memory()
-        scores.append(itr_scores)
-        log(f"Scores for iteration {idx}: {itr_scores}", level=logging.DEBUG)
-    return scores

--- a/src/euroeval/split_utils.py
+++ b/src/euroeval/split_utils.py
@@ -7,6 +7,31 @@ from huggingface_hub import HfApi
 from .caching_utils import cache_arguments
 
 
+def get_repo_splits(
+    hf_api: HfApi, dataset_id: str
+) -> tuple[str | None, str | None, str | None]:
+    """Return the (train, val, test) split names for a Hugging Face dataset repo.
+
+    Args:
+        hf_api:
+            The Hugging Face API object.
+        dataset_id:
+            The ID of the dataset to get the split names for.
+
+    Returns:
+        A 3-tuple (train_split, val_split, test_split) where each element is either
+            the name of the matching split or None if no such split exists.
+    """
+    splits = get_repo_split_names(hf_api=hf_api, dataset_id=dataset_id)
+    if splits is None:
+        return None, None, None
+    return (
+        find_split(splits=splits, keyword="train"),
+        find_split(splits=splits, keyword="val"),
+        find_split(splits=splits, keyword="test"),
+    )
+
+
 def find_split(splits: list[str], keyword: str) -> str | None:
     """Return the shortest split name containing `keyword`, or None.
 
@@ -62,28 +87,3 @@ def get_repo_split_names(hf_api: HfApi, dataset_id: str) -> list[str] | None:
             return split_names
 
     return None
-
-
-def get_repo_splits(
-    hf_api: HfApi, dataset_id: str
-) -> tuple[str | None, str | None, str | None]:
-    """Return the (train, val, test) split names for a Hugging Face dataset repo.
-
-    Args:
-        hf_api:
-            The Hugging Face API object.
-        dataset_id:
-            The ID of the dataset to get the split names for.
-
-    Returns:
-        A 3-tuple (train_split, val_split, test_split) where each element is either
-            the name of the matching split or None if no such split exists.
-    """
-    splits = get_repo_split_names(hf_api=hf_api, dataset_id=dataset_id)
-    if splits is None:
-        return None, None, None
-    return (
-        find_split(splits=splits, keyword="train"),
-        find_split(splits=splits, keyword="val"),
-        find_split(splits=splits, keyword="test"),
-    )

--- a/src/euroeval/task_group_utils/question_answering.py
+++ b/src/euroeval/task_group_utils/question_answering.py
@@ -32,297 +32,6 @@ if t.TYPE_CHECKING:
     from ..types import Labels
 
 
-def compute_metrics(
-    model_outputs_and_labels: "tuple[Predictions, Labels] | EvalPrediction",
-    dataset_config: "DatasetConfig",
-    benchmark_config: "BenchmarkConfig",
-    dataset: "Dataset",
-) -> dict[str, float]:
-    """Compute the metrics needed for evaluation.
-
-    Args:
-        model_outputs_and_labels:
-            The first sequence contains the model outputs and the second sequence
-            contains the true labels.
-        dataset_config:
-            The configuration of the dataset.
-        benchmark_config:
-            The configuration of the benchmark.
-        dataset:
-            The dataset used for evaluation. This is only used in case any additional
-            metadata is used to compute the metrics.
-
-    Returns:
-        A dictionary with the names of the metrics as keys and the metric values as
-        values.
-    """
-    _, labels, predictions = normalise_model_outputs(
-        model_outputs_and_labels=model_outputs_and_labels
-    )
-
-    return compute_simple_metrics(
-        predictions=predictions,
-        references=labels,
-        dataset=dataset,
-        dataset_config=dataset_config,
-        benchmark_config=benchmark_config,
-    )
-
-
-def find_valid_answers(
-    start_logits: np.ndarray,
-    end_logits: np.ndarray,
-    offset_mapping: c.Sequence[tuple[int, int]],
-    context: str,
-    max_answer_length: int,
-    num_best_logits: int,
-    min_null_score: float,
-) -> c.Sequence[dict]:
-    """Find the valid answers from the start and end indexes.
-
-    Args:
-        start_logits:
-            The logits for the start of the answer.
-        end_logits:
-            The logits for the end of the answer.
-        offset_mapping:
-            The offset mapping, being a list of pairs of integers for each token index,
-            containing the start and end character index in the original context.
-        context:
-            The context of the example.
-        max_answer_length:
-            The maximum length of the answer.
-        num_best_logits:
-            The number of best logits to consider. Note that this function will run in
-            O(`num_best_logits` ^ 2) time.
-        min_null_score:
-            The minimum score an answer can have.
-
-    Returns:
-        A list of the valid answers, each being a dictionary with keys "text" and
-        "score", the score being the sum of the start and end logits.
-    """
-    # Fetch the top-k predictions for the start- and end token indices
-    start_indexes = np.argsort(start_logits)[-1 : -num_best_logits - 1 : -1].tolist()
-    end_indexes = np.argsort(end_logits)[-1 : -num_best_logits - 1 : -1].tolist()
-
-    # We loop over all combinations of starting and ending indexes for valid answers
-    valid_answers = list()
-    for start_index in start_indexes:
-        for end_index in end_indexes:
-            # If the starting or ending index is out-of-scope, meaning that they are
-            # either out of bounds or correspond to part of the input_ids that are not
-            # in the context, then we skip this index
-            if (
-                start_index >= len(offset_mapping)
-                or end_index >= len(offset_mapping)
-                or tuple(offset_mapping[start_index]) == (-1, -1)
-                or tuple(offset_mapping[end_index]) == (-1, -1)
-            ):
-                continue
-
-            # Do not consider answers with a length that is either negative or greater
-            # than the context length
-            max_val = max_answer_length + start_index - 1
-            if end_index < start_index or end_index > max_val:
-                continue
-
-            # If we got to this point then the answer is valid, so we store the
-            # corresponding start- and end character indices in the original context,
-            # and from these extract the answer
-            start_char = offset_mapping[start_index][0]
-            end_char = offset_mapping[end_index][1]
-            text = context[start_char:end_char]
-
-            # Compute the score of the answer, being the sum of the start and end
-            # logits. Intuitively, this indicates how likely the answer is to be
-            # correct, and allows us to pick the best valid answer.
-            score = start_logits[start_index] + end_logits[end_index]
-
-            # Add the answer to the list of valid answers, if the score is greater
-            # than the minimum null score
-            if score > min_null_score:
-                valid_answers.append(dict(score=score, text=text))
-
-    return valid_answers
-
-
-def find_best_answer(
-    all_start_logits: np.ndarray,
-    all_end_logits: np.ndarray,
-    prepared_dataset: "Dataset",
-    feature_indices: c.Sequence[int],
-    context: str,
-    max_answer_length: int,
-    num_best_logits: int,
-    min_null_score: float,
-    cls_token_index: int,
-) -> str:
-    """Find the best answer for a given example.
-
-    Args:
-        all_start_logits:
-            The start logits for all the features.
-        all_end_logits:
-            The end logits for all the features.
-        prepared_dataset:
-            The dataset containing the prepared examples.
-        feature_indices:
-            The indices of the features associated with the current example.
-        context:
-            The context of the example.
-        max_answer_length:
-            The maximum length of the answer.
-        num_best_logits:
-            The number of best logits to consider.
-        min_null_score:
-            The minimum score an answer can have.
-        cls_token_index:
-            The index of the CLS token.
-
-    Returns:
-        The best answer for the example.
-    """
-    # Loop through all the features associated to the current example
-    valid_answers: list[dict] = list()
-    for feature_index in feature_indices:
-        # Get the features associated with the current example
-        features = prepared_dataset[feature_index]
-
-        # Get the predictions of the model for this feature
-        start_logits = all_start_logits[feature_index]
-        end_logits = all_end_logits[feature_index]
-
-        # Update minimum null prediction
-        cls_index = features["input_ids"].index(cls_token_index)
-        feature_null_score = (start_logits[cls_index] + end_logits[cls_index]).item()
-        if min_null_score < feature_null_score:
-            min_null_score = feature_null_score
-
-        # Find the valid answers for the feature
-        valid_answers_for_feature = find_valid_answers(
-            start_logits=start_logits,
-            end_logits=end_logits,
-            offset_mapping=features["offset_mapping"],
-            context=context,
-            max_answer_length=max_answer_length,
-            num_best_logits=num_best_logits,
-            min_null_score=min_null_score,
-        )
-        valid_answers.extend(valid_answers_for_feature)
-
-    # In the very rare edge case we have not a single non-null prediction, we create a
-    # fake prediction to avoid failure
-    if not valid_answers:
-        return ""
-
-    # Otherwise, we select the answer with the largest score as the best answer, and
-    # return it
-    best_answer_dict = sorted(valid_answers, key=lambda x: x["score"], reverse=True)[0]
-    return best_answer_dict["text"]
-
-
-def postprocess_predictions_and_labels(
-    predictions: tuple[np.ndarray, ...],
-    dataset: "Dataset",
-    prepared_dataset: "Dataset",
-    cls_token_index: int,
-) -> tuple[c.Sequence[dict], c.Sequence[dict]]:
-    """Postprocess the predictions and labels, to allow easier metric computation.
-
-    Args:
-        predictions:
-            A tuple whose first two elements are (start_logits, end_logits).
-        dataset:
-            The dataset containing the examples.
-        prepared_dataset:
-            The dataset containing the prepared examples.
-        cls_token_index:
-            The index of the CLS token.
-
-    Returns:
-        The postprocessed predictions and labels.
-
-    Raises:
-        InvalidBenchmark:
-            If the predictions are not a tuple with the first two elements being
-            (start_logits, end_logits).
-    """
-    if len(predictions) < 2:
-        raise InvalidBenchmark(
-            "The predictions should be a tuple with the first two elements being "
-            "(start_logits, end_logits), but got {len(predictions)} elements instead: "
-            f"{predictions}."
-        )
-
-    all_start_logits, all_end_logits = predictions[:2]
-
-    # Build a map from an example to its corresponding features, being the blocks of
-    # text from the context that we're feeding into the model. An example can have
-    # multiple features/blocks if it has a long context.
-    id_to_index = {k: i for i, k in enumerate(dataset["id"])}
-    features_per_example = defaultdict(list)
-    for i, feature in enumerate(prepared_dataset):
-        assert isinstance(feature, dict), (
-            "Each feature in the prepared dataset should be a dictionary, "
-            f"but got {type(feature)} instead."
-        )
-        id = feature["id"]
-        example_index = id_to_index[id]
-        features_per_example[example_index].append(i)
-
-    # Loop over all the examples
-    prediction_list: list[dict[str, t.Any]] = list()
-    labels = list()
-    for example_index, example in enumerate(dataset):
-        assert isinstance(example, dict), (
-            "Each example in the dataset should be a dictionary, but got "
-            f"{type(example)} instead."
-        )
-        context = example["context"]
-        assert isinstance(context, str), (
-            f"Each example's context should be a string, but got {type(context)} "
-            "instead."
-        )
-
-        # Extract the best valid answer associated with the current example
-        best_answer = find_best_answer(
-            all_start_logits=all_start_logits,
-            all_end_logits=all_end_logits,
-            prepared_dataset=prepared_dataset,
-            feature_indices=features_per_example[example_index],
-            context=context,
-            max_answer_length=30,
-            num_best_logits=20,
-            min_null_score=0.0,
-            cls_token_index=cls_token_index,
-        )
-
-        # Create the final prediction dictionary, to be added to the list of
-        # predictions
-        prediction = dict(
-            id=example["id"], prediction_text=best_answer, no_answer_probability=0.0
-        )
-
-        # Add the answer to the list of predictions
-        prediction_list.append(prediction)
-
-        # Create the associated reference dictionary, to be added to the list of
-        # references
-        label = dict(
-            id=example["id"],
-            answers=dict(
-                text=example["answers"]["text"],
-                answer_start=example["answers"]["answer_start"],
-            ),
-        )
-
-        # Add the answer and label to the list of predictions and labels, respectively
-        labels.append(label)
-
-    return prediction_list, labels
-
-
 class QuestionAnsweringTrainer(Trainer):
     """Trainer subclass for question answering tasks."""
 
@@ -433,6 +142,297 @@ class QuestionAnsweringTrainer(Trainer):
             args=self.args, state=self.state, control=self.control, metrics=metrics
         )
         return metrics
+
+
+def compute_metrics(
+    model_outputs_and_labels: "tuple[Predictions, Labels] | EvalPrediction",
+    dataset_config: "DatasetConfig",
+    benchmark_config: "BenchmarkConfig",
+    dataset: "Dataset",
+) -> dict[str, float]:
+    """Compute the metrics needed for evaluation.
+
+    Args:
+        model_outputs_and_labels:
+            The first sequence contains the model outputs and the second sequence
+            contains the true labels.
+        dataset_config:
+            The configuration of the dataset.
+        benchmark_config:
+            The configuration of the benchmark.
+        dataset:
+            The dataset used for evaluation. This is only used in case any additional
+            metadata is used to compute the metrics.
+
+    Returns:
+        A dictionary with the names of the metrics as keys and the metric values as
+        values.
+    """
+    _, labels, predictions = normalise_model_outputs(
+        model_outputs_and_labels=model_outputs_and_labels
+    )
+
+    return compute_simple_metrics(
+        predictions=predictions,
+        references=labels,
+        dataset=dataset,
+        dataset_config=dataset_config,
+        benchmark_config=benchmark_config,
+    )
+
+
+def postprocess_predictions_and_labels(
+    predictions: tuple[np.ndarray, ...],
+    dataset: "Dataset",
+    prepared_dataset: "Dataset",
+    cls_token_index: int,
+) -> tuple[c.Sequence[dict], c.Sequence[dict]]:
+    """Postprocess the predictions and labels, to allow easier metric computation.
+
+    Args:
+        predictions:
+            A tuple whose first two elements are (start_logits, end_logits).
+        dataset:
+            The dataset containing the examples.
+        prepared_dataset:
+            The dataset containing the prepared examples.
+        cls_token_index:
+            The index of the CLS token.
+
+    Returns:
+        The postprocessed predictions and labels.
+
+    Raises:
+        InvalidBenchmark:
+            If the predictions are not a tuple with the first two elements being
+            (start_logits, end_logits).
+    """
+    if len(predictions) < 2:
+        raise InvalidBenchmark(
+            "The predictions should be a tuple with the first two elements being "
+            "(start_logits, end_logits), but got {len(predictions)} elements instead: "
+            f"{predictions}."
+        )
+
+    all_start_logits, all_end_logits = predictions[:2]
+
+    # Build a map from an example to its corresponding features, being the blocks of
+    # text from the context that we're feeding into the model. An example can have
+    # multiple features/blocks if it has a long context.
+    id_to_index = {k: i for i, k in enumerate(dataset["id"])}
+    features_per_example = defaultdict(list)
+    for i, feature in enumerate(prepared_dataset):
+        assert isinstance(feature, dict), (
+            "Each feature in the prepared dataset should be a dictionary, "
+            f"but got {type(feature)} instead."
+        )
+        id = feature["id"]
+        example_index = id_to_index[id]
+        features_per_example[example_index].append(i)
+
+    # Loop over all the examples
+    prediction_list: list[dict[str, t.Any]] = list()
+    labels = list()
+    for example_index, example in enumerate(dataset):
+        assert isinstance(example, dict), (
+            "Each example in the dataset should be a dictionary, but got "
+            f"{type(example)} instead."
+        )
+        context = example["context"]
+        assert isinstance(context, str), (
+            f"Each example's context should be a string, but got {type(context)} "
+            "instead."
+        )
+
+        # Extract the best valid answer associated with the current example
+        best_answer = find_best_answer(
+            all_start_logits=all_start_logits,
+            all_end_logits=all_end_logits,
+            prepared_dataset=prepared_dataset,
+            feature_indices=features_per_example[example_index],
+            context=context,
+            max_answer_length=30,
+            num_best_logits=20,
+            min_null_score=0.0,
+            cls_token_index=cls_token_index,
+        )
+
+        # Create the final prediction dictionary, to be added to the list of
+        # predictions
+        prediction = dict(
+            id=example["id"], prediction_text=best_answer, no_answer_probability=0.0
+        )
+
+        # Add the answer to the list of predictions
+        prediction_list.append(prediction)
+
+        # Create the associated reference dictionary, to be added to the list of
+        # references
+        label = dict(
+            id=example["id"],
+            answers=dict(
+                text=example["answers"]["text"],
+                answer_start=example["answers"]["answer_start"],
+            ),
+        )
+
+        # Add the answer and label to the list of predictions and labels, respectively
+        labels.append(label)
+
+    return prediction_list, labels
+
+
+def find_best_answer(
+    all_start_logits: np.ndarray,
+    all_end_logits: np.ndarray,
+    prepared_dataset: "Dataset",
+    feature_indices: c.Sequence[int],
+    context: str,
+    max_answer_length: int,
+    num_best_logits: int,
+    min_null_score: float,
+    cls_token_index: int,
+) -> str:
+    """Find the best answer for a given example.
+
+    Args:
+        all_start_logits:
+            The start logits for all the features.
+        all_end_logits:
+            The end logits for all the features.
+        prepared_dataset:
+            The dataset containing the prepared examples.
+        feature_indices:
+            The indices of the features associated with the current example.
+        context:
+            The context of the example.
+        max_answer_length:
+            The maximum length of the answer.
+        num_best_logits:
+            The number of best logits to consider.
+        min_null_score:
+            The minimum score an answer can have.
+        cls_token_index:
+            The index of the CLS token.
+
+    Returns:
+        The best answer for the example.
+    """
+    # Loop through all the features associated to the current example
+    valid_answers: list[dict] = list()
+    for feature_index in feature_indices:
+        # Get the features associated with the current example
+        features = prepared_dataset[feature_index]
+
+        # Get the predictions of the model for this feature
+        start_logits = all_start_logits[feature_index]
+        end_logits = all_end_logits[feature_index]
+
+        # Update minimum null prediction
+        cls_index = features["input_ids"].index(cls_token_index)
+        feature_null_score = (start_logits[cls_index] + end_logits[cls_index]).item()
+        if min_null_score < feature_null_score:
+            min_null_score = feature_null_score
+
+        # Find the valid answers for the feature
+        valid_answers_for_feature = find_valid_answers(
+            start_logits=start_logits,
+            end_logits=end_logits,
+            offset_mapping=features["offset_mapping"],
+            context=context,
+            max_answer_length=max_answer_length,
+            num_best_logits=num_best_logits,
+            min_null_score=min_null_score,
+        )
+        valid_answers.extend(valid_answers_for_feature)
+
+    # In the very rare edge case we have not a single non-null prediction, we create a
+    # fake prediction to avoid failure
+    if not valid_answers:
+        return ""
+
+    # Otherwise, we select the answer with the largest score as the best answer, and
+    # return it
+    best_answer_dict = sorted(valid_answers, key=lambda x: x["score"], reverse=True)[0]
+    return best_answer_dict["text"]
+
+
+def find_valid_answers(
+    start_logits: np.ndarray,
+    end_logits: np.ndarray,
+    offset_mapping: c.Sequence[tuple[int, int]],
+    context: str,
+    max_answer_length: int,
+    num_best_logits: int,
+    min_null_score: float,
+) -> c.Sequence[dict]:
+    """Find the valid answers from the start and end indexes.
+
+    Args:
+        start_logits:
+            The logits for the start of the answer.
+        end_logits:
+            The logits for the end of the answer.
+        offset_mapping:
+            The offset mapping, being a list of pairs of integers for each token index,
+            containing the start and end character index in the original context.
+        context:
+            The context of the example.
+        max_answer_length:
+            The maximum length of the answer.
+        num_best_logits:
+            The number of best logits to consider. Note that this function will run in
+            O(`num_best_logits` ^ 2) time.
+        min_null_score:
+            The minimum score an answer can have.
+
+    Returns:
+        A list of the valid answers, each being a dictionary with keys "text" and
+        "score", the score being the sum of the start and end logits.
+    """
+    # Fetch the top-k predictions for the start- and end token indices
+    start_indexes = np.argsort(start_logits)[-1 : -num_best_logits - 1 : -1].tolist()
+    end_indexes = np.argsort(end_logits)[-1 : -num_best_logits - 1 : -1].tolist()
+
+    # We loop over all combinations of starting and ending indexes for valid answers
+    valid_answers = list()
+    for start_index in start_indexes:
+        for end_index in end_indexes:
+            # If the starting or ending index is out-of-scope, meaning that they are
+            # either out of bounds or correspond to part of the input_ids that are not
+            # in the context, then we skip this index
+            if (
+                start_index >= len(offset_mapping)
+                or end_index >= len(offset_mapping)
+                or tuple(offset_mapping[start_index]) == (-1, -1)
+                or tuple(offset_mapping[end_index]) == (-1, -1)
+            ):
+                continue
+
+            # Do not consider answers with a length that is either negative or greater
+            # than the context length
+            max_val = max_answer_length + start_index - 1
+            if end_index < start_index or end_index > max_val:
+                continue
+
+            # If we got to this point then the answer is valid, so we store the
+            # corresponding start- and end character indices in the original context,
+            # and from these extract the answer
+            start_char = offset_mapping[start_index][0]
+            end_char = offset_mapping[end_index][1]
+            text = context[start_char:end_char]
+
+            # Compute the score of the answer, being the sum of the start and end
+            # logits. Intuitively, this indicates how likely the answer is to be
+            # correct, and allows us to pick the best valid answer.
+            score = start_logits[start_index] + end_logits[end_index]
+
+            # Add the answer to the list of valid answers, if the score is greater
+            # than the minimum null score
+            if score > min_null_score:
+                valid_answers.append(dict(score=score, text=text))
+
+    return valid_answers
 
 
 def extract_labels_from_generation(

--- a/src/euroeval/task_group_utils/sequence_classification.py
+++ b/src/euroeval/task_group_utils/sequence_classification.py
@@ -98,147 +98,6 @@ def compute_metrics(
     )
 
 
-def get_closest_logprobs_labels(
-    generation_logprobs: c.Sequence[c.Sequence[c.Sequence[tuple[str, float]]]],
-    first_label_token_mapping: dict[str, str] | t.Literal[True],
-    candidate_labels: c.Sequence[c.Sequence[str]],
-) -> c.Sequence[str] | None:
-    """Get the labels with the highest predicted logprob value.
-
-    In case a candidate label is split into multiple tokens, we only use the first
-    token to compute the logprob value. E.g., if the candidate label "positive" is
-    tokenised as ["pos", "itive"], we only use the logprob value of "pos" to
-    represent the logprob value of the entire label.
-
-    Args:
-        generation_logprobs:
-            The logprobs of the generated tokens, for all samples in the batch. Of shape
-            (batch_size, num_tokens, num_logprobs).
-        first_label_token_mapping:
-            A mapping from labels to the first token in each label, or alternatively a
-            `True` value indicating that the model should output logprobs.
-        candidate_labels:
-            The candidate labels for each sample in the batch.
-
-    Returns:
-        The predicted labels, or None if labels could not be extracted.
-
-    Raises:
-        InvalidBenchmark:
-            If no candidate label can be found for any of the generated labels.
-    """
-    output_labels: list[str] = list()
-    for idx, sample in enumerate(generation_logprobs):
-        for logprob_list in sample:
-            generated_labels = [
-                re.sub(pattern=r"^[^a-zæøåüöä0-9]+$", repl="", string=label.lower())
-                for label, _ in logprob_list
-            ]
-            generated_labels = [label for label in generated_labels if label != ""]
-
-            # We want to use the first generated label which contains a unique candidate
-            # label, as the output label
-            output_label: str | None = None
-            for generated_label in generated_labels:
-                # Get the candidate labels. If we have a first label token mapping, we
-                # use it to get the candidate labels. Otherwise, we check if any of the
-                # labels start with the generated label.
-                if isinstance(first_label_token_mapping, dict):
-                    if any(
-                        candidate_label not in first_label_token_mapping
-                        for candidate_label in candidate_labels[idx]
-                    ):
-                        raise InvalidBenchmark(
-                            "There is a label not present in the first label token "
-                            "mapping - this should never happen! Please report this "
-                            "issue to the EuroEval team at "
-                            "github.com/EuroEval/EuroEval/issues."
-                        )
-
-                    candidate_output_labels = {
-                        candidate_label
-                        for candidate_label in candidate_labels[idx]
-                        if generated_label == first_label_token_mapping[candidate_label]
-                    }
-                else:
-                    candidate_output_labels = {
-                        candidate_label
-                        for candidate_label in candidate_labels[idx]
-                        if candidate_label.startswith(generated_label.strip())
-                    }
-
-                # If we can uniquely determine the output label, we break the loop.
-                if len(candidate_output_labels) == 1:
-                    output_label = candidate_output_labels.pop()
-                    break
-
-                # If we have multiple candidate labels, we cannot uniquely determine the
-                # output label, so we abandon extracting the labels using logprobs and
-                # fall back to using word edit distance.
-                elif len(candidate_output_labels) > 1:
-                    log_once(
-                        "Multiple candidate labels found for the generated label "
-                        f"{generated_label!r}: {candidate_output_labels}. This means "
-                        "that using logprobs to extract the labels is not reliable, "
-                        "and we will instead fall back to extracting the labels "
-                        "using word edit distance.",
-                        level=logging.DEBUG,
-                    )
-                    return None
-
-                # If no candidate label is found, we first check if any of the labels
-                # start with the generated label. This could be the case if the labels
-                # in the first token mapping is inaccurate or incomplete, for instance
-                # if 'pos' is in the first label token mapping, but the model outputted
-                # 'posit'. If this is the case then we cannot trust the first label
-                # token mapping, and we fall back to using word edit distance.
-                # Otherwise, the generated label is just bad, and we skip to the next
-                # generated label.
-                elif len(candidate_output_labels) == 0:
-                    candidate_output_labels_starting_with_generated_label = [
-                        candidate_label
-                        for candidate_label in candidate_labels[idx]
-                        if candidate_label.startswith(generated_label)
-                    ]
-                    if candidate_output_labels_starting_with_generated_label:
-                        log_once(
-                            f"No candidate label found for the generated label "
-                            f"{generated_label!r}, but there are candidate labels "
-                            f"starting with it: "
-                            f"{candidate_output_labels_starting_with_generated_label}. "
-                            "This means that the first label token mapping is not "
-                            "reliable, and we will instead fall back to extracting "
-                            "the labels using word edit distance.",
-                            level=logging.DEBUG,
-                        )
-                        return None
-
-            if output_label is not None:
-                output_labels.append(output_label)
-                break
-        else:
-            if len(sample) == 0:
-                log_once(
-                    "The model outputted an empty string, so no candidate labels could "
-                    "be determined. This means that using logprobs to extract the "
-                    "labels is not reliable, and we will instead fall back to "
-                    "extracting the labels using word edit distance.",
-                    level=logging.DEBUG,
-                )
-            else:
-                log_once(
-                    "No candidate label found for any of the generated labels, which "
-                    "means that using logprobs to extract the labels is not reliable, "
-                    "and we will instead fall back to extracting the labels using "
-                    "word edit distance.",
-                    level=logging.DEBUG,
-                )
-            return None
-
-    assert len(output_labels) == len(generation_logprobs)
-    return output_labels
-
-
 def extract_labels_from_generation(
     input_batch: dict[str, list],
     model_output: "GenerativeModelOutput",
@@ -383,3 +242,144 @@ def extract_labels_from_generation(
             )
 
     return new_predicted_labels
+
+
+def get_closest_logprobs_labels(
+    generation_logprobs: c.Sequence[c.Sequence[c.Sequence[tuple[str, float]]]],
+    first_label_token_mapping: dict[str, str] | t.Literal[True],
+    candidate_labels: c.Sequence[c.Sequence[str]],
+) -> c.Sequence[str] | None:
+    """Get the labels with the highest predicted logprob value.
+
+    In case a candidate label is split into multiple tokens, we only use the first
+    token to compute the logprob value. E.g., if the candidate label "positive" is
+    tokenised as ["pos", "itive"], we only use the logprob value of "pos" to
+    represent the logprob value of the entire label.
+
+    Args:
+        generation_logprobs:
+            The logprobs of the generated tokens, for all samples in the batch. Of shape
+            (batch_size, num_tokens, num_logprobs).
+        first_label_token_mapping:
+            A mapping from labels to the first token in each label, or alternatively a
+            `True` value indicating that the model should output logprobs.
+        candidate_labels:
+            The candidate labels for each sample in the batch.
+
+    Returns:
+        The predicted labels, or None if labels could not be extracted.
+
+    Raises:
+        InvalidBenchmark:
+            If no candidate label can be found for any of the generated labels.
+    """
+    output_labels: list[str] = list()
+    for idx, sample in enumerate(generation_logprobs):
+        for logprob_list in sample:
+            generated_labels = [
+                re.sub(pattern=r"^[^a-zæøåüöä0-9]+$", repl="", string=label.lower())
+                for label, _ in logprob_list
+            ]
+            generated_labels = [label for label in generated_labels if label != ""]
+
+            # We want to use the first generated label which contains a unique candidate
+            # label, as the output label
+            output_label: str | None = None
+            for generated_label in generated_labels:
+                # Get the candidate labels. If we have a first label token mapping, we
+                # use it to get the candidate labels. Otherwise, we check if any of the
+                # labels start with the generated label.
+                if isinstance(first_label_token_mapping, dict):
+                    if any(
+                        candidate_label not in first_label_token_mapping
+                        for candidate_label in candidate_labels[idx]
+                    ):
+                        raise InvalidBenchmark(
+                            "There is a label not present in the first label token "
+                            "mapping - this should never happen! Please report this "
+                            "issue to the EuroEval team at "
+                            "github.com/EuroEval/EuroEval/issues."
+                        )
+
+                    candidate_output_labels = {
+                        candidate_label
+                        for candidate_label in candidate_labels[idx]
+                        if generated_label == first_label_token_mapping[candidate_label]
+                    }
+                else:
+                    candidate_output_labels = {
+                        candidate_label
+                        for candidate_label in candidate_labels[idx]
+                        if candidate_label.startswith(generated_label.strip())
+                    }
+
+                # If we can uniquely determine the output label, we break the loop.
+                if len(candidate_output_labels) == 1:
+                    output_label = candidate_output_labels.pop()
+                    break
+
+                # If we have multiple candidate labels, we cannot uniquely determine the
+                # output label, so we abandon extracting the labels using logprobs and
+                # fall back to using word edit distance.
+                elif len(candidate_output_labels) > 1:
+                    log_once(
+                        "Multiple candidate labels found for the generated label "
+                        f"{generated_label!r}: {candidate_output_labels}. This means "
+                        "that using logprobs to extract the labels is not reliable, "
+                        "and we will instead fall back to extracting the labels "
+                        "using word edit distance.",
+                        level=logging.DEBUG,
+                    )
+                    return None
+
+                # If no candidate label is found, we first check if any of the labels
+                # start with the generated label. This could be the case if the labels
+                # in the first token mapping is inaccurate or incomplete, for instance
+                # if 'pos' is in the first label token mapping, but the model outputted
+                # 'posit'. If this is the case then we cannot trust the first label
+                # token mapping, and we fall back to using word edit distance.
+                # Otherwise, the generated label is just bad, and we skip to the next
+                # generated label.
+                elif len(candidate_output_labels) == 0:
+                    candidate_output_labels_starting_with_generated_label = [
+                        candidate_label
+                        for candidate_label in candidate_labels[idx]
+                        if candidate_label.startswith(generated_label)
+                    ]
+                    if candidate_output_labels_starting_with_generated_label:
+                        log_once(
+                            f"No candidate label found for the generated label "
+                            f"{generated_label!r}, but there are candidate labels "
+                            f"starting with it: "
+                            f"{candidate_output_labels_starting_with_generated_label}. "
+                            "This means that the first label token mapping is not "
+                            "reliable, and we will instead fall back to extracting "
+                            "the labels using word edit distance.",
+                            level=logging.DEBUG,
+                        )
+                        return None
+
+            if output_label is not None:
+                output_labels.append(output_label)
+                break
+        else:
+            if len(sample) == 0:
+                log_once(
+                    "The model outputted an empty string, so no candidate labels could "
+                    "be determined. This means that using logprobs to extract the "
+                    "labels is not reliable, and we will instead fall back to "
+                    "extracting the labels using word edit distance.",
+                    level=logging.DEBUG,
+                )
+            else:
+                log_once(
+                    "No candidate label found for any of the generated labels, which "
+                    "means that using logprobs to extract the labels is not reliable, "
+                    "and we will instead fall back to extracting the labels using "
+                    "word edit distance.",
+                    level=logging.DEBUG,
+                )
+            return None
+
+    assert len(output_labels) == len(generation_logprobs)
+    return output_labels

--- a/src/euroeval/task_group_utils/token_classification.py
+++ b/src/euroeval/task_group_utils/token_classification.py
@@ -23,6 +23,87 @@ if t.TYPE_CHECKING:
     from ..types import Labels, Predictions
 
 
+def compute_metrics(
+    model_outputs_and_labels: "tuple[Predictions, Labels] | EvalPrediction",
+    has_misc_tags: bool,
+    dataset_config: "DatasetConfig",
+    benchmark_config: "BenchmarkConfig",
+    dataset: "Dataset",
+) -> dict[str, float]:
+    """Compute the metrics needed for evaluation.
+
+    Args:
+        model_outputs_and_labels:
+            The first array contains the probability predictions and the second
+            array contains the true labels.
+        has_misc_tags:
+            Whether the dataset has MISC tags.
+        dataset_config:
+            The configuration of the dataset.
+        benchmark_config:
+            The configuration of the benchmark.
+        dataset:
+            The dataset used for evaluation. This is only used in case any additional
+            metadata is used to compute the metrics.
+
+    Returns:
+        A dictionary with the names of the metrics as keys and the metric values as
+        values.
+    """
+    predictions, labels = _extract_predictions_and_labels(
+        model_outputs_and_labels=model_outputs_and_labels, dataset_config=dataset_config
+    )
+
+    raise_if_model_output_contains_nan_values(model_output=predictions)
+
+    # Replace predicted tag with either MISC or O tags if they are not part of the
+    # dataset
+    labels_without_misc = {
+        label
+        for label in dataset_config.id2label.values()
+        if label not in {"b-misc", "i-misc"}
+    }
+    _replace_ner_tags_with_misc_or_o(
+        predictions=predictions,
+        has_misc_tags=has_misc_tags,
+        labels_without_misc=labels_without_misc,
+    )
+
+    # Build no-misc variants only when needed by any metric
+    needs_no_misc = any(
+        m.name == "micro_f1_no_misc" for m in dataset_config.task.metrics
+    )
+    predictions_no_misc: list[list[str]] = []
+    labels_no_misc: list[list[str]] = []
+    if needs_no_misc:
+        predictions_no_misc, labels_no_misc = _build_no_misc_variants(
+            predictions=predictions, labels=labels
+        )
+
+    # Compute each metric defined on the task
+    result: dict[str, float] = {}
+    for metric in dataset_config.task.metrics:
+        # Select the appropriate predictions/labels variant
+        if metric.name == "micro_f1_no_misc":
+            preds = predictions_no_misc
+            refs = labels_no_misc
+        else:
+            preds = predictions
+            refs = list(labels)
+
+        result[metric.name] = _compute_single_metric(
+            metric=metric,
+            metric_name=metric.name,
+            predictions=preds,
+            labels=refs,
+            dataset=dataset,
+            dataset_config=dataset_config,
+            benchmark_config=benchmark_config,
+        )
+
+    return result
+
+
 def _build_no_misc_variants(
     predictions: list[list[str]], labels: list[list[str]]
 ) -> "tuple[list[list[str]], list[list[str]]]":
@@ -189,87 +270,6 @@ def _replace_ner_tags_with_misc_or_o(
                     predictions[i][j] = "o"
 
 
-def compute_metrics(
-    model_outputs_and_labels: "tuple[Predictions, Labels] | EvalPrediction",
-    has_misc_tags: bool,
-    dataset_config: "DatasetConfig",
-    benchmark_config: "BenchmarkConfig",
-    dataset: "Dataset",
-) -> dict[str, float]:
-    """Compute the metrics needed for evaluation.
-
-    Args:
-        model_outputs_and_labels:
-            The first array contains the probability predictions and the second
-            array contains the true labels.
-        has_misc_tags:
-            Whether the dataset has MISC tags.
-        dataset_config:
-            The configuration of the dataset.
-        benchmark_config:
-            The configuration of the benchmark.
-        dataset:
-            The dataset used for evaluation. This is only used in case any additional
-            metadata is used to compute the metrics.
-
-    Returns:
-        A dictionary with the names of the metrics as keys and the metric values as
-        values.
-    """
-    predictions, labels = _extract_predictions_and_labels(
-        model_outputs_and_labels=model_outputs_and_labels, dataset_config=dataset_config
-    )
-
-    raise_if_model_output_contains_nan_values(model_output=predictions)
-
-    # Replace predicted tag with either MISC or O tags if they are not part of the
-    # dataset
-    labels_without_misc = {
-        label
-        for label in dataset_config.id2label.values()
-        if label not in {"b-misc", "i-misc"}
-    }
-    _replace_ner_tags_with_misc_or_o(
-        predictions=predictions,
-        has_misc_tags=has_misc_tags,
-        labels_without_misc=labels_without_misc,
-    )
-
-    # Build no-misc variants only when needed by any metric
-    needs_no_misc = any(
-        m.name == "micro_f1_no_misc" for m in dataset_config.task.metrics
-    )
-    predictions_no_misc: list[list[str]] = []
-    labels_no_misc: list[list[str]] = []
-    if needs_no_misc:
-        predictions_no_misc, labels_no_misc = _build_no_misc_variants(
-            predictions=predictions, labels=labels
-        )
-
-    # Compute each metric defined on the task
-    result: dict[str, float] = {}
-    for metric in dataset_config.task.metrics:
-        # Select the appropriate predictions/labels variant
-        if metric.name == "micro_f1_no_misc":
-            preds = predictions_no_misc
-            refs = labels_no_misc
-        else:
-            preds = predictions
-            refs = list(labels)
-
-        result[metric.name] = _compute_single_metric(
-            metric=metric,
-            metric_name=metric.name,
-            predictions=preds,
-            labels=refs,
-            dataset=dataset,
-            dataset_config=dataset_config,
-            benchmark_config=benchmark_config,
-        )
-
-    return result
-
-
 def extract_labels_from_generation(
     input_batch: dict[str, list],
     model_output: "GenerativeModelOutput",
@@ -344,63 +344,6 @@ def extract_labels_from_generation(
                             ):
                                 predicted_labels[idx][token_idx] = f"i-{tag_name}"
     return predicted_labels
-
-
-def handle_unk_tokens(
-    tokeniser: "PreTrainedTokenizer", tokens: list[str], words: c.Sequence[str]
-) -> c.Sequence[str]:
-    """Replace unknown tokens in the tokens with the corresponding word.
-
-    Args:
-        tokeniser:
-            The tokeniser used to tokenise the words.
-        tokens:
-            The list of tokens.
-        words:
-            The list of words.
-
-    Returns:
-        The list of tokens with unknown tokens replaced by the corresponding word.
-    """
-    # Locate the token indices of the unknown tokens
-    token_unk_idxs = [i for i, tok in enumerate(tokens) if tok == tokeniser.unk_token]
-
-    # Locate the word indices of the words which contain an unknown token
-    word_unk_idxs = [
-        i
-        for i, word in enumerate(words)
-        if tokeniser.unk_token
-        in tokeniser.convert_ids_to_tokens(
-            tokeniser.encode(word, add_special_tokens=False)
-        )
-    ]
-
-    # Iterate over the token index and word index pairs
-    for tok_idx, word_idx in zip(token_unk_idxs, word_unk_idxs):
-        # Fetch the word
-        word = words[word_idx]
-
-        # Tokenise the word, which is now a list containing at least one UNK token
-        tokens_with_unk = tokeniser.convert_ids_to_tokens(
-            tokeniser.encode(word, add_special_tokens=False)
-        )
-
-        # Iterate over the tokens in the word
-        for possible_unk_token in tokens_with_unk:
-            # If the token is not an UNK token then we remove the first occurence
-            # of the content of this token from the word. The result of the `word`
-            # variable will be the content of the UNK token.
-            # NOTE: This is a bit hacky and not bulletproof. For instance, if the
-            # word is "1925-1950" and the tokeniser splits it into ["[UNK]", "-",
-            # "19", "50"], then the result will be 2519 instead of 1925. This
-            # happens almost never, however, so we can live with it.
-            if possible_unk_token != tokeniser.unk_token:
-                word = word.replace(possible_unk_token, "", 1)
-
-        # Replace the token with the word
-        tokens[tok_idx] = word
-
-    return tokens
 
 
 def serialise_ner_tags(
@@ -600,3 +543,60 @@ def tokenize_and_align_labels(
         all_labels.append(label_ids)
     tokenized_inputs["labels"] = all_labels
     return tokenized_inputs
+
+
+def handle_unk_tokens(
+    tokeniser: "PreTrainedTokenizer", tokens: list[str], words: c.Sequence[str]
+) -> c.Sequence[str]:
+    """Replace unknown tokens in the tokens with the corresponding word.
+
+    Args:
+        tokeniser:
+            The tokeniser used to tokenise the words.
+        tokens:
+            The list of tokens.
+        words:
+            The list of words.
+
+    Returns:
+        The list of tokens with unknown tokens replaced by the corresponding word.
+    """
+    # Locate the token indices of the unknown tokens
+    token_unk_idxs = [i for i, tok in enumerate(tokens) if tok == tokeniser.unk_token]
+
+    # Locate the word indices of the words which contain an unknown token
+    word_unk_idxs = [
+        i
+        for i, word in enumerate(words)
+        if tokeniser.unk_token
+        in tokeniser.convert_ids_to_tokens(
+            tokeniser.encode(word, add_special_tokens=False)
+        )
+    ]
+
+    # Iterate over the token index and word index pairs
+    for tok_idx, word_idx in zip(token_unk_idxs, word_unk_idxs):
+        # Fetch the word
+        word = words[word_idx]
+
+        # Tokenise the word, which is now a list containing at least one UNK token
+        tokens_with_unk = tokeniser.convert_ids_to_tokens(
+            tokeniser.encode(word, add_special_tokens=False)
+        )
+
+        # Iterate over the tokens in the word
+        for possible_unk_token in tokens_with_unk:
+            # If the token is not an UNK token then we remove the first occurence
+            # of the content of this token from the word. The result of the `word`
+            # variable will be the content of the UNK token.
+            # NOTE: This is a bit hacky and not bulletproof. For instance, if the
+            # word is "1925-1950" and the tokeniser splits it into ["[UNK]", "-",
+            # "19", "50"], then the result will be 2519 instead of 1925. This
+            # happens almost never, however, so we can live with it.
+            if possible_unk_token != tokeniser.unk_token:
+                word = word.replace(possible_unk_token, "", 1)
+
+        # Replace the token with the word
+        tokens[tok_idx] = word
+
+    return tokens

--- a/src/euroeval/tokenisation_utils.py
+++ b/src/euroeval/tokenisation_utils.py
@@ -28,96 +28,6 @@ if t.TYPE_CHECKING:
     from .data_models import DatasetConfig, ModelConfig
 
 
-def has_chat_template(tokeniser: Tokeniser) -> bool:
-    """Check if a tokeniser has a chat template.
-
-    Args:
-        tokeniser:
-            The tokeniser.
-
-    Returns:
-        Whether the tokeniser has a chat template.
-    """
-    if isinstance(tokeniser, MistralCommonTokenizer):
-        log_once(
-            "The tokeniser is a Mistral tokeniser, so assuming that the model is "
-            "instruction tuned.",
-            level=logging.DEBUG,
-        )
-        return True
-    elif hasattr(tokeniser, "chat_template"):
-        has_template = tokeniser.chat_template is not None
-        if has_template:
-            log_once(
-                "The tokeniser has a chat template, so assuming that the model is "
-                "instruction tuned.",
-                level=logging.DEBUG,
-            )
-        return has_template
-    else:
-        log_once(
-            "We cannot find a chat template for the tokeniser, so assuming that the "
-            "model isn't instruction tuned.",
-            level=logging.DEBUG,
-        )
-        return False
-
-
-def apply_chat_template(
-    conversation: list[dict[str, str]],
-    tokeniser: Tokeniser,
-    tokenise: bool,
-    add_generation_prompt: bool,
-    **extra_kwargs,
-) -> str | list[int]:
-    """Apply the chat template to a prompt.
-
-    Args:
-        conversation:
-            The conversation to apply the chat template to.
-        tokeniser:
-            The tokeniser.
-        tokenise:
-            Whether to tokenise the resulting prompt, returning a list of token IDs
-            instead of a string.
-        add_generation_prompt:
-            Whether to add a generation prompt at the end of the conversation. This is
-            only relevant for regular Hugging Face tokenisers, as Mistral tokenisers
-            always add a generation prompt.
-        **extra_kwargs:
-            Extra keyword arguments to pass to the tokeniser's `apply_chat_template`
-            method. Only relevant for regular Hugging Face tokenisers.
-
-    Returns:
-        The prompt with the chat template applied, either as a string or a list of
-        token IDs, depending on the value of `tokenise`.
-
-    Raises:
-        InvalidModel:
-            If the tokeniser does not have a chat template.
-    """
-    # Ensure that the first user message is not empty, as this can cause issues with
-    # Jinja2
-    conversation[0]["content"] = conversation[0]["content"] or " "
-
-    if not has_chat_template(tokeniser=tokeniser):
-        raise InvalidModel(
-            "The tokeniser does not have a chat template, so cannot apply it."
-        )
-    elif isinstance(tokeniser, MistralCommonTokenizer):
-        templated_prompt = tokeniser.apply_chat_template(
-            conversation=conversation, tokenize=tokenise
-        )
-    else:
-        templated_prompt = tokeniser.apply_chat_template(
-            conversation=conversation,
-            add_generation_prompt=add_generation_prompt,
-            tokenize=tokenise,
-            **extra_kwargs,
-        )
-    return templated_prompt  # ty: ignore[invalid-return-type]
-
-
 def get_bos_token(tokeniser: Tokeniser) -> tuple[str, int] | tuple[None, None]:
     """Get the beginning-of-sequence token from a tokeniser.
 
@@ -231,6 +141,96 @@ def get_end_of_chat_token_ids(
     return end_of_chat_tokens
 
 
+def apply_chat_template(
+    conversation: list[dict[str, str]],
+    tokeniser: Tokeniser,
+    tokenise: bool,
+    add_generation_prompt: bool,
+    **extra_kwargs,
+) -> str | list[int]:
+    """Apply the chat template to a prompt.
+
+    Args:
+        conversation:
+            The conversation to apply the chat template to.
+        tokeniser:
+            The tokeniser.
+        tokenise:
+            Whether to tokenise the resulting prompt, returning a list of token IDs
+            instead of a string.
+        add_generation_prompt:
+            Whether to add a generation prompt at the end of the conversation. This is
+            only relevant for regular Hugging Face tokenisers, as Mistral tokenisers
+            always add a generation prompt.
+        **extra_kwargs:
+            Extra keyword arguments to pass to the tokeniser's `apply_chat_template`
+            method. Only relevant for regular Hugging Face tokenisers.
+
+    Returns:
+        The prompt with the chat template applied, either as a string or a list of
+        token IDs, depending on the value of `tokenise`.
+
+    Raises:
+        InvalidModel:
+            If the tokeniser does not have a chat template.
+    """
+    # Ensure that the first user message is not empty, as this can cause issues with
+    # Jinja2
+    conversation[0]["content"] = conversation[0]["content"] or " "
+
+    if not has_chat_template(tokeniser=tokeniser):
+        raise InvalidModel(
+            "The tokeniser does not have a chat template, so cannot apply it."
+        )
+    elif isinstance(tokeniser, MistralCommonTokenizer):
+        templated_prompt = tokeniser.apply_chat_template(
+            conversation=conversation, tokenize=tokenise
+        )
+    else:
+        templated_prompt = tokeniser.apply_chat_template(
+            conversation=conversation,
+            add_generation_prompt=add_generation_prompt,
+            tokenize=tokenise,
+            **extra_kwargs,
+        )
+    return templated_prompt  # ty: ignore[invalid-return-type]
+
+
+def has_chat_template(tokeniser: Tokeniser) -> bool:
+    """Check if a tokeniser has a chat template.
+
+    Args:
+        tokeniser:
+            The tokeniser.
+
+    Returns:
+        Whether the tokeniser has a chat template.
+    """
+    if isinstance(tokeniser, MistralCommonTokenizer):
+        log_once(
+            "The tokeniser is a Mistral tokeniser, so assuming that the model is "
+            "instruction tuned.",
+            level=logging.DEBUG,
+        )
+        return True
+    elif hasattr(tokeniser, "chat_template"):
+        has_template = tokeniser.chat_template is not None
+        if has_template:
+            log_once(
+                "The tokeniser has a chat template, so assuming that the model is "
+                "instruction tuned.",
+                level=logging.DEBUG,
+            )
+        return has_template
+    else:
+        log_once(
+            "We cannot find a chat template for the tokeniser, so assuming that the "
+            "model isn't instruction tuned.",
+            level=logging.DEBUG,
+        )
+        return False
+
+
 def get_eos_token(tokeniser: Tokeniser) -> tuple[str, int] | tuple[None, None]:
     """Get the end-of-sequence token from a tokeniser.
 
@@ -267,86 +267,6 @@ def get_eos_token(tokeniser: Tokeniser) -> tuple[str, int] | tuple[None, None]:
         level=logging.WARNING,
     )
     return eos_token, eos_token_id
-
-
-def should_prompts_be_stripped(
-    labels_to_be_generated: c.Sequence[str], tokeniser: Tokeniser
-) -> bool:
-    """Determine if we should strip the prompts for few-shot evaluation.
-
-    This is the case if the tokeniser needs to include the space as part of the label
-    token. The strategy is thus to tokenise a label with a preceeding colon (as in the
-    prompts), i.e., ": positive", and check if the tokenisation starts with the tokens
-    of ": ". If this is the case, then we should not strip the prompts, since the
-    tokeniser produces the whitespace token separately.
-
-    Args:
-        labels_to_be_generated:
-            The labels that are to be generated.
-        tokeniser:
-            The tokeniser used to tokenise the labels.
-
-    Returns:
-        Whether we should strip the prompts.
-    """
-    strip_prompts = True
-    for label in labels_to_be_generated:
-        colon_tokens = tokeniser(": ", add_special_tokens=False).input_ids
-        label_tokens = tokeniser(": " + label, add_special_tokens=False).input_ids
-
-        if isinstance(colon_tokens, torch.Tensor):
-            colon_tokens = list(colon_tokens.squeeze(0))
-        if isinstance(label_tokens, torch.Tensor):
-            label_tokens = list(label_tokens.squeeze(0))
-
-        label_tokens_start_with_colon_tokens = (
-            label_tokens[: len(colon_tokens)] == colon_tokens
-        )
-        if label_tokens_start_with_colon_tokens:
-            strip_prompts = False
-
-    return strip_prompts
-
-
-def should_prefix_space_be_added_to_labels(
-    labels_to_be_generated: c.Sequence[str], tokeniser: Tokeniser
-) -> bool:
-    """Determine if we should add a prefix space to the labels.
-
-    This is the case if the prompts are stripped and the tokeniser doesn't
-    automatically add prefix whitespaces to the labels.
-
-    Args:
-        labels_to_be_generated:
-            The labels that are to be generated.
-        tokeniser:
-            The tokeniser used to tokenise the labels.
-
-    Returns:
-        Whether we should add a prefix space to the labels.
-    """
-    if not should_prompts_be_stripped(
-        labels_to_be_generated=labels_to_be_generated, tokeniser=tokeniser
-    ):
-        return False
-
-    whitespace_token = tokeniser.convert_ids_to_tokens(
-        ids=tokeniser(" ", add_special_tokens=False).input_ids[0]
-    )[0]
-
-    add_prefix_space = True
-    for label in labels_to_be_generated:
-        label_tokens = tokeniser(label, add_special_tokens=False).input_ids
-        if isinstance(label_tokens, torch.Tensor):
-            label_tokens = list(label_tokens.squeeze(0))
-        first_label_token: int = int(label_tokens[0])
-        first_character_of_label = tokeniser.convert_ids_to_tokens(first_label_token)[0]
-        has_prefix_space = first_character_of_label == whitespace_token
-        if has_prefix_space:
-            add_prefix_space = False
-            break
-
-    return add_prefix_space
 
 
 @cache_arguments("dataset_config", "model_config")
@@ -501,6 +421,86 @@ def get_first_label_token_mapping(
                 level=logging.DEBUG,
             )
         return False
+
+
+def should_prefix_space_be_added_to_labels(
+    labels_to_be_generated: c.Sequence[str], tokeniser: Tokeniser
+) -> bool:
+    """Determine if we should add a prefix space to the labels.
+
+    This is the case if the prompts are stripped and the tokeniser doesn't
+    automatically add prefix whitespaces to the labels.
+
+    Args:
+        labels_to_be_generated:
+            The labels that are to be generated.
+        tokeniser:
+            The tokeniser used to tokenise the labels.
+
+    Returns:
+        Whether we should add a prefix space to the labels.
+    """
+    if not should_prompts_be_stripped(
+        labels_to_be_generated=labels_to_be_generated, tokeniser=tokeniser
+    ):
+        return False
+
+    whitespace_token = tokeniser.convert_ids_to_tokens(
+        ids=tokeniser(" ", add_special_tokens=False).input_ids[0]
+    )[0]
+
+    add_prefix_space = True
+    for label in labels_to_be_generated:
+        label_tokens = tokeniser(label, add_special_tokens=False).input_ids
+        if isinstance(label_tokens, torch.Tensor):
+            label_tokens = list(label_tokens.squeeze(0))
+        first_label_token: int = int(label_tokens[0])
+        first_character_of_label = tokeniser.convert_ids_to_tokens(first_label_token)[0]
+        has_prefix_space = first_character_of_label == whitespace_token
+        if has_prefix_space:
+            add_prefix_space = False
+            break
+
+    return add_prefix_space
+
+
+def should_prompts_be_stripped(
+    labels_to_be_generated: c.Sequence[str], tokeniser: Tokeniser
+) -> bool:
+    """Determine if we should strip the prompts for few-shot evaluation.
+
+    This is the case if the tokeniser needs to include the space as part of the label
+    token. The strategy is thus to tokenise a label with a preceeding colon (as in the
+    prompts), i.e., ": positive", and check if the tokenisation starts with the tokens
+    of ": ". If this is the case, then we should not strip the prompts, since the
+    tokeniser produces the whitespace token separately.
+
+    Args:
+        labels_to_be_generated:
+            The labels that are to be generated.
+        tokeniser:
+            The tokeniser used to tokenise the labels.
+
+    Returns:
+        Whether we should strip the prompts.
+    """
+    strip_prompts = True
+    for label in labels_to_be_generated:
+        colon_tokens = tokeniser(": ", add_special_tokens=False).input_ids
+        label_tokens = tokeniser(": " + label, add_special_tokens=False).input_ids
+
+        if isinstance(colon_tokens, torch.Tensor):
+            colon_tokens = list(colon_tokens.squeeze(0))
+        if isinstance(label_tokens, torch.Tensor):
+            label_tokens = list(label_tokens.squeeze(0))
+
+        label_tokens_start_with_colon_tokens = (
+            label_tokens[: len(colon_tokens)] == colon_tokens
+        )
+        if label_tokens_start_with_colon_tokens:
+            strip_prompts = False
+
+    return strip_prompts
 
 
 def get_pad_token(tokeniser: Tokeniser) -> tuple[str, int] | tuple[None, None]:

--- a/src/euroeval/yaml_config.py
+++ b/src/euroeval/yaml_config.py
@@ -21,67 +21,220 @@ from .split_utils import get_repo_splits
 from .tasks import OPEN_ENDED_QA, get_all_tasks
 
 
-def infer_task_from_inspect_ai(
-    raw: dict[str, object], task_map: dict[str, Task]
-) -> Task | None:
-    """Try to infer the EuroEval task from Inspect AI YAML fields.
-
-    Currently detects:
-
-    * A solver with `name: multiple_choice` in `tasks[0].solvers`
-      -> `multiple-choice`
-    * A `choices` key in `tasks[0].field_spec` -> `multiple-choice`
-    * A scorer with `name: model_graded_fact` in `tasks[0].scorers`
-      -> `open-ended-qa` task with an LLM-as-a-judge metric.
-      The judge model is read from `scorers[0].args.model`; when absent, the
-      default judge defined in `OPEN_ENDED_QA` is used.
+def load_yaml_config(
+    hf_api: HfApi, dataset_id: str, cache_dir: Path
+) -> DatasetConfig | None:
+    """Load a dataset config from an eval.yaml file in a Hugging Face repo.
 
     Args:
-        raw:
-            The raw YAML data.
-        task_map:
-            The mapping from task names to task objects.
+        hf_api:
+            The Hugging Face API object.
+        dataset_id:
+            The ID of the dataset to get the config for.
+        cache_dir:
+            The directory to store the cache in.
 
     Returns:
-        The inferred task, or None if the task cannot be inferred.
+        The dataset config if it exists, otherwise None.
     """
-    tasks_raw = raw.get("tasks")
-    if not isinstance(tasks_raw, list) or not tasks_raw:
+    external_config_path = cache_dir / "external_dataset_configs" / dataset_id
+    external_config_path.mkdir(parents=True, exist_ok=True)
+    hf_api.hf_hub_download(
+        repo_id=dataset_id,
+        repo_type="dataset",
+        filename="eval.yaml",
+        local_dir=external_config_path,
+        local_dir_use_symlinks=False,
+    )
+
+    repo_dataset_info = hf_api.dataset_info(repo_id=dataset_id)
+    fallback_language_codes: list[str] | None = None
+    if repo_dataset_info.card_data is not None:
+        lang_meta = getattr(repo_dataset_info.card_data, "language", None)
+        if isinstance(lang_meta, list) and lang_meta:
+            fallback_language_codes = [str(c) for c in lang_meta if c]
+
+    inspect_ai_config: str | None = None
+    inspect_ai_split: str | None = None
+    yaml_file_path = external_config_path / "eval.yaml"
+    try:
+        with yaml_file_path.open(encoding="utf-8") as fh:
+            raw_peek = yaml.safe_load(fh)
+        if isinstance(raw_peek, dict):
+            tasks_peek = raw_peek.get("tasks")
+            if isinstance(tasks_peek, list) and tasks_peek:
+                first_task_peek = tasks_peek[0]
+                if isinstance(first_task_peek, dict):
+                    config_val = first_task_peek.get("config")
+                    if isinstance(config_val, str) and config_val:
+                        inspect_ai_config = config_val
+                    split_val = first_task_peek.get("split")
+                    if isinstance(split_val, str) and split_val:
+                        inspect_ai_split = split_val
+    except (yaml.YAMLError, OSError):
+        pass
+
+    repo_dataset_config = load_dataset_config_from_yaml(
+        yaml_path=yaml_file_path, fallback_language_codes=fallback_language_codes
+    )
+    if repo_dataset_config is None:
         return None
-    first_task: dict[str, object] = cast(dict[str, object], tasks_raw[0])
-    if not isinstance(first_task, dict):
+
+    train_split, val_split, auto_test_split = get_repo_splits(
+        hf_api=hf_api, dataset_id=dataset_id
+    )
+    test_split = inspect_ai_split if inspect_ai_split is not None else auto_test_split
+    if test_split is None:
+        log_once(
+            message=(
+                f"Dataset {dataset_id} does not have a test split, so we cannot load "
+                "it. Please ensure that the dataset has a test split."
+            ),
+            level=logging.ERROR,
+        )
         return None
 
-    solvers = first_task.get("solvers")
-    if isinstance(solvers, list):
-        for solver in solvers:
-            if isinstance(solver, dict):
-                _s: dict[str, object] = cast(dict[str, object], solver)
-                if _s.get("name") == "multiple_choice":
-                    return task_map.get("multiple-choice")
+    if train_split is None and val_split is not None:
+        log_once(
+            message=(
+                f"Dataset {dataset_id!r} has no training split. Using the validation "
+                f"split {val_split!r} as the training split instead."
+            ),
+            level=logging.DEBUG,
+        )
+        train_split = val_split
+        val_split = None
 
-    scorers = first_task.get("scorers")
-    if isinstance(scorers, list):
-        for scorer in scorers:
-            if isinstance(scorer, dict):
-                _sc: dict[str, object] = cast(dict[str, object], scorer)
-                if _sc.get("name") == "model_graded_fact":
-                    judge_id: str | None = None
-                    args = _sc.get("args") or {}
-                    if isinstance(args, dict):
-                        model_val = args.get("model")
-                        if isinstance(model_val, str) and model_val:
-                            judge_id = model_val
-                    if judge_id is not None:
-                        metric = create_model_graded_fact_metric(judge_id=judge_id)
-                        return dataclasses.replace(OPEN_ENDED_QA, metrics=[metric])
-                    return OPEN_ENDED_QA
+    source = f"{dataset_id}::{inspect_ai_config}" if inspect_ai_config else dataset_id
 
-    field_spec = first_task.get("field_spec")
-    if isinstance(field_spec, dict) and "choices" in field_spec:
-        return task_map.get("multiple-choice")
+    repo_dataset_config.name = dataset_id
+    repo_dataset_config.pretty_name = dataset_id
+    repo_dataset_config.source = source
+    repo_dataset_config.train_split = train_split
+    repo_dataset_config.val_split = val_split
+    repo_dataset_config.test_split = test_split
+    return repo_dataset_config
 
-    return None
+
+def load_dataset_config_from_yaml(
+    yaml_path: Path, fallback_language_codes: list[str] | None = None
+) -> DatasetConfig | None:
+    """Load a dataset config from a YAML file.
+
+    The file is fully compatible with the Inspect AI `eval.yaml` format
+    (https://inspect.aisi.org.uk/tasks.html#hugging-face). The EuroEval-specific
+    `task` and `languages` keys are optional:
+
+    * `task` -- if absent, the task is inferred from Inspect AI hints: a solver
+      with `name: multiple_choice` or a `field_spec.choices` entry both map to the
+      `multiple-choice` task. If the task cannot be inferred an error is logged and
+      None is returned.
+    * `languages` -- if absent, the `fallback_language_codes` argument (a list
+      of ISO 639-1 codes) is used. When called from
+      `try_get_dataset_config_from_repo`, the Hugging Face Hub repo metadata
+      supplies this fallback automatically. If neither source provides a language
+      list, English (`"en"`) is used as the final fallback and a warning is logged.
+
+    Column mappings may be specified either as flat top-level keys
+    (`input_column` / `target_column` / `choices_column`) or via a
+    `tasks[0].field_spec` block using the Inspect AI `input` / `target` /
+    `choices` sub-keys. Top-level keys take precedence when both are present.
+
+    `tasks[0].split` is used as the test split. `try_get_dataset_config_from_repo`
+    auto-detects the train and val splits from the repository, and also uses
+    `tasks[0].config` as the HuggingFace dataset config/subset name.
+
+    When reading `field_spec`:
+
+    * `field_spec.input` is used as `input_column`.
+    * `field_spec.target` is used as `target_column` only when it is a plain
+      column name. Inspect AI also allows `"literal:<value>"` (a hard-coded
+      answer string) and bare integers (which Inspect AI maps to letters A, B, C
+      ...); both are silently skipped because they are not column names.
+    * `field_spec.choices` is used as `choices_column` (a single column name or
+      a list of column names).
+
+    Example -- EuroEval flat format:
+
+        task: classification
+        languages:
+          - en
+        labels:
+          - positive
+          - negative
+
+    Example -- pure Inspect AI format (task and languages are inferred automatically):
+
+        # eval.yaml -- no EuroEval-specific keys required
+        name: My Dataset
+        tasks:
+          - id: my_dataset
+            split: test
+            field_spec:
+              input: question
+              target: answer
+              choices: options
+            solvers:
+              - name: multiple_choice
+            scorers:
+              - name: choice
+
+    Example -- Inspect AI format with optional EuroEval overrides:
+
+        # eval.yaml
+        name: My Dataset
+        tasks:
+          - id: my_dataset
+            split: test
+            field_spec:
+              input: text
+              target: label
+            solvers:
+              - name: multiple_choice
+            scorers:
+              - name: choice
+        # EuroEval-specific keys (optional; ignored by Inspect AI)
+        task: multiple-choice
+        languages:
+          - en
+
+    Args:
+        yaml_path:
+            Path to the YAML config file.
+        fallback_language_codes:
+            ISO 639-1 language codes to use when the YAML file does not contain a
+            `languages` key. Typically supplied from HuggingFace Hub repo metadata
+            by `try_get_dataset_config_from_repo`.
+
+    Returns:
+        A `DatasetConfig` built from the YAML data, or None if the file could not
+            be parsed or contains invalid values.
+    """
+    raw = load_yaml_file(yaml_path=yaml_path)
+    if raw is None:
+        return None
+
+    promote_field_spec_fields(raw=raw)
+
+    task_obj = validate_and_get_task(raw=raw, yaml_path=yaml_path)
+    if task_obj is None:
+        return None
+
+    language_objs = parse_languages(
+        raw=raw, fallback_codes=fallback_language_codes, yaml_path=yaml_path
+    )
+    if language_objs is None:
+        return None
+
+    kwargs = build_kwargs(raw=raw, yaml_path=yaml_path)
+    if kwargs is None:
+        return None
+
+    kwargs.setdefault("test_split", "test")
+    kwargs.setdefault("bootstrap_samples", True)
+    kwargs.setdefault("unofficial", False)
+    kwargs.setdefault("input_column", "text")
+    return DatasetConfig(task=task_obj, languages=language_objs, **kwargs)  # ty: ignore[invalid-argument-type]
 
 
 def parse_languages(
@@ -228,285 +381,70 @@ def validate_and_get_task(raw: dict[str, object], yaml_path: Path) -> Task | Non
     return task_obj
 
 
-def load_dataset_config_from_yaml(
-    yaml_path: Path, fallback_language_codes: list[str] | None = None
-) -> DatasetConfig | None:
-    """Load a dataset config from a YAML file.
+def infer_task_from_inspect_ai(
+    raw: dict[str, object], task_map: dict[str, Task]
+) -> Task | None:
+    """Try to infer the EuroEval task from Inspect AI YAML fields.
 
-    The file is fully compatible with the Inspect AI `eval.yaml` format
-    (https://inspect.aisi.org.uk/tasks.html#hugging-face). The EuroEval-specific
-    `task` and `languages` keys are optional:
+    Currently detects:
 
-    * `task` -- if absent, the task is inferred from Inspect AI hints: a solver
-      with `name: multiple_choice` or a `field_spec.choices` entry both map to the
-      `multiple-choice` task. If the task cannot be inferred an error is logged and
-      None is returned.
-    * `languages` -- if absent, the `fallback_language_codes` argument (a list
-      of ISO 639-1 codes) is used. When called from
-      `try_get_dataset_config_from_repo`, the Hugging Face Hub repo metadata
-      supplies this fallback automatically. If neither source provides a language
-      list, English (`"en"`) is used as the final fallback and a warning is logged.
-
-    Column mappings may be specified either as flat top-level keys
-    (`input_column` / `target_column` / `choices_column`) or via a
-    `tasks[0].field_spec` block using the Inspect AI `input` / `target` /
-    `choices` sub-keys. Top-level keys take precedence when both are present.
-
-    `tasks[0].split` is used as the test split. `try_get_dataset_config_from_repo`
-    auto-detects the train and val splits from the repository, and also uses
-    `tasks[0].config` as the HuggingFace dataset config/subset name.
-
-    When reading `field_spec`:
-
-    * `field_spec.input` is used as `input_column`.
-    * `field_spec.target` is used as `target_column` only when it is a plain
-      column name. Inspect AI also allows `"literal:<value>"` (a hard-coded
-      answer string) and bare integers (which Inspect AI maps to letters A, B, C
-      ...); both are silently skipped because they are not column names.
-    * `field_spec.choices` is used as `choices_column` (a single column name or
-      a list of column names).
-
-    Example -- EuroEval flat format:
-
-        task: classification
-        languages:
-          - en
-        labels:
-          - positive
-          - negative
-
-    Example -- pure Inspect AI format (task and languages are inferred automatically):
-
-        # eval.yaml -- no EuroEval-specific keys required
-        name: My Dataset
-        tasks:
-          - id: my_dataset
-            split: test
-            field_spec:
-              input: question
-              target: answer
-              choices: options
-            solvers:
-              - name: multiple_choice
-            scorers:
-              - name: choice
-
-    Example -- Inspect AI format with optional EuroEval overrides:
-
-        # eval.yaml
-        name: My Dataset
-        tasks:
-          - id: my_dataset
-            split: test
-            field_spec:
-              input: text
-              target: label
-            solvers:
-              - name: multiple_choice
-            scorers:
-              - name: choice
-        # EuroEval-specific keys (optional; ignored by Inspect AI)
-        task: multiple-choice
-        languages:
-          - en
+    * A solver with `name: multiple_choice` in `tasks[0].solvers`
+      -> `multiple-choice`
+    * A `choices` key in `tasks[0].field_spec` -> `multiple-choice`
+    * A scorer with `name: model_graded_fact` in `tasks[0].scorers`
+      -> `open-ended-qa` task with an LLM-as-a-judge metric.
+      The judge model is read from `scorers[0].args.model`; when absent, the
+      default judge defined in `OPEN_ENDED_QA` is used.
 
     Args:
-        yaml_path:
-            Path to the YAML config file.
-        fallback_language_codes:
-            ISO 639-1 language codes to use when the YAML file does not contain a
-            `languages` key. Typically supplied from HuggingFace Hub repo metadata
-            by `try_get_dataset_config_from_repo`.
+        raw:
+            The raw YAML data.
+        task_map:
+            The mapping from task names to task objects.
 
     Returns:
-        A `DatasetConfig` built from the YAML data, or None if the file could not
-            be parsed or contains invalid values.
+        The inferred task, or None if the task cannot be inferred.
     """
-    raw = load_yaml_file(yaml_path=yaml_path)
-    if raw is None:
+    tasks_raw = raw.get("tasks")
+    if not isinstance(tasks_raw, list) or not tasks_raw:
+        return None
+    first_task: dict[str, object] = cast(dict[str, object], tasks_raw[0])
+    if not isinstance(first_task, dict):
         return None
 
-    promote_field_spec_fields(raw=raw)
+    solvers = first_task.get("solvers")
+    if isinstance(solvers, list):
+        for solver in solvers:
+            if isinstance(solver, dict):
+                _s: dict[str, object] = cast(dict[str, object], solver)
+                if _s.get("name") == "multiple_choice":
+                    return task_map.get("multiple-choice")
 
-    task_obj = validate_and_get_task(raw=raw, yaml_path=yaml_path)
-    if task_obj is None:
-        return None
+    scorers = first_task.get("scorers")
+    if isinstance(scorers, list):
+        for scorer in scorers:
+            if isinstance(scorer, dict):
+                _sc: dict[str, object] = cast(dict[str, object], scorer)
+                if _sc.get("name") == "model_graded_fact":
+                    judge_id: str | None = None
+                    args = _sc.get("args") or {}
+                    if isinstance(args, dict):
+                        model_val = args.get("model")
+                        if isinstance(model_val, str) and model_val:
+                            judge_id = model_val
+                    if judge_id is not None:
+                        metric = create_model_graded_fact_metric(judge_id=judge_id)
+                        return dataclasses.replace(OPEN_ENDED_QA, metrics=[metric])
+                    return OPEN_ENDED_QA
 
-    language_objs = parse_languages(
-        raw=raw, fallback_codes=fallback_language_codes, yaml_path=yaml_path
-    )
-    if language_objs is None:
-        return None
+    field_spec = first_task.get("field_spec")
+    if isinstance(field_spec, dict) and "choices" in field_spec:
+        return task_map.get("multiple-choice")
 
-    kwargs = build_kwargs(raw=raw, yaml_path=yaml_path)
-    if kwargs is None:
-        return None
-
-    kwargs.setdefault("test_split", "test")
-    kwargs.setdefault("bootstrap_samples", True)
-    kwargs.setdefault("unofficial", False)
-    kwargs.setdefault("input_column", "text")
-    return DatasetConfig(task=task_obj, languages=language_objs, **kwargs)  # ty: ignore[invalid-argument-type]
-
-
-def load_yaml_config(
-    hf_api: HfApi, dataset_id: str, cache_dir: Path
-) -> DatasetConfig | None:
-    """Load a dataset config from an eval.yaml file in a Hugging Face repo.
-
-    Args:
-        hf_api:
-            The Hugging Face API object.
-        dataset_id:
-            The ID of the dataset to get the config for.
-        cache_dir:
-            The directory to store the cache in.
-
-    Returns:
-        The dataset config if it exists, otherwise None.
-    """
-    external_config_path = cache_dir / "external_dataset_configs" / dataset_id
-    external_config_path.mkdir(parents=True, exist_ok=True)
-    hf_api.hf_hub_download(
-        repo_id=dataset_id,
-        repo_type="dataset",
-        filename="eval.yaml",
-        local_dir=external_config_path,
-        local_dir_use_symlinks=False,
-    )
-
-    repo_dataset_info = hf_api.dataset_info(repo_id=dataset_id)
-    fallback_language_codes: list[str] | None = None
-    if repo_dataset_info.card_data is not None:
-        lang_meta = getattr(repo_dataset_info.card_data, "language", None)
-        if isinstance(lang_meta, list) and lang_meta:
-            fallback_language_codes = [str(c) for c in lang_meta if c]
-
-    inspect_ai_config: str | None = None
-    inspect_ai_split: str | None = None
-    yaml_file_path = external_config_path / "eval.yaml"
-    try:
-        with yaml_file_path.open(encoding="utf-8") as fh:
-            raw_peek = yaml.safe_load(fh)
-        if isinstance(raw_peek, dict):
-            tasks_peek = raw_peek.get("tasks")
-            if isinstance(tasks_peek, list) and tasks_peek:
-                first_task_peek = tasks_peek[0]
-                if isinstance(first_task_peek, dict):
-                    config_val = first_task_peek.get("config")
-                    if isinstance(config_val, str) and config_val:
-                        inspect_ai_config = config_val
-                    split_val = first_task_peek.get("split")
-                    if isinstance(split_val, str) and split_val:
-                        inspect_ai_split = split_val
-    except (yaml.YAMLError, OSError):
-        pass
-
-    repo_dataset_config = load_dataset_config_from_yaml(
-        yaml_path=yaml_file_path, fallback_language_codes=fallback_language_codes
-    )
-    if repo_dataset_config is None:
-        return None
-
-    train_split, val_split, auto_test_split = get_repo_splits(
-        hf_api=hf_api, dataset_id=dataset_id
-    )
-    test_split = inspect_ai_split if inspect_ai_split is not None else auto_test_split
-    if test_split is None:
-        log_once(
-            message=(
-                f"Dataset {dataset_id} does not have a test split, so we cannot load "
-                "it. Please ensure that the dataset has a test split."
-            ),
-            level=logging.ERROR,
-        )
-        return None
-
-    if train_split is None and val_split is not None:
-        log_once(
-            message=(
-                f"Dataset {dataset_id!r} has no training split. Using the validation "
-                f"split {val_split!r} as the training split instead."
-            ),
-            level=logging.DEBUG,
-        )
-        train_split = val_split
-        val_split = None
-
-    source = f"{dataset_id}::{inspect_ai_config}" if inspect_ai_config else dataset_id
-
-    repo_dataset_config.name = dataset_id
-    repo_dataset_config.pretty_name = dataset_id
-    repo_dataset_config.source = source
-    repo_dataset_config.train_split = train_split
-    repo_dataset_config.val_split = val_split
-    repo_dataset_config.test_split = test_split
-    return repo_dataset_config
+    return None
 
 
 DatasetKwargs = dict[str, str | int | bool | list[str] | dict[str, str]]
-
-
-def parse_int_field(
-    raw: dict[str, object], field_name: str, yaml_path: Path
-) -> int | None:
-    """Parse and validate an integer field from YAML.
-
-    Args:
-        raw:
-            The parsed YAML data.
-        field_name:
-            The name of the field to parse.
-        yaml_path:
-            Path to the YAML config file (for error messages).
-
-    Returns:
-        The field value as an integer, or None if validation failed.
-    """
-    value = raw.get(field_name)
-    if value is not None:
-        if isinstance(value, bool) or not isinstance(value, int):
-            log_once(
-                message=(
-                    f"Field '{field_name}' in YAML config at {yaml_path} must be an "
-                    "integer."
-                ),
-                level=logging.ERROR,
-            )
-            return None
-        return value
-    return None
-
-
-def parse_string_field(
-    raw: dict[str, object], field_name: str, yaml_path: Path
-) -> str | None:
-    """Parse and validate a string field from YAML.
-
-    Args:
-        raw:
-            The parsed YAML data.
-        field_name:
-            The name of the field to parse.
-        yaml_path:
-            Path to the YAML config file (for error messages).
-
-    Returns:
-        The field value as a string, or None if validation failed.
-    """
-    value = raw.get(field_name)
-    if value is not None:
-        if not isinstance(value, str):
-            log_once(
-                message=(
-                    f"Field '{field_name}' in YAML config at {yaml_path} must be a "
-                    "string."
-                ),
-                level=logging.ERROR,
-            )
-            return None
-        return value
-    return None
 
 
 def build_kwargs(raw: dict[str, object], yaml_path: Path) -> DatasetKwargs | None:
@@ -595,6 +533,68 @@ def build_kwargs(raw: dict[str, object], yaml_path: Path) -> DatasetKwargs | Non
             return None
 
     return kwargs
+
+
+def parse_int_field(
+    raw: dict[str, object], field_name: str, yaml_path: Path
+) -> int | None:
+    """Parse and validate an integer field from YAML.
+
+    Args:
+        raw:
+            The parsed YAML data.
+        field_name:
+            The name of the field to parse.
+        yaml_path:
+            Path to the YAML config file (for error messages).
+
+    Returns:
+        The field value as an integer, or None if validation failed.
+    """
+    value = raw.get(field_name)
+    if value is not None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            log_once(
+                message=(
+                    f"Field '{field_name}' in YAML config at {yaml_path} must be an "
+                    "integer."
+                ),
+                level=logging.ERROR,
+            )
+            return None
+        return value
+    return None
+
+
+def parse_string_field(
+    raw: dict[str, object], field_name: str, yaml_path: Path
+) -> str | None:
+    """Parse and validate a string field from YAML.
+
+    Args:
+        raw:
+            The parsed YAML data.
+        field_name:
+            The name of the field to parse.
+        yaml_path:
+            Path to the YAML config file (for error messages).
+
+    Returns:
+        The field value as a string, or None if validation failed.
+    """
+    value = raw.get(field_name)
+    if value is not None:
+        if not isinstance(value, str):
+            log_once(
+                message=(
+                    f"Field '{field_name}' in YAML config at {yaml_path} must be a "
+                    "string."
+                ),
+                level=logging.ERROR,
+            )
+            return None
+        return value
+    return None
 
 
 def load_yaml_file(yaml_path: Path) -> dict[str, object] | None:

--- a/src/leaderboards/backup.py
+++ b/src/leaderboards/backup.py
@@ -36,166 +36,47 @@ from .eee_validation import is_eee_record
 logger = logging.getLogger(__name__)
 
 
-def _backup_hash(backup: Path) -> str | None:
-    """Extract the content-hash slug from a backup filename.
+def backup_results(source: Path = RESULTS_DIR) -> Path | None:
+    """Snapshot `source` into BACKUPS_DIR, then prune oldest if over cap.
+
+    Validates that results exist and have valid JSON structure before creating
+    the backup. Note: raw results may be missing the "precious" metadata fields
+    (commercially_licensed, open, trained_from_scratch); those are filled in
+    later by ``add_missing_entries`` and enforced for processed output only.
+
+    Skips if `source`'s contents are unchanged since the newest existing backup,
+    so repeated runs without changes don't fill the backup directory.
 
     Args:
-        backup:
-            A backup path named ``results_<timestamp>_<hash>.tar.gz``.
+        source (optional):
+            The results directory to back up. Defaults to RESULTS_DIR.
 
     Returns:
-        The embedded hash, or None if the name doesn't carry one (e.g. a
-        legacy backup written before content hashing).
+        The Path of the new backup, or None if nothing was written.
+
+    Raises:
+        OSError:
+            If the backup directory (a pCloud Drive path) is unavailable and
+            stdin is not a TTY, so the operator cannot be prompted to retry.
     """
-    stem = backup.name[len(BACKUP_PREFIX) : -len(BACKUP_SUFFIX)]
-    candidate = stem.rpartition("_")[2]
-    return candidate if len(candidate) == BACKUP_HASH_LEN else None
+    # Validate results before backing up
+    _validate_results()
 
-
-def _content_hash(paths: list[Path]) -> str:
-    """Return a short stable hash of the given files' names and contents.
-
-    Args:
-        paths:
-            The files to hash. Will be sorted by relative path for stable
-            ordering regardless of input order.
-
-    Returns:
-        The first `BACKUP_HASH_LEN` hex characters of a SHA-256 over each
-        file's relative path and bytes.
-    """
-    hasher = hashlib.sha256()
-    # Compute relative paths and sort by them for stable ordering
-
-    def _rel_path(p: Path) -> str:
-        return str(p.relative_to(p.parent.parent))
-
-    sorted_paths = sorted(paths, key=_rel_path)
-    for path in sorted_paths:
-        # Use the relative path from results root for stable identity
-        # (e.g., "model_name/dataset__split__shot.json")
-        rel_path = _rel_path(path)
-        hasher.update(rel_path.encode("utf-8"))
-        hasher.update(b"\0")
-        hasher.update(path.read_bytes())
-        hasher.update(b"\0")
-    return hasher.hexdigest()[:BACKUP_HASH_LEN]
-
-
-def _extract_backup(archive: Path, dest: Path) -> None:
-    """Extract the per-record JSON tree from `archive` into `dest`.
-
-    Preserves the tree structure: `results/<model>/<record>.json`.
-    Path traversal is prevented by ensuring all members live under the
-    archive root prefix.
-
-    Args:
-        archive:
-            The ``.tar.gz`` backup to read.
-        dest:
-            The directory to populate with the per-record JSON tree.
-    """
-    dest.mkdir(parents=True, exist_ok=True)
-    with tarfile.open(archive, "r:gz") as tar:
-        for member in tar.getmembers():
-            # Only process files under the results/ prefix
-            if not member.name.startswith(f"{BACKUP_ARCHIVE_ROOT}/"):
-                continue
-            if not member.isfile() or not member.name.endswith(".json"):
-                continue
-            # Strip the "results/" prefix to get relative path within dest
-            rel_path = Path(member.name).relative_to(BACKUP_ARCHIVE_ROOT)
-            target_path = dest / rel_path
-            # Ensure we don't write outside dest (path traversal protection)
-            try:
-                target_path.relative_to(dest)
-            except ValueError:
-                logger.warning(f"Skipping {member.name} - path traversal detected")
-                continue
-            target_path.parent.mkdir(parents=True, exist_ok=True)
-            extracted = tar.extractfile(member)
-            if extracted is None:
-                continue
-            target_path.write_bytes(extracted.read())
-
-
-def _is_only_previous_day_backup(backups: list[Path]) -> bool:
-    """Check if there is exactly one backup from a previous day.
-
-    Args:
-        backups:
-            List of all backups (newest first).
-
-    Returns:
-        True if exactly one backup is from a previous day, False otherwise.
-    """
-    today = dt.datetime.now().date()
-    previous_day_count = sum(
-        1
-        for backup in backups
-        if dt.datetime.fromtimestamp(backup.stat().st_mtime).date() < today
-    )
-    return previous_day_count == 1
-
-
-def _list_backups() -> list[Path]:
-    """List the backup archives in BACKUPS_DIR, newest first.
-
-    Returns:
-        The backup paths matching the ``results_*.tar.gz`` naming, sorted by
-        modification time with the newest first. Empty if BACKUPS_DIR is
-        missing.
-    """
-    if not BACKUPS_DIR.exists():
-        return []
-    backups = [
-        p
-        for p in BACKUPS_DIR.iterdir()
-        if p.is_file()
-        and p.name.startswith(BACKUP_PREFIX)
-        and p.name.endswith(BACKUP_SUFFIX)
-    ]
-    # Newest first.
-    backups.sort(key=lambda p: p.stat().st_mtime, reverse=True)
-    return backups
-
-
-def _prune_backups() -> None:
-    """Delete oldest backups until under BACKUPS_MAX_BYTES.
-
-    Always keeps at least one backup from a previous day (if any exist),
-    ensuring it's possible to revert to a prior day's state.
-    """
-    backups = _list_backups()
-
-    # Identify the newest backup from a previous day (if any exist).
-    today = dt.datetime.now().date()
-    previous_day_backup: Path | None = None
-    for backup in backups:
-        backup_date = dt.datetime.fromtimestamp(backup.stat().st_mtime).date()
-        if backup_date < today:
-            previous_day_backup = backup
-            break
-
-    # Prune by size if over cap
-    total = sum(p.stat().st_size for p in backups)
-    if total <= BACKUPS_MAX_BYTES:
-        return
-
-    # Walk from oldest forward, deleting until under cap. Always keep the
-    # newest one and the previous-day backup (if it's the only one from yesterday).
-    for old in list(reversed(backups)):
-        if total <= BACKUPS_MAX_BYTES:
-            break
-
-        # Protect the last backup from a previous day
-        if old is previous_day_backup and _is_only_previous_day_backup(backups):
-            logger.info(f"Skipping prune of {old.name} - last backup from previous day")
-            continue
-        size = old.stat().st_size
-        old.unlink()
-        total -= size
-        logger.info(f"Pruned old backup {old.name} ({size:,} bytes) - over size limit")
+    # The backup directory lives on pCloud Drive, which raises OSError when
+    # pCloud is not running. When attached to a terminal, prompt the operator
+    # to start pCloud and retry; otherwise (CI) let the OSError propagate so
+    # the caller's non-interactive safety net handles it.
+    while True:
+        try:
+            return _write_snapshot(source=source)
+        except OSError as exc:
+            if not sys.stdin.isatty():
+                raise
+            logger.warning(f"Backup failed; pCloud may be unavailable: {exc}")
+            input(
+                f"Could not write the backup to {BACKUPS_DIR}. pCloud appears to "
+                "be unavailable. Start pCloud and press Enter to retry..."
+            )
 
 
 def _validate_results() -> None:
@@ -323,47 +204,129 @@ def _write_snapshot(source: Path) -> Path | None:
     return backup_path
 
 
-def backup_results(source: Path = RESULTS_DIR) -> Path | None:
-    """Snapshot `source` into BACKUPS_DIR, then prune oldest if over cap.
-
-    Validates that results exist and have valid JSON structure before creating
-    the backup. Note: raw results may be missing the "precious" metadata fields
-    (commercially_licensed, open, trained_from_scratch); those are filled in
-    later by ``add_missing_entries`` and enforced for processed output only.
-
-    Skips if `source`'s contents are unchanged since the newest existing backup,
-    so repeated runs without changes don't fill the backup directory.
+def _backup_hash(backup: Path) -> str | None:
+    """Extract the content-hash slug from a backup filename.
 
     Args:
-        source (optional):
-            The results directory to back up. Defaults to RESULTS_DIR.
+        backup:
+            A backup path named ``results_<timestamp>_<hash>.tar.gz``.
 
     Returns:
-        The Path of the new backup, or None if nothing was written.
-
-    Raises:
-        OSError:
-            If the backup directory (a pCloud Drive path) is unavailable and
-            stdin is not a TTY, so the operator cannot be prompted to retry.
+        The embedded hash, or None if the name doesn't carry one (e.g. a
+        legacy backup written before content hashing).
     """
-    # Validate results before backing up
-    _validate_results()
+    stem = backup.name[len(BACKUP_PREFIX) : -len(BACKUP_SUFFIX)]
+    candidate = stem.rpartition("_")[2]
+    return candidate if len(candidate) == BACKUP_HASH_LEN else None
 
-    # The backup directory lives on pCloud Drive, which raises OSError when
-    # pCloud is not running. When attached to a terminal, prompt the operator
-    # to start pCloud and retry; otherwise (CI) let the OSError propagate so
-    # the caller's non-interactive safety net handles it.
-    while True:
-        try:
-            return _write_snapshot(source=source)
-        except OSError as exc:
-            if not sys.stdin.isatty():
-                raise
-            logger.warning(f"Backup failed; pCloud may be unavailable: {exc}")
-            input(
-                f"Could not write the backup to {BACKUPS_DIR}. pCloud appears to "
-                "be unavailable. Start pCloud and press Enter to retry..."
-            )
+
+def _content_hash(paths: list[Path]) -> str:
+    """Return a short stable hash of the given files' names and contents.
+
+    Args:
+        paths:
+            The files to hash. Will be sorted by relative path for stable
+            ordering regardless of input order.
+
+    Returns:
+        The first `BACKUP_HASH_LEN` hex characters of a SHA-256 over each
+        file's relative path and bytes.
+    """
+    hasher = hashlib.sha256()
+    # Compute relative paths and sort by them for stable ordering
+
+    def _rel_path(p: Path) -> str:
+        return str(p.relative_to(p.parent.parent))
+
+    sorted_paths = sorted(paths, key=_rel_path)
+    for path in sorted_paths:
+        # Use the relative path from results root for stable identity
+        # (e.g., "model_name/dataset__split__shot.json")
+        rel_path = _rel_path(path)
+        hasher.update(rel_path.encode("utf-8"))
+        hasher.update(b"\0")
+        hasher.update(path.read_bytes())
+        hasher.update(b"\0")
+    return hasher.hexdigest()[:BACKUP_HASH_LEN]
+
+
+def _list_backups() -> list[Path]:
+    """List the backup archives in BACKUPS_DIR, newest first.
+
+    Returns:
+        The backup paths matching the ``results_*.tar.gz`` naming, sorted by
+        modification time with the newest first. Empty if BACKUPS_DIR is
+        missing.
+    """
+    if not BACKUPS_DIR.exists():
+        return []
+    backups = [
+        p
+        for p in BACKUPS_DIR.iterdir()
+        if p.is_file()
+        and p.name.startswith(BACKUP_PREFIX)
+        and p.name.endswith(BACKUP_SUFFIX)
+    ]
+    # Newest first.
+    backups.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return backups
+
+
+def _prune_backups() -> None:
+    """Delete oldest backups until under BACKUPS_MAX_BYTES.
+
+    Always keeps at least one backup from a previous day (if any exist),
+    ensuring it's possible to revert to a prior day's state.
+    """
+    backups = _list_backups()
+
+    # Identify the newest backup from a previous day (if any exist).
+    today = dt.datetime.now().date()
+    previous_day_backup: Path | None = None
+    for backup in backups:
+        backup_date = dt.datetime.fromtimestamp(backup.stat().st_mtime).date()
+        if backup_date < today:
+            previous_day_backup = backup
+            break
+
+    # Prune by size if over cap
+    total = sum(p.stat().st_size for p in backups)
+    if total <= BACKUPS_MAX_BYTES:
+        return
+
+    # Walk from oldest forward, deleting until under cap. Always keep the
+    # newest one and the previous-day backup (if it's the only one from yesterday).
+    for old in list(reversed(backups)):
+        if total <= BACKUPS_MAX_BYTES:
+            break
+
+        # Protect the last backup from a previous day
+        if old is previous_day_backup and _is_only_previous_day_backup(backups):
+            logger.info(f"Skipping prune of {old.name} - last backup from previous day")
+            continue
+        size = old.stat().st_size
+        old.unlink()
+        total -= size
+        logger.info(f"Pruned old backup {old.name} ({size:,} bytes) - over size limit")
+
+
+def _is_only_previous_day_backup(backups: list[Path]) -> bool:
+    """Check if there is exactly one backup from a previous day.
+
+    Args:
+        backups:
+            List of all backups (newest first).
+
+    Returns:
+        True if exactly one backup is from a previous day, False otherwise.
+    """
+    today = dt.datetime.now().date()
+    previous_day_count = sum(
+        1
+        for backup in backups
+        if dt.datetime.fromtimestamp(backup.stat().st_mtime).date() < today
+    )
+    return previous_day_count == 1
 
 
 def restore_from_backup_if_missing(target: Path = RESULTS_DIR) -> bool:
@@ -387,3 +350,40 @@ def restore_from_backup_if_missing(target: Path = RESULTS_DIR) -> bool:
     logger.info(f"Restoring {target} from backup {newest.name}")
     _extract_backup(archive=newest, dest=target)
     return True
+
+
+def _extract_backup(archive: Path, dest: Path) -> None:
+    """Extract the per-record JSON tree from `archive` into `dest`.
+
+    Preserves the tree structure: `results/<model>/<record>.json`.
+    Path traversal is prevented by ensuring all members live under the
+    archive root prefix.
+
+    Args:
+        archive:
+            The ``.tar.gz`` backup to read.
+        dest:
+            The directory to populate with the per-record JSON tree.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(archive, "r:gz") as tar:
+        for member in tar.getmembers():
+            # Only process files under the results/ prefix
+            if not member.name.startswith(f"{BACKUP_ARCHIVE_ROOT}/"):
+                continue
+            if not member.isfile() or not member.name.endswith(".json"):
+                continue
+            # Strip the "results/" prefix to get relative path within dest
+            rel_path = Path(member.name).relative_to(BACKUP_ARCHIVE_ROOT)
+            target_path = dest / rel_path
+            # Ensure we don't write outside dest (path traversal protection)
+            try:
+                target_path.relative_to(dest)
+            except ValueError:
+                logger.warning(f"Skipping {member.name} - path traversal detected")
+                continue
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            extracted = tar.extractfile(member)
+            if extracted is None:
+                continue
+            target_path.write_bytes(extracted.read())

--- a/src/leaderboards/bootstrap_cis.py
+++ b/src/leaderboards/bootstrap_cis.py
@@ -21,307 +21,6 @@ from .constants import LEADERBOARD_CATEGORIES
 from .task_metadata import category_includes_task
 
 
-def _aggregate_scores_to_categories(
-    dataset_scores: dict[str, float], configs: dict[str, dict[str, list[str]]]
-) -> tuple[dict[str, float], float | None]:
-    """Aggregate per-dataset scores up to language and overall mean rank scores.
-
-    Hierarchy: dataset -> task -> language -> overall.
-
-    Args:
-        dataset_scores:
-            dataset -> score mapping for this model.
-        configs:
-            Per-language task -> dataset mappings.
-
-    Returns:
-        A tuple of (language_scores, overall_score). Language scores is a dict
-        mapping language name to mean rank score. Overall score is the mean
-        across languages. Returns ({}, None) if there is no data.
-    """
-    lang_task_scores: dict[str, dict[str, list[float]]] = {}
-
-    for ds, score in dataset_scores.items():
-        task = None
-        found_lang = None
-        for lang_name, config in configs.items():
-            for task_name, task_ds in config.items():
-                if ds in task_ds:
-                    task = task_name
-                    found_lang = lang_name
-                    break
-            if task:
-                break
-        if task and task not in ORTHOGONAL_TASKS and found_lang:
-            lang_task_scores.setdefault(found_lang, {}).setdefault(task, []).append(
-                score
-            )
-
-    if not lang_task_scores:
-        return {}, None
-
-    language_scores: dict[str, float] = {}
-    lang_means = []
-    for lang, task_scores in lang_task_scores.items():
-        task_means = [np.mean(scores) for scores in task_scores.values()]
-        if task_means:
-            lang_mean = float(np.mean(task_means))
-            language_scores[lang] = lang_mean
-            lang_means.append(lang_mean)
-
-    overall = float(np.mean(lang_means)) if lang_means else None
-    return language_scores, overall
-
-
-def _aggregate_bootstrap_sample(
-    model_id: str,
-    categories: tuple[str, ...],
-    all_rank_scores: dict[str, dict[str, dict[str, float]]],
-    configs: dict[str, dict[str, list[str]]],
-) -> dict[str, dict[str, float | None]]:
-    """Aggregate per-dataset scores for one model in one bootstrap sample.
-
-    Returns:
-        category -> {lang: score, "overall": overall or None}
-    """
-    result: dict[str, dict[str, float | None]] = {}
-    for category in categories:
-        model_rank_scores = all_rank_scores.get(model_id, {}).get(category, {})
-        if not model_rank_scores:
-            continue
-        language_scores, overall = _aggregate_scores_to_categories(
-            dataset_scores=model_rank_scores, configs=configs
-        )
-        result[category] = {**language_scores, "overall": overall}
-    return result
-
-
-def _compute_dataset_stats(
-    sampled_set: set[str],
-    dataset_models: dict[str, set[str]],
-    model_datasets: dict[str, set[str]],
-    model_results: dict[str, dict[str, list[tuple[list[float], float, float]]]],
-) -> dict[str, tuple[float, float]]:
-    """Compute pooled SD and best model for each sampled dataset.
-
-    Args:
-        sampled_set:
-            Set of sampled datasets.
-        dataset_models:
-            Mapping of dataset to set of models.
-        model_datasets:
-            Mapping of model to set of datasets.
-        model_results:
-            The model results.
-
-    Returns:
-        Dict of dataset -> (best_mean, pooled_sd).
-    """
-    dataset_stats: dict[str, tuple[float, float]] = {}
-    for ds in sampled_set:
-        models_on_ds = dataset_models.get(ds, set())
-        if not models_on_ds:
-            continue
-        scores: list[tuple[str, float, list[float]]] = []
-        for mid in models_on_ds:
-            if mid in model_results and ds in model_datasets[mid]:
-                raw, mean_sc, _ = model_results[mid][ds][0]
-                if np.isfinite(mean_sc):
-                    scores.append((mid, mean_sc, raw))
-        if not scores:
-            continue
-        scores.sort(key=lambda x: x[1], reverse=True)
-        best_mean = scores[0][1]
-        all_raw = [score for _, _, r in scores for score in r]
-        pooled_sd = np.std(all_raw) if len(all_raw) > 1 else 1.0
-        dataset_stats[ds] = (best_mean, float(pooled_sd))
-    return dataset_stats
-
-
-def _compute_rank_scores(
-    dataset_stats: dict[str, tuple[float, float]],
-    dataset_models: dict[str, set[str]],
-    model_datasets: dict[str, set[str]],
-    model_results: dict[str, dict[str, list[tuple[list[float], float, float]]]],
-    dataset_to_category: dict[str, set[str]],
-    rng: np.random.Generator,
-) -> dict[str, dict[str, dict[str, float]]]:
-    """Compute rank scores for all models on all sampled datasets.
-
-    Args:
-        dataset_stats:
-            Per-dataset statistics.
-        dataset_models:
-            Mapping of dataset to set of models.
-        model_datasets:
-            Mapping of model to set of datasets.
-        model_results:
-            The model results.
-        dataset_to_category:
-            Mapping of dataset to categories.
-        rng:
-            Random number generator.
-
-    Returns:
-        Nested dict: model_id -> category -> dataset -> score.
-    """
-    all_rank_scores: dict[str, dict[str, dict[str, float]]] = {}
-    for ds, (best_mean, pooled_sd) in dataset_stats.items():
-        if pooled_sd <= 0:
-            continue
-        models_on_ds = dataset_models.get(ds, set())
-        for mid in models_on_ds:
-            if mid not in model_results or ds not in model_datasets[mid]:
-                continue
-            raw, mean_sc, _ = model_results[mid][ds][0]
-            if not np.isfinite(mean_sc):
-                continue
-            resampled_raw = rng.choice(raw, size=len(raw), replace=True)
-            resampled_mean = float(np.mean(resampled_raw))
-            diff = (best_mean - resampled_mean) / pooled_sd
-            score = 1.0 + diff
-            for cat in dataset_to_category.get(ds, set()):
-                all_rank_scores.setdefault(mid, {}).setdefault(cat, {})[ds] = score
-    return all_rank_scores
-
-
-def _bootstrap_single_iteration(
-    task_datasets: dict[str, list[str]],
-    dataset_models: dict[str, set[str]],
-    model_datasets: dict[str, set[str]],
-    model_results: dict[str, dict[str, list[tuple[list[float], float, float]]]],
-    dataset_to_category: dict[str, set[str]],
-    configs: dict[str, dict[str, list[str]]],
-    categories: tuple[str, ...],
-    rng: np.random.Generator,
-) -> dict[str, dict[str, dict[str, float]]]:
-    """Run a single bootstrap iteration and return aggregated scores.
-
-    Args:
-        task_datasets:
-            Mapping of task to list of datasets.
-        dataset_models:
-            Mapping of dataset to set of models.
-        model_datasets:
-            Mapping of model to set of datasets.
-        model_results:
-            The model results.
-        dataset_to_category:
-            Mapping of dataset to categories.
-        configs:
-            Per-language task -> dataset mappings.
-        categories:
-            Categories to compute.
-        rng:
-            Random number generator.
-
-    Returns:
-        Nested dict: model_id -> category -> language -> score.
-    """
-    # Resample datasets with replacement (stratified by task)
-    sampled_datasets: dict[str, list[str]] = {}
-    for task, ds_list in task_datasets.items():
-        n = len(ds_list)
-        indices = rng.integers(0, n, size=n)
-        sampled_datasets[task] = [ds_list[i] for i in indices]
-
-    sampled_set: set[str] = set()
-    for ds_list in sampled_datasets.values():
-        sampled_set.update(ds_list)
-
-    dataset_stats = _compute_dataset_stats(
-        sampled_set=sampled_set,
-        dataset_models=dataset_models,
-        model_datasets=model_datasets,
-        model_results=model_results,
-    )
-
-    all_rank_scores = _compute_rank_scores(
-        dataset_stats=dataset_stats,
-        dataset_models=dataset_models,
-        model_datasets=model_datasets,
-        model_results=model_results,
-        dataset_to_category=dataset_to_category,
-        rng=rng,
-    )
-
-    aggregated: dict[str, dict[str, dict[str, float]]] = {}
-    for model_id in model_results:
-        model_agg = _aggregate_bootstrap_sample(
-            model_id=model_id,
-            categories=categories,
-            all_rank_scores=all_rank_scores,
-            configs=configs,
-        )
-        for category, cat_data in model_agg.items():
-            for key, score in cat_data.items():
-                if score is not None:
-                    aggregated.setdefault(model_id, {}).setdefault(category, {})[
-                        key
-                    ] = score
-    return aggregated
-
-
-def _build_dataset_mappings(
-    configs: dict[str, dict[str, list[str]]], categories: tuple[str, ...]
-) -> tuple[dict[str, list[str]], dict[str, set[str]]]:
-    """Build task->datasets and dataset->categories mappings for bootstrap.
-
-    Args:
-        configs:
-            Per-language task -> dataset mappings.
-        categories:
-            Categories to compute.
-
-    Returns:
-        Tuple of (task_datasets dict, dataset_to_category dict).
-    """
-    dataset_to_task: dict[str, str] = {}
-    for _language, config in configs.items():
-        for task, task_datasets_list in config.items():
-            if task in ORTHOGONAL_TASKS:
-                continue
-            for ds in task_datasets_list:
-                dataset_to_task[ds] = task
-
-    task_datasets: dict[str, list[str]] = defaultdict(list)
-    for ds, task in dataset_to_task.items():
-        task_datasets[task].append(ds)
-
-    dataset_to_category: dict[str, set[str]] = {}
-    for ds, task in dataset_to_task.items():
-        cats: set[str] = set()
-        for category in categories:
-            if category_includes_task(category=category, task=task):
-                cats.add(category)
-        if cats:
-            dataset_to_category[ds] = cats
-
-    return task_datasets, dataset_to_category
-
-
-def _convert_bootstrap_scores_to_arrays(
-    bootstrap_scores: dict[str, dict[str, dict[str, list[float]]]],
-) -> dict[str, dict[str, dict[str, np.ndarray]]]:
-    """Convert bootstrap score lists to numpy arrays.
-
-    Args:
-        bootstrap_scores:
-            Nested dict with lists of bootstrap scores.
-
-    Returns:
-        Same structure but with np.ndarray values.
-    """
-    result: dict[str, dict[str, dict[str, np.ndarray]]] = {}
-    for mid, cats_data in bootstrap_scores.items():
-        result[mid] = {}
-        for cat, langs in cats_data.items():
-            result[mid][cat] = {
-                lang: np.array(scores) for lang, scores in langs.items()
-            }
-    return result
-
-
 def bootstrap_confidence_intervals(
     bootstrap_scores: dict[str, dict[str, dict[str, np.ndarray]]], alpha: float = 0.05
 ) -> dict[str, dict[str, dict[str, dict[str, float]]]]:
@@ -429,3 +128,304 @@ def bootstrap_rank_scores(
                     bootstrap_scores[model_id][category][key].append(score)
 
     return _convert_bootstrap_scores_to_arrays(bootstrap_scores)
+
+
+def _bootstrap_single_iteration(
+    task_datasets: dict[str, list[str]],
+    dataset_models: dict[str, set[str]],
+    model_datasets: dict[str, set[str]],
+    model_results: dict[str, dict[str, list[tuple[list[float], float, float]]]],
+    dataset_to_category: dict[str, set[str]],
+    configs: dict[str, dict[str, list[str]]],
+    categories: tuple[str, ...],
+    rng: np.random.Generator,
+) -> dict[str, dict[str, dict[str, float]]]:
+    """Run a single bootstrap iteration and return aggregated scores.
+
+    Args:
+        task_datasets:
+            Mapping of task to list of datasets.
+        dataset_models:
+            Mapping of dataset to set of models.
+        model_datasets:
+            Mapping of model to set of datasets.
+        model_results:
+            The model results.
+        dataset_to_category:
+            Mapping of dataset to categories.
+        configs:
+            Per-language task -> dataset mappings.
+        categories:
+            Categories to compute.
+        rng:
+            Random number generator.
+
+    Returns:
+        Nested dict: model_id -> category -> language -> score.
+    """
+    # Resample datasets with replacement (stratified by task)
+    sampled_datasets: dict[str, list[str]] = {}
+    for task, ds_list in task_datasets.items():
+        n = len(ds_list)
+        indices = rng.integers(0, n, size=n)
+        sampled_datasets[task] = [ds_list[i] for i in indices]
+
+    sampled_set: set[str] = set()
+    for ds_list in sampled_datasets.values():
+        sampled_set.update(ds_list)
+
+    dataset_stats = _compute_dataset_stats(
+        sampled_set=sampled_set,
+        dataset_models=dataset_models,
+        model_datasets=model_datasets,
+        model_results=model_results,
+    )
+
+    all_rank_scores = _compute_rank_scores(
+        dataset_stats=dataset_stats,
+        dataset_models=dataset_models,
+        model_datasets=model_datasets,
+        model_results=model_results,
+        dataset_to_category=dataset_to_category,
+        rng=rng,
+    )
+
+    aggregated: dict[str, dict[str, dict[str, float]]] = {}
+    for model_id in model_results:
+        model_agg = _aggregate_bootstrap_sample(
+            model_id=model_id,
+            categories=categories,
+            all_rank_scores=all_rank_scores,
+            configs=configs,
+        )
+        for category, cat_data in model_agg.items():
+            for key, score in cat_data.items():
+                if score is not None:
+                    aggregated.setdefault(model_id, {}).setdefault(category, {})[
+                        key
+                    ] = score
+    return aggregated
+
+
+def _aggregate_bootstrap_sample(
+    model_id: str,
+    categories: tuple[str, ...],
+    all_rank_scores: dict[str, dict[str, dict[str, float]]],
+    configs: dict[str, dict[str, list[str]]],
+) -> dict[str, dict[str, float | None]]:
+    """Aggregate per-dataset scores for one model in one bootstrap sample.
+
+    Returns:
+        category -> {lang: score, "overall": overall or None}
+    """
+    result: dict[str, dict[str, float | None]] = {}
+    for category in categories:
+        model_rank_scores = all_rank_scores.get(model_id, {}).get(category, {})
+        if not model_rank_scores:
+            continue
+        language_scores, overall = _aggregate_scores_to_categories(
+            dataset_scores=model_rank_scores, configs=configs
+        )
+        result[category] = {**language_scores, "overall": overall}
+    return result
+
+
+def _aggregate_scores_to_categories(
+    dataset_scores: dict[str, float], configs: dict[str, dict[str, list[str]]]
+) -> tuple[dict[str, float], float | None]:
+    """Aggregate per-dataset scores up to language and overall mean rank scores.
+
+    Hierarchy: dataset -> task -> language -> overall.
+
+    Args:
+        dataset_scores:
+            dataset -> score mapping for this model.
+        configs:
+            Per-language task -> dataset mappings.
+
+    Returns:
+        A tuple of (language_scores, overall_score). Language scores is a dict
+        mapping language name to mean rank score. Overall score is the mean
+        across languages. Returns ({}, None) if there is no data.
+    """
+    lang_task_scores: dict[str, dict[str, list[float]]] = {}
+
+    for ds, score in dataset_scores.items():
+        task = None
+        found_lang = None
+        for lang_name, config in configs.items():
+            for task_name, task_ds in config.items():
+                if ds in task_ds:
+                    task = task_name
+                    found_lang = lang_name
+                    break
+            if task:
+                break
+        if task and task not in ORTHOGONAL_TASKS and found_lang:
+            lang_task_scores.setdefault(found_lang, {}).setdefault(task, []).append(
+                score
+            )
+
+    if not lang_task_scores:
+        return {}, None
+
+    language_scores: dict[str, float] = {}
+    lang_means = []
+    for lang, task_scores in lang_task_scores.items():
+        task_means = [np.mean(scores) for scores in task_scores.values()]
+        if task_means:
+            lang_mean = float(np.mean(task_means))
+            language_scores[lang] = lang_mean
+            lang_means.append(lang_mean)
+
+    overall = float(np.mean(lang_means)) if lang_means else None
+    return language_scores, overall
+
+
+def _compute_dataset_stats(
+    sampled_set: set[str],
+    dataset_models: dict[str, set[str]],
+    model_datasets: dict[str, set[str]],
+    model_results: dict[str, dict[str, list[tuple[list[float], float, float]]]],
+) -> dict[str, tuple[float, float]]:
+    """Compute pooled SD and best model for each sampled dataset.
+
+    Args:
+        sampled_set:
+            Set of sampled datasets.
+        dataset_models:
+            Mapping of dataset to set of models.
+        model_datasets:
+            Mapping of model to set of datasets.
+        model_results:
+            The model results.
+
+    Returns:
+        Dict of dataset -> (best_mean, pooled_sd).
+    """
+    dataset_stats: dict[str, tuple[float, float]] = {}
+    for ds in sampled_set:
+        models_on_ds = dataset_models.get(ds, set())
+        if not models_on_ds:
+            continue
+        scores: list[tuple[str, float, list[float]]] = []
+        for mid in models_on_ds:
+            if mid in model_results and ds in model_datasets[mid]:
+                raw, mean_sc, _ = model_results[mid][ds][0]
+                if np.isfinite(mean_sc):
+                    scores.append((mid, mean_sc, raw))
+        if not scores:
+            continue
+        scores.sort(key=lambda x: x[1], reverse=True)
+        best_mean = scores[0][1]
+        all_raw = [score for _, _, r in scores for score in r]
+        pooled_sd = np.std(all_raw) if len(all_raw) > 1 else 1.0
+        dataset_stats[ds] = (best_mean, float(pooled_sd))
+    return dataset_stats
+
+
+def _compute_rank_scores(
+    dataset_stats: dict[str, tuple[float, float]],
+    dataset_models: dict[str, set[str]],
+    model_datasets: dict[str, set[str]],
+    model_results: dict[str, dict[str, list[tuple[list[float], float, float]]]],
+    dataset_to_category: dict[str, set[str]],
+    rng: np.random.Generator,
+) -> dict[str, dict[str, dict[str, float]]]:
+    """Compute rank scores for all models on all sampled datasets.
+
+    Args:
+        dataset_stats:
+            Per-dataset statistics.
+        dataset_models:
+            Mapping of dataset to set of models.
+        model_datasets:
+            Mapping of model to set of datasets.
+        model_results:
+            The model results.
+        dataset_to_category:
+            Mapping of dataset to categories.
+        rng:
+            Random number generator.
+
+    Returns:
+        Nested dict: model_id -> category -> dataset -> score.
+    """
+    all_rank_scores: dict[str, dict[str, dict[str, float]]] = {}
+    for ds, (best_mean, pooled_sd) in dataset_stats.items():
+        if pooled_sd <= 0:
+            continue
+        models_on_ds = dataset_models.get(ds, set())
+        for mid in models_on_ds:
+            if mid not in model_results or ds not in model_datasets[mid]:
+                continue
+            raw, mean_sc, _ = model_results[mid][ds][0]
+            if not np.isfinite(mean_sc):
+                continue
+            resampled_raw = rng.choice(raw, size=len(raw), replace=True)
+            resampled_mean = float(np.mean(resampled_raw))
+            diff = (best_mean - resampled_mean) / pooled_sd
+            score = 1.0 + diff
+            for cat in dataset_to_category.get(ds, set()):
+                all_rank_scores.setdefault(mid, {}).setdefault(cat, {})[ds] = score
+    return all_rank_scores
+
+
+def _build_dataset_mappings(
+    configs: dict[str, dict[str, list[str]]], categories: tuple[str, ...]
+) -> tuple[dict[str, list[str]], dict[str, set[str]]]:
+    """Build task->datasets and dataset->categories mappings for bootstrap.
+
+    Args:
+        configs:
+            Per-language task -> dataset mappings.
+        categories:
+            Categories to compute.
+
+    Returns:
+        Tuple of (task_datasets dict, dataset_to_category dict).
+    """
+    dataset_to_task: dict[str, str] = {}
+    for _language, config in configs.items():
+        for task, task_datasets_list in config.items():
+            if task in ORTHOGONAL_TASKS:
+                continue
+            for ds in task_datasets_list:
+                dataset_to_task[ds] = task
+
+    task_datasets: dict[str, list[str]] = defaultdict(list)
+    for ds, task in dataset_to_task.items():
+        task_datasets[task].append(ds)
+
+    dataset_to_category: dict[str, set[str]] = {}
+    for ds, task in dataset_to_task.items():
+        cats: set[str] = set()
+        for category in categories:
+            if category_includes_task(category=category, task=task):
+                cats.add(category)
+        if cats:
+            dataset_to_category[ds] = cats
+
+    return task_datasets, dataset_to_category
+
+
+def _convert_bootstrap_scores_to_arrays(
+    bootstrap_scores: dict[str, dict[str, dict[str, list[float]]]],
+) -> dict[str, dict[str, dict[str, np.ndarray]]]:
+    """Convert bootstrap score lists to numpy arrays.
+
+    Args:
+        bootstrap_scores:
+            Nested dict with lists of bootstrap scores.
+
+    Returns:
+        Same structure but with np.ndarray values.
+    """
+    result: dict[str, dict[str, dict[str, np.ndarray]]] = {}
+    for mid, cats_data in bootstrap_scores.items():
+        result[mid] = {}
+        for cat, langs in cats_data.items():
+            result[mid][cat] = {
+                lang: np.array(scores) for lang, scores in langs.items()
+            }
+    return result

--- a/src/leaderboards/bucket_sync.py
+++ b/src/leaderboards/bucket_sync.py
@@ -30,48 +30,6 @@ load_dotenv()
 logger = logging.getLogger(__name__)
 
 
-def _cleanup_empty_bucket_files(hf_token: str) -> None:
-    """Delete 0-byte JSON files from the Hugging Face bucket.
-
-    Lists all files in the bucket, identifies empty JSON files by size,
-    and removes them via batch operation.
-
-    Args:
-        hf_token:
-            Hugging Face authentication token.
-    """
-    api = HfApi()
-    empty_files: list[str] = []
-
-    try:
-        # List all files in the bucket
-        files = list_bucket_tree(
-            bucket_id=HF_RESULTS_BUCKET, token=hf_token, recursive=True
-        )
-        for file_info in files:
-            # Check if it's a JSON file with size 0
-            if isinstance(file_info, BucketFile):
-                if file_info.path.endswith(".json") and file_info.size == 0:
-                    empty_files.append(file_info.path)
-            elif isinstance(file_info, dict):
-                # Handle dict format if API returns that
-                path = str(file_info.get("path", ""))
-                size = file_info.get("size", 0)
-                if path.endswith(".json") and size == 0:
-                    empty_files.append(path)
-    except HfHubHTTPError as e:
-        logger.error(f"Failed to list bucket files: {e}")
-        return
-
-    if empty_files:
-        logger.info(f"Found {len(empty_files)} empty file(s) in bucket, deleting...")
-        try:
-            api.batch_bucket_files(bucket_id=HF_RESULTS_BUCKET, delete=empty_files)
-            logger.info(f"Deleted {len(empty_files)} empty file(s) from bucket.")
-        except HfHubHTTPError as e:
-            logger.error(f"Failed to delete empty bucket files: {e}")
-
-
 def _sort_key(record: dict) -> tuple[str, str]:
     """Extract sort key from a record for deterministic ordering.
 
@@ -144,29 +102,6 @@ def download_missing_bucket_files() -> int:
     return len(to_download)
 
 
-def remove_empty_json_files(results_dir: Path) -> list[str]:
-    """Find and delete empty JSON files (0 bytes).
-
-    Scans recursively for all *.json files and removes any with zero size.
-
-    Args:
-        results_dir:
-            Directory to scan for empty JSON files.
-
-    Returns:
-        List of relative paths that were deleted.
-    """
-    deleted: list[str] = []
-    for json_file in results_dir.rglob("*.json"):
-        if json_file.is_file() and json_file.stat().st_size == 0:
-            logger.info(f"Removing empty file {json_file}")
-            json_file.unlink()
-            deleted.append(str(json_file.relative_to(results_dir)))
-    if deleted:
-        logger.info(f"Deleted {len(deleted)} empty JSON file(s).")
-    return deleted
-
-
 def merge_results(results_file: Path) -> int:
     """Merge per-record JSON tree into a single JSONL file.
 
@@ -236,6 +171,29 @@ def merge_results(results_file: Path) -> int:
         for record in sorted(existing.values(), key=_sort_key):
             f.write(json.dumps(record) + "\n")
     return len(existing)
+
+
+def remove_empty_json_files(results_dir: Path) -> list[str]:
+    """Find and delete empty JSON files (0 bytes).
+
+    Scans recursively for all *.json files and removes any with zero size.
+
+    Args:
+        results_dir:
+            Directory to scan for empty JSON files.
+
+    Returns:
+        List of relative paths that were deleted.
+    """
+    deleted: list[str] = []
+    for json_file in results_dir.rglob("*.json"):
+        if json_file.is_file() and json_file.stat().st_size == 0:
+            logger.info(f"Removing empty file {json_file}")
+            json_file.unlink()
+            deleted.append(str(json_file.relative_to(results_dir)))
+    if deleted:
+        logger.info(f"Deleted {len(deleted)} empty JSON file(s).")
+    return deleted
 
 
 def sync_bucket(ignore_sizes: bool = False, delete_empty: bool = True) -> None:
@@ -350,6 +308,48 @@ def sync_bucket(ignore_sizes: bool = False, delete_empty: bool = True) -> None:
         _cleanup_empty_bucket_files(hf_token)
 
     logger.info(f"Synced bucket {HF_RESULTS_BUCKET}.")
+
+
+def _cleanup_empty_bucket_files(hf_token: str) -> None:
+    """Delete 0-byte JSON files from the Hugging Face bucket.
+
+    Lists all files in the bucket, identifies empty JSON files by size,
+    and removes them via batch operation.
+
+    Args:
+        hf_token:
+            Hugging Face authentication token.
+    """
+    api = HfApi()
+    empty_files: list[str] = []
+
+    try:
+        # List all files in the bucket
+        files = list_bucket_tree(
+            bucket_id=HF_RESULTS_BUCKET, token=hf_token, recursive=True
+        )
+        for file_info in files:
+            # Check if it's a JSON file with size 0
+            if isinstance(file_info, BucketFile):
+                if file_info.path.endswith(".json") and file_info.size == 0:
+                    empty_files.append(file_info.path)
+            elif isinstance(file_info, dict):
+                # Handle dict format if API returns that
+                path = str(file_info.get("path", ""))
+                size = file_info.get("size", 0)
+                if path.endswith(".json") and size == 0:
+                    empty_files.append(path)
+    except HfHubHTTPError as e:
+        logger.error(f"Failed to list bucket files: {e}")
+        return
+
+    if empty_files:
+        logger.info(f"Found {len(empty_files)} empty file(s) in bucket, deleting...")
+        try:
+            api.batch_bucket_files(bucket_id=HF_RESULTS_BUCKET, delete=empty_files)
+            logger.info(f"Deleted {len(empty_files)} empty file(s) from bucket.")
+        except HfHubHTTPError as e:
+            logger.error(f"Failed to delete empty bucket files: {e}")
 
 
 def upload_results_to_bucket(results_file: Path) -> None:

--- a/src/leaderboards/cache.py
+++ b/src/leaderboards/cache.py
@@ -18,26 +18,6 @@ from .records import plain_model_id
 logger = logging.getLogger(__name__)
 
 
-def _normalise_model_id_for_hf_matching(model_id: str) -> str:
-    """Normalise a model ID for Hugging Face URL/repo matching.
-
-    Strips HTML anchor, variant suffixes, AND parameter/revision suffixes.
-    This is narrower than :func:`plain_model_id` which preserves #param and
-    @revision for meaningful model differentiation.
-
-    Args:
-        model_id:
-            The model ID to normalise.
-
-    Returns:
-        The base repo ID suitable for HF URL comparison (e.g. "org/repo").
-    """
-    # Strip anchor and variant suffix first
-    model_id = plain_model_id(model_id)
-    # Then strip #param and @revision for HF repo comparison
-    return split_model_id(model_id).model_id
-
-
 @dataclass
 class Cache:
     """A cache for model metadata.
@@ -64,6 +44,36 @@ class Cache:
     open: dict[str, bool] = field(default_factory=dict)
     trained_from_scratch: dict[str, bool] = field(default_factory=dict)
     model_url: dict[str, str | None] = field(default_factory=dict)
+
+    @classmethod
+    def from_results_dir(cls, results_dir: Path) -> "Cache":
+        """Create a cache from records in the results directory.
+
+        Walks the JSON tree structure (``results_dir/<model>/*.json``) and
+        loads all records. Preserves metadata fields in
+        ``model_info.additional_details`` (commercially_licensed, open,
+        trained_from_scratch, model_url, etc.).
+
+        Args:
+            results_dir:
+                The path to the directory containing per-record JSON files
+                with metadata.
+
+        Returns:
+            A Cache instance populated with model metadata.
+
+        Raises:
+            FileNotFoundError:
+                If the results directory does not exist.
+        """
+        if not results_dir.exists():
+            raise FileNotFoundError(f"Results directory {results_dir} not found.")
+
+        records = load_records_from_result_tree(results_dir=results_dir)
+
+        return cls._from_records(
+            records=records, desc="Building caches from results dir"
+        )
 
     @classmethod
     def _from_records(cls, records: list[dict[str, object]], desc: str) -> "Cache":
@@ -109,35 +119,25 @@ class Cache:
 
         return cache
 
-    @classmethod
-    def from_results_dir(cls, results_dir: Path) -> "Cache":
-        """Create a cache from records in the results directory.
 
-        Walks the JSON tree structure (``results_dir/<model>/*.json``) and
-        loads all records. Preserves metadata fields in
-        ``model_info.additional_details`` (commercially_licensed, open,
-        trained_from_scratch, model_url, etc.).
+def _normalise_model_id_for_hf_matching(model_id: str) -> str:
+    """Normalise a model ID for Hugging Face URL/repo matching.
 
-        Args:
-            results_dir:
-                The path to the directory containing per-record JSON files
-                with metadata.
+    Strips HTML anchor, variant suffixes, AND parameter/revision suffixes.
+    This is narrower than :func:`plain_model_id` which preserves #param and
+    @revision for meaningful model differentiation.
 
-        Returns:
-            A Cache instance populated with model metadata.
+    Args:
+        model_id:
+            The model ID to normalise.
 
-        Raises:
-            FileNotFoundError:
-                If the results directory does not exist.
-        """
-        if not results_dir.exists():
-            raise FileNotFoundError(f"Results directory {results_dir} not found.")
-
-        records = load_records_from_result_tree(results_dir=results_dir)
-
-        return cls._from_records(
-            records=records, desc="Building caches from results dir"
-        )
+    Returns:
+        The base repo ID suitable for HF URL comparison (e.g. "org/repo").
+    """
+    # Strip anchor and variant suffix first
+    model_id = plain_model_id(model_id)
+    # Then strip #param and @revision for HF repo comparison
+    return split_model_id(model_id).model_id
 
 
 def _is_hf_url_for_model(model_url: str, model_id: str) -> bool:

--- a/src/leaderboards/core_models.py
+++ b/src/leaderboards/core_models.py
@@ -55,16 +55,6 @@ from .task_metadata import (
 logger = logging.getLogger(__name__)
 
 
-class ModelType(enum.StrEnum):
-    """The architectural / training-stage category of a core model."""
-
-    ENCODER = "encoder"
-    BASE_DECODER = "base_decoder"
-    INSTRUCTION_TUNED_DECODER = "instruction_tuned_decoder"
-    REASONING_DECODER = "reasoning_decoder"
-    API = "api"
-
-
 class SizeBucket(enum.StrEnum):
     """Bucket label used to group models in the GitHub issue."""
 
@@ -74,6 +64,16 @@ class SizeBucket(enum.StrEnum):
     MEDIUM = "medium"
     LARGE = "large"
     XLARGE = "xlarge"
+    API = "api"
+
+
+class ModelType(enum.StrEnum):
+    """The architectural / training-stage category of a core model."""
+
+    ENCODER = "encoder"
+    BASE_DECODER = "base_decoder"
+    INSTRUCTION_TUNED_DECODER = "instruction_tuned_decoder"
+    REASONING_DECODER = "reasoning_decoder"
     API = "api"
 
 
@@ -112,205 +112,6 @@ class CoreModel:
     eu: bool
     osai_rank: int | None
     api: bool
-
-
-def _classify_model(model_id: str, metadata: dict) -> ModelType:
-    """Return the architectural/training type for a model.
-
-    Args:
-        model_id:
-            The HuggingFace-style model identifier.
-        metadata:
-            The metadata entry from `extract_model_metadata`.
-
-    Returns:
-        One of the `ModelType` literals.
-    """
-    plain = plain_model_id(model_id).split("#")[0]
-    if any(p.fullmatch(plain) for p in API_MODEL_PATTERNS):
-        return ModelType.API
-    generative_type = metadata.get("generative_type")
-    if generative_type is None:
-        return ModelType.ENCODER
-    model_type = GENERATIVE_TYPE_TO_MODEL_TYPE.get(generative_type)
-    return ModelType(model_type) if model_type is not None else ModelType.BASE_DECODER
-
-
-def _is_on_pareto_frontier(
-    model_id: str,
-    params: float,
-    rank: float,
-    sized_ranked: list[tuple[str, float, float]],
-) -> bool:
-    """Check if a model is on the Pareto frontier.
-
-    A model is on the Pareto frontier if no other model with <= parameters
-    has a strictly better (lower) rank score.
-
-    Args:
-        model_id:
-            The model ID to check.
-        params:
-            The model's parameter count.
-        rank:
-            The model's rank score.
-        sized_ranked:
-            List of (model_id, params, rank) tuples for all comparable models.
-
-    Returns:
-        True if the model is on the Pareto frontier.
-    """
-    return not any(
-        other_params <= params and other_rank < rank
-        for other_id, other_params, other_rank in sized_ranked
-        if other_id != model_id
-    )
-
-
-def _process_pareto_for_category(
-    model_type: ModelType,
-    category: str,
-    members: list[tuple[str, float]],
-    languages: list[str],
-    ranks: dict[str, dict[str, dict[str, dict[str, float]]]],
-    pareto: dict[str, set[str]],
-) -> None:
-    """Process Pareto frontier for a single model type and category.
-
-    Args:
-        model_type:
-            The model type being processed.
-        category:
-            The category (e.g. "generative" or "all_models").
-        members:
-            List of (model_id, params) tuples for this model type.
-        languages:
-            Languages to consider.
-        ranks:
-            Output of `compute_ranks`.
-        pareto:
-            Accumulator dict to update.
-    """
-    for language in languages:
-        # Collect sized&ranked models for this (type, category, language)
-        sized_ranked: list[tuple[str, float, float]] = []
-        for model_id, params in members:
-            rank_entry = (
-                ranks.get(model_id, {}).get(category, {}).get(language, {}).get("score")
-            )
-            if rank_entry is None or not math.isfinite(rank_entry):
-                continue
-            sized_ranked.append((model_id, params, rank_entry))
-
-        for model_id, params, rank in sized_ranked:
-            if _is_on_pareto_frontier(
-                model_id=model_id, params=params, rank=rank, sized_ranked=sized_ranked
-            ):
-                pareto[model_id].add(language)
-
-
-# ---------------------------------------------------------------------------
-# Pareto frontier
-# ---------------------------------------------------------------------------
-def _pareto_languages_per_model(
-    ranks: dict[str, dict[str, dict[str, dict[str, float]]]],
-    metadata: dict[str, dict],
-    model_types: dict[str, ModelType],
-    languages: list[str],
-) -> dict[str, list[str]]:
-    """For each model, return the languages where it is on its Pareto frontier.
-
-    A model M with type T and parameter count P is on the Pareto frontier
-    for language L iff no other model with type T and parameters <= P has
-    a strictly better (smaller) rank score in L. Models with unknown
-    parameter counts are skipped: we can't compare them on the (size, rank)
-    plane.
-
-    Args:
-        ranks:
-            Output of `compute_ranks`: model -> category -> language ->
-            {"score", "ci_lower", "ci_upper"}.
-        metadata:
-            Output of `extract_model_metadata`.
-        model_types:
-            Mapping of model_id to its `ModelType`.
-        languages:
-            Languages to consider (each must appear as a key in the inner
-            dicts of `ranks`).
-
-    Returns:
-        model_id -> sorted list of languages where the model qualifies.
-    """
-    logger.info("Fetching the Pareto frontier languages for each model...")
-
-    # Encoders only get scored on the NLU-restricted `all_models`
-    # category. Generative models live on both leaderboards: `generative`
-    # spans every task and `all_models` restricts to NLU — a generative
-    # model that's Pareto-optimal in either category counts, so we
-    # consider both and union the languages.
-    categories_for_type: dict[ModelType, tuple[str, ...]] = {
-        ModelType.ENCODER: ("all_models",),
-        ModelType.BASE_DECODER: ("generative", "all_models"),
-        ModelType.INSTRUCTION_TUNED_DECODER: ("generative", "all_models"),
-        ModelType.REASONING_DECODER: ("generative", "all_models"),
-    }
-
-    # Group candidate models by type, dropping anything we can't size.
-    by_type: dict[ModelType, list[tuple[str, float]]] = defaultdict(list)
-    for model_id, model_type in model_types.items():
-        if model_type == ModelType.API:
-            continue
-        params = metadata.get(model_id, {}).get("parameters", float("nan"))
-        if not math.isfinite(params):
-            continue
-        by_type[model_type].append((model_id, params))
-
-    pareto: dict[str, set[str]] = defaultdict(set)
-    for model_type, members in by_type.items():
-        for category in categories_for_type[model_type]:
-            _process_pareto_for_category(
-                model_type=model_type,
-                category=category,
-                members=members,
-                languages=languages,
-                ranks=ranks,
-                pareto=pareto,
-            )
-
-    logger.info("Fetched the Pareto frontier languages for each model.")
-    return {model_id: sorted(langs) for model_id, langs in pareto.items()}
-
-
-# ---------------------------------------------------------------------------
-# Model classification helpers
-# ---------------------------------------------------------------------------
-def _size_bucket(model_type: ModelType, parameters: float) -> SizeBucket:
-    """Map a model's type and parameter count to a bucket for the issue.
-
-    Args:
-        model_type:
-            The classification from `_classify_model`.
-        parameters:
-            Number of parameters; NaN for API/unknown.
-
-    Returns:
-        The bucket label used to group models in the issue body.
-    """
-    if model_type == ModelType.ENCODER:
-        return SizeBucket.ENCODER
-    if model_type == ModelType.API:
-        return SizeBucket.API
-    if not math.isfinite(parameters):
-        return SizeBucket.XLARGE
-    if parameters < 2_000_000_000:
-        return SizeBucket.TINY
-    if parameters < 10_000_000_000:
-        return SizeBucket.SMALL
-    if parameters < 40_000_000_000:
-        return SizeBucket.MEDIUM
-    if parameters < 80_000_000_000:
-        return SizeBucket.LARGE
-    return SizeBucket.XLARGE
 
 
 # ---------------------------------------------------------------------------
@@ -442,3 +243,202 @@ def build_core_model_list(
         key=lambda m: (PARAM_SIZE_BUCKET_ORDER[m.size_bucket], m.model_id.lower())
     )
     return core
+
+
+def _classify_model(model_id: str, metadata: dict) -> ModelType:
+    """Return the architectural/training type for a model.
+
+    Args:
+        model_id:
+            The HuggingFace-style model identifier.
+        metadata:
+            The metadata entry from `extract_model_metadata`.
+
+    Returns:
+        One of the `ModelType` literals.
+    """
+    plain = plain_model_id(model_id).split("#")[0]
+    if any(p.fullmatch(plain) for p in API_MODEL_PATTERNS):
+        return ModelType.API
+    generative_type = metadata.get("generative_type")
+    if generative_type is None:
+        return ModelType.ENCODER
+    model_type = GENERATIVE_TYPE_TO_MODEL_TYPE.get(generative_type)
+    return ModelType(model_type) if model_type is not None else ModelType.BASE_DECODER
+
+
+# ---------------------------------------------------------------------------
+# Pareto frontier
+# ---------------------------------------------------------------------------
+def _pareto_languages_per_model(
+    ranks: dict[str, dict[str, dict[str, dict[str, float]]]],
+    metadata: dict[str, dict],
+    model_types: dict[str, ModelType],
+    languages: list[str],
+) -> dict[str, list[str]]:
+    """For each model, return the languages where it is on its Pareto frontier.
+
+    A model M with type T and parameter count P is on the Pareto frontier
+    for language L iff no other model with type T and parameters <= P has
+    a strictly better (smaller) rank score in L. Models with unknown
+    parameter counts are skipped: we can't compare them on the (size, rank)
+    plane.
+
+    Args:
+        ranks:
+            Output of `compute_ranks`: model -> category -> language ->
+            {"score", "ci_lower", "ci_upper"}.
+        metadata:
+            Output of `extract_model_metadata`.
+        model_types:
+            Mapping of model_id to its `ModelType`.
+        languages:
+            Languages to consider (each must appear as a key in the inner
+            dicts of `ranks`).
+
+    Returns:
+        model_id -> sorted list of languages where the model qualifies.
+    """
+    logger.info("Fetching the Pareto frontier languages for each model...")
+
+    # Encoders only get scored on the NLU-restricted `all_models`
+    # category. Generative models live on both leaderboards: `generative`
+    # spans every task and `all_models` restricts to NLU — a generative
+    # model that's Pareto-optimal in either category counts, so we
+    # consider both and union the languages.
+    categories_for_type: dict[ModelType, tuple[str, ...]] = {
+        ModelType.ENCODER: ("all_models",),
+        ModelType.BASE_DECODER: ("generative", "all_models"),
+        ModelType.INSTRUCTION_TUNED_DECODER: ("generative", "all_models"),
+        ModelType.REASONING_DECODER: ("generative", "all_models"),
+    }
+
+    # Group candidate models by type, dropping anything we can't size.
+    by_type: dict[ModelType, list[tuple[str, float]]] = defaultdict(list)
+    for model_id, model_type in model_types.items():
+        if model_type == ModelType.API:
+            continue
+        params = metadata.get(model_id, {}).get("parameters", float("nan"))
+        if not math.isfinite(params):
+            continue
+        by_type[model_type].append((model_id, params))
+
+    pareto: dict[str, set[str]] = defaultdict(set)
+    for model_type, members in by_type.items():
+        for category in categories_for_type[model_type]:
+            _process_pareto_for_category(
+                model_type=model_type,
+                category=category,
+                members=members,
+                languages=languages,
+                ranks=ranks,
+                pareto=pareto,
+            )
+
+    logger.info("Fetched the Pareto frontier languages for each model.")
+    return {model_id: sorted(langs) for model_id, langs in pareto.items()}
+
+
+def _process_pareto_for_category(
+    model_type: ModelType,
+    category: str,
+    members: list[tuple[str, float]],
+    languages: list[str],
+    ranks: dict[str, dict[str, dict[str, dict[str, float]]]],
+    pareto: dict[str, set[str]],
+) -> None:
+    """Process Pareto frontier for a single model type and category.
+
+    Args:
+        model_type:
+            The model type being processed.
+        category:
+            The category (e.g. "generative" or "all_models").
+        members:
+            List of (model_id, params) tuples for this model type.
+        languages:
+            Languages to consider.
+        ranks:
+            Output of `compute_ranks`.
+        pareto:
+            Accumulator dict to update.
+    """
+    for language in languages:
+        # Collect sized&ranked models for this (type, category, language)
+        sized_ranked: list[tuple[str, float, float]] = []
+        for model_id, params in members:
+            rank_entry = (
+                ranks.get(model_id, {}).get(category, {}).get(language, {}).get("score")
+            )
+            if rank_entry is None or not math.isfinite(rank_entry):
+                continue
+            sized_ranked.append((model_id, params, rank_entry))
+
+        for model_id, params, rank in sized_ranked:
+            if _is_on_pareto_frontier(
+                model_id=model_id, params=params, rank=rank, sized_ranked=sized_ranked
+            ):
+                pareto[model_id].add(language)
+
+
+def _is_on_pareto_frontier(
+    model_id: str,
+    params: float,
+    rank: float,
+    sized_ranked: list[tuple[str, float, float]],
+) -> bool:
+    """Check if a model is on the Pareto frontier.
+
+    A model is on the Pareto frontier if no other model with <= parameters
+    has a strictly better (lower) rank score.
+
+    Args:
+        model_id:
+            The model ID to check.
+        params:
+            The model's parameter count.
+        rank:
+            The model's rank score.
+        sized_ranked:
+            List of (model_id, params, rank) tuples for all comparable models.
+
+    Returns:
+        True if the model is on the Pareto frontier.
+    """
+    return not any(
+        other_params <= params and other_rank < rank
+        for other_id, other_params, other_rank in sized_ranked
+        if other_id != model_id
+    )
+
+
+# ---------------------------------------------------------------------------
+# Model classification helpers
+# ---------------------------------------------------------------------------
+def _size_bucket(model_type: ModelType, parameters: float) -> SizeBucket:
+    """Map a model's type and parameter count to a bucket for the issue.
+
+    Args:
+        model_type:
+            The classification from `_classify_model`.
+        parameters:
+            Number of parameters; NaN for API/unknown.
+
+    Returns:
+        The bucket label used to group models in the issue body.
+    """
+    if model_type == ModelType.ENCODER:
+        return SizeBucket.ENCODER
+    if model_type == ModelType.API:
+        return SizeBucket.API
+    if not math.isfinite(parameters):
+        return SizeBucket.XLARGE
+    if parameters < 2_000_000_000:
+        return SizeBucket.TINY
+    if parameters < 10_000_000_000:
+        return SizeBucket.SMALL
+    if parameters < 40_000_000_000:
+        return SizeBucket.MEDIUM
+    if parameters < 80_000_000_000:
+        return SizeBucket.LARGE
+    return SizeBucket.XLARGE

--- a/src/leaderboards/eee_validation.py
+++ b/src/leaderboards/eee_validation.py
@@ -10,22 +10,36 @@ from .constants import REQUIRED_METADATA_FIELDS
 logger = logging.getLogger(__name__)
 
 
-def is_eee_record(record: dict[str, object]) -> bool:
-    """Return whether a record uses the EEE envelope.
+def dump_jsonl_records(records: list[dict[str, object]]) -> str:
+    """Serialise EEE records as JSONL.
 
     Args:
-        record:
-            Record to inspect.
+        records:
+            Records to serialise. All records must already be EEE-valid.
 
     Returns:
-        True if the record has the required EEE top-level structures.
+        JSONL text with a trailing newline if records are present.
+
     """
-    return (
-        "schema_version" in record
-        and isinstance(record.get("model_info"), dict)
-        and isinstance(record.get("eval_library"), dict)
-        and isinstance(record.get("evaluation_results"), list)
-    )
+    validate_eee_records(records=records, context="JSONL output")
+    if not records:
+        return ""
+    lines = [json.dumps(record, ensure_ascii=False) for record in records]
+    return "\n".join(lines) + "\n"
+
+
+def validate_eee_records(records: list[dict[str, object]], context: str) -> None:
+    """Validate a list of EEE result records.
+
+    Args:
+        records:
+            Records to validate.
+        context:
+            Human-readable source name used in error messages.
+
+    """
+    for idx, record in enumerate(records, start=1):
+        validate_eee_record(record=record, context=f"{context} record {idx:,}")
 
 
 def validate_eee_record(record: dict[str, object], context: str = "record") -> None:
@@ -64,33 +78,19 @@ def validate_eee_record(record: dict[str, object], context: str = "record") -> N
         )
 
 
-def validate_eee_records(records: list[dict[str, object]], context: str) -> None:
-    """Validate a list of EEE result records.
+def is_eee_record(record: dict[str, object]) -> bool:
+    """Return whether a record uses the EEE envelope.
 
     Args:
-        records:
-            Records to validate.
-        context:
-            Human-readable source name used in error messages.
-
-    """
-    for idx, record in enumerate(records, start=1):
-        validate_eee_record(record=record, context=f"{context} record {idx:,}")
-
-
-def dump_jsonl_records(records: list[dict[str, object]]) -> str:
-    """Serialise EEE records as JSONL.
-
-    Args:
-        records:
-            Records to serialise. All records must already be EEE-valid.
+        record:
+            Record to inspect.
 
     Returns:
-        JSONL text with a trailing newline if records are present.
-
+        True if the record has the required EEE top-level structures.
     """
-    validate_eee_records(records=records, context="JSONL output")
-    if not records:
-        return ""
-    lines = [json.dumps(record, ensure_ascii=False) for record in records]
-    return "\n".join(lines) + "\n"
+    return (
+        "schema_version" in record
+        and isinstance(record.get("model_info"), dict)
+        and isinstance(record.get("eval_library"), dict)
+        and isinstance(record.get("evaluation_results"), list)
+    )

--- a/src/leaderboards/evaluation_common.py
+++ b/src/leaderboards/evaluation_common.py
@@ -96,293 +96,6 @@ PROVIDERS: list[Provider] = [
 PROVIDERS_BY_NAME: dict[str, Provider] = {p.name: p for p in PROVIDERS}
 
 
-def _build_euroeval_cmd(
-    model_id: str,
-    languages: c.Sequence[str],
-    datasets: c.Sequence[str] | None,
-    evaluate_test_split: bool,
-    zero_shot: bool,
-    gpu_memory_utilization: float | None,
-    clear_model_cache: bool,
-    trust_remote_code: bool,
-) -> list[str]:
-    """Build the euroeval CLI command list.
-
-    Args:
-        model_id:
-            The model ID.
-        languages:
-            The languages to evaluate.
-        datasets:
-            The datasets to evaluate, or None for all.
-        evaluate_test_split:
-            Whether to evaluate the test split.
-        zero_shot:
-            Whether to use zero-shot evaluation.
-        gpu_memory_utilization:
-            The GPU memory utilization.
-        clear_model_cache:
-            Whether to clear the model cache.
-        trust_remote_code:
-            Whether to trust remote code.
-
-    Returns:
-        The command list.
-    """
-    cmd: list[str] = ["euroeval", "--model", model_id]
-    if clear_model_cache:
-        cmd.append("--clear-model-cache")
-    if trust_remote_code:
-        cmd.append("--trust-remote-code")
-    cmd.append(
-        "--evaluate-test-split" if evaluate_test_split else "--evaluate-val-split"
-    )
-    if zero_shot:
-        cmd.append("--zero-shot")
-    for lang in languages:
-        cmd += ["--language", lang]
-    for dataset in datasets or []:
-        cmd += ["--dataset", dataset]
-    if gpu_memory_utilization is not None:
-        cmd += ["--gpu-memory-utilization", str(gpu_memory_utilization)]
-    return cmd
-
-
-def resolve_hf_token() -> str | None:
-    """Return the HF token from env or the ``hf auth login`` cache.
-
-    Returns:
-        The token string, or None if neither env nor cache yields one.
-    """
-    return os.environ.get("HF_TOKEN") or get_token()
-
-
-def _build_euroeval_env(stream_output: bool) -> dict[str, str]:
-    """Build the environment for the euroeval CLI subprocess.
-
-    Args:
-        stream_output:
-            Whether to stream output.
-
-    Returns:
-        The environment dictionary.
-    """
-    env = os.environ.copy()
-    if stream_output:
-        env["FULL_LOG"] = "1"
-    token = resolve_hf_token()
-    if token:
-        env.setdefault("HF_TOKEN", token)
-        env.setdefault("HUGGINGFACE_API_KEY", token)
-    return env
-
-
-def _cleanup_pty_process(
-    parent_fd: int,
-    spawned_pgid: int | None,
-    log_fh: t.IO[bytes] | None,
-    log_file: Path | t.IO[bytes] | None,
-) -> None:
-    """Clean up PTY file descriptor and kill process group."""
-    os.close(parent_fd)
-    if spawned_pgid is not None:
-        try:
-            os.killpg(spawned_pgid, signal.SIGTERM)
-        except (ProcessLookupError, OSError):
-            pass
-    if log_fh is not None and isinstance(log_file, Path):
-        log_fh.close()
-
-
-def _dtype_bits(dtype: str) -> int | None:
-    """Infer the number of bits used by a safetensors dtype string.
-
-    Args:
-        dtype:
-            The safetensors dtype string.
-
-    Returns:
-        The bit-width, or None when it cannot be inferred.
-    """
-    normalised_dtype = dtype.upper()
-    if normalised_dtype in DTYPE_BYTES:
-        return DTYPE_BYTES[normalised_dtype] * 8
-
-    for match in re.findall(pattern=r"\d+", string=normalised_dtype):
-        bits = int(match)
-        if bits > 0:
-            return bits
-    return None
-
-
-def _killed_by_signal_note(returncode: int | None) -> str | None:
-    """Return a diagnostic note when a subprocess was killed by a signal.
-
-    A negative ``returncode`` (as reported by ``subprocess.Popen``) means the
-    process was terminated by a signal rather than exiting normally. Such
-    deaths leave no Python traceback, so without this note the failure
-    comment falls back to "(no output captured)". Resolving the signal to a
-    name gives the operator a cause; SIGKILL is flagged as a likely
-    out-of-memory kill, the common failure mode for large model evaluations.
-
-    Args:
-        returncode:
-            The ``Popen.returncode`` to interpret.
-
-    Returns:
-        A diagnostic line, or None when ``returncode`` is not a signal death.
-    """
-    if returncode is None or returncode >= 0:
-        return None
-    signum = abs(returncode)
-    try:
-        name = signal.Signals(signum).name
-    except ValueError:
-        return (
-            f"Process was killed by signal {signum} - likely out of memory."
-            if signum == signal.SIGKILL
-            else f"Process was killed by signal {signum}."
-        )
-    if signum == signal.SIGKILL:
-        return f"Process was killed by signal {signum} ({name}) - likely out of memory."
-    return f"Process was killed by signal {signum} ({name})."
-
-
-def _run_pty_loop(
-    parent_fd: int,
-    proc: subprocess.Popen[bytes],
-    stream_output: bool,
-    log_fh: t.IO[bytes] | None,
-) -> list[bytes]:
-    """Read from PTY until subprocess exits, with drain timeout.
-
-    Args:
-        parent_fd:
-            The parent file descriptor.
-        proc:
-            The subprocess.
-        stream_output:
-            Whether to stream output.
-        log_fh:
-            The log file handle.
-
-    Returns:
-        The captured output as bytes.
-    """
-    captured: list[bytes] = []
-    MAX_DRAIN_TIME_AFTER_EXIT = 2.0
-    parent_exit_time: float | None = None
-
-    while True:
-        if parent_exit_time is not None:
-            elapsed = time.monotonic() - parent_exit_time
-            if elapsed > MAX_DRAIN_TIME_AFTER_EXIT:
-                break
-
-        ready, _, _ = select.select([parent_fd], [], [], 0.1)
-        try:
-            chunk = os.read(parent_fd, 4096) if ready else b""
-        except OSError:
-            break
-
-        if chunk:
-            if stream_output:
-                sys.stderr.buffer.write(chunk)
-                sys.stderr.buffer.flush()
-            if log_fh is not None:
-                log_fh.write(chunk)
-                log_fh.flush()
-            captured.append(chunk)
-            if proc.poll() is not None and parent_exit_time is None:
-                parent_exit_time = time.monotonic()
-        elif proc.poll() is not None:
-            if parent_exit_time is None:
-                parent_exit_time = time.monotonic()
-
-    return captured
-
-
-def _set_pty_window_size(fd: int) -> None:
-    """Give a freshly-opened pty a sensible window size.
-
-    ``pty.openpty()`` creates the slave with a default window size of 0 rows by
-    0 columns. Progress bars (tqdm, driven by vLLM) can't render a bar in 0
-    columns, so they fall back to emitting a bare newline on every refresh --
-    flooding the captured output and the tmux panes with blank lines. Setting a
-    real window size makes tqdm render a single in-place-updating line instead.
-
-    The size is inherited from this process's own controlling terminal when it
-    has one (so the bar matches the operator's pane), falling back to a roomy
-    80x200 default for non-interactive runs (cron, redirected output).
-
-    Args:
-        fd:
-            The pty file descriptor whose window size should be set.
-    """
-    rows, cols = 50, 200
-    for stream in (sys.stderr, sys.stdout, sys.stdin):
-        try:
-            packed = fcntl.ioctl(
-                stream.fileno(), termios.TIOCGWINSZ, struct.pack("HHHH", 0, 0, 0, 0)
-            )
-            src_rows, src_cols, _, _ = struct.unpack("HHHH", packed)
-        except (OSError, ValueError, AttributeError):
-            continue
-        if src_rows > 0 and src_cols > 0:
-            rows, cols = src_rows, src_cols
-            break
-    try:
-        fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
-    except OSError as e:
-        logger.debug(f"Could not set pty window size: {e}")
-
-
-def estimated_model_bytes(model_id: str) -> int | None:
-    """Estimate the weight footprint of a model in bytes.
-
-    Reads the safetensors header(s) so quantised checkpoints are sized
-    correctly.
-
-    Args:
-        model_id:
-            The HuggingFace repo id, optionally suffixed with ``@<revision>``.
-
-    Returns:
-        The total weight bytes across all tensors, or None when the repo
-        is not a safetensors repo or metadata cannot be parsed.
-    """
-    # Deferred: see the module-level note on avoiding heavy euroeval import cost.
-    from euroeval.string_utils import split_model_id  # noqa: PLC0415
-
-    components = split_model_id(model_id=model_id)
-    repo = components.model_id
-    revision = components.revision
-    token = os.environ.get("HF_TOKEN")
-    try:
-        meta = get_safetensors_metadata(repo_id=repo, revision=revision, token=token)
-    except (
-        NotASafetensorsRepoError,
-        SafetensorsParsingError,
-        RepositoryNotFoundError,
-        GatedRepoError,
-        HfHubHTTPError,
-    ) as e:
-        logger.debug(f"safetensors metadata unavailable for {model_id}: {e}")
-        return None
-
-    total = 0
-    for dtype, count in meta.parameter_count.items():
-        dtype_bits = _dtype_bits(dtype=dtype)
-        if dtype_bits is None:
-            logger.debug(
-                f"Unknown safetensors dtype {dtype!r} for {model_id}; "
-                "assuming 2 bytes/param."
-            )
-            dtype_bits = 16
-        total += (count * dtype_bits + 7) // 8
-    return total
-
-
 def extract_language_groups(body: str | None) -> list[str]:
     """Return the language-group labels that are ticked in an issue body.
 
@@ -435,6 +148,38 @@ def gpu_total_memory_bytes() -> int | None:
 
     # Use available (not total) system RAM for CPU-only or unified memory hosts.
     return int(psutil.virtual_memory().available)
+
+
+def missing_official_dataset_language_pairs(
+    lines: c.Iterable[str], requested_languages: c.Iterable[str]
+) -> set[tuple[str, str]]:
+    """Return missing official dataset/language pairs for the requested languages.
+
+    Only counts results from the validation split (or validation_split=None for
+    backwards compatibility) as "complete" for queue purposes. Test-split results
+    do not count towards completion.
+
+    Args:
+        lines:
+            Benchmark-result JSONL lines that have already been produced.
+        requested_languages:
+            The language codes the leaderboard requested.
+
+    Returns:
+        The set of official (dataset, language) pairs that have no result yet.
+    """
+    requested = set(requested_languages)
+    expected_pairs = {
+        pair for pair in official_dataset_language_pairs() if pair[1] in requested
+    }
+    observed_triples = result_dataset_language_pairs(lines=lines)
+    # Only count validation-split (True) or None (backwards compatibility) as complete
+    observed_pairs: set[tuple[str, str]] = {
+        (dataset, lang)
+        for dataset, lang, validation_split in observed_triples
+        if validation_split is True or validation_split is None
+    }
+    return expected_pairs - observed_pairs
 
 
 @lru_cache(maxsize=1)
@@ -492,38 +237,6 @@ def result_dataset_language_pairs(
     return pairs
 
 
-def missing_official_dataset_language_pairs(
-    lines: c.Iterable[str], requested_languages: c.Iterable[str]
-) -> set[tuple[str, str]]:
-    """Return missing official dataset/language pairs for the requested languages.
-
-    Only counts results from the validation split (or validation_split=None for
-    backwards compatibility) as "complete" for queue purposes. Test-split results
-    do not count towards completion.
-
-    Args:
-        lines:
-            Benchmark-result JSONL lines that have already been produced.
-        requested_languages:
-            The language codes the leaderboard requested.
-
-    Returns:
-        The set of official (dataset, language) pairs that have no result yet.
-    """
-    requested = set(requested_languages)
-    expected_pairs = {
-        pair for pair in official_dataset_language_pairs() if pair[1] in requested
-    }
-    observed_triples = result_dataset_language_pairs(lines=lines)
-    # Only count validation-split (True) or None (backwards compatibility) as complete
-    observed_pairs: set[tuple[str, str]] = {
-        (dataset, lang)
-        for dataset, lang, validation_split in observed_triples
-        if validation_split is True or validation_split is None
-    }
-    return expected_pairs - observed_pairs
-
-
 def model_fits_locally(model_id: str, gpu_bytes: int | None) -> tuple[bool, int | None]:
     """Return whether an open-weight model fits the local memory budget.
 
@@ -548,6 +261,73 @@ def model_fits_locally(model_id: str, gpu_bytes: int | None) -> tuple[bool, int 
         return True, None
     needed = int(needed * GPU_FIT_OVERHEAD)
     return needed <= gpu_bytes, needed
+
+
+def estimated_model_bytes(model_id: str) -> int | None:
+    """Estimate the weight footprint of a model in bytes.
+
+    Reads the safetensors header(s) so quantised checkpoints are sized
+    correctly.
+
+    Args:
+        model_id:
+            The HuggingFace repo id, optionally suffixed with ``@<revision>``.
+
+    Returns:
+        The total weight bytes across all tensors, or None when the repo
+        is not a safetensors repo or metadata cannot be parsed.
+    """
+    # Deferred: see the module-level note on avoiding heavy euroeval import cost.
+    from euroeval.string_utils import split_model_id  # noqa: PLC0415
+
+    components = split_model_id(model_id=model_id)
+    repo = components.model_id
+    revision = components.revision
+    token = os.environ.get("HF_TOKEN")
+    try:
+        meta = get_safetensors_metadata(repo_id=repo, revision=revision, token=token)
+    except (
+        NotASafetensorsRepoError,
+        SafetensorsParsingError,
+        RepositoryNotFoundError,
+        GatedRepoError,
+        HfHubHTTPError,
+    ) as e:
+        logger.debug(f"safetensors metadata unavailable for {model_id}: {e}")
+        return None
+
+    total = 0
+    for dtype, count in meta.parameter_count.items():
+        dtype_bits = _dtype_bits(dtype=dtype)
+        if dtype_bits is None:
+            logger.debug(
+                f"Unknown safetensors dtype {dtype!r} for {model_id}; "
+                "assuming 2 bytes/param."
+            )
+            dtype_bits = 16
+        total += (count * dtype_bits + 7) // 8
+    return total
+
+
+def _dtype_bits(dtype: str) -> int | None:
+    """Infer the number of bits used by a safetensors dtype string.
+
+    Args:
+        dtype:
+            The safetensors dtype string.
+
+    Returns:
+        The bit-width, or None when it cannot be inferred.
+    """
+    normalised_dtype = dtype.upper()
+    if normalised_dtype in DTYPE_BYTES:
+        return DTYPE_BYTES[normalised_dtype] * 8
+
+    for match in re.findall(pattern=r"\d+", string=normalised_dtype):
+        bits = int(match)
+        if bits > 0:
+            return bits
+    return None
 
 
 def provider_for_model_id(
@@ -698,3 +478,223 @@ def run_euroeval(
     if note:
         output += f"\n{note}\n"
     return proc.returncode, output
+
+
+def _build_euroeval_cmd(
+    model_id: str,
+    languages: c.Sequence[str],
+    datasets: c.Sequence[str] | None,
+    evaluate_test_split: bool,
+    zero_shot: bool,
+    gpu_memory_utilization: float | None,
+    clear_model_cache: bool,
+    trust_remote_code: bool,
+) -> list[str]:
+    """Build the euroeval CLI command list.
+
+    Args:
+        model_id:
+            The model ID.
+        languages:
+            The languages to evaluate.
+        datasets:
+            The datasets to evaluate, or None for all.
+        evaluate_test_split:
+            Whether to evaluate the test split.
+        zero_shot:
+            Whether to use zero-shot evaluation.
+        gpu_memory_utilization:
+            The GPU memory utilization.
+        clear_model_cache:
+            Whether to clear the model cache.
+        trust_remote_code:
+            Whether to trust remote code.
+
+    Returns:
+        The command list.
+    """
+    cmd: list[str] = ["euroeval", "--model", model_id]
+    if clear_model_cache:
+        cmd.append("--clear-model-cache")
+    if trust_remote_code:
+        cmd.append("--trust-remote-code")
+    cmd.append(
+        "--evaluate-test-split" if evaluate_test_split else "--evaluate-val-split"
+    )
+    if zero_shot:
+        cmd.append("--zero-shot")
+    for lang in languages:
+        cmd += ["--language", lang]
+    for dataset in datasets or []:
+        cmd += ["--dataset", dataset]
+    if gpu_memory_utilization is not None:
+        cmd += ["--gpu-memory-utilization", str(gpu_memory_utilization)]
+    return cmd
+
+
+def _build_euroeval_env(stream_output: bool) -> dict[str, str]:
+    """Build the environment for the euroeval CLI subprocess.
+
+    Args:
+        stream_output:
+            Whether to stream output.
+
+    Returns:
+        The environment dictionary.
+    """
+    env = os.environ.copy()
+    if stream_output:
+        env["FULL_LOG"] = "1"
+    token = resolve_hf_token()
+    if token:
+        env.setdefault("HF_TOKEN", token)
+        env.setdefault("HUGGINGFACE_API_KEY", token)
+    return env
+
+
+def resolve_hf_token() -> str | None:
+    """Return the HF token from env or the ``hf auth login`` cache.
+
+    Returns:
+        The token string, or None if neither env nor cache yields one.
+    """
+    return os.environ.get("HF_TOKEN") or get_token()
+
+
+def _cleanup_pty_process(
+    parent_fd: int,
+    spawned_pgid: int | None,
+    log_fh: t.IO[bytes] | None,
+    log_file: Path | t.IO[bytes] | None,
+) -> None:
+    """Clean up PTY file descriptor and kill process group."""
+    os.close(parent_fd)
+    if spawned_pgid is not None:
+        try:
+            os.killpg(spawned_pgid, signal.SIGTERM)
+        except (ProcessLookupError, OSError):
+            pass
+    if log_fh is not None and isinstance(log_file, Path):
+        log_fh.close()
+
+
+def _killed_by_signal_note(returncode: int | None) -> str | None:
+    """Return a diagnostic note when a subprocess was killed by a signal.
+
+    A negative ``returncode`` (as reported by ``subprocess.Popen``) means the
+    process was terminated by a signal rather than exiting normally. Such
+    deaths leave no Python traceback, so without this note the failure
+    comment falls back to "(no output captured)". Resolving the signal to a
+    name gives the operator a cause; SIGKILL is flagged as a likely
+    out-of-memory kill, the common failure mode for large model evaluations.
+
+    Args:
+        returncode:
+            The ``Popen.returncode`` to interpret.
+
+    Returns:
+        A diagnostic line, or None when ``returncode`` is not a signal death.
+    """
+    if returncode is None or returncode >= 0:
+        return None
+    signum = abs(returncode)
+    try:
+        name = signal.Signals(signum).name
+    except ValueError:
+        return (
+            f"Process was killed by signal {signum} - likely out of memory."
+            if signum == signal.SIGKILL
+            else f"Process was killed by signal {signum}."
+        )
+    if signum == signal.SIGKILL:
+        return f"Process was killed by signal {signum} ({name}) - likely out of memory."
+    return f"Process was killed by signal {signum} ({name})."
+
+
+def _run_pty_loop(
+    parent_fd: int,
+    proc: subprocess.Popen[bytes],
+    stream_output: bool,
+    log_fh: t.IO[bytes] | None,
+) -> list[bytes]:
+    """Read from PTY until subprocess exits, with drain timeout.
+
+    Args:
+        parent_fd:
+            The parent file descriptor.
+        proc:
+            The subprocess.
+        stream_output:
+            Whether to stream output.
+        log_fh:
+            The log file handle.
+
+    Returns:
+        The captured output as bytes.
+    """
+    captured: list[bytes] = []
+    MAX_DRAIN_TIME_AFTER_EXIT = 2.0
+    parent_exit_time: float | None = None
+
+    while True:
+        if parent_exit_time is not None:
+            elapsed = time.monotonic() - parent_exit_time
+            if elapsed > MAX_DRAIN_TIME_AFTER_EXIT:
+                break
+
+        ready, _, _ = select.select([parent_fd], [], [], 0.1)
+        try:
+            chunk = os.read(parent_fd, 4096) if ready else b""
+        except OSError:
+            break
+
+        if chunk:
+            if stream_output:
+                sys.stderr.buffer.write(chunk)
+                sys.stderr.buffer.flush()
+            if log_fh is not None:
+                log_fh.write(chunk)
+                log_fh.flush()
+            captured.append(chunk)
+            if proc.poll() is not None and parent_exit_time is None:
+                parent_exit_time = time.monotonic()
+        elif proc.poll() is not None:
+            if parent_exit_time is None:
+                parent_exit_time = time.monotonic()
+
+    return captured
+
+
+def _set_pty_window_size(fd: int) -> None:
+    """Give a freshly-opened pty a sensible window size.
+
+    ``pty.openpty()`` creates the slave with a default window size of 0 rows by
+    0 columns. Progress bars (tqdm, driven by vLLM) can't render a bar in 0
+    columns, so they fall back to emitting a bare newline on every refresh --
+    flooding the captured output and the tmux panes with blank lines. Setting a
+    real window size makes tqdm render a single in-place-updating line instead.
+
+    The size is inherited from this process's own controlling terminal when it
+    has one (so the bar matches the operator's pane), falling back to a roomy
+    80x200 default for non-interactive runs (cron, redirected output).
+
+    Args:
+        fd:
+            The pty file descriptor whose window size should be set.
+    """
+    rows, cols = 50, 200
+    for stream in (sys.stderr, sys.stdout, sys.stdin):
+        try:
+            packed = fcntl.ioctl(
+                stream.fileno(), termios.TIOCGWINSZ, struct.pack("HHHH", 0, 0, 0, 0)
+            )
+            src_rows, src_cols, _, _ = struct.unpack("HHHH", packed)
+        except (OSError, ValueError, AttributeError):
+            continue
+        if src_rows > 0 and src_cols > 0:
+            rows, cols = src_rows, src_cols
+            break
+    try:
+        fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+    except OSError as e:
+        logger.debug(f"Could not set pty window size: {e}")

--- a/src/leaderboards/github_api.py
+++ b/src/leaderboards/github_api.py
@@ -22,17 +22,21 @@ from .constants import FAILED_LABEL, GATED_LABEL, REPO, RESULTS_READY_LABEL, USE
 logger = logging.getLogger(__name__)
 
 
-def _token() -> str:
-    """Return the GitHub API token from the environment, or exit on failure.
+def add_failed_label(number: int) -> None:
+    """Attach the ``evaluation-failed`` label to an issue.
 
-    Returns:
-        The value of the ``GITHUB_TOKEN`` environment variable.
+    Args:
+        number:
+            The issue number to label.
     """
-    token = os.environ.get("GITHUB_TOKEN")
-    if not token:
-        logger.error("GITHUB_TOKEN env var is required.")
-        sys.exit(1)
-    return token
+    try:
+        gh_request(
+            path=f"/repos/{REPO}/issues/{number}/labels",
+            method="POST",
+            body={"labels": [FAILED_LABEL]},
+        )
+    except urllib.error.HTTPError as e:
+        logger.warning(f"#{number}: could not add {FAILED_LABEL!r} label: {e}")
 
 
 def gh_request(
@@ -78,21 +82,17 @@ def gh_request(
         return json.loads(raw) if raw else None
 
 
-def add_failed_label(number: int) -> None:
-    """Attach the ``evaluation-failed`` label to an issue.
+def _token() -> str:
+    """Return the GitHub API token from the environment, or exit on failure.
 
-    Args:
-        number:
-            The issue number to label.
+    Returns:
+        The value of the ``GITHUB_TOKEN`` environment variable.
     """
-    try:
-        gh_request(
-            path=f"/repos/{REPO}/issues/{number}/labels",
-            method="POST",
-            body={"labels": [FAILED_LABEL]},
-        )
-    except urllib.error.HTTPError as e:
-        logger.warning(f"#{number}: could not add {FAILED_LABEL!r} label: {e}")
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        logger.error("GITHUB_TOKEN env var is required.")
+        sys.exit(1)
+    return token
 
 
 def add_gated_label(number: int) -> None:

--- a/src/leaderboards/leaderboard_generation.py
+++ b/src/leaderboards/leaderboard_generation.py
@@ -25,785 +25,6 @@ from .task_metadata import category_includes_task, official_datasets_for_languag
 logger = logging.getLogger(__name__)
 
 
-def _apply_display_transforms(
-    df: pd.DataFrame,
-    category_to_orthogonal_datasets: dict[str, dict[str, str]],
-    category: str,
-) -> pd.DataFrame:
-    """Apply display transforms: booleans to symbols, generative_type to emojis.
-
-    Args:
-        df:
-            The DataFrame to transform.
-        category_to_orthogonal_datasets:
-            Category to orthogonal datasets mapping.
-        category:
-            The current category.
-
-    Returns:
-        The transformed DataFrame.
-    """
-    boolean_columns = ["commercial", "merge", "open", "trained_from_scratch"]
-    for col in boolean_columns:
-        df[col] = df[col].apply(lambda x: "✓" if x else "✗")
-
-    for orthogonal_task in category_to_orthogonal_datasets[category].values():
-        col_name = orthogonal_task.replace("-", "_")
-        df[col_name] = df.apply(
-            lambda row: (
-                row[col_name]
-                if row.generative_type in ["instruction_tuned", "reasoning"]
-                else "N/A"
-            ),
-            axis=1,
-        )
-
-    generative_type_emoji_mapping = {
-        "base": "🧠",
-        "instruction_tuned": "📝",
-        "reasoning": "🤔",
-    }
-    df["generative_type"] = df.generative_type.map(
-        lambda x: generative_type_emoji_mapping.get(x, "🔍")
-    )
-    return df
-
-
-def _build_category_dataset_maps(
-    categories: list[t.Literal["generative", "all_models"]],
-    leaderboard_configs: dict[str, dict[str, list[str]]],
-) -> "tuple[dict[str, list[str]], dict[str, dict[str, str]]]":
-    """Build category to datasets and orthogonal datasets mappings.
-
-    Args:
-        categories:
-            The categories of leaderboards to generate.
-        leaderboard_configs:
-            The leaderboard configurations.
-
-    Returns:
-        Tuple of (category_to_datasets, category_to_orthogonal_datasets).
-    """
-    category_to_datasets = {
-        category: [
-            dataset
-            for config in leaderboard_configs.values()
-            for task, task_datasets in config.items()
-            for dataset in task_datasets
-            if category_includes_task(category=category, task=task)
-        ]
-        for category in categories
-    }
-
-    category_to_orthogonal_datasets = {
-        category: {
-            dataset: task
-            for config in leaderboard_configs.values()
-            for task, task_datasets in config.items()
-            for dataset in task_datasets
-            if task in ORTHOGONAL_TASKS
-            and category_includes_task(category=category, task=task)
-        }
-        for category in categories
-    }
-
-    return (  # ty: ignore[invalid-return-type]
-        category_to_datasets,
-        category_to_orthogonal_datasets,
-    )
-
-
-def _format_rank_score(entry: object) -> str:
-    """Render a {"score", "ci_upper", ...} dict as "score +/- margin", or "-".
-
-    Args:
-        entry:
-            The dict to format.
-
-    Returns:
-        The formatted string.
-    """
-    if not isinstance(entry, dict):
-        return "-"
-    score = entry.get("score", float("nan"))
-    ci_upper = entry.get("ci_upper", float("nan"))
-    if not (isinstance(score, (int, float)) and math.isfinite(score)):
-        return "-"
-    margin = (
-        (ci_upper - score)
-        if isinstance(ci_upper, int | float) and math.isfinite(ci_upper)
-        else 0.0
-    )
-    return f"{score:.2f} \u00b1 {margin:.2f}"
-
-
-def _build_model_row_data(
-    model_id: str,
-    results: dict[str, list[tuple[list[float], float, float]]],
-    eligible_model_results: dict[
-        str, dict[str, list[tuple[list[float], float, float]]]
-    ],
-    all_standard_ranks: dict,
-    ranks: dict[str, dict[str, dict[str, dict[str, float]]]],
-    category: str,
-    language_to_required_datasets: dict[str, list[str]],
-    leaderboard_configs: dict[str, dict[str, list[str]]],
-    category_to_datasets: dict[str, list[str]],
-    category_to_orthogonal_datasets: dict[str, dict[str, str]],
-    orthogonal_scores_by_plain: dict[str, dict[str, float]],
-    metadata_dict: dict[str, dict],
-) -> dict[str, t.Any]:
-    """Build the data dictionary entry for a single model row.
-
-    Args:
-        model_id:
-            The model id.
-        results:
-            The model results for this model.
-        eligible_model_results:
-            The eligible model results.
-        all_standard_ranks:
-            The standard ranks.
-        ranks:
-            The ranks dictionary.
-        category:
-            The current category.
-        language_to_required_datasets:
-            Language to required datasets mapping.
-        leaderboard_configs:
-            The leaderboard configurations.
-        category_to_datasets:
-            Category to datasets mapping.
-        category_to_orthogonal_datasets:
-            Category to orthogonal datasets mapping.
-        orthogonal_scores_by_plain:
-            Orthogonal scores by plain model id.
-        metadata_dict:
-            The metadata dictionary.
-
-    Returns:
-        Dictionary with all values for this model row.
-
-    Raises:
-        ValueError:
-            If duplicate records are found for a dataset.
-    """
-    has_all_datasets = model_id in eligible_model_results
-
-    rank = all_standard_ranks.get(model_id, {}).get(category, math.nan)
-    cat_ranks = ranks.get(model_id, {}).get(category, {})
-    rank_data = cat_ranks.get("overall", {})
-    mean_rank_score_str = _format_rank_score(rank_data) if has_all_datasets else "-"
-    if mean_rank_score_str == "-":
-        rank = math.nan
-    language_ranks = cat_ranks.copy()
-    language_ranks.pop("overall", None)
-
-    for lang in leaderboard_configs:
-        if lang not in language_ranks:
-            language_ranks[lang] = {}
-
-    language_ranks_scores = {
-        lang: _format_rank_score(entry)
-        if all(ds in results for ds in language_to_required_datasets.get(lang, []))
-        else "-"
-        for lang, entry in language_ranks.items()
-    }
-
-    default_dataset_values = (
-        {ds: float("nan") for ds in category_to_datasets[category]}
-        | {f"{ds}_version": "-" for ds in category_to_datasets[category]}
-        | {f"{ds}_failures": "-" for ds in category_to_datasets[category]}
-        | {f"{ds}_scored": "-" for ds in category_to_datasets[category]}
-    )
-    default_orthogonal_values = {
-        task: float("nan")
-        for task in category_to_orthogonal_datasets[category].values()
-    }
-
-    plain_id = plain_model_id(model_id)
-    orthogonal_scores = defaultdict(list)
-    for dataset, orthogonal_main_score in orthogonal_scores_by_plain.get(
-        plain_id, {}
-    ).items():
-        orthogonal_task = category_to_orthogonal_datasets[category][dataset]
-        orthogonal_scores[orthogonal_task].append(orthogonal_main_score)
-
-    total_results = {}
-    for dataset in category_to_datasets[category]:
-        if dataset in results:
-            scores = results[dataset]
-            if len(scores) > 2:
-                raise ValueError(
-                    f"Model {model_id!r} has {len(scores)} scores for "
-                    f"dataset {dataset!r} (expected at most 2, one per "
-                    f"metric): {[score for _, score, _ in scores]}. This "
-                    "indicates duplicate records survived deduplication."
-                )
-        else:
-            scores = [(list(), float("nan"), 0)]
-        main_score = scores[0][1]
-        if not math.isnan(main_score):
-            score_str = " / ".join(
-                f"{total_score:,.2f} ± {std_err:,.2f}"
-                for _, total_score, std_err in scores
-            )
-        else:
-            score_str = "-"
-        total_results[dataset] = score_str
-
-    orthogonal_task_scores = {
-        task: np.mean(score_list).item() if len(score_list) > 0 else float("nan")
-        for task, score_list in orthogonal_scores.items()
-    }
-
-    metadata = {
-        key: value
-        for key, value in metadata_dict[model_id].items()
-        if not key.endswith(("_version", "_failures", "_scored"))
-        or key.removesuffix("_version")
-        .removesuffix("_failures")
-        .removesuffix("_scored")
-        in category_to_datasets[category]
-    }
-
-    model_url = metadata.get("model_url")
-    display_model = f"<a href='{model_url}'>{model_id}</a>" if model_url else model_id
-
-    model_values = (
-        dict(model=display_model, rank=rank, mean_rank_score=mean_rank_score_str)
-        | default_orthogonal_values
-        | default_dataset_values
-        | orthogonal_task_scores
-        | metadata
-        | language_ranks_scores
-        | total_results
-    )
-    for key, value in model_values.items():
-        if isinstance(value, float):
-            model_values[key] = round(value, 2)
-
-    return model_values
-
-
-def _collect_orthogonal_scores(
-    model_results: dict[str, dict[str, list[tuple[list[float], float, float]]]],
-    category: str,
-    category_to_orthogonal_datasets: dict[str, dict[str, str]],
-) -> dict[str, dict[str, float]]:
-    """Collect orthogonal scores keyed by plain model id.
-
-    Args:
-        model_results:
-            The model results.
-        category:
-            The current category.
-        category_to_orthogonal_datasets:
-            Category to orthogonal datasets mapping.
-
-    Returns:
-        Dictionary mapping plain model ids to orthogonal scores.
-    """
-    orthogonal_scores_by_plain: dict[str, dict[str, float]] = defaultdict(dict)
-    for other_model_id, other_results in model_results.items():
-        other_plain_id = plain_model_id(other_model_id)
-        for dataset in category_to_orthogonal_datasets[category]:
-            if dataset not in other_results:
-                continue
-            main_score = other_results[dataset][0][1]
-            if not math.isnan(main_score):
-                orthogonal_scores_by_plain[other_plain_id][dataset] = main_score
-    return orthogonal_scores_by_plain
-
-
-def _compute_eligible_models_and_ranks(
-    model_results: dict[str, dict[str, list[tuple[list[float], float, float]]]],
-    category: str,
-    category_to_datasets: dict[str, list[str]],
-    category_to_orthogonal_datasets: dict[str, dict[str, str]],
-    leaderboard_configs: dict[str, dict[str, list[str]]],
-) -> "tuple[dict[str, dict[str, list[tuple[list[float], float, float]]]], dict[str, list[str]], dict]":  # noqa: E501
-    """Compute eligible models and bootstrap ranks for a category.
-
-    Args:
-        model_results:
-            The model results.
-        category:
-            The current category.
-        category_to_datasets:
-            Category to datasets mapping.
-        category_to_orthogonal_datasets:
-            Category to orthogonal datasets mapping.
-        leaderboard_configs:
-            The leaderboard configurations.
-
-    Returns:
-        Tuple of (eligible_model_results, language_to_required_datasets,
-        all_standard_ranks).
-    """
-    required_datasets = [
-        ds
-        for ds in category_to_datasets[category]
-        if ds not in category_to_orthogonal_datasets[category]
-    ]
-    eligible_model_results = {
-        mid: r
-        for mid, r in model_results.items()
-        if all(ds in r for ds in required_datasets)
-    }
-
-    language_to_required_datasets = {
-        language: [
-            dataset
-            for task, task_datasets in config.items()
-            for dataset in task_datasets
-            if category_includes_task(category=category, task=task)
-            and task not in ORTHOGONAL_TASKS
-        ]
-        for language, config in leaderboard_configs.items()
-    }
-
-    all_standard_ranks = compute_standard_ranks_bootstrap(
-        model_results=eligible_model_results,
-        configs=leaderboard_configs,
-        n_bootstraps=NUM_BOOTSTRAPS,
-        seed=42,
-    )
-
-    return eligible_model_results, language_to_required_datasets, all_standard_ranks
-
-
-def _create_leaderboard_headers(
-    df: pd.DataFrame | pd.Series, leaderboard_configs: dict[str, dict[str, list[str]]]
-) -> tuple[list[str], list[str]]:
-    """Create the leaderboard headers.
-
-    The first header includes the task types (with links), and the second header
-    contains the 'original' header but with html links to the datasets.
-
-    Args:
-        df:
-            The dataframe.
-        leaderboard_configs:
-            The leaderboard configurations.
-
-    Returns:
-        The first and second header.
-    """
-    # Extract information from each dataset, and set up an anchor tag template which
-    # will replace the dataset column name with a link
-    all_datasets = []
-    dataset_to_language = {}
-    dataset_to_task_info = {}
-    for language, tasks in leaderboard_configs.items():
-        dataset_link_tag = (
-            f"<a href='https://euroeval.com/datasets/{language}#"
-            + "{anchor}'>{dataset}</a>"
-        )
-
-        language_datasets = list(chain.from_iterable(tasks.values()))
-        all_datasets.extend(language_datasets)
-
-        for dataset in language_datasets:
-            dataset_to_language[dataset] = (language, dataset_link_tag)
-
-        for task, datasets in tasks.items():
-            for dataset in datasets:
-                dataset_to_task_info[dataset] = (task, len(datasets))
-
-    top_header = []
-    second_header = []
-    processed_tasks_per_language: dict[str, set[str]] = {}
-    seen_version_col = False
-    for id_, col in enumerate(df.columns):
-        if (task := col.replace(" ", "-").lower()) in ORTHOGONAL_TASKS:
-            top_header.append("")
-            second_header.append(
-                f'<a href="https://euroeval.com/tasks/{task}">{col}</a>'
-            )
-
-        # Replace dataset columns with task links in the first header, and dataset links
-        # in the second header
-        elif (leaderboard_col := col.replace("_", "-")) in all_datasets:
-            language, dataset_link_tag = dataset_to_language[leaderboard_col]
-            task, num_datasets = dataset_to_task_info[leaderboard_col]
-
-            if language not in processed_tasks_per_language:
-                processed_tasks_per_language[language] = set()
-
-            if task in processed_tasks_per_language[language]:
-                top_header.append("")
-                second_header.append(
-                    dataset_link_tag.format(anchor=leaderboard_col, dataset=col)
-                )
-                continue
-
-            task_link = generate_task_link(id_, task)
-            if num_datasets > 1:
-                task_link = f"~~~{task_link}~~~"
-
-            top_header.append(task_link)
-            second_header.append(
-                dataset_link_tag.format(anchor=leaderboard_col, dataset=col)
-            )
-            processed_tasks_per_language[language].add(task)
-
-        # Special case if it's a dataset version column
-        else:
-            if "version" in col and not seen_version_col:
-                top_header.append("<span style='visibility: hidden;'>hidden</span>")
-                seen_version_col = True
-            else:
-                top_header.append("")
-
-            second_header.append(col)
-
-    # Add "Task Type" label to the top-left cell, and make cell (0, 1) invisible to
-    # ensure proper alignment
-    top_header[0] = (
-        "<span style='font-size: 12px; font-weight: normal; opacity: 0.6;'>"
-        "Task Type"
-        "</span>"
-    )
-    top_header[1] = "<span style='visibility: hidden;'>dummy</span>"
-
-    return top_header, second_header
-
-
-def _create_simplified_and_rename(
-    df: pd.DataFrame,
-    rank_cols: list[str],
-    category_to_orthogonal_datasets: dict[str, dict[str, str]],
-    category: str,
-) -> "tuple[pd.DataFrame, pd.DataFrame]":
-    """Create simplified DataFrame and rename columns for display.
-
-    Args:
-        df:
-            The full DataFrame.
-        rank_cols:
-            The rank column names.
-        category_to_orthogonal_datasets:
-            Category to orthogonal datasets mapping.
-        category:
-            The current category.
-
-    Returns:
-        Tuple of (df, df_simplified) with renamed columns.
-    """
-    df_simplified = df[
-        [
-            "rank",
-            "model",
-            "mean_rank_score",
-            "generative_type",
-            "open",
-            "commercial",
-            "merge",
-            "trained_from_scratch",
-            "parameters",
-            "vocabulary_size",
-            "context",
-        ]
-    ]
-    df_simplified = df_simplified.query("rank != '-'")
-    df_simplified = df_simplified.convert_dtypes()
-
-    renaming_dict = (
-        {
-            "model": "Model",
-            "generative_type": "Type",
-            "rank": "Rank",
-            "parameters": "Parameters",
-            "vocabulary_size": "Vocabulary",
-            "context": "Context",
-            "commercial": "Commercial",
-            "merge": "Merge",
-            "open": "Open",
-            "trained_from_scratch": "Trained from scratch",
-        }
-        | {"mean_rank_score": "Rank score"}
-        | {rank_col: rank_col.title() for rank_col in rank_cols[2:]}
-        | {
-            orthogonal_task.replace("-", "_"): orthogonal_task.replace("-", " ").title()
-            for orthogonal_task in category_to_orthogonal_datasets[category].values()
-        }
-    )
-    df = df.rename(renaming_dict, axis="columns")
-
-    return df, df_simplified
-
-
-def _filter_orthogonal_only_models(
-    df: pd.DataFrame,
-    category: str,
-    orthogonal_cols: list[str],
-    dataset_cols: list[str],
-    rank_cols: list[str],
-) -> pd.DataFrame:
-    """Filter out models with only orthogonal values.
-
-    Args:
-        df:
-            The DataFrame to filter.
-        category:
-            The current category.
-        orthogonal_cols:
-            The orthogonal column names.
-        dataset_cols:
-            The dataset column names.
-        rank_cols:
-            The rank column names.
-
-    Returns:
-        The filtered DataFrame.
-    """
-    num_before = len(df)
-    value_cols = [col for col in dataset_cols + rank_cols[1:] if col in df.columns]
-    model_ids_with_dataset_values = df.query(
-        " or ".join([f"({col} != '-')" for col in value_cols])
-    ).model.tolist()
-    model_ids_with_orthogonal_values = df[
-        df[orthogonal_cols].notna().any(axis=1)
-    ].model.tolist()
-    model_ids_to_drop = set(model_ids_with_orthogonal_values) - set(
-        model_ids_with_dataset_values
-    )
-    df = df[~df.model.isin(model_ids_to_drop)].reset_index(drop=True)
-    num_after = len(df)
-    if num_after < num_before:
-        logger.info(
-            f"Dropped {num_before - num_after:,} models from the {category!r} "
-            "leaderboard that had only orthogonal scores but no dataset scores."
-        )
-    return df
-
-
-def _format_ordinal_rank_column(df: pd.DataFrame, rank_cols: list[str]) -> pd.DataFrame:
-    """Format the ordinal rank column with sentinel for NaN.
-
-    Args:
-        df:
-            The DataFrame to format.
-        rank_cols:
-            The rank column names.
-
-    Returns:
-        The formatted DataFrame.
-    """
-    df["rank"] = [
-        str(int(value))
-        if isinstance(value, (int, float)) and math.isfinite(value)
-        else "-"
-        for value in df["rank"]
-    ]
-    for col in rank_cols[1:]:
-        df[col] = [v if isinstance(v, str) and v != "-" else "-" for v in df[col]]
-    return df
-
-
-def _reorder_columns(
-    df: pd.DataFrame,
-    category: str,
-    category_to_orthogonal_datasets: dict[str, dict[str, str]],
-    category_to_datasets: dict[str, list[str]],
-    rank_cols: list[str],
-    include_dataset_columns: bool,
-) -> pd.DataFrame:
-    """Reorder DataFrame columns to the standard order.
-
-    Args:
-        df:
-            The DataFrame to reorder.
-        category:
-            The current category.
-        category_to_orthogonal_datasets:
-            Category to orthogonal datasets mapping.
-        category_to_datasets:
-            Category to datasets mapping.
-        rank_cols:
-            The rank column names.
-        include_dataset_columns:
-            Whether to include dataset columns.
-
-    Returns:
-        The DataFrame with reordered columns.
-    """
-    orthogonal_cols = list(
-        {
-            orthogonal_task.replace("-", "_")
-            for orthogonal_task in category_to_orthogonal_datasets[category].values()
-        }
-    )
-    dataset_cols = [
-        dataset.replace("-", "_")
-        for dataset in category_to_datasets[category]
-        if dataset not in category_to_orthogonal_datasets[category]
-    ]
-    cols = (
-        ["rank", "model", "mean_rank_score"]
-        + orthogonal_cols
-        + [
-            "generative_type",
-            "open",
-            "commercial",
-            "merge",
-            "trained_from_scratch",
-            "parameters",
-            "vocabulary_size",
-            "context",
-        ]
-        + rank_cols[2:]
-    )
-    if include_dataset_columns:
-        cols += dataset_cols
-        cols += [f"{dataset}_version" for dataset in dataset_cols]
-        cols += [f"{dataset}_failures" for dataset in dataset_cols]
-        cols += [f"{dataset}_scored" for dataset in dataset_cols]
-    return df[cols]
-
-
-def _generate_dataframe(
-    model_results: dict[str, dict[str, list[tuple[list[float], float, float]]]],
-    ranks: dict[str, dict[str, dict[str, dict[str, float]]]],
-    metadata_dict: dict[str, dict],
-    categories: list[t.Literal["generative", "all_models"]],
-    leaderboard_configs: dict[str, dict[str, list[str]]],
-    include_dataset_columns: bool,
-) -> list[tuple[pd.DataFrame, pd.DataFrame]]:
-    """Generate DataFrames from the model results.
-
-    Args:
-        model_results:
-            The model results.
-        ranks:
-            The ranks of the models (from compute_ranks).
-        metadata_dict:
-            The metadata.
-        categories:
-            The categories of leaderboards to generate.
-        leaderboard_configs:
-            The leaderboard configurations.
-        include_dataset_columns:
-            Whether to include dataset columns in the DataFrame.
-
-    Returns:
-        A list of pairs (df, df_simplified), where df is the full leaderboard DataFrame
-        and df_simplified is the simplified version.
-    """
-    if model_results == {}:
-        logger.error("No model results found, skipping leaderboard generation.")
-        return []
-
-    category_to_datasets, category_to_orthogonal_datasets = (
-        _build_category_dataset_maps(categories, leaderboard_configs)
-    )
-
-    dfs: list[tuple[pd.DataFrame, pd.DataFrame]] = []
-    for category in categories:
-        (eligible_model_results, language_to_required_datasets, all_standard_ranks) = (
-            _compute_eligible_models_and_ranks(
-                model_results=model_results,
-                category=category,
-                category_to_datasets=category_to_datasets,
-                category_to_orthogonal_datasets=category_to_orthogonal_datasets,
-                leaderboard_configs=leaderboard_configs,
-            )
-        )
-
-        orthogonal_scores_by_plain = _collect_orthogonal_scores(
-            model_results=model_results,
-            category=category,
-            category_to_orthogonal_datasets=category_to_orthogonal_datasets,
-        )
-
-        data_dict: dict[str, list] = defaultdict(list)
-        for model_id, results in model_results.items():
-            model_values = _build_model_row_data(
-                model_id=model_id,
-                results=results,
-                eligible_model_results=eligible_model_results,
-                all_standard_ranks=all_standard_ranks,
-                ranks=ranks,
-                category=category,
-                language_to_required_datasets=language_to_required_datasets,
-                leaderboard_configs=leaderboard_configs,
-                category_to_datasets=category_to_datasets,
-                category_to_orthogonal_datasets=category_to_orthogonal_datasets,
-                orthogonal_scores_by_plain=orthogonal_scores_by_plain,
-                metadata_dict=metadata_dict,
-            )
-            for key, value in model_values.items():
-                data_dict[key].append(value)
-
-            assert len({len(values) for values in data_dict.values()}) == 1, (
-                f"Length of data_dict values must be equal, but got "
-                f"{ {key: len(values) for key, values in data_dict.items()} }."
-            )
-
-        df = (
-            pd.DataFrame(data_dict)
-            .sort_values(by="rank", na_position="last")
-            .reset_index(drop=True)
-        )
-
-        rank_cols = ["rank", "mean_rank_score"]
-        if len(leaderboard_configs) > 1:
-            rank_cols += list(leaderboard_configs.keys())
-
-        df = _format_ordinal_rank_column(df, rank_cols)
-
-        df.columns = df.columns.str.replace("-", "_")
-
-        orthogonal_cols = list(
-            {
-                orthogonal_task.replace("-", "_")
-                for orthogonal_task in category_to_orthogonal_datasets[
-                    category
-                ].values()
-            }
-        )
-        dataset_cols = [
-            dataset.replace("-", "_")
-            for dataset in category_to_datasets[category]
-            if dataset not in category_to_orthogonal_datasets[category]
-        ]
-        df = _reorder_columns(
-            df=df,
-            category=category,
-            category_to_orthogonal_datasets=category_to_orthogonal_datasets,
-            category_to_datasets=category_to_datasets,
-            rank_cols=rank_cols,
-            include_dataset_columns=include_dataset_columns,
-        )
-
-        df = _filter_orthogonal_only_models(
-            df=df,
-            category=category,
-            orthogonal_cols=orthogonal_cols,
-            dataset_cols=dataset_cols,
-            rank_cols=rank_cols,
-        )
-
-        df = _apply_display_transforms(
-            df=df,
-            category_to_orthogonal_datasets=category_to_orthogonal_datasets,
-            category=category,
-        )
-
-        df, df_simplified = _create_simplified_and_rename(
-            df=df,
-            rank_cols=rank_cols,
-            category_to_orthogonal_datasets=category_to_orthogonal_datasets,
-            category=category,
-        )
-
-        assert isinstance(df, pd.DataFrame)
-        dfs.append((df, df_simplified))
-
-    return dfs
-
-
 def generate_leaderboard(
     leaderboard_name: str,
     language_names: list[str],
@@ -1057,3 +278,782 @@ def generate_leaderboard(
                 f"No updates to the {category!r} category of the {leaderboard_title} "
                 "leaderboard."
             )
+
+
+def _create_leaderboard_headers(
+    df: pd.DataFrame | pd.Series, leaderboard_configs: dict[str, dict[str, list[str]]]
+) -> tuple[list[str], list[str]]:
+    """Create the leaderboard headers.
+
+    The first header includes the task types (with links), and the second header
+    contains the 'original' header but with html links to the datasets.
+
+    Args:
+        df:
+            The dataframe.
+        leaderboard_configs:
+            The leaderboard configurations.
+
+    Returns:
+        The first and second header.
+    """
+    # Extract information from each dataset, and set up an anchor tag template which
+    # will replace the dataset column name with a link
+    all_datasets = []
+    dataset_to_language = {}
+    dataset_to_task_info = {}
+    for language, tasks in leaderboard_configs.items():
+        dataset_link_tag = (
+            f"<a href='https://euroeval.com/datasets/{language}#"
+            + "{anchor}'>{dataset}</a>"
+        )
+
+        language_datasets = list(chain.from_iterable(tasks.values()))
+        all_datasets.extend(language_datasets)
+
+        for dataset in language_datasets:
+            dataset_to_language[dataset] = (language, dataset_link_tag)
+
+        for task, datasets in tasks.items():
+            for dataset in datasets:
+                dataset_to_task_info[dataset] = (task, len(datasets))
+
+    top_header = []
+    second_header = []
+    processed_tasks_per_language: dict[str, set[str]] = {}
+    seen_version_col = False
+    for id_, col in enumerate(df.columns):
+        if (task := col.replace(" ", "-").lower()) in ORTHOGONAL_TASKS:
+            top_header.append("")
+            second_header.append(
+                f'<a href="https://euroeval.com/tasks/{task}">{col}</a>'
+            )
+
+        # Replace dataset columns with task links in the first header, and dataset links
+        # in the second header
+        elif (leaderboard_col := col.replace("_", "-")) in all_datasets:
+            language, dataset_link_tag = dataset_to_language[leaderboard_col]
+            task, num_datasets = dataset_to_task_info[leaderboard_col]
+
+            if language not in processed_tasks_per_language:
+                processed_tasks_per_language[language] = set()
+
+            if task in processed_tasks_per_language[language]:
+                top_header.append("")
+                second_header.append(
+                    dataset_link_tag.format(anchor=leaderboard_col, dataset=col)
+                )
+                continue
+
+            task_link = generate_task_link(id_, task)
+            if num_datasets > 1:
+                task_link = f"~~~{task_link}~~~"
+
+            top_header.append(task_link)
+            second_header.append(
+                dataset_link_tag.format(anchor=leaderboard_col, dataset=col)
+            )
+            processed_tasks_per_language[language].add(task)
+
+        # Special case if it's a dataset version column
+        else:
+            if "version" in col and not seen_version_col:
+                top_header.append("<span style='visibility: hidden;'>hidden</span>")
+                seen_version_col = True
+            else:
+                top_header.append("")
+
+            second_header.append(col)
+
+    # Add "Task Type" label to the top-left cell, and make cell (0, 1) invisible to
+    # ensure proper alignment
+    top_header[0] = (
+        "<span style='font-size: 12px; font-weight: normal; opacity: 0.6;'>"
+        "Task Type"
+        "</span>"
+    )
+    top_header[1] = "<span style='visibility: hidden;'>dummy</span>"
+
+    return top_header, second_header
+
+
+def _generate_dataframe(
+    model_results: dict[str, dict[str, list[tuple[list[float], float, float]]]],
+    ranks: dict[str, dict[str, dict[str, dict[str, float]]]],
+    metadata_dict: dict[str, dict],
+    categories: list[t.Literal["generative", "all_models"]],
+    leaderboard_configs: dict[str, dict[str, list[str]]],
+    include_dataset_columns: bool,
+) -> list[tuple[pd.DataFrame, pd.DataFrame]]:
+    """Generate DataFrames from the model results.
+
+    Args:
+        model_results:
+            The model results.
+        ranks:
+            The ranks of the models (from compute_ranks).
+        metadata_dict:
+            The metadata.
+        categories:
+            The categories of leaderboards to generate.
+        leaderboard_configs:
+            The leaderboard configurations.
+        include_dataset_columns:
+            Whether to include dataset columns in the DataFrame.
+
+    Returns:
+        A list of pairs (df, df_simplified), where df is the full leaderboard DataFrame
+        and df_simplified is the simplified version.
+    """
+    if model_results == {}:
+        logger.error("No model results found, skipping leaderboard generation.")
+        return []
+
+    category_to_datasets, category_to_orthogonal_datasets = (
+        _build_category_dataset_maps(categories, leaderboard_configs)
+    )
+
+    dfs: list[tuple[pd.DataFrame, pd.DataFrame]] = []
+    for category in categories:
+        (eligible_model_results, language_to_required_datasets, all_standard_ranks) = (
+            _compute_eligible_models_and_ranks(
+                model_results=model_results,
+                category=category,
+                category_to_datasets=category_to_datasets,
+                category_to_orthogonal_datasets=category_to_orthogonal_datasets,
+                leaderboard_configs=leaderboard_configs,
+            )
+        )
+
+        orthogonal_scores_by_plain = _collect_orthogonal_scores(
+            model_results=model_results,
+            category=category,
+            category_to_orthogonal_datasets=category_to_orthogonal_datasets,
+        )
+
+        data_dict: dict[str, list] = defaultdict(list)
+        for model_id, results in model_results.items():
+            model_values = _build_model_row_data(
+                model_id=model_id,
+                results=results,
+                eligible_model_results=eligible_model_results,
+                all_standard_ranks=all_standard_ranks,
+                ranks=ranks,
+                category=category,
+                language_to_required_datasets=language_to_required_datasets,
+                leaderboard_configs=leaderboard_configs,
+                category_to_datasets=category_to_datasets,
+                category_to_orthogonal_datasets=category_to_orthogonal_datasets,
+                orthogonal_scores_by_plain=orthogonal_scores_by_plain,
+                metadata_dict=metadata_dict,
+            )
+            for key, value in model_values.items():
+                data_dict[key].append(value)
+
+            assert len({len(values) for values in data_dict.values()}) == 1, (
+                f"Length of data_dict values must be equal, but got "
+                f"{ {key: len(values) for key, values in data_dict.items()} }."
+            )
+
+        df = (
+            pd.DataFrame(data_dict)
+            .sort_values(by="rank", na_position="last")
+            .reset_index(drop=True)
+        )
+
+        rank_cols = ["rank", "mean_rank_score"]
+        if len(leaderboard_configs) > 1:
+            rank_cols += list(leaderboard_configs.keys())
+
+        df = _format_ordinal_rank_column(df, rank_cols)
+
+        df.columns = df.columns.str.replace("-", "_")
+
+        orthogonal_cols = list(
+            {
+                orthogonal_task.replace("-", "_")
+                for orthogonal_task in category_to_orthogonal_datasets[
+                    category
+                ].values()
+            }
+        )
+        dataset_cols = [
+            dataset.replace("-", "_")
+            for dataset in category_to_datasets[category]
+            if dataset not in category_to_orthogonal_datasets[category]
+        ]
+        df = _reorder_columns(
+            df=df,
+            category=category,
+            category_to_orthogonal_datasets=category_to_orthogonal_datasets,
+            category_to_datasets=category_to_datasets,
+            rank_cols=rank_cols,
+            include_dataset_columns=include_dataset_columns,
+        )
+
+        df = _filter_orthogonal_only_models(
+            df=df,
+            category=category,
+            orthogonal_cols=orthogonal_cols,
+            dataset_cols=dataset_cols,
+            rank_cols=rank_cols,
+        )
+
+        df = _apply_display_transforms(
+            df=df,
+            category_to_orthogonal_datasets=category_to_orthogonal_datasets,
+            category=category,
+        )
+
+        df, df_simplified = _create_simplified_and_rename(
+            df=df,
+            rank_cols=rank_cols,
+            category_to_orthogonal_datasets=category_to_orthogonal_datasets,
+            category=category,
+        )
+
+        assert isinstance(df, pd.DataFrame)
+        dfs.append((df, df_simplified))
+
+    return dfs
+
+
+def _apply_display_transforms(
+    df: pd.DataFrame,
+    category_to_orthogonal_datasets: dict[str, dict[str, str]],
+    category: str,
+) -> pd.DataFrame:
+    """Apply display transforms: booleans to symbols, generative_type to emojis.
+
+    Args:
+        df:
+            The DataFrame to transform.
+        category_to_orthogonal_datasets:
+            Category to orthogonal datasets mapping.
+        category:
+            The current category.
+
+    Returns:
+        The transformed DataFrame.
+    """
+    boolean_columns = ["commercial", "merge", "open", "trained_from_scratch"]
+    for col in boolean_columns:
+        df[col] = df[col].apply(lambda x: "✓" if x else "✗")
+
+    for orthogonal_task in category_to_orthogonal_datasets[category].values():
+        col_name = orthogonal_task.replace("-", "_")
+        df[col_name] = df.apply(
+            lambda row: (
+                row[col_name]
+                if row.generative_type in ["instruction_tuned", "reasoning"]
+                else "N/A"
+            ),
+            axis=1,
+        )
+
+    generative_type_emoji_mapping = {
+        "base": "🧠",
+        "instruction_tuned": "📝",
+        "reasoning": "🤔",
+    }
+    df["generative_type"] = df.generative_type.map(
+        lambda x: generative_type_emoji_mapping.get(x, "🔍")
+    )
+    return df
+
+
+def _build_category_dataset_maps(
+    categories: list[t.Literal["generative", "all_models"]],
+    leaderboard_configs: dict[str, dict[str, list[str]]],
+) -> "tuple[dict[str, list[str]], dict[str, dict[str, str]]]":
+    """Build category to datasets and orthogonal datasets mappings.
+
+    Args:
+        categories:
+            The categories of leaderboards to generate.
+        leaderboard_configs:
+            The leaderboard configurations.
+
+    Returns:
+        Tuple of (category_to_datasets, category_to_orthogonal_datasets).
+    """
+    category_to_datasets = {
+        category: [
+            dataset
+            for config in leaderboard_configs.values()
+            for task, task_datasets in config.items()
+            for dataset in task_datasets
+            if category_includes_task(category=category, task=task)
+        ]
+        for category in categories
+    }
+
+    category_to_orthogonal_datasets = {
+        category: {
+            dataset: task
+            for config in leaderboard_configs.values()
+            for task, task_datasets in config.items()
+            for dataset in task_datasets
+            if task in ORTHOGONAL_TASKS
+            and category_includes_task(category=category, task=task)
+        }
+        for category in categories
+    }
+
+    return (  # ty: ignore[invalid-return-type]
+        category_to_datasets,
+        category_to_orthogonal_datasets,
+    )
+
+
+def _build_model_row_data(
+    model_id: str,
+    results: dict[str, list[tuple[list[float], float, float]]],
+    eligible_model_results: dict[
+        str, dict[str, list[tuple[list[float], float, float]]]
+    ],
+    all_standard_ranks: dict,
+    ranks: dict[str, dict[str, dict[str, dict[str, float]]]],
+    category: str,
+    language_to_required_datasets: dict[str, list[str]],
+    leaderboard_configs: dict[str, dict[str, list[str]]],
+    category_to_datasets: dict[str, list[str]],
+    category_to_orthogonal_datasets: dict[str, dict[str, str]],
+    orthogonal_scores_by_plain: dict[str, dict[str, float]],
+    metadata_dict: dict[str, dict],
+) -> dict[str, t.Any]:
+    """Build the data dictionary entry for a single model row.
+
+    Args:
+        model_id:
+            The model id.
+        results:
+            The model results for this model.
+        eligible_model_results:
+            The eligible model results.
+        all_standard_ranks:
+            The standard ranks.
+        ranks:
+            The ranks dictionary.
+        category:
+            The current category.
+        language_to_required_datasets:
+            Language to required datasets mapping.
+        leaderboard_configs:
+            The leaderboard configurations.
+        category_to_datasets:
+            Category to datasets mapping.
+        category_to_orthogonal_datasets:
+            Category to orthogonal datasets mapping.
+        orthogonal_scores_by_plain:
+            Orthogonal scores by plain model id.
+        metadata_dict:
+            The metadata dictionary.
+
+    Returns:
+        Dictionary with all values for this model row.
+
+    Raises:
+        ValueError:
+            If duplicate records are found for a dataset.
+    """
+    has_all_datasets = model_id in eligible_model_results
+
+    rank = all_standard_ranks.get(model_id, {}).get(category, math.nan)
+    cat_ranks = ranks.get(model_id, {}).get(category, {})
+    rank_data = cat_ranks.get("overall", {})
+    mean_rank_score_str = _format_rank_score(rank_data) if has_all_datasets else "-"
+    if mean_rank_score_str == "-":
+        rank = math.nan
+    language_ranks = cat_ranks.copy()
+    language_ranks.pop("overall", None)
+
+    for lang in leaderboard_configs:
+        if lang not in language_ranks:
+            language_ranks[lang] = {}
+
+    language_ranks_scores = {
+        lang: _format_rank_score(entry)
+        if all(ds in results for ds in language_to_required_datasets.get(lang, []))
+        else "-"
+        for lang, entry in language_ranks.items()
+    }
+
+    default_dataset_values = (
+        {ds: float("nan") for ds in category_to_datasets[category]}
+        | {f"{ds}_version": "-" for ds in category_to_datasets[category]}
+        | {f"{ds}_failures": "-" for ds in category_to_datasets[category]}
+        | {f"{ds}_scored": "-" for ds in category_to_datasets[category]}
+    )
+    default_orthogonal_values = {
+        task: float("nan")
+        for task in category_to_orthogonal_datasets[category].values()
+    }
+
+    plain_id = plain_model_id(model_id)
+    orthogonal_scores = defaultdict(list)
+    for dataset, orthogonal_main_score in orthogonal_scores_by_plain.get(
+        plain_id, {}
+    ).items():
+        orthogonal_task = category_to_orthogonal_datasets[category][dataset]
+        orthogonal_scores[orthogonal_task].append(orthogonal_main_score)
+
+    total_results = {}
+    for dataset in category_to_datasets[category]:
+        if dataset in results:
+            scores = results[dataset]
+            if len(scores) > 2:
+                raise ValueError(
+                    f"Model {model_id!r} has {len(scores)} scores for "
+                    f"dataset {dataset!r} (expected at most 2, one per "
+                    f"metric): {[score for _, score, _ in scores]}. This "
+                    "indicates duplicate records survived deduplication."
+                )
+        else:
+            scores = [(list(), float("nan"), 0)]
+        main_score = scores[0][1]
+        if not math.isnan(main_score):
+            score_str = " / ".join(
+                f"{total_score:,.2f} ± {std_err:,.2f}"
+                for _, total_score, std_err in scores
+            )
+        else:
+            score_str = "-"
+        total_results[dataset] = score_str
+
+    orthogonal_task_scores = {
+        task: np.mean(score_list).item() if len(score_list) > 0 else float("nan")
+        for task, score_list in orthogonal_scores.items()
+    }
+
+    metadata = {
+        key: value
+        for key, value in metadata_dict[model_id].items()
+        if not key.endswith(("_version", "_failures", "_scored"))
+        or key.removesuffix("_version")
+        .removesuffix("_failures")
+        .removesuffix("_scored")
+        in category_to_datasets[category]
+    }
+
+    model_url = metadata.get("model_url")
+    display_model = f"<a href='{model_url}'>{model_id}</a>" if model_url else model_id
+
+    model_values = (
+        dict(model=display_model, rank=rank, mean_rank_score=mean_rank_score_str)
+        | default_orthogonal_values
+        | default_dataset_values
+        | orthogonal_task_scores
+        | metadata
+        | language_ranks_scores
+        | total_results
+    )
+    for key, value in model_values.items():
+        if isinstance(value, float):
+            model_values[key] = round(value, 2)
+
+    return model_values
+
+
+def _format_rank_score(entry: object) -> str:
+    """Render a {"score", "ci_upper", ...} dict as "score +/- margin", or "-".
+
+    Args:
+        entry:
+            The dict to format.
+
+    Returns:
+        The formatted string.
+    """
+    if not isinstance(entry, dict):
+        return "-"
+    score = entry.get("score", float("nan"))
+    ci_upper = entry.get("ci_upper", float("nan"))
+    if not (isinstance(score, (int, float)) and math.isfinite(score)):
+        return "-"
+    margin = (
+        (ci_upper - score)
+        if isinstance(ci_upper, int | float) and math.isfinite(ci_upper)
+        else 0.0
+    )
+    return f"{score:.2f} \u00b1 {margin:.2f}"
+
+
+def _collect_orthogonal_scores(
+    model_results: dict[str, dict[str, list[tuple[list[float], float, float]]]],
+    category: str,
+    category_to_orthogonal_datasets: dict[str, dict[str, str]],
+) -> dict[str, dict[str, float]]:
+    """Collect orthogonal scores keyed by plain model id.
+
+    Args:
+        model_results:
+            The model results.
+        category:
+            The current category.
+        category_to_orthogonal_datasets:
+            Category to orthogonal datasets mapping.
+
+    Returns:
+        Dictionary mapping plain model ids to orthogonal scores.
+    """
+    orthogonal_scores_by_plain: dict[str, dict[str, float]] = defaultdict(dict)
+    for other_model_id, other_results in model_results.items():
+        other_plain_id = plain_model_id(other_model_id)
+        for dataset in category_to_orthogonal_datasets[category]:
+            if dataset not in other_results:
+                continue
+            main_score = other_results[dataset][0][1]
+            if not math.isnan(main_score):
+                orthogonal_scores_by_plain[other_plain_id][dataset] = main_score
+    return orthogonal_scores_by_plain
+
+
+def _compute_eligible_models_and_ranks(
+    model_results: dict[str, dict[str, list[tuple[list[float], float, float]]]],
+    category: str,
+    category_to_datasets: dict[str, list[str]],
+    category_to_orthogonal_datasets: dict[str, dict[str, str]],
+    leaderboard_configs: dict[str, dict[str, list[str]]],
+) -> "tuple[dict[str, dict[str, list[tuple[list[float], float, float]]]], dict[str, list[str]], dict]":  # noqa: E501
+    """Compute eligible models and bootstrap ranks for a category.
+
+    Args:
+        model_results:
+            The model results.
+        category:
+            The current category.
+        category_to_datasets:
+            Category to datasets mapping.
+        category_to_orthogonal_datasets:
+            Category to orthogonal datasets mapping.
+        leaderboard_configs:
+            The leaderboard configurations.
+
+    Returns:
+        Tuple of (eligible_model_results, language_to_required_datasets,
+        all_standard_ranks).
+    """
+    required_datasets = [
+        ds
+        for ds in category_to_datasets[category]
+        if ds not in category_to_orthogonal_datasets[category]
+    ]
+    eligible_model_results = {
+        mid: r
+        for mid, r in model_results.items()
+        if all(ds in r for ds in required_datasets)
+    }
+
+    language_to_required_datasets = {
+        language: [
+            dataset
+            for task, task_datasets in config.items()
+            for dataset in task_datasets
+            if category_includes_task(category=category, task=task)
+            and task not in ORTHOGONAL_TASKS
+        ]
+        for language, config in leaderboard_configs.items()
+    }
+
+    all_standard_ranks = compute_standard_ranks_bootstrap(
+        model_results=eligible_model_results,
+        configs=leaderboard_configs,
+        n_bootstraps=NUM_BOOTSTRAPS,
+        seed=42,
+    )
+
+    return eligible_model_results, language_to_required_datasets, all_standard_ranks
+
+
+def _create_simplified_and_rename(
+    df: pd.DataFrame,
+    rank_cols: list[str],
+    category_to_orthogonal_datasets: dict[str, dict[str, str]],
+    category: str,
+) -> "tuple[pd.DataFrame, pd.DataFrame]":
+    """Create simplified DataFrame and rename columns for display.
+
+    Args:
+        df:
+            The full DataFrame.
+        rank_cols:
+            The rank column names.
+        category_to_orthogonal_datasets:
+            Category to orthogonal datasets mapping.
+        category:
+            The current category.
+
+    Returns:
+        Tuple of (df, df_simplified) with renamed columns.
+    """
+    df_simplified = df[
+        [
+            "rank",
+            "model",
+            "mean_rank_score",
+            "generative_type",
+            "open",
+            "commercial",
+            "merge",
+            "trained_from_scratch",
+            "parameters",
+            "vocabulary_size",
+            "context",
+        ]
+    ]
+    df_simplified = df_simplified.query("rank != '-'")
+    df_simplified = df_simplified.convert_dtypes()
+
+    renaming_dict = (
+        {
+            "model": "Model",
+            "generative_type": "Type",
+            "rank": "Rank",
+            "parameters": "Parameters",
+            "vocabulary_size": "Vocabulary",
+            "context": "Context",
+            "commercial": "Commercial",
+            "merge": "Merge",
+            "open": "Open",
+            "trained_from_scratch": "Trained from scratch",
+        }
+        | {"mean_rank_score": "Rank score"}
+        | {rank_col: rank_col.title() for rank_col in rank_cols[2:]}
+        | {
+            orthogonal_task.replace("-", "_"): orthogonal_task.replace("-", " ").title()
+            for orthogonal_task in category_to_orthogonal_datasets[category].values()
+        }
+    )
+    df = df.rename(renaming_dict, axis="columns")
+
+    return df, df_simplified
+
+
+def _filter_orthogonal_only_models(
+    df: pd.DataFrame,
+    category: str,
+    orthogonal_cols: list[str],
+    dataset_cols: list[str],
+    rank_cols: list[str],
+) -> pd.DataFrame:
+    """Filter out models with only orthogonal values.
+
+    Args:
+        df:
+            The DataFrame to filter.
+        category:
+            The current category.
+        orthogonal_cols:
+            The orthogonal column names.
+        dataset_cols:
+            The dataset column names.
+        rank_cols:
+            The rank column names.
+
+    Returns:
+        The filtered DataFrame.
+    """
+    num_before = len(df)
+    value_cols = [col for col in dataset_cols + rank_cols[1:] if col in df.columns]
+    model_ids_with_dataset_values = df.query(
+        " or ".join([f"({col} != '-')" for col in value_cols])
+    ).model.tolist()
+    model_ids_with_orthogonal_values = df[
+        df[orthogonal_cols].notna().any(axis=1)
+    ].model.tolist()
+    model_ids_to_drop = set(model_ids_with_orthogonal_values) - set(
+        model_ids_with_dataset_values
+    )
+    df = df[~df.model.isin(model_ids_to_drop)].reset_index(drop=True)
+    num_after = len(df)
+    if num_after < num_before:
+        logger.info(
+            f"Dropped {num_before - num_after:,} models from the {category!r} "
+            "leaderboard that had only orthogonal scores but no dataset scores."
+        )
+    return df
+
+
+def _format_ordinal_rank_column(df: pd.DataFrame, rank_cols: list[str]) -> pd.DataFrame:
+    """Format the ordinal rank column with sentinel for NaN.
+
+    Args:
+        df:
+            The DataFrame to format.
+        rank_cols:
+            The rank column names.
+
+    Returns:
+        The formatted DataFrame.
+    """
+    df["rank"] = [
+        str(int(value))
+        if isinstance(value, (int, float)) and math.isfinite(value)
+        else "-"
+        for value in df["rank"]
+    ]
+    for col in rank_cols[1:]:
+        df[col] = [v if isinstance(v, str) and v != "-" else "-" for v in df[col]]
+    return df
+
+
+def _reorder_columns(
+    df: pd.DataFrame,
+    category: str,
+    category_to_orthogonal_datasets: dict[str, dict[str, str]],
+    category_to_datasets: dict[str, list[str]],
+    rank_cols: list[str],
+    include_dataset_columns: bool,
+) -> pd.DataFrame:
+    """Reorder DataFrame columns to the standard order.
+
+    Args:
+        df:
+            The DataFrame to reorder.
+        category:
+            The current category.
+        category_to_orthogonal_datasets:
+            Category to orthogonal datasets mapping.
+        category_to_datasets:
+            Category to datasets mapping.
+        rank_cols:
+            The rank column names.
+        include_dataset_columns:
+            Whether to include dataset columns.
+
+    Returns:
+        The DataFrame with reordered columns.
+    """
+    orthogonal_cols = list(
+        {
+            orthogonal_task.replace("-", "_")
+            for orthogonal_task in category_to_orthogonal_datasets[category].values()
+        }
+    )
+    dataset_cols = [
+        dataset.replace("-", "_")
+        for dataset in category_to_datasets[category]
+        if dataset not in category_to_orthogonal_datasets[category]
+    ]
+    cols = (
+        ["rank", "model", "mean_rank_score"]
+        + orthogonal_cols
+        + [
+            "generative_type",
+            "open",
+            "commercial",
+            "merge",
+            "trained_from_scratch",
+            "parameters",
+            "vocabulary_size",
+            "context",
+        ]
+        + rank_cols[2:]
+    )
+    if include_dataset_columns:
+        cols += dataset_cols
+        cols += [f"{dataset}_version" for dataset in dataset_cols]
+        cols += [f"{dataset}_failures" for dataset in dataset_cols]
+        cols += [f"{dataset}_scored" for dataset in dataset_cols]
+    return df[cols]

--- a/src/leaderboards/link_generation.py
+++ b/src/leaderboards/link_generation.py
@@ -33,107 +33,6 @@ logger = logging.getLogger(__name__)
 
 @cache
 @cache
-@cache
-def _check_model_exists_with_retry(model_id: str, hf_api: HfApi) -> None:
-    """Check if a model exists on the Hugging Face Hub with retry logic.
-
-    Retries only on connection-related errors (not repository errors).
-
-    Args:
-        model_id:
-            The Hugging Face model ID.
-        hf_api:
-            The Hugging Face API client.
-
-    Raises:
-        RepositoryNotFoundError:
-            If the repository does not exist (not retried).
-        GatedRepoError:
-            If the repository is gated (not retried).
-        HFValidationError:
-            If the model ID is invalid (not retried).
-        httpx.RemoteProtocolError:
-            If the server disconnects without sending a response (retried).
-        ConnectionError:
-            If there is a network connection error (retried).
-    """
-    max_attempts = 3
-    for attempt in range(max_attempts):
-        try:
-            hf_api.model_info(repo_id=model_id)
-            return
-        except (httpx.RemoteProtocolError, ConnectionError) as e:
-            if attempt == max_attempts - 1:
-                raise  # Re-raise on last attempt
-            wait_time = 2**attempt  # Exponential backoff: 1s, 2s, 4s
-            logger.warning(
-                f"Connection error checking {model_id}: {e}. "
-                f"Retrying in {wait_time}s..."
-            )
-            time.sleep(wait_time)
-        except (RepositoryNotFoundError, GatedRepoError, HFValidationError):
-            raise  # Don't retry these errors
-
-
-@cache
-@cache
-def _load_model_url_decisions() -> dict[str, bool]:
-    """Load cached model URL decisions (remove or keep).
-
-    Returns:
-        A dict mapping model IDs to whether they should be removed (True)
-        or kept without a URL (False). Returns an empty dict if the cache
-        file does not exist.
-    """
-    if not MODELS_WITHOUT_URLS_CACHE.exists():
-        return {}
-    with MODELS_WITHOUT_URLS_CACHE.open("r") as f:
-        data = safe_load(f) or {}
-    # Backwards compatibility: old format was a list of model IDs to keep
-    if isinstance(data, list):
-        return {model_id: False for model_id in data}
-    return data
-
-
-@cache
-def _load_model_url_decision(model_id: str) -> bool | None:
-    """Load a cached decision for a specific model.
-
-    Args:
-        model_id:
-            The model ID to look up.
-
-    Returns:
-        True if the model should be removed, False if it should be kept
-        without a URL, or None if no cached decision exists.
-    """
-    decisions = _load_model_url_decisions()
-    return decisions.get(model_id)
-
-
-@cache
-@cache
-def _remember_model_url_decision(model_id: str, remove: bool) -> None:
-    """Persist a model URL decision to the cache.
-
-    Args:
-        model_id:
-            The model ID.
-        remove:
-            True if the model should be removed, False if it should be
-            kept without a URL.
-    """
-    decisions = _load_model_url_decisions()
-    if model_id in decisions:
-        return
-    decisions[model_id] = remove
-    with MODELS_WITHOUT_URLS_CACHE.open("w") as f:
-        safe_dump(dict(sorted(decisions.items())), f)
-    _load_model_url_decisions.cache_clear()
-
-
-@cache
-@cache
 def ask_user_to_remove_model(model_id: str) -> bool:
     """Ask the user if they want to remove a model from the results.
 
@@ -160,6 +59,63 @@ def ask_user_to_remove_model(model_id: str) -> bool:
         remove = user_input == "y"
         _remember_model_url_decision(model_id=model_id, remove=remove)
         return remove
+
+
+@cache
+def _load_model_url_decision(model_id: str) -> bool | None:
+    """Load a cached decision for a specific model.
+
+    Args:
+        model_id:
+            The model ID to look up.
+
+    Returns:
+        True if the model should be removed, False if it should be kept
+        without a URL, or None if no cached decision exists.
+    """
+    decisions = _load_model_url_decisions()
+    return decisions.get(model_id)
+
+
+@cache
+@cache
+def _load_model_url_decisions() -> dict[str, bool]:
+    """Load cached model URL decisions (remove or keep).
+
+    Returns:
+        A dict mapping model IDs to whether they should be removed (True)
+        or kept without a URL (False). Returns an empty dict if the cache
+        file does not exist.
+    """
+    if not MODELS_WITHOUT_URLS_CACHE.exists():
+        return {}
+    with MODELS_WITHOUT_URLS_CACHE.open("r") as f:
+        data = safe_load(f) or {}
+    # Backwards compatibility: old format was a list of model IDs to keep
+    if isinstance(data, list):
+        return {model_id: False for model_id in data}
+    return data
+
+
+@cache
+@cache
+def _remember_model_url_decision(model_id: str, remove: bool) -> None:
+    """Persist a model URL decision to the cache.
+
+    Args:
+        model_id:
+            The model ID.
+        remove:
+            True if the model should be removed, False if it should be
+            kept without a URL.
+    """
+    decisions = _load_model_url_decisions()
+    if model_id in decisions:
+        return
+    decisions[model_id] = remove
+    with MODELS_WITHOUT_URLS_CACHE.open("w") as f:
+        safe_dump(dict(sorted(decisions.items())), f)
+    _load_model_url_decisions.cache_clear()
 
 
 @cache
@@ -262,6 +218,50 @@ def generate_hf_hub_url(model_id: str) -> str | None:
 
 @cache
 @cache
+@cache
+def _check_model_exists_with_retry(model_id: str, hf_api: HfApi) -> None:
+    """Check if a model exists on the Hugging Face Hub with retry logic.
+
+    Retries only on connection-related errors (not repository errors).
+
+    Args:
+        model_id:
+            The Hugging Face model ID.
+        hf_api:
+            The Hugging Face API client.
+
+    Raises:
+        RepositoryNotFoundError:
+            If the repository does not exist (not retried).
+        GatedRepoError:
+            If the repository is gated (not retried).
+        HFValidationError:
+            If the model ID is invalid (not retried).
+        httpx.RemoteProtocolError:
+            If the server disconnects without sending a response (retried).
+        ConnectionError:
+            If there is a network connection error (retried).
+    """
+    max_attempts = 3
+    for attempt in range(max_attempts):
+        try:
+            hf_api.model_info(repo_id=model_id)
+            return
+        except (httpx.RemoteProtocolError, ConnectionError) as e:
+            if attempt == max_attempts - 1:
+                raise  # Re-raise on last attempt
+            wait_time = 2**attempt  # Exponential backoff: 1s, 2s, 4s
+            logger.warning(
+                f"Connection error checking {model_id}: {e}. "
+                f"Retrying in {wait_time}s..."
+            )
+            time.sleep(wait_time)
+        except (RepositoryNotFoundError, GatedRepoError, HFValidationError):
+            raise  # Don't retry these errors
+
+
+@cache
+@cache
 def generate_model_url(model_id: str) -> str | None:
     """Generate a URL for a model.
 
@@ -337,34 +337,6 @@ def generate_ollama_url(model_id: str) -> str | None:
 @cache
 @cache
 @cache
-@cache
-def get_openai_models() -> list[str]:
-    """Get a list of all OpenAI models.
-
-    Returns:
-        A list of all OpenAI models.
-
-    Raises:
-        Exception if there was an error fetching the OpenAI models, and no cache file
-        exists.
-    """
-    cache_path = REPO_ROOT / "src" / "leaderboards" / "openai_models.yaml"
-    try:
-        results: list[str] = [model_info.id for model_info in openai.models.list().data]
-        with cache_path.open("w") as f:
-            safe_dump(results, f)
-        return results
-    except Exception as e:
-        if cache_path.exists():
-            with cache_path.open("r") as f:
-                results = safe_load(f)
-            return results
-        raise e
-
-
-@cache
-@cache
-@cache
 def generate_openai_url(model_id: str) -> str | None:
     """Generate a model URL for a model hosted on OpenAI.
 
@@ -395,6 +367,34 @@ def generate_openai_url(model_id: str) -> str | None:
     ):
         return f"https://platform.openai.com/docs/models/{model_id_without_version_id}"
     return None
+
+
+@cache
+@cache
+@cache
+@cache
+def get_openai_models() -> list[str]:
+    """Get a list of all OpenAI models.
+
+    Returns:
+        A list of all OpenAI models.
+
+    Raises:
+        Exception if there was an error fetching the OpenAI models, and no cache file
+        exists.
+    """
+    cache_path = REPO_ROOT / "src" / "leaderboards" / "openai_models.yaml"
+    try:
+        results: list[str] = [model_info.id for model_info in openai.models.list().data]
+        with cache_path.open("w") as f:
+            safe_dump(results, f)
+        return results
+    except Exception as e:
+        if cache_path.exists():
+            with cache_path.open("r") as f:
+                results = safe_load(f)
+            return results
+        raise e
 
 
 @cache

--- a/src/leaderboards/model_metadata.py
+++ b/src/leaderboards/model_metadata.py
@@ -36,19 +36,61 @@ from .result_identity import sanitise_model_dir_name
 logger = logging.getLogger(__name__)
 
 
-def _remove_model_results(model_id: str) -> None:
-    """Delete a model's result directory from RESULTS_DIR.
+def add_missing_entries(
+    record: dict, trained_from_scratch_patterns: list[re.Pattern], cache: Cache
+) -> dict:
+    """Adds missing entries to a record.
 
-    ``RESULTS_DIR`` is the source of truth for the leaderboard, so removing
-    the directory drops the model from future builds.
+    Fields are stored in their appropriate nested locations within the EEE
+    record (``model_info`` and ``eval_library``).
 
     Args:
-        model_id:
-            The model id whose result directory should be removed.
+        record:
+            A record from the JSONL file.
+        trained_from_scratch_patterns:
+            A list of regex patterns for trained-from-scratch models.
+        cache:
+            The cache.
+
+    Returns:
+        The record with missing entries added.
     """
-    model_dir = RESULTS_DIR / sanitise_model_dir_name(plain_model_id(model_id))
-    shutil.rmtree(model_dir, ignore_errors=True)
-    logger.info(f"Removed result directory {model_dir.name} for {model_id}.")
+    model_info = record.setdefault("model_info", {})
+    model_additional = model_info.setdefault("additional_details", {})
+    eval_lib = record.setdefault("eval_library", {})
+    eval_additional = eval_lib.setdefault("additional_details", {})
+
+    if "validation_split" not in eval_additional:
+        eval_additional["validation_split"] = False
+    if "few_shot" not in eval_additional:
+        eval_additional["few_shot"] = True
+    if "generative" not in model_additional:
+        model_additional["generative"] = False
+    if "generative_type" not in model_additional:
+        model_additional["generative_type"] = _get_generative_type(
+            record=record, cache=cache
+        )
+    if "merge" not in model_additional:
+        model_additional["merge"] = is_merge(record=record, cache=cache)
+
+    if "commercially_licensed" not in model_additional:
+        model_additional["commercially_licensed"] = is_commercially_licensed(
+            record=record, cache=cache
+        )
+    if "open" not in model_additional:
+        model_additional["open"] = is_open(record=record, cache=cache)
+    if "trained_from_scratch" not in model_additional:
+        model_additional["trained_from_scratch"] = is_trained_from_scratch(
+            record=record,
+            trained_from_scratch_patterns=trained_from_scratch_patterns,
+            cache=cache,
+        )
+    if "model_url" not in model_additional or model_additional["model_url"] is None:
+        model_additional["model_url"] = _generate_model_url_with_cache(
+            model_id=plain_model_id(get_model_name(record=record)), cache=cache
+        )
+
+    return record
 
 
 def _generate_model_url_with_cache(model_id: str, cache: Cache) -> str | None:
@@ -77,6 +119,73 @@ def _generate_model_url_with_cache(model_id: str, cache: Cache) -> str | None:
         _remove_model_results(model_id=model_id)
     cache.model_url[model_id] = model_url
     return model_url
+
+
+def _remove_model_results(model_id: str) -> None:
+    """Delete a model's result directory from RESULTS_DIR.
+
+    ``RESULTS_DIR`` is the source of truth for the leaderboard, so removing
+    the directory drops the model from future builds.
+
+    Args:
+        model_id:
+            The model id whose result directory should be removed.
+    """
+    model_dir = RESULTS_DIR / sanitise_model_dir_name(plain_model_id(model_id))
+    shutil.rmtree(model_dir, ignore_errors=True)
+    logger.info(f"Removed result directory {model_dir.name} for {model_id}.")
+
+
+def _get_generative_type(record: dict, cache: Cache) -> str | None:
+    """Asks for the generative type of a model.
+
+    Args:
+        record:
+            A record from the JSONL file.
+        cache:
+            The cache.
+
+    Returns:
+        The generative type of the model.
+    """
+    raw_model_id = _model_id_from_record(record=record)
+
+    # Check special suffixes first
+    if "#thinking" in raw_model_id:
+        cache.generative_type[raw_model_id] = "reasoning"
+        return "reasoning"
+    if "#no-thinking" in raw_model_id:
+        cache.generative_type[raw_model_id] = "instruction_tuned"
+        return "instruction_tuned"
+
+    # Normalise model ID
+    model_id = split_model_id(model_id=plain_model_id(raw_model_id)).model_id
+
+    while True:
+        # Check cache
+        if model_id in cache.generative_type:
+            return cache.generative_type[model_id]
+
+        # Try keyword inference
+        inferred_type = _get_generative_type_from_keywords(model_id=model_id)
+        if inferred_type is not None:
+            cache.generative_type[model_id] = inferred_type
+            return inferred_type
+
+        # Ask user
+        msg = f"What is the generative type of {model_id!r}?"
+        if "/" in model_id:
+            msg += f" (https://hf.co/{model_id})"
+        msg += " [0=null, 1=base, 2=instruction_tuned, 3=reasoning] "
+        user_input = input(msg)
+        parsed = _parse_generative_type_input(user_input)
+        if parsed == "EXPLICIT_NULL":
+            cache.generative_type[model_id] = None
+            return None
+        if parsed is not None:
+            cache.generative_type[model_id] = parsed
+            return parsed
+        logger.error("Invalid input. Please try again.")
 
 
 def _get_generative_type_from_keywords(model_id: str) -> str | None:
@@ -141,8 +250,12 @@ def _parse_generative_type_input(
     return None
 
 
-def _get_generative_type(record: dict, cache: Cache) -> str | None:
-    """Asks for the generative type of a model.
+def is_commercially_licensed(record: dict, cache: Cache) -> bool:
+    """Determine if a model is commercially licensed.
+
+    First checks the cache, then tries best-effort inference from the
+    Hugging Face model licence. Falls back to user prompt if licence
+    cannot be inferred.
 
     Args:
         record:
@@ -151,45 +264,44 @@ def _get_generative_type(record: dict, cache: Cache) -> str | None:
             The cache.
 
     Returns:
-        The generative type of the model.
+        Whether the model is commercially licensed.
     """
-    raw_model_id = _model_id_from_record(record=record)
+    model_id = split_model_id(
+        model_id=plain_model_id(_model_id_from_record(record=record))
+    ).model_id
 
-    # Check special suffixes first
-    if "#thinking" in raw_model_id:
-        cache.generative_type[raw_model_id] = "reasoning"
-        return "reasoning"
-    if "#no-thinking" in raw_model_id:
-        cache.generative_type[raw_model_id] = "instruction_tuned"
-        return "instruction_tuned"
+    # Assume that non-generative models are always commercially licensed
+    if not get_bool_field(record, "generative", True):
+        cache.commercially_licensed[model_id] = True
+        return True
 
-    # Normalise model ID
-    model_id = split_model_id(model_id=plain_model_id(raw_model_id)).model_id
+    # Check cache first
+    if model_id in cache.commercially_licensed:
+        return cache.commercially_licensed[model_id]
 
+    # Best-effort inference from HF licence
+    # Use a separate cache dict since inference can return None on error
+    licence_cache: dict[str, bool | None] = {}
+    inferred = _infer_commercial_from_hf_licence(
+        model_id=model_id, licence_cache=licence_cache
+    )
+    if inferred is not None:
+        cache.commercially_licensed[model_id] = inferred
+        return inferred
+
+    # Fall back to user prompt
     while True:
-        # Check cache
-        if model_id in cache.generative_type:
-            return cache.generative_type[model_id]
-
-        # Try keyword inference
-        inferred_type = _get_generative_type_from_keywords(model_id=model_id)
-        if inferred_type is not None:
-            cache.generative_type[model_id] = inferred_type
-            return inferred_type
-
-        # Ask user
-        msg = f"What is the generative type of {model_id!r}?"
+        msg = f"Is {model_id!r} commercially licensed?"
         if "/" in model_id:
             msg += f" (https://hf.co/{model_id})"
-        msg += " [0=null, 1=base, 2=instruction_tuned, 3=reasoning] "
+        msg += " [y/n] "
         user_input = input(msg)
-        parsed = _parse_generative_type_input(user_input)
-        if parsed == "EXPLICIT_NULL":
-            cache.generative_type[model_id] = None
-            return None
-        if parsed is not None:
-            cache.generative_type[model_id] = parsed
-            return parsed
+        if user_input.lower() in {"y", "yes"}:
+            cache.commercially_licensed[model_id] = True
+            return True
+        if user_input.lower() in {"n", "no"}:
+            cache.commercially_licensed[model_id] = False
+            return False
         logger.error("Invalid input. Please try again.")
 
 
@@ -248,61 +360,6 @@ def _infer_commercial_from_hf_licence(
     result = licence in PERMISSIVE_LICENSES if licence else None
     licence_cache[model_id] = result
     return result
-
-
-def is_commercially_licensed(record: dict, cache: Cache) -> bool:
-    """Determine if a model is commercially licensed.
-
-    First checks the cache, then tries best-effort inference from the
-    Hugging Face model licence. Falls back to user prompt if licence
-    cannot be inferred.
-
-    Args:
-        record:
-            A record from the JSONL file.
-        cache:
-            The cache.
-
-    Returns:
-        Whether the model is commercially licensed.
-    """
-    model_id = split_model_id(
-        model_id=plain_model_id(_model_id_from_record(record=record))
-    ).model_id
-
-    # Assume that non-generative models are always commercially licensed
-    if not get_bool_field(record, "generative", True):
-        cache.commercially_licensed[model_id] = True
-        return True
-
-    # Check cache first
-    if model_id in cache.commercially_licensed:
-        return cache.commercially_licensed[model_id]
-
-    # Best-effort inference from HF licence
-    # Use a separate cache dict since inference can return None on error
-    licence_cache: dict[str, bool | None] = {}
-    inferred = _infer_commercial_from_hf_licence(
-        model_id=model_id, licence_cache=licence_cache
-    )
-    if inferred is not None:
-        cache.commercially_licensed[model_id] = inferred
-        return inferred
-
-    # Fall back to user prompt
-    while True:
-        msg = f"Is {model_id!r} commercially licensed?"
-        if "/" in model_id:
-            msg += f" (https://hf.co/{model_id})"
-        msg += " [y/n] "
-        user_input = input(msg)
-        if user_input.lower() in {"y", "yes"}:
-            cache.commercially_licensed[model_id] = True
-            return True
-        if user_input.lower() in {"n", "no"}:
-            cache.commercially_licensed[model_id] = False
-            return False
-        logger.error("Invalid input. Please try again.")
 
 
 def is_merge(record: dict, cache: Cache) -> bool:
@@ -434,63 +491,6 @@ def is_trained_from_scratch(
             cache.trained_from_scratch[model_id] = False
             return False
         logger.error("Invalid input. Please try again.")
-
-
-def add_missing_entries(
-    record: dict, trained_from_scratch_patterns: list[re.Pattern], cache: Cache
-) -> dict:
-    """Adds missing entries to a record.
-
-    Fields are stored in their appropriate nested locations within the EEE
-    record (``model_info`` and ``eval_library``).
-
-    Args:
-        record:
-            A record from the JSONL file.
-        trained_from_scratch_patterns:
-            A list of regex patterns for trained-from-scratch models.
-        cache:
-            The cache.
-
-    Returns:
-        The record with missing entries added.
-    """
-    model_info = record.setdefault("model_info", {})
-    model_additional = model_info.setdefault("additional_details", {})
-    eval_lib = record.setdefault("eval_library", {})
-    eval_additional = eval_lib.setdefault("additional_details", {})
-
-    if "validation_split" not in eval_additional:
-        eval_additional["validation_split"] = False
-    if "few_shot" not in eval_additional:
-        eval_additional["few_shot"] = True
-    if "generative" not in model_additional:
-        model_additional["generative"] = False
-    if "generative_type" not in model_additional:
-        model_additional["generative_type"] = _get_generative_type(
-            record=record, cache=cache
-        )
-    if "merge" not in model_additional:
-        model_additional["merge"] = is_merge(record=record, cache=cache)
-
-    if "commercially_licensed" not in model_additional:
-        model_additional["commercially_licensed"] = is_commercially_licensed(
-            record=record, cache=cache
-        )
-    if "open" not in model_additional:
-        model_additional["open"] = is_open(record=record, cache=cache)
-    if "trained_from_scratch" not in model_additional:
-        model_additional["trained_from_scratch"] = is_trained_from_scratch(
-            record=record,
-            trained_from_scratch_patterns=trained_from_scratch_patterns,
-            cache=cache,
-        )
-    if "model_url" not in model_additional or model_additional["model_url"] is None:
-        model_additional["model_url"] = _generate_model_url_with_cache(
-            model_id=plain_model_id(get_model_name(record=record)), cache=cache
-        )
-
-    return record
 
 
 def fix_metadata(record: dict[str, t.Any]) -> dict[str, t.Any]:

--- a/src/leaderboards/osai.py
+++ b/src/leaderboards/osai.py
@@ -30,47 +30,75 @@ from .constants import (
 logger = logging.getLogger(__name__)
 
 
-class _OsaiEntry(t.TypedDict):
-    """A single parsed OSAI model entry.
+def osai_top_models(
+    limit: int = 10, overrides: list[str] | None = None
+) -> list[tuple[str, int]]:
+    """Return the top OSAI 'truly open' text models as (model_id, rank) pairs.
 
-    Attributes:
-        name:
-            The model's system name.
-        endmodelname:
-            The end-model name.
-        type:
-            The model type (e.g. ``"text"``).
-        open_count:
-            Number of openness ranking fields marked open.
-        required_open:
-            Whether trainingcode and datasources_basemodel are both open.
-        weight_links:
-            Mapping from each open weights field name to its HF URL.
-    """
-
-    name: str
-    endmodelname: str
-    type: str
-    open_count: int
-    required_open: bool
-    weight_links: dict[str, str]
-
-
-def _fetch(url: str, timeout: float = 20.0) -> str:
-    """Fetch a URL as text.
+    The OSAI index is filtered to text models with open base weights,
+    training code, and data sources. Models are ranked by total open-field
+    count (descending). We scrape the live JS bundle; on any failure (no
+    bundle reachable, regex match yields zero entries, etc.) we return
+    the override list from the YAML config so the pipeline stays
+    deterministic.
 
     Args:
-        url:
-            The URL to fetch.
-        timeout (optional):
-            Socket timeout in seconds. Defaults to 20.0.
+        limit (optional):
+            Number of top models to return. Defaults to 10.
+        overrides (optional):
+            Fallback list of `org/repo` model IDs in rank order, used
+            verbatim when the scrape fails. Defaults to None.
 
     Returns:
-        The response body as text.
+        List of `(model_id, rank)` pairs in 1-based rank order. Empty
+        list if both the scrape and overrides yield nothing.
     """
-    req = urllib.request.Request(url, headers={"User-Agent": "EuroEval-CoreModels/1"})
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
-        return resp.read().decode("utf-8", errors="replace")
+    logger.info(f"Fetching the top-{limit} OSAI open models...")
+
+    bundle = _osai_bundle()
+    if bundle is None:
+        logger.warning("OSAI: bundle not found; using overrides.")
+        return _overrides_to_ranked(overrides=overrides, limit=limit)
+
+    entries = _parse_osai_models(bundle=bundle)
+    if not entries:
+        logger.warning("OSAI: parsed zero model entries; using overrides.")
+        return _overrides_to_ranked(overrides=overrides, limit=limit)
+
+    # A model qualifies if training code and base-model data sources are
+    # open and at least one of base/end-model weights is open. When both
+    # weights are open, both are added to the eval target list — they're
+    # different checkpoints worth scoring independently.
+    qualifying = [
+        e
+        for e in entries
+        if e["type"] == "text" and e["required_open"] and e["weight_links"]
+    ]
+    qualifying.sort(key=lambda e: (-e["open_count"], e["endmodelname"].lower()))
+
+    seen: set[str] = set()
+    ranked: list[tuple[str, int]] = []
+    for entry in qualifying:
+        # Stable ordering: prefer the base-model checkpoint first, then end.
+        for field in OSAI_WEIGHT_CRITERIA:
+            link = entry["weight_links"].get(field)
+            if not link:
+                continue
+            model_id = _hf_url_to_model_id(url=link)
+            if model_id is None:
+                logger.info(
+                    f"OSAI: skipping {entry['endmodelname']!r} ({field}): "
+                    f"cannot map {link!r} to org/repo."
+                )
+                continue
+            if model_id in seen:
+                continue
+            seen.add(model_id)
+            ranked.append((model_id, len(ranked) + 1))
+            if len(ranked) >= limit:
+                return ranked
+    logger.info(f"Fetched {len(ranked)} OSAI models.")
+    return ranked
 
 
 def _hf_url_to_model_id(url: str) -> str | None:
@@ -142,6 +170,23 @@ def _osai_bundle() -> str | None:
     return None
 
 
+def _fetch(url: str, timeout: float = 20.0) -> str:
+    """Fetch a URL as text.
+
+    Args:
+        url:
+            The URL to fetch.
+        timeout (optional):
+            Socket timeout in seconds. Defaults to 20.0.
+
+    Returns:
+        The response body as text.
+    """
+    req = urllib.request.Request(url, headers={"User-Agent": "EuroEval-CoreModels/1"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read().decode("utf-8", errors="replace")
+
+
 def _overrides_to_ranked(
     overrides: list[str] | None, limit: int
 ) -> list[tuple[str, int]]:
@@ -159,6 +204,32 @@ def _overrides_to_ranked(
     if not overrides:
         return []
     return [(model_id, rank) for rank, model_id in enumerate(overrides[:limit], 1)]
+
+
+class _OsaiEntry(t.TypedDict):
+    """A single parsed OSAI model entry.
+
+    Attributes:
+        name:
+            The model's system name.
+        endmodelname:
+            The end-model name.
+        type:
+            The model type (e.g. ``"text"``).
+        open_count:
+            Number of openness ranking fields marked open.
+        required_open:
+            Whether trainingcode and datasources_basemodel are both open.
+        weight_links:
+            Mapping from each open weights field name to its HF URL.
+    """
+
+    name: str
+    endmodelname: str
+    type: str
+    open_count: int
+    required_open: bool
+    weight_links: dict[str, str]
 
 
 def _parse_osai_models(bundle: str) -> list[_OsaiEntry]:
@@ -218,74 +289,3 @@ def _parse_osai_models(bundle: str) -> list[_OsaiEntry]:
             )
         )
     return entries
-
-
-def osai_top_models(
-    limit: int = 10, overrides: list[str] | None = None
-) -> list[tuple[str, int]]:
-    """Return the top OSAI 'truly open' text models as (model_id, rank) pairs.
-
-    The OSAI index is filtered to text models with open base weights,
-    training code, and data sources. Models are ranked by total open-field
-    count (descending). We scrape the live JS bundle; on any failure (no
-    bundle reachable, regex match yields zero entries, etc.) we return
-    the override list from the YAML config so the pipeline stays
-    deterministic.
-
-    Args:
-        limit (optional):
-            Number of top models to return. Defaults to 10.
-        overrides (optional):
-            Fallback list of `org/repo` model IDs in rank order, used
-            verbatim when the scrape fails. Defaults to None.
-
-    Returns:
-        List of `(model_id, rank)` pairs in 1-based rank order. Empty
-        list if both the scrape and overrides yield nothing.
-    """
-    logger.info(f"Fetching the top-{limit} OSAI open models...")
-
-    bundle = _osai_bundle()
-    if bundle is None:
-        logger.warning("OSAI: bundle not found; using overrides.")
-        return _overrides_to_ranked(overrides=overrides, limit=limit)
-
-    entries = _parse_osai_models(bundle=bundle)
-    if not entries:
-        logger.warning("OSAI: parsed zero model entries; using overrides.")
-        return _overrides_to_ranked(overrides=overrides, limit=limit)
-
-    # A model qualifies if training code and base-model data sources are
-    # open and at least one of base/end-model weights is open. When both
-    # weights are open, both are added to the eval target list — they're
-    # different checkpoints worth scoring independently.
-    qualifying = [
-        e
-        for e in entries
-        if e["type"] == "text" and e["required_open"] and e["weight_links"]
-    ]
-    qualifying.sort(key=lambda e: (-e["open_count"], e["endmodelname"].lower()))
-
-    seen: set[str] = set()
-    ranked: list[tuple[str, int]] = []
-    for entry in qualifying:
-        # Stable ordering: prefer the base-model checkpoint first, then end.
-        for field in OSAI_WEIGHT_CRITERIA:
-            link = entry["weight_links"].get(field)
-            if not link:
-                continue
-            model_id = _hf_url_to_model_id(url=link)
-            if model_id is None:
-                logger.info(
-                    f"OSAI: skipping {entry['endmodelname']!r} ({field}): "
-                    f"cannot map {link!r} to org/repo."
-                )
-                continue
-            if model_id in seen:
-                continue
-            seen.add(model_id)
-            ranked.append((model_id, len(ranked) + 1))
-            if len(ranked) >= limit:
-                return ranked
-    logger.info(f"Fetched {len(ranked)} OSAI models.")
-    return ranked

--- a/src/leaderboards/queue_env.py
+++ b/src/leaderboards/queue_env.py
@@ -106,40 +106,6 @@ def load_dotenv_into_environ(env_path: Path) -> None:
         logger.warning(f"Could not read {env_path}: {e}")
 
 
-def persist_env_var(env_path: Path, name: str, value: str) -> None:
-    """Write ``NAME=VALUE`` to ``env_path``, replacing any prior entry.
-
-    Args:
-        env_path:
-            The dotenv file to update.
-        name:
-            The env var name to persist.
-        value:
-            The value to associate with ``name``.
-    """
-    try:
-        existing = ""
-        if env_path.is_file():
-            existing = env_path.read_text(encoding="utf-8")
-        lines = existing.splitlines()
-        replaced = False
-        for i, raw_line in enumerate(lines):
-            stripped = raw_line.strip()
-            if not stripped or stripped.startswith("#") or "=" not in stripped:
-                continue
-            key, _, _ = stripped.partition("=")
-            if key.strip() == name:
-                lines[i] = f"{name}={value}"
-                replaced = True
-                break
-        if not replaced:
-            lines.append(f"{name}={value}")
-        env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-        logger.info(f"Saved {name} to {env_path}.")
-    except OSError as e:
-        logger.warning(f"Could not persist {name} to {env_path}: {e}")
-
-
 def prompt_and_persist_env_var(
     env_path: Path, name: str, prompt_text: str, secret: bool = False
 ) -> str:
@@ -195,6 +161,40 @@ def prompt_and_persist_env_var(
             logger.error("Value cannot be empty; please try again.")
     persist_env_var(env_path=env_path, name=name, value=value)
     return value
+
+
+def persist_env_var(env_path: Path, name: str, value: str) -> None:
+    """Write ``NAME=VALUE`` to ``env_path``, replacing any prior entry.
+
+    Args:
+        env_path:
+            The dotenv file to update.
+        name:
+            The env var name to persist.
+        value:
+            The value to associate with ``name``.
+    """
+    try:
+        existing = ""
+        if env_path.is_file():
+            existing = env_path.read_text(encoding="utf-8")
+        lines = existing.splitlines()
+        replaced = False
+        for i, raw_line in enumerate(lines):
+            stripped = raw_line.strip()
+            if not stripped or stripped.startswith("#") or "=" not in stripped:
+                continue
+            key, _, _ = stripped.partition("=")
+            if key.strip() == name:
+                lines[i] = f"{name}={value}"
+                replaced = True
+                break
+        if not replaced:
+            lines.append(f"{name}={value}")
+        env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        logger.info(f"Saved {name} to {env_path}.")
+    except OSError as e:
+        logger.warning(f"Could not persist {name} to {env_path}: {e}")
 
 
 def resolve_assignee_from_token() -> str:

--- a/src/leaderboards/queue_hf_cache.py
+++ b/src/leaderboards/queue_hf_cache.py
@@ -24,6 +24,85 @@ from .constants import HF_CACHE_PATH, HF_CACHE_TTL_SECONDS
 logger = logging.getLogger(__name__)
 
 
+def cached_model_summary(model_id: str) -> dict | None:
+    """Return a ``{param_count, gated, gguf, generative}`` summary for a model id.
+
+    Looks up :data:`HF_CACHE_PATH` first and falls back to
+    ``HfApi.model_info`` only on cache miss or stale entry. Negative
+    results (model not found) are not cached so that typo corrections take
+    effect immediately.
+
+    Args:
+        model_id:
+            The Hugging Face repo id to look up.
+
+    Returns:
+        A dict with keys:
+
+        - ``param_count`` (int, possibly ``sys.maxsize`` for unknown).
+        - ``gated`` (bool, True when the configured assignee does not have
+          read access to a gated repo -- i.e. ``model_info`` raised
+          ``GatedRepoError``).
+        - ``gguf`` (bool, True when the repo is a GGUF model, which the
+          evaluation queue cannot run).
+        - ``generative`` (bool, True for generative models and False for
+          encoder models; see :func:`is_generative_model`). Defaults to True
+          for gated repos and legacy cache entries whose type is unknown.
+
+        Returns None when the model is not on the Hub.
+    """
+    cache = _load_hf_cache()
+    entry = cache.get(model_id)
+    if entry is not None and "param_count" in entry:
+        return {
+            "param_count": int(entry["param_count"]),
+            "gated": False,
+            "gguf": bool(entry.get("gguf", False)),
+            "generative": bool(entry.get("generative", True)),
+        }
+
+    try:
+        info = HfApi().model_info(repo_id=model_id)
+    except GatedRepoError:
+        # Don't cache: access can be granted at any time, and we want to
+        # pick that up on the next run.
+        return {
+            "param_count": sys.maxsize,
+            "gated": True,
+            "gguf": False,
+            "generative": True,
+        }
+    except RepositoryNotFoundError:
+        # Expected for typo-d / since-deleted repos; just drop the candidate.
+        return None
+    except Exception as e:  # noqa: BLE001
+        # Best-effort network lookup: any other failure (transient HTTP, timeout,
+        # unexpected payload) should just drop the candidate, never crash the run.
+        logger.warning(f"HF model lookup failed for {model_id}: {e}")
+        return None
+
+    safetensors = getattr(info, "safetensors", None)
+    total = getattr(safetensors, "total", None) if safetensors else None
+    param_count = total if isinstance(total, int) and total > 0 else sys.maxsize
+
+    gguf = is_gguf_model(info=info)
+    generative = is_generative_model(info=info)
+
+    cache[model_id] = {
+        "timestamp": time.time(),
+        "param_count": param_count,
+        "gguf": gguf,
+        "generative": generative,
+    }
+    _write_hf_cache(cache=cache)
+    return {
+        "param_count": param_count,
+        "gated": False,
+        "gguf": gguf,
+        "generative": generative,
+    }
+
+
 def _load_hf_cache() -> dict[str, dict]:
     """Read the on-disk HF Hub lookup cache, or return an empty dict.
 
@@ -126,82 +205,3 @@ def is_gguf_model(info: ModelInfo) -> bool:
         name.endswith(".safetensors") for name in filenames
     )
     return has_gguf and not has_safetensors
-
-
-def cached_model_summary(model_id: str) -> dict | None:
-    """Return a ``{param_count, gated, gguf, generative}`` summary for a model id.
-
-    Looks up :data:`HF_CACHE_PATH` first and falls back to
-    ``HfApi.model_info`` only on cache miss or stale entry. Negative
-    results (model not found) are not cached so that typo corrections take
-    effect immediately.
-
-    Args:
-        model_id:
-            The Hugging Face repo id to look up.
-
-    Returns:
-        A dict with keys:
-
-        - ``param_count`` (int, possibly ``sys.maxsize`` for unknown).
-        - ``gated`` (bool, True when the configured assignee does not have
-          read access to a gated repo -- i.e. ``model_info`` raised
-          ``GatedRepoError``).
-        - ``gguf`` (bool, True when the repo is a GGUF model, which the
-          evaluation queue cannot run).
-        - ``generative`` (bool, True for generative models and False for
-          encoder models; see :func:`is_generative_model`). Defaults to True
-          for gated repos and legacy cache entries whose type is unknown.
-
-        Returns None when the model is not on the Hub.
-    """
-    cache = _load_hf_cache()
-    entry = cache.get(model_id)
-    if entry is not None and "param_count" in entry:
-        return {
-            "param_count": int(entry["param_count"]),
-            "gated": False,
-            "gguf": bool(entry.get("gguf", False)),
-            "generative": bool(entry.get("generative", True)),
-        }
-
-    try:
-        info = HfApi().model_info(repo_id=model_id)
-    except GatedRepoError:
-        # Don't cache: access can be granted at any time, and we want to
-        # pick that up on the next run.
-        return {
-            "param_count": sys.maxsize,
-            "gated": True,
-            "gguf": False,
-            "generative": True,
-        }
-    except RepositoryNotFoundError:
-        # Expected for typo-d / since-deleted repos; just drop the candidate.
-        return None
-    except Exception as e:  # noqa: BLE001
-        # Best-effort network lookup: any other failure (transient HTTP, timeout,
-        # unexpected payload) should just drop the candidate, never crash the run.
-        logger.warning(f"HF model lookup failed for {model_id}: {e}")
-        return None
-
-    safetensors = getattr(info, "safetensors", None)
-    total = getattr(safetensors, "total", None) if safetensors else None
-    param_count = total if isinstance(total, int) and total > 0 else sys.maxsize
-
-    gguf = is_gguf_model(info=info)
-    generative = is_generative_model(info=info)
-
-    cache[model_id] = {
-        "timestamp": time.time(),
-        "param_count": param_count,
-        "gguf": gguf,
-        "generative": generative,
-    }
-    _write_hf_cache(cache=cache)
-    return {
-        "param_count": param_count,
-        "gated": False,
-        "gguf": gguf,
-        "generative": generative,
-    }

--- a/src/leaderboards/queue_parsing.py
+++ b/src/leaderboards/queue_parsing.py
@@ -63,124 +63,6 @@ _WORKERPROC_FAILED_RE = re.compile(r"WorkerProc initialization failed", re.IGNOR
 _MAX_LINE_CHARS = 600
 
 
-def _build_error_summary_parts(
-    lines: list[str], worker_block: str | None, traceback: str | None
-) -> list[str]:
-    """Build error summary parts from worker errors and traceback.
-
-    Args:
-        lines:
-            Cleaned output lines.
-        worker_block:
-            Worker error block from _worker_errors.
-        traceback:
-            Traceback from _last_traceback.
-
-    Returns:
-        List of summary parts.
-    """
-    parts: list[str] = []
-    # Prefer worker block unless a genuine traceback was captured
-    if worker_block and (traceback is None or _WORKERPROC_FAILED_RE.search(traceback)):
-        parts.append(worker_block)
-    elif traceback:
-        parts.append(traceback)
-
-    # Add load error (skip vLLM excuse line if traceback present)
-    for line in reversed(lines):
-        if _LOAD_ERROR_RE.search(line):
-            if traceback and "did not mention exactly what" in line:
-                break
-            parts.append(line.strip())
-            break
-
-    # Add summary line if found
-    for line in reversed(lines):
-        if _SUMMARY_LINE_RE.search(line):
-            parts.append(line.strip())
-            break
-
-    return parts
-
-
-def _is_noise_line(line: str) -> bool:
-    """Return True if a line is verbose ``FULL_LOG`` output rather than an error.
-
-    Args:
-        line:
-            A single (already ANSI-stripped) line of euroeval output.
-
-    Returns:
-        True if the line is a serialised result record or a training-progress
-        dict that should be dropped from an error summary.
-    """
-    stripped = line.strip()
-    if any(sub in stripped for sub in _NOISE_SUBSTRINGS):
-        return True
-    return bool(_TRAINING_PROGRESS_RE.match(stripped))
-
-
-def _last_traceback(lines: list[str]) -> str | None:
-    """Return the last Python traceback in ``lines``, or None if there is none.
-
-    Args:
-        lines:
-            The cleaned, noise-filtered output lines.
-
-    Returns:
-        The traceback text, from its ``Traceback (most recent call last):``
-        header through the terminating exception line, or None.
-    """
-    start = None
-    for i, line in enumerate(lines):
-        if line.strip().startswith(_TRACEBACK_START):
-            start = i
-    if start is None:
-        return None
-    # Extend to the exception line that closes the traceback (the first line at
-    # the end that is not an indented frame), keeping the block compact.
-    end = start
-    for i in range(start + 1, len(lines)):
-        end = i
-        if _EXCEPTION_LINE_RE.match(lines[i].strip()):
-            break
-    return "\n".join(lines[start : end + 1]).strip()
-
-
-def _worker_errors(lines: list[str]) -> str | None:
-    """Return the first worker-prefixed error block in ``lines``, or None.
-
-    vLLM's ``WorkerProc`` logs the real cause of an initialisation failure from
-    the worker subprocess, prefixing every line with ``(Worker_TP* pid=*)``.
-    The main process only re-raises a generic ``WorkerProc initialization
-    failed`` exception, so without this helper the actual error -- buried in
-    worker-prefixed ``ERROR`` lines -- is never surfaced.
-
-    Args:
-        lines:
-            The cleaned, noise-filtered output lines.
-
-    Returns:
-        The first worker ``ERROR`` line together with the consecutive
-        worker-prefixed lines that follow it (typically the worker's
-        traceback), joined with newlines, or None when no worker error is
-        present.
-    """
-    start = None
-    for i, line in enumerate(lines):
-        if _WORKER_ERROR_RE.match(line.strip()):
-            start = i
-            break
-    if start is None:
-        return None
-    end = start
-    for i in range(start + 1, len(lines)):
-        if not _WORKER_PREFIX_RE.match(lines[i].strip()):
-            break
-        end = i
-    return "\n".join(lines[start : end + 1]).strip()
-
-
 def completed_languages(lines: list[str], requested_languages: list[str]) -> list[str]:
     """Return requested languages whose official pair coverage is complete.
 
@@ -382,3 +264,121 @@ def summarise_evaluation_error(output: str, max_chars: int = 4000) -> str:
     if len(summary) > max_chars:
         summary = summary[-max_chars:].strip()
     return summary or "(no output captured)"
+
+
+def _build_error_summary_parts(
+    lines: list[str], worker_block: str | None, traceback: str | None
+) -> list[str]:
+    """Build error summary parts from worker errors and traceback.
+
+    Args:
+        lines:
+            Cleaned output lines.
+        worker_block:
+            Worker error block from _worker_errors.
+        traceback:
+            Traceback from _last_traceback.
+
+    Returns:
+        List of summary parts.
+    """
+    parts: list[str] = []
+    # Prefer worker block unless a genuine traceback was captured
+    if worker_block and (traceback is None or _WORKERPROC_FAILED_RE.search(traceback)):
+        parts.append(worker_block)
+    elif traceback:
+        parts.append(traceback)
+
+    # Add load error (skip vLLM excuse line if traceback present)
+    for line in reversed(lines):
+        if _LOAD_ERROR_RE.search(line):
+            if traceback and "did not mention exactly what" in line:
+                break
+            parts.append(line.strip())
+            break
+
+    # Add summary line if found
+    for line in reversed(lines):
+        if _SUMMARY_LINE_RE.search(line):
+            parts.append(line.strip())
+            break
+
+    return parts
+
+
+def _is_noise_line(line: str) -> bool:
+    """Return True if a line is verbose ``FULL_LOG`` output rather than an error.
+
+    Args:
+        line:
+            A single (already ANSI-stripped) line of euroeval output.
+
+    Returns:
+        True if the line is a serialised result record or a training-progress
+        dict that should be dropped from an error summary.
+    """
+    stripped = line.strip()
+    if any(sub in stripped for sub in _NOISE_SUBSTRINGS):
+        return True
+    return bool(_TRAINING_PROGRESS_RE.match(stripped))
+
+
+def _last_traceback(lines: list[str]) -> str | None:
+    """Return the last Python traceback in ``lines``, or None if there is none.
+
+    Args:
+        lines:
+            The cleaned, noise-filtered output lines.
+
+    Returns:
+        The traceback text, from its ``Traceback (most recent call last):``
+        header through the terminating exception line, or None.
+    """
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip().startswith(_TRACEBACK_START):
+            start = i
+    if start is None:
+        return None
+    # Extend to the exception line that closes the traceback (the first line at
+    # the end that is not an indented frame), keeping the block compact.
+    end = start
+    for i in range(start + 1, len(lines)):
+        end = i
+        if _EXCEPTION_LINE_RE.match(lines[i].strip()):
+            break
+    return "\n".join(lines[start : end + 1]).strip()
+
+
+def _worker_errors(lines: list[str]) -> str | None:
+    """Return the first worker-prefixed error block in ``lines``, or None.
+
+    vLLM's ``WorkerProc`` logs the real cause of an initialisation failure from
+    the worker subprocess, prefixing every line with ``(Worker_TP* pid=*)``.
+    The main process only re-raises a generic ``WorkerProc initialization
+    failed`` exception, so without this helper the actual error -- buried in
+    worker-prefixed ``ERROR`` lines -- is never surfaced.
+
+    Args:
+        lines:
+            The cleaned, noise-filtered output lines.
+
+    Returns:
+        The first worker ``ERROR`` line together with the consecutive
+        worker-prefixed lines that follow it (typically the worker's
+        traceback), joined with newlines, or None when no worker error is
+        present.
+    """
+    start = None
+    for i, line in enumerate(lines):
+        if _WORKER_ERROR_RE.match(line.strip()):
+            start = i
+            break
+    if start is None:
+        return None
+    end = start
+    for i in range(start + 1, len(lines)):
+        if not _WORKER_PREFIX_RE.match(lines[i].strip()):
+            break
+        end = i
+    return "\n".join(lines[start : end + 1]).strip()

--- a/src/leaderboards/queue_runtime.py
+++ b/src/leaderboards/queue_runtime.py
@@ -46,6 +46,50 @@ class ThermalConfig:
     poll_interval_seconds: float = 15.0
 
 
+def cool_down_between_issues(config: ThermalConfig) -> None:
+    """Pause between issues, extending the pause until the GPU has cooled.
+
+    Always waits at least ``config.inter_issue_sleep_seconds``. If
+    ``nvidia-smi`` reports a GPU at or above ``config.pause_temp_c``,
+    keeps sleeping in ``config.poll_interval_seconds`` chunks until the
+    hottest GPU has dropped below ``config.resume_temp_c``.
+
+    Args:
+        config:
+            The thermal configuration controlling the pause behaviour.
+    """
+    time.sleep(config.inter_issue_sleep_seconds)
+    wait_for_gpu_to_cool(config=config)
+
+
+def wait_for_gpu_to_cool(config: ThermalConfig) -> None:
+    """Block until the GPU is below ``resume_temp_c``; return immediately if cool.
+
+    Unlike :func:`cool_down_between_issues`, this does not impose a
+    minimum sleep -- if the GPU is already cool (or ``nvidia-smi`` is
+    unavailable), it returns without sleeping at all.
+
+    Args:
+        config:
+            The thermal configuration controlling the pause behaviour.
+    """
+    temp = read_gpu_temperature_c()
+    if temp is None or temp < config.pause_temp_c:
+        return
+    logger.info(
+        f"GPU at {temp:.0f}C (>= {config.pause_temp_c:.0f}C); pausing until "
+        f"it cools below {config.resume_temp_c:.0f}C."
+    )
+    while True:
+        time.sleep(config.poll_interval_seconds)
+        temp = read_gpu_temperature_c()
+        if temp is None:
+            return
+        if temp < config.resume_temp_c:
+            logger.info(f"GPU cooled to {temp:.0f}C; resuming.")
+            return
+
+
 def read_gpu_temperature_c() -> float | None:
     """Return the hottest GPU temperature reported by ``nvidia-smi``, in C.
 
@@ -86,50 +130,6 @@ def read_gpu_temperature_c() -> float | None:
         except ValueError:
             continue
     return max(temps) if temps else None
-
-
-def wait_for_gpu_to_cool(config: ThermalConfig) -> None:
-    """Block until the GPU is below ``resume_temp_c``; return immediately if cool.
-
-    Unlike :func:`cool_down_between_issues`, this does not impose a
-    minimum sleep -- if the GPU is already cool (or ``nvidia-smi`` is
-    unavailable), it returns without sleeping at all.
-
-    Args:
-        config:
-            The thermal configuration controlling the pause behaviour.
-    """
-    temp = read_gpu_temperature_c()
-    if temp is None or temp < config.pause_temp_c:
-        return
-    logger.info(
-        f"GPU at {temp:.0f}C (>= {config.pause_temp_c:.0f}C); pausing until "
-        f"it cools below {config.resume_temp_c:.0f}C."
-    )
-    while True:
-        time.sleep(config.poll_interval_seconds)
-        temp = read_gpu_temperature_c()
-        if temp is None:
-            return
-        if temp < config.resume_temp_c:
-            logger.info(f"GPU cooled to {temp:.0f}C; resuming.")
-            return
-
-
-def cool_down_between_issues(config: ThermalConfig) -> None:
-    """Pause between issues, extending the pause until the GPU has cooled.
-
-    Always waits at least ``config.inter_issue_sleep_seconds``. If
-    ``nvidia-smi`` reports a GPU at or above ``config.pause_temp_c``,
-    keeps sleeping in ``config.poll_interval_seconds`` chunks until the
-    hottest GPU has dropped below ``config.resume_temp_c``.
-
-    Args:
-        config:
-            The thermal configuration controlling the pause behaviour.
-    """
-    time.sleep(config.inter_issue_sleep_seconds)
-    wait_for_gpu_to_cool(config=config)
 
 
 def lower_process_priority() -> None:

--- a/src/leaderboards/record_fields.py
+++ b/src/leaderboards/record_fields.py
@@ -9,6 +9,42 @@ import typing as t
 from .records import get_bool_field, get_record_hash
 
 
+def deduplicate_records(records: list[dict[str, t.Any]]) -> list[dict[str, t.Any]]:
+    """Deduplicate records by hash, keeping the newest EuroEval version per hash.
+
+    Records sharing a :func:`~leaderboards.records.get_record_hash` value render
+    on the same leaderboard row, so only one should survive. Among records with
+    an equal (newest) version, the one with richer metadata wins (more non-default
+    fields for commercially_licensed, open, merge, trained_from_scratch,
+    generative_type, model_url). If still tied, the first one in input order is
+    kept to preserve explicit boolean values against conflicting later duplicates.
+    Output is ordered by hash for stable, diff-friendly downstream files.
+
+    Args:
+        records:
+            The records to deduplicate. Every record must carry a dataset (so
+            that hashing succeeds).
+
+    Returns:
+        The deduplicated records, ordered by hash. Note that
+        ``get_record_hash`` raises ``ValueError`` if any record has no dataset.
+    """
+    best: dict[str, tuple[list[int], int, dict[str, t.Any]]] = {}
+    for record in records:
+        hash_value = get_record_hash(record=record)
+        version = list(map(int, (get_version(record=record) or "0.0.0").split(".")))
+        richness = _metadata_richness_score(record=record)
+        existing = best.get(hash_value)
+        # Prefer: newer version > richer metadata
+        # On tie (same version and richness), keep existing record to preserve
+        # explicit boolean values (e.g. False) against conflicting later duplicates
+        if existing is None or version > existing[0]:
+            best[hash_value] = (version, richness, record)
+        elif version == existing[0] and richness > existing[1]:
+            best[hash_value] = (version, richness, record)
+    return [record for _, (_, _, record) in sorted(best.items())]
+
+
 def _metadata_richness_score(record: dict) -> int:
     """Score how "rich" a record's metadata is.
 
@@ -69,42 +105,6 @@ def get_version(record: dict) -> str | None:
     if version:
         return re.sub(r"\.dev\d+", "", version)
     return None
-
-
-def deduplicate_records(records: list[dict[str, t.Any]]) -> list[dict[str, t.Any]]:
-    """Deduplicate records by hash, keeping the newest EuroEval version per hash.
-
-    Records sharing a :func:`~leaderboards.records.get_record_hash` value render
-    on the same leaderboard row, so only one should survive. Among records with
-    an equal (newest) version, the one with richer metadata wins (more non-default
-    fields for commercially_licensed, open, merge, trained_from_scratch,
-    generative_type, model_url). If still tied, the first one in input order is
-    kept to preserve explicit boolean values against conflicting later duplicates.
-    Output is ordered by hash for stable, diff-friendly downstream files.
-
-    Args:
-        records:
-            The records to deduplicate. Every record must carry a dataset (so
-            that hashing succeeds).
-
-    Returns:
-        The deduplicated records, ordered by hash. Note that
-        ``get_record_hash`` raises ``ValueError`` if any record has no dataset.
-    """
-    best: dict[str, tuple[list[int], int, dict[str, t.Any]]] = {}
-    for record in records:
-        hash_value = get_record_hash(record=record)
-        version = list(map(int, (get_version(record=record) or "0.0.0").split(".")))
-        richness = _metadata_richness_score(record=record)
-        existing = best.get(hash_value)
-        # Prefer: newer version > richer metadata
-        # On tie (same version and richness), keep existing record to preserve
-        # explicit boolean values (e.g. False) against conflicting later duplicates
-        if existing is None or version > existing[0]:
-            best[hash_value] = (version, richness, record)
-        elif version == existing[0] and richness > existing[1]:
-            best[hash_value] = (version, richness, record)
-    return [record for _, (_, _, record) in sorted(best.items())]
 
 
 def get_few_shot(record: dict) -> bool:

--- a/src/leaderboards/records.py
+++ b/src/leaderboards/records.py
@@ -23,31 +23,6 @@ def convert_to_float(value: str | float) -> float | str:
         return value
 
 
-def strip_val_suffix(model_id: str) -> str | None:
-    """Return the model ID with the 'val' note removed, or None if absent.
-
-    Args:
-        model_id:
-            The model ID, possibly wrapped in an anchor tag and possibly
-            carrying a parenthesised note like ``(val)`` or ``(zero-shot, val)``.
-
-    Returns:
-        The model ID with ``val`` removed from its note, or ``None`` if the
-        model ID did not contain a ``val`` note.
-    """
-    match = re.match(r"^(.*)\s*\(([^()]+)\)(\s*</a>)?$", model_id)
-    if not match:
-        return None
-    prefix, note, suffix = match.group(1), match.group(2), match.group(3) or ""
-    items = [item.strip() for item in note.split(",")]
-    if "val" not in items:
-        return None
-    items = [item for item in items if item != "val"]
-    if not items:
-        return f"{prefix.rstrip()}{suffix}"
-    return f"{prefix.rstrip()} ({', '.join(items)}){suffix}"
-
-
 def drop_val_duplicates(
     model_results: dict[str, dict[str, list[tuple[list[float], float, float]]]],
 ) -> dict[str, dict[str, list[tuple[list[float], float, float]]]]:
@@ -76,6 +51,59 @@ def drop_val_duplicates(
                 continue
         filtered[model_id] = results
     return filtered
+
+
+def strip_val_suffix(model_id: str) -> str | None:
+    """Return the model ID with the 'val' note removed, or None if absent.
+
+    Args:
+        model_id:
+            The model ID, possibly wrapped in an anchor tag and possibly
+            carrying a parenthesised note like ``(val)`` or ``(zero-shot, val)``.
+
+    Returns:
+        The model ID with ``val`` removed from its note, or ``None`` if the
+        model ID did not contain a ``val`` note.
+    """
+    match = re.match(r"^(.*)\s*\(([^()]+)\)(\s*</a>)?$", model_id)
+    if not match:
+        return None
+    prefix, note, suffix = match.group(1), match.group(2), match.group(3) or ""
+    items = [item.strip() for item in note.split(",")]
+    if "val" not in items:
+        return None
+    items = [item for item in items if item != "val"]
+    if not items:
+        return f"{prefix.rstrip()}{suffix}"
+    return f"{prefix.rstrip()} ({', '.join(items)}){suffix}"
+
+
+def extract_model_ids_from_record(record: dict) -> list[str]:
+    """Extract the model ID candidates from a record.
+
+    Args:
+        record:
+            The record.
+
+    Returns:
+        The model ID candidates.
+    """
+    # Strip any anchor tag so that records stored with an already-anchored name
+    # (``<a ...>org/repo</a>``) and records stored with the plain ``org/repo``
+    # name collapse to the same identifier — otherwise the model is split into
+    # two leaderboard rows. The anchor is re-applied at render time.
+    model_id = strip_anchor(get_model_name(record))
+
+    few_shot = get_bool_field(record, "few_shot", True)
+    validation_split = get_bool_field(record, "validation_split", False)
+
+    note = [] if few_shot else ["zero-shot"]
+    if validation_split:
+        note.append("val")
+    if not note:
+        return [model_id]
+
+    return [f"{model_id} ({', '.join(note)})"]
 
 
 def get_bool_field(record: dict, field: str, default: bool) -> bool:
@@ -135,55 +163,6 @@ def strip_anchor(model_id: str) -> str:
     return match.group("inner").strip() if match else model_id
 
 
-def extract_model_ids_from_record(record: dict) -> list[str]:
-    """Extract the model ID candidates from a record.
-
-    Args:
-        record:
-            The record.
-
-    Returns:
-        The model ID candidates.
-    """
-    # Strip any anchor tag so that records stored with an already-anchored name
-    # (``<a ...>org/repo</a>``) and records stored with the plain ``org/repo``
-    # name collapse to the same identifier — otherwise the model is split into
-    # two leaderboard rows. The anchor is re-applied at render time.
-    model_id = strip_anchor(get_model_name(record))
-
-    few_shot = get_bool_field(record, "few_shot", True)
-    validation_split = get_bool_field(record, "validation_split", False)
-
-    note = [] if few_shot else ["zero-shot"]
-    if validation_split:
-        note.append("val")
-    if not note:
-        return [model_id]
-
-    return [f"{model_id} ({', '.join(note)})"]
-
-
-def get_dataset(record: dict) -> str | None:
-    """Get the dataset from an EEE record.
-
-    Args:
-        record:
-            A result record in EEE format.
-
-    Returns:
-        The dataset name, or None if not found.
-    """
-    additional = record.get("eval_library", {}).get("additional_details", {})
-    if "dataset" in additional:
-        return additional["dataset"]
-    eval_results = record.get("evaluation_results", [])
-    if eval_results and isinstance(eval_results, list):
-        source_data = eval_results[0].get("source_data", {})
-        if "dataset_name" in source_data:
-            return source_data["dataset_name"]
-    return None
-
-
 def get_record_hash(record: dict) -> str:
     """Returns a hash value for a record.
 
@@ -218,6 +197,27 @@ def get_record_hash(record: dict) -> str:
     validation_split = get_bool_field(record, "validation_split", False)
     few_shot = get_bool_field(record, "few_shot", True)
     return f"{model}{dataset}{int(validation_split)}{int(few_shot)}"
+
+
+def get_dataset(record: dict) -> str | None:
+    """Get the dataset from an EEE record.
+
+    Args:
+        record:
+            A result record in EEE format.
+
+    Returns:
+        The dataset name, or None if not found.
+    """
+    additional = record.get("eval_library", {}).get("additional_details", {})
+    if "dataset" in additional:
+        return additional["dataset"]
+    eval_results = record.get("evaluation_results", [])
+    if eval_results and isinstance(eval_results, list):
+        source_data = eval_results[0].get("source_data", {})
+        if "dataset_name" in source_data:
+            return source_data["dataset_name"]
+    return None
 
 
 def plain_model_id(model_id: str) -> str:

--- a/src/leaderboards/result_identity.py
+++ b/src/leaderboards/result_identity.py
@@ -20,28 +20,48 @@ from .record_fields import get_version
 ResultIdentity = tuple[str, str, bool | None, bool | None]
 
 
-def _parse_version(version: str) -> list[int]:
-    """Parse a version string into numeric components.
+def dedup_newer_record(record_a: dict, record_b: dict) -> dict:
+    """Determine which of two records with the same identity is newer.
 
-    Splits on non-digit characters and converts each component to int.
-    Non-numeric parts are treated as 0.
+    Compares by ``eval_library.version`` (semver-ish, higher wins),
+    tie-broken by ``retrieved_timestamp`` (higher/newer wins).
 
     Args:
-        version:
-            Version string (e.g., "1.2.3", "2.0.1rc1").
+        record_a:
+            First record in EEE format.
+        record_b:
+            Second record in EEE format.
 
     Returns:
-        List of integer components.
+        The newer record (either record_a or record_b).
+
+    Raises:
+        ValueError:
+            If the records do not share the same identity.
     """
-    parts = re.split(r"[^0-9]+", version)
-    result = []
-    for part in parts:
-        if part:
-            try:
-                result.append(int(part))
-            except ValueError:
-                result.append(0)
-    return result
+    identity_a = identity_from_eee_record(record_a)
+    identity_b = identity_from_eee_record(record_b)
+
+    if identity_a != identity_b:
+        raise ValueError(
+            f"Records have different identities: {identity_a} vs {identity_b}"
+        )
+
+    version_a = get_version(record=record_a)
+    version_b = get_version(record=record_b)
+
+    version_cmp = _compare_versions(version_a, version_b)
+    if version_cmp > 0:
+        return record_a
+    if version_cmp < 0:
+        return record_b
+
+    timestamp_a = _extract_timestamp(record_a)
+    timestamp_b = _extract_timestamp(record_b)
+
+    if timestamp_a >= timestamp_b:
+        return record_a
+    return record_b
 
 
 def _compare_versions(version_a: str | None, version_b: str | None) -> int:
@@ -85,6 +105,30 @@ def _compare_versions(version_a: str | None, version_b: str | None) -> int:
     return 0
 
 
+def _parse_version(version: str) -> list[int]:
+    """Parse a version string into numeric components.
+
+    Splits on non-digit characters and converts each component to int.
+    Non-numeric parts are treated as 0.
+
+    Args:
+        version:
+            Version string (e.g., "1.2.3", "2.0.1rc1").
+
+    Returns:
+        List of integer components.
+    """
+    parts = re.split(r"[^0-9]+", version)
+    result = []
+    for part in parts:
+        if part:
+            try:
+                result.append(int(part))
+            except ValueError:
+                result.append(0)
+    return result
+
+
 def _extract_timestamp(record: dict) -> int:
     """Extract the retrieved_timestamp from a record.
 
@@ -116,41 +160,6 @@ def _extract_timestamp(record: dict) -> int:
         except (ValueError, TypeError):
             pass
     return 0
-
-
-def normalise_bool_value(value: bool | str | None) -> bool | None:
-    """Normalise a boolean value that may arrive as bool, string, or None.
-
-    Handles Python bool, None, or lowercase strings 'true'/'false'/'none'.
-
-    Args:
-        value:
-            The value to normalise. May be a bool, a string ('true', 'false',
-            'none', case-insensitive), or None.
-
-    Returns:
-        A normalised bool or None.
-
-    Raises:
-        ValueError:
-            If the string value is not one of 'true', 'false', or 'none'.
-        TypeError:
-            If the value is not a bool, str, or None.
-    """
-    if value is None:
-        return None
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        lower = value.lower()
-        if lower == "true":
-            return True
-        if lower == "false":
-            return False
-        if lower == "none":
-            return None
-        raise ValueError(f"Invalid boolean string value: {value!r}")
-    raise TypeError(f"Unexpected type for boolean value: {type(value)}")
 
 
 def identity_from_eee_record(record: dict) -> ResultIdentity:
@@ -198,48 +207,39 @@ def identity_from_eee_record(record: dict) -> ResultIdentity:
     return (model_id, dataset, validation_split, few_shot)
 
 
-def dedup_newer_record(record_a: dict, record_b: dict) -> dict:
-    """Determine which of two records with the same identity is newer.
+def normalise_bool_value(value: bool | str | None) -> bool | None:
+    """Normalise a boolean value that may arrive as bool, string, or None.
 
-    Compares by ``eval_library.version`` (semver-ish, higher wins),
-    tie-broken by ``retrieved_timestamp`` (higher/newer wins).
+    Handles Python bool, None, or lowercase strings 'true'/'false'/'none'.
 
     Args:
-        record_a:
-            First record in EEE format.
-        record_b:
-            Second record in EEE format.
+        value:
+            The value to normalise. May be a bool, a string ('true', 'false',
+            'none', case-insensitive), or None.
 
     Returns:
-        The newer record (either record_a or record_b).
+        A normalised bool or None.
 
     Raises:
         ValueError:
-            If the records do not share the same identity.
+            If the string value is not one of 'true', 'false', or 'none'.
+        TypeError:
+            If the value is not a bool, str, or None.
     """
-    identity_a = identity_from_eee_record(record_a)
-    identity_b = identity_from_eee_record(record_b)
-
-    if identity_a != identity_b:
-        raise ValueError(
-            f"Records have different identities: {identity_a} vs {identity_b}"
-        )
-
-    version_a = get_version(record=record_a)
-    version_b = get_version(record=record_b)
-
-    version_cmp = _compare_versions(version_a, version_b)
-    if version_cmp > 0:
-        return record_a
-    if version_cmp < 0:
-        return record_b
-
-    timestamp_a = _extract_timestamp(record_a)
-    timestamp_b = _extract_timestamp(record_b)
-
-    if timestamp_a >= timestamp_b:
-        return record_a
-    return record_b
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lower = value.lower()
+        if lower == "true":
+            return True
+        if lower == "false":
+            return False
+        if lower == "none":
+            return None
+        raise ValueError(f"Invalid boolean string value: {value!r}")
+    raise TypeError(f"Unexpected type for boolean value: {type(value)}")
 
 
 def identity_from_benchmark_result(result: BenchmarkResult) -> ResultIdentity:
@@ -256,6 +256,94 @@ def identity_from_benchmark_result(result: BenchmarkResult) -> ResultIdentity:
         Identity tuple ``(model_id, dataset, validation_split, few_shot)``.
     """
     return (result.model, result.dataset, result.validation_split, result.few_shot)
+
+
+def raise_on_collision(identity_a: ResultIdentity, identity_b: ResultIdentity) -> None:
+    """Raise an error if two distinct identities would sanitise to the same path.
+
+    Args:
+        identity_a:
+            First identity tuple.
+        identity_b:
+            Second identity tuple.
+
+    Raises:
+        ValueError:
+            If the identities are different but would produce the same path.
+    """
+    if identity_a != identity_b:
+        path_a = identity_to_path(identity_a)
+        path_b = identity_to_path(identity_b)
+        if path_a == path_b:
+            raise ValueError(
+                f"Identity collision detected: {identity_a} and {identity_b} "
+                f"both sanitise to {path_a}"
+            )
+
+
+def identity_to_path(identity: ResultIdentity) -> Path:
+    """Produce the full relative path for a result identity.
+
+    Args:
+        identity:
+            Identity tuple ``(model_id, dataset, validation_split, few_shot)``.
+
+    Returns:
+        Path object representing the relative path.
+    """
+    model_id, dataset, validation_split, few_shot = identity
+    return record_relative_path(model_id, dataset, validation_split, few_shot)
+
+
+def record_relative_path(
+    model_id: str, dataset: str, validation_split: bool | None, few_shot: bool | None
+) -> Path:
+    """Produce the full relative path for a result record.
+
+    Path format: ``<sanitise(model_id)>/<sanitise(dataset)>__<split>__<shot>.json``
+
+    Args:
+        model_id:
+            The full model identifier.
+        dataset:
+            The dataset name.
+        validation_split:
+            The validation split flag.
+        few_shot:
+            The few-shot flag.
+
+    Returns:
+        Path object representing the relative path.
+    """
+    model_dir = sanitise_model_dir_name(model_id)
+    filename = record_filename(dataset, validation_split, few_shot)
+    return Path(model_dir) / filename
+
+
+def record_filename(
+    dataset: str, validation_split: bool | None, few_shot: bool | None
+) -> str:
+    """Produce the per-record filename for a given identity.
+
+    Format: ``<sanitise(dataset)>__<split_label>__<shot_label>.json``
+
+    Args:
+        dataset:
+            The dataset name.
+        validation_split:
+            The validation split flag. Maps to: True -> 'val', False -> 'test',
+            None -> 'none'.
+        few_shot:
+            The few-shot flag. Maps to: True -> 'fewshot', False -> 'zeroshot',
+            None -> 'none'.
+
+    Returns:
+        Filename string suitable for storing the result record.
+    """
+    sanitised_dataset = sanitise_dataset_name(dataset)
+    split_lbl = split_label(validation_split)
+    shot_lbl = shot_label(few_shot)
+    return f"{sanitised_dataset}__{split_lbl}__{shot_lbl}.json"
 
 
 def sanitise_dataset_name(dataset: str) -> str:
@@ -307,32 +395,6 @@ def split_label(validation_split: bool | None) -> str:
     return "none"
 
 
-def record_filename(
-    dataset: str, validation_split: bool | None, few_shot: bool | None
-) -> str:
-    """Produce the per-record filename for a given identity.
-
-    Format: ``<sanitise(dataset)>__<split_label>__<shot_label>.json``
-
-    Args:
-        dataset:
-            The dataset name.
-        validation_split:
-            The validation split flag. Maps to: True -> 'val', False -> 'test',
-            None -> 'none'.
-        few_shot:
-            The few-shot flag. Maps to: True -> 'fewshot', False -> 'zeroshot',
-            None -> 'none'.
-
-    Returns:
-        Filename string suitable for storing the result record.
-    """
-    sanitised_dataset = sanitise_dataset_name(dataset)
-    split_lbl = split_label(validation_split)
-    shot_lbl = shot_label(few_shot)
-    return f"{sanitised_dataset}__{split_lbl}__{shot_lbl}.json"
-
-
 def sanitise_model_dir_name(model_id: str) -> str:
     """Produce a sanitised model directory name from a model id.
 
@@ -349,65 +411,3 @@ def sanitise_model_dir_name(model_id: str) -> str:
         A sanitised string suitable for use as a directory name.
     """
     return model_id.replace("/", "_")
-
-
-def record_relative_path(
-    model_id: str, dataset: str, validation_split: bool | None, few_shot: bool | None
-) -> Path:
-    """Produce the full relative path for a result record.
-
-    Path format: ``<sanitise(model_id)>/<sanitise(dataset)>__<split>__<shot>.json``
-
-    Args:
-        model_id:
-            The full model identifier.
-        dataset:
-            The dataset name.
-        validation_split:
-            The validation split flag.
-        few_shot:
-            The few-shot flag.
-
-    Returns:
-        Path object representing the relative path.
-    """
-    model_dir = sanitise_model_dir_name(model_id)
-    filename = record_filename(dataset, validation_split, few_shot)
-    return Path(model_dir) / filename
-
-
-def identity_to_path(identity: ResultIdentity) -> Path:
-    """Produce the full relative path for a result identity.
-
-    Args:
-        identity:
-            Identity tuple ``(model_id, dataset, validation_split, few_shot)``.
-
-    Returns:
-        Path object representing the relative path.
-    """
-    model_id, dataset, validation_split, few_shot = identity
-    return record_relative_path(model_id, dataset, validation_split, few_shot)
-
-
-def raise_on_collision(identity_a: ResultIdentity, identity_b: ResultIdentity) -> None:
-    """Raise an error if two distinct identities would sanitise to the same path.
-
-    Args:
-        identity_a:
-            First identity tuple.
-        identity_b:
-            Second identity tuple.
-
-    Raises:
-        ValueError:
-            If the identities are different but would produce the same path.
-    """
-    if identity_a != identity_b:
-        path_a = identity_to_path(identity_a)
-        path_b = identity_to_path(identity_b)
-        if path_a == path_b:
-            raise ValueError(
-                f"Identity collision detected: {identity_a} and {identity_b} "
-                f"both sanitise to {path_a}"
-            )

--- a/src/leaderboards/result_loading.py
+++ b/src/leaderboards/result_loading.py
@@ -16,6 +16,57 @@ from .result_identity import dedup_newer_record, identity_from_eee_record
 logger = logging.getLogger(__name__)
 
 
+@cache
+def load_raw_results() -> list[dict[str, t.Any]]:
+    """Load all EEE-format results from the results directory.
+
+    Syncs the EuroEval/results bucket into RESULTS_DIR, then reads every
+    per-record JSON file from the tree structure
+    (``results/<model>/<dataset>__<split>__<shot>.json``). Records staged in
+    NEW_RESULTS_PATH (a transient JSONL file) are folded in (and the staging
+    file removed) so manually added results are picked up exactly once. No
+    distinction is made between raw and processed results; leaderboard consumers
+    receive the EEE records exactly as stored.
+
+    Deduplicates by the canonical storage identity
+    ``(model_id, dataset, validation_split, few_shot)`` using
+    :func:`.result_identity.dedup_newer_record` to keep the newest record per
+    identity.
+
+    Only the EEE envelope structure is validated here. The "precious" metadata
+    fields (commercially_licensed, open, trained_from_scratch) are intentionally
+    not required at load time: results posted from compute VMs can't supply them,
+    so they're filled in later by the interactive ``add_missing_entries`` step
+    and enforced when the processed records are written back out.
+
+    Returns:
+        All evaluation results in EEE format, deduplicated by storage identity.
+
+    Raises:
+        ValueError:
+            If a loaded record is not an EEE-format record.
+    """
+    _sync_results_from_bucket()
+
+    records = load_records_from_result_tree(results_dir=RESULTS_DIR)
+    logger.info(f"Loaded {len(records):,} existing results from {RESULTS_DIR}.")
+
+    if NEW_RESULTS_PATH.exists():
+        new_records = load_records_from_jsonl_files(paths=[NEW_RESULTS_PATH])
+        logger.info(f"Loaded {len(new_records):,} new results from staging file.")
+        records.extend(new_records)
+        NEW_RESULTS_PATH.unlink()
+
+    # Deduplicate by storage identity, keeping the newest record per identity
+    records = _dedup_by_storage_identity(records=records)
+
+    for idx, record in enumerate(records, start=1):
+        if not is_eee_record(record=record):
+            raise ValueError(f"raw results record {idx:,} is not an EEE-format record.")
+
+    return records
+
+
 def _dedup_by_storage_identity(
     records: list[dict[str, t.Any]],
 ) -> list[dict[str, t.Any]]:
@@ -71,54 +122,3 @@ def _sync_results_from_bucket() -> None:
     backup_path = backup_results()
     if backup_path:
         logger.info(f"Backup created at {backup_path}.")
-
-
-@cache
-def load_raw_results() -> list[dict[str, t.Any]]:
-    """Load all EEE-format results from the results directory.
-
-    Syncs the EuroEval/results bucket into RESULTS_DIR, then reads every
-    per-record JSON file from the tree structure
-    (``results/<model>/<dataset>__<split>__<shot>.json``). Records staged in
-    NEW_RESULTS_PATH (a transient JSONL file) are folded in (and the staging
-    file removed) so manually added results are picked up exactly once. No
-    distinction is made between raw and processed results; leaderboard consumers
-    receive the EEE records exactly as stored.
-
-    Deduplicates by the canonical storage identity
-    ``(model_id, dataset, validation_split, few_shot)`` using
-    :func:`.result_identity.dedup_newer_record` to keep the newest record per
-    identity.
-
-    Only the EEE envelope structure is validated here. The "precious" metadata
-    fields (commercially_licensed, open, trained_from_scratch) are intentionally
-    not required at load time: results posted from compute VMs can't supply them,
-    so they're filled in later by the interactive ``add_missing_entries`` step
-    and enforced when the processed records are written back out.
-
-    Returns:
-        All evaluation results in EEE format, deduplicated by storage identity.
-
-    Raises:
-        ValueError:
-            If a loaded record is not an EEE-format record.
-    """
-    _sync_results_from_bucket()
-
-    records = load_records_from_result_tree(results_dir=RESULTS_DIR)
-    logger.info(f"Loaded {len(records):,} existing results from {RESULTS_DIR}.")
-
-    if NEW_RESULTS_PATH.exists():
-        new_records = load_records_from_jsonl_files(paths=[NEW_RESULTS_PATH])
-        logger.info(f"Loaded {len(new_records):,} new results from staging file.")
-        records.extend(new_records)
-        NEW_RESULTS_PATH.unlink()
-
-    # Deduplicate by storage identity, keeping the newest record per identity
-    records = _dedup_by_storage_identity(records=records)
-
-    for idx, record in enumerate(records, start=1):
-        if not is_eee_record(record=record):
-            raise ValueError(f"raw results record {idx:,} is not an EEE-format record.")
-
-    return records

--- a/src/leaderboards/result_processing.py
+++ b/src/leaderboards/result_processing.py
@@ -36,51 +36,84 @@ from .result_loading import load_raw_results
 logger = logging.getLogger(__name__)
 
 
-def _write_record_file(
-    relative_path: Path, record: dict[str, t.Any], results_dir: Path
-) -> tuple[Path, str] | None:
-    """Write a single record file if it doesn't exist or content differs.
+def process_results(
+    min_version: str,
+    min_number_of_model_records: int,
+    banned_versions: list[str],
+    banned_model_patterns: list[re.Pattern],
+    api_model_patterns: list[re.Pattern],
+    trained_from_scratch_patterns: list[re.Pattern],
+) -> None:
+    """Process EuroEval records from a JSONL file.
 
     Args:
-        relative_path:
-            Relative path for the record file.
-        record:
-            The record dict to serialize.
-        results_dir:
-            The results directory.
-
-    Returns:
-        Tuple of (file_path, relative_path_str) if written, None if skipped.
+        min_version:
+            The minimum EuroEval version to include.
+        min_number_of_model_records:
+            The minimum number of records for a model to be included.
+        banned_versions:
+            A list of banned EuroEval versions to filter out.
+        banned_model_patterns:
+            A list of regex patterns to filter out models that should not be
+            included.
+        api_model_patterns:
+            A list of regex patterns for API inference models.
+        trained_from_scratch_patterns:
+            A list of regex patterns for trained-from-scratch models.
     """
-    file_path = results_dir / relative_path
-    file_path.parent.mkdir(parents=True, exist_ok=True)
+    # Load raw results first so per-model files in RESULTS_DIR are synced.
+    records = load_raw_results()
 
-    # Use canonical JSON serialization for consistent comparison
-    canonical_content = json.dumps(
-        record, sort_keys=True, separators=(",", ":"), ensure_ascii=False
-    )
+    # Build the metadata cache from the synced per-model result files.
+    cache = Cache.from_results_dir(RESULTS_DIR)
+    num_raw_records = len(records)
 
-    # Only write if file doesn't exist or content differs
-    if file_path.exists():
-        try:
-            existing_content = file_path.read_text(encoding="utf-8").strip()
-            existing_record = json.loads(existing_content)
-            canonical_existing = json.dumps(
-                existing_record,
-                sort_keys=True,
-                separators=(",", ":"),
-                ensure_ascii=False,
-            )
-            if canonical_existing == canonical_content:
-                return None  # Skip unchanged files
-        except (json.JSONDecodeError, OSError):
-            pass  # If we can't parse existing, overwrite it
+    records = deduplicate_records(records=records)
+    num_duplicates = num_raw_records - len(records)
+    if num_duplicates:
+        logger.info(f"Removed {num_duplicates:,} duplicates.")
 
-    file_path.write_text(canonical_content + "\n", encoding="utf-8")
-    # Skip empty files
-    if file_path.stat().st_size > 0:
-        return (file_path, str(relative_path))
-    return None
+    fixed_records = [
+        fix_metadata(record=record)
+        for record in tqdm(records, desc="Fixing metadata in records")
+    ]
+
+    processed_records = [
+        record
+        for record in fixed_records
+        if record_is_valid(
+            record=record,
+            min_version=min_version,
+            banned_versions=banned_versions,
+            banned_model_patterns=banned_model_patterns,
+            api_model_patterns=api_model_patterns,
+        )
+    ]
+
+    # Remove records for models with few records
+    counter = Counter([get_model_name(record) for record in processed_records])
+    processed_records = [
+        record
+        for record in processed_records
+        if counter[get_model_name(record)] >= min_number_of_model_records
+    ]
+
+    num_invalid_records = num_raw_records - num_duplicates - len(processed_records)
+    if num_invalid_records > 0:
+        logger.info(f"Removed {num_invalid_records:,} invalid records.")
+
+    processed_records = [
+        add_missing_entries(
+            record=record,
+            trained_from_scratch_patterns=trained_from_scratch_patterns,
+            cache=cache,
+        )
+        for record in tqdm(processed_records, desc="Adding missing entries")
+    ]
+
+    _upload_per_model_files(processed_records=processed_records)
+    load_raw_results.cache_clear()
+    logger.info("Cleared load_raw_results cache.")
 
 
 def _upload_per_model_files(processed_records: list[dict[str, t.Any]]) -> None:
@@ -165,81 +198,48 @@ def _upload_per_model_files(processed_records: list[dict[str, t.Any]]) -> None:
         logger.info(f"Dropped {dropped_count:,} records with unresolvable identities.")
 
 
-def process_results(
-    min_version: str,
-    min_number_of_model_records: int,
-    banned_versions: list[str],
-    banned_model_patterns: list[re.Pattern],
-    api_model_patterns: list[re.Pattern],
-    trained_from_scratch_patterns: list[re.Pattern],
-) -> None:
-    """Process EuroEval records from a JSONL file.
+def _write_record_file(
+    relative_path: Path, record: dict[str, t.Any], results_dir: Path
+) -> tuple[Path, str] | None:
+    """Write a single record file if it doesn't exist or content differs.
 
     Args:
-        min_version:
-            The minimum EuroEval version to include.
-        min_number_of_model_records:
-            The minimum number of records for a model to be included.
-        banned_versions:
-            A list of banned EuroEval versions to filter out.
-        banned_model_patterns:
-            A list of regex patterns to filter out models that should not be
-            included.
-        api_model_patterns:
-            A list of regex patterns for API inference models.
-        trained_from_scratch_patterns:
-            A list of regex patterns for trained-from-scratch models.
+        relative_path:
+            Relative path for the record file.
+        record:
+            The record dict to serialize.
+        results_dir:
+            The results directory.
+
+    Returns:
+        Tuple of (file_path, relative_path_str) if written, None if skipped.
     """
-    # Load raw results first so per-model files in RESULTS_DIR are synced.
-    records = load_raw_results()
+    file_path = results_dir / relative_path
+    file_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Build the metadata cache from the synced per-model result files.
-    cache = Cache.from_results_dir(RESULTS_DIR)
-    num_raw_records = len(records)
+    # Use canonical JSON serialization for consistent comparison
+    canonical_content = json.dumps(
+        record, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
 
-    records = deduplicate_records(records=records)
-    num_duplicates = num_raw_records - len(records)
-    if num_duplicates:
-        logger.info(f"Removed {num_duplicates:,} duplicates.")
+    # Only write if file doesn't exist or content differs
+    if file_path.exists():
+        try:
+            existing_content = file_path.read_text(encoding="utf-8").strip()
+            existing_record = json.loads(existing_content)
+            canonical_existing = json.dumps(
+                existing_record,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+            )
+            if canonical_existing == canonical_content:
+                return None  # Skip unchanged files
+        except (json.JSONDecodeError, OSError):
+            pass  # If we can't parse existing, overwrite it
 
-    fixed_records = [
-        fix_metadata(record=record)
-        for record in tqdm(records, desc="Fixing metadata in records")
-    ]
-
-    processed_records = [
-        record
-        for record in fixed_records
-        if record_is_valid(
-            record=record,
-            min_version=min_version,
-            banned_versions=banned_versions,
-            banned_model_patterns=banned_model_patterns,
-            api_model_patterns=api_model_patterns,
-        )
-    ]
-
-    # Remove records for models with few records
-    counter = Counter([get_model_name(record) for record in processed_records])
-    processed_records = [
-        record
-        for record in processed_records
-        if counter[get_model_name(record)] >= min_number_of_model_records
-    ]
-
-    num_invalid_records = num_raw_records - num_duplicates - len(processed_records)
-    if num_invalid_records > 0:
-        logger.info(f"Removed {num_invalid_records:,} invalid records.")
-
-    processed_records = [
-        add_missing_entries(
-            record=record,
-            trained_from_scratch_patterns=trained_from_scratch_patterns,
-            cache=cache,
-        )
-        for record in tqdm(processed_records, desc="Adding missing entries")
-    ]
-
-    _upload_per_model_files(processed_records=processed_records)
-    load_raw_results.cache_clear()
-    logger.info("Cleared load_raw_results cache.")
+    file_path.write_text(canonical_content + "\n", encoding="utf-8")
+    # Skip empty files
+    if file_path.stat().st_size > 0:
+        return (file_path, str(relative_path))
+    return None

--- a/src/leaderboards/score_computation.py
+++ b/src/leaderboards/score_computation.py
@@ -16,243 +16,6 @@ from .task_metadata import category_includes_task
 logger = logging.getLogger(__name__)
 
 
-def _compute_margin(entries: list[dict[str, float]]) -> float:
-    """Compute confidence margin from a list of CI entries.
-
-    Args:
-        entries:
-            List of dicts with "ci_upper" and "ci_lower" keys.
-
-    Returns:
-        The computed margin.
-    """
-    vars_ = [((e["ci_upper"] - e["ci_lower"]) / (2 * Z_SCORE_95)) ** 2 for e in entries]
-    mean_var = np.sum(vars_) / (len(entries) ** 2)
-    return Z_SCORE_95 * math.sqrt(mean_var)
-
-
-def _aggregate_to_language_level(
-    model_id: str,
-    category: str,
-    configs: dict[str, dict[str, list[str]]],
-    model_task_ranks: dict,
-    orthogonal_tasks: c.Container[str],
-) -> tuple[dict[str, dict[str, float]], list[dict[str, float]]]:
-    """Aggregate task ranks to language level.
-
-    Args:
-        model_id:
-            The model ID.
-        category:
-            The category.
-        configs:
-            Per-language task -> dataset mappings.
-        model_task_ranks:
-            Task-level ranks.
-        orthogonal_tasks:
-            List of orthogonal task names.
-
-    Returns:
-        Tuple of (lang_scores dict, overall_entries list).
-    """
-    lang_scores: dict[str, dict[str, float]] = {}
-    overall_entries: list[dict[str, float]] = []
-
-    for language, config in configs.items():
-        task_entries = [
-            model_task_ranks[model_id][category][language].get(task)
-            for task in config
-            if task not in orthogonal_tasks
-            and category_includes_task(category=category, task=task)
-        ]
-        task_entries = [e for e in task_entries if e is not None]
-        if not task_entries:
-            continue
-
-        mean_score = float(np.mean([e["score"] for e in task_entries]))
-        margin = _compute_margin(task_entries)
-
-        lang_scores[language] = {
-            "score": round(mean_score, 6),
-            "ci_lower": round(mean_score - margin, 6),
-            "ci_upper": round(mean_score + margin, 6),
-        }
-        overall_entries.append(lang_scores[language])
-
-    return lang_scores, overall_entries
-
-
-def _aggregate_to_task_level(
-    model_id: str,
-    category: str,
-    language: str,
-    config: dict[str, list[str]],
-    model_dataset_ranks: dict[str, dict[str, dict[str, dict[str, float]]]],
-    orthogonal_tasks: c.Container[str],
-) -> dict[str, dict[str, float]] | None:
-    """Aggregate dataset ranks to task level for a single language.
-
-    Args:
-        model_id:
-            The model ID.
-        category:
-            The category.
-        language:
-            The language.
-        config:
-            Task -> datasets mapping for this language.
-        model_dataset_ranks:
-            Dataset-level ranks.
-        orthogonal_tasks:
-            List of orthogonal task names to exclude.
-
-    Returns:
-        Dict of task -> {score, ci_lower, ci_upper} or None.
-    """
-    task_results: dict[str, dict[str, float]] = {}
-    for task, task_datasets in config.items():
-        if task in orthogonal_tasks:
-            continue
-        if not category_includes_task(category=category, task=task):
-            continue
-
-        entries = [
-            model_dataset_ranks[model_id][category][ds]
-            for ds in task_datasets
-            if ds in model_dataset_ranks[model_id][category]
-        ]
-        if not entries:
-            continue
-
-        mean_score = float(np.mean([e["score"] for e in entries]))
-        margin = _compute_margin(entries)
-
-        task_results[task] = {
-            "score": round(mean_score, 6),
-            "ci_lower": round(mean_score - margin, 6),
-            "ci_upper": round(mean_score + margin, 6),
-        }
-    return task_results if task_results else None
-
-
-def _bootstrap_single_dataset_ranks(
-    model_scores: dict[str, tuple[float, list[float]]],
-    dataset: str,
-    category: str,
-    n_bootstraps: int,
-    rng: np.random.Generator,
-) -> dict[str, dict[str, float]]:
-    """Compute bootstrap ranks for a single dataset.
-
-    Args:
-        model_scores:
-            Dict of model_id -> (mean_score, raw_scores).
-        dataset:
-            Dataset name.
-        category:
-            Category name.
-        n_bootstraps:
-            Number of bootstrap replicates.
-        rng:
-            Random number generator.
-
-    Returns:
-        Dict of model_id -> {score, ci_lower, ci_upper}.
-    """
-    # Sort by mean score descending, so the best model is first
-    sorted_models = sorted(model_scores.items(), key=lambda x: x[1][0], reverse=True)
-    mean_best = sorted_models[0][1][0]
-    all_raw = [score for _, raw_scores in model_scores.values() for score in raw_scores]
-    pooled_sd = np.std(all_raw) if len(all_raw) > 1 else 1.0
-    if pooled_sd <= 0:
-        pooled_sd = 1.0
-
-    results: dict[str, dict[str, float]] = {}
-    for mid, (_, raw) in model_scores.items():
-        bootstrap_scores: list[float] = []
-        for _ in range(n_bootstraps):
-            resampled_raw = rng.choice(raw, size=len(raw), replace=True)
-            resampled_mean = float(np.mean(resampled_raw))
-            diff = float((mean_best - resampled_mean) / pooled_sd)
-            bootstrap_scores.append(1.0 + diff)
-
-        if not bootstrap_scores:
-            continue
-
-        score = float(np.median(bootstrap_scores))
-        ci_lower = float(np.percentile(bootstrap_scores, 2.5))
-        ci_upper = float(np.percentile(bootstrap_scores, 97.5))
-        results[mid] = {
-            "score": round(score, 6),
-            "ci_lower": round(ci_lower, 6),
-            "ci_upper": round(ci_upper, 6),
-        }
-    return results
-
-
-def compute_dataset_ranks_bootstrap(
-    model_results: dict[str, dict[str, list[tuple[list[float], float, float]]]],
-    configs: dict[str, dict[str, list[str]]],
-    n_bootstraps: int,
-    seed: int | None = None,
-) -> dict[str, dict[str, dict[str, dict[str, float]]]]:
-    """Compute per-dataset rank scores with bootstrap confidence intervals.
-
-    For each model-dataset pair, resamples the raw iteration scores with
-    replacement (n_bootstraps times), recomputes the rank score each time,
-    and returns the empirical distribution's median and percentile CIs.
-
-    The best model (highest mean score) is fixed from the observed data;
-    only the candidate model's mean is resampled, keeping the normalisation
-    stable across bootstrap replicates.
-
-    Args:
-        model_results: Model results grouped by model and dataset.
-        configs: Per-language task -> dataset mappings.
-        n_bootstraps: Number of bootstrap replicates.
-        seed: Random seed for reproducibility.
-
-    Returns:
-        model_id -> category -> dataset -> {"score", "ci_lower", "ci_upper"}.
-    """
-    rng = np.random.default_rng(seed)
-    out: dict[str, dict[str, dict[str, dict[str, float]]]] = defaultdict(
-        lambda: defaultdict(dict)
-    )
-
-    for _language, config in configs.items():
-        for category in LEADERBOARD_CATEGORIES:
-            datasets = [
-                ds
-                for task, task_ds in config.items()
-                for ds in task_ds
-                if task not in ORTHOGONAL_TASKS
-                and category_includes_task(category, task)
-            ]
-            for dataset in datasets:
-                model_scores: dict[str, tuple[float, list[float]]] = {}
-                for model_id, results in model_results.items():
-                    if dataset in results and results[dataset]:
-                        raw, mean_sc, _ = results[dataset][0]
-                        if np.isfinite(mean_sc):
-                            model_scores[model_id] = (mean_sc, raw)
-
-                if not model_scores:
-                    continue
-
-                dataset_results = _bootstrap_single_dataset_ranks(
-                    model_scores=model_scores,
-                    dataset=dataset,
-                    category=category,
-                    n_bootstraps=n_bootstraps,
-                    rng=rng,
-                )
-                for mid, result_data in dataset_results.items():
-                    out[mid][category][dataset] = result_data
-
-    return out
-
-
 def compute_ranks(
     model_results: dict[str, dict[str, list[tuple[list[float], float, float]]]],
     configs: dict[str, dict[str, list[str]]],
@@ -352,6 +115,243 @@ def compute_ranks(
 
     logger.info("Finished computing ranks.")
     return final
+
+
+def _aggregate_to_language_level(
+    model_id: str,
+    category: str,
+    configs: dict[str, dict[str, list[str]]],
+    model_task_ranks: dict,
+    orthogonal_tasks: c.Container[str],
+) -> tuple[dict[str, dict[str, float]], list[dict[str, float]]]:
+    """Aggregate task ranks to language level.
+
+    Args:
+        model_id:
+            The model ID.
+        category:
+            The category.
+        configs:
+            Per-language task -> dataset mappings.
+        model_task_ranks:
+            Task-level ranks.
+        orthogonal_tasks:
+            List of orthogonal task names.
+
+    Returns:
+        Tuple of (lang_scores dict, overall_entries list).
+    """
+    lang_scores: dict[str, dict[str, float]] = {}
+    overall_entries: list[dict[str, float]] = []
+
+    for language, config in configs.items():
+        task_entries = [
+            model_task_ranks[model_id][category][language].get(task)
+            for task in config
+            if task not in orthogonal_tasks
+            and category_includes_task(category=category, task=task)
+        ]
+        task_entries = [e for e in task_entries if e is not None]
+        if not task_entries:
+            continue
+
+        mean_score = float(np.mean([e["score"] for e in task_entries]))
+        margin = _compute_margin(task_entries)
+
+        lang_scores[language] = {
+            "score": round(mean_score, 6),
+            "ci_lower": round(mean_score - margin, 6),
+            "ci_upper": round(mean_score + margin, 6),
+        }
+        overall_entries.append(lang_scores[language])
+
+    return lang_scores, overall_entries
+
+
+def _compute_margin(entries: list[dict[str, float]]) -> float:
+    """Compute confidence margin from a list of CI entries.
+
+    Args:
+        entries:
+            List of dicts with "ci_upper" and "ci_lower" keys.
+
+    Returns:
+        The computed margin.
+    """
+    vars_ = [((e["ci_upper"] - e["ci_lower"]) / (2 * Z_SCORE_95)) ** 2 for e in entries]
+    mean_var = np.sum(vars_) / (len(entries) ** 2)
+    return Z_SCORE_95 * math.sqrt(mean_var)
+
+
+def _aggregate_to_task_level(
+    model_id: str,
+    category: str,
+    language: str,
+    config: dict[str, list[str]],
+    model_dataset_ranks: dict[str, dict[str, dict[str, dict[str, float]]]],
+    orthogonal_tasks: c.Container[str],
+) -> dict[str, dict[str, float]] | None:
+    """Aggregate dataset ranks to task level for a single language.
+
+    Args:
+        model_id:
+            The model ID.
+        category:
+            The category.
+        language:
+            The language.
+        config:
+            Task -> datasets mapping for this language.
+        model_dataset_ranks:
+            Dataset-level ranks.
+        orthogonal_tasks:
+            List of orthogonal task names to exclude.
+
+    Returns:
+        Dict of task -> {score, ci_lower, ci_upper} or None.
+    """
+    task_results: dict[str, dict[str, float]] = {}
+    for task, task_datasets in config.items():
+        if task in orthogonal_tasks:
+            continue
+        if not category_includes_task(category=category, task=task):
+            continue
+
+        entries = [
+            model_dataset_ranks[model_id][category][ds]
+            for ds in task_datasets
+            if ds in model_dataset_ranks[model_id][category]
+        ]
+        if not entries:
+            continue
+
+        mean_score = float(np.mean([e["score"] for e in entries]))
+        margin = _compute_margin(entries)
+
+        task_results[task] = {
+            "score": round(mean_score, 6),
+            "ci_lower": round(mean_score - margin, 6),
+            "ci_upper": round(mean_score + margin, 6),
+        }
+    return task_results if task_results else None
+
+
+def compute_dataset_ranks_bootstrap(
+    model_results: dict[str, dict[str, list[tuple[list[float], float, float]]]],
+    configs: dict[str, dict[str, list[str]]],
+    n_bootstraps: int,
+    seed: int | None = None,
+) -> dict[str, dict[str, dict[str, dict[str, float]]]]:
+    """Compute per-dataset rank scores with bootstrap confidence intervals.
+
+    For each model-dataset pair, resamples the raw iteration scores with
+    replacement (n_bootstraps times), recomputes the rank score each time,
+    and returns the empirical distribution's median and percentile CIs.
+
+    The best model (highest mean score) is fixed from the observed data;
+    only the candidate model's mean is resampled, keeping the normalisation
+    stable across bootstrap replicates.
+
+    Args:
+        model_results: Model results grouped by model and dataset.
+        configs: Per-language task -> dataset mappings.
+        n_bootstraps: Number of bootstrap replicates.
+        seed: Random seed for reproducibility.
+
+    Returns:
+        model_id -> category -> dataset -> {"score", "ci_lower", "ci_upper"}.
+    """
+    rng = np.random.default_rng(seed)
+    out: dict[str, dict[str, dict[str, dict[str, float]]]] = defaultdict(
+        lambda: defaultdict(dict)
+    )
+
+    for _language, config in configs.items():
+        for category in LEADERBOARD_CATEGORIES:
+            datasets = [
+                ds
+                for task, task_ds in config.items()
+                for ds in task_ds
+                if task not in ORTHOGONAL_TASKS
+                and category_includes_task(category, task)
+            ]
+            for dataset in datasets:
+                model_scores: dict[str, tuple[float, list[float]]] = {}
+                for model_id, results in model_results.items():
+                    if dataset in results and results[dataset]:
+                        raw, mean_sc, _ = results[dataset][0]
+                        if np.isfinite(mean_sc):
+                            model_scores[model_id] = (mean_sc, raw)
+
+                if not model_scores:
+                    continue
+
+                dataset_results = _bootstrap_single_dataset_ranks(
+                    model_scores=model_scores,
+                    dataset=dataset,
+                    category=category,
+                    n_bootstraps=n_bootstraps,
+                    rng=rng,
+                )
+                for mid, result_data in dataset_results.items():
+                    out[mid][category][dataset] = result_data
+
+    return out
+
+
+def _bootstrap_single_dataset_ranks(
+    model_scores: dict[str, tuple[float, list[float]]],
+    dataset: str,
+    category: str,
+    n_bootstraps: int,
+    rng: np.random.Generator,
+) -> dict[str, dict[str, float]]:
+    """Compute bootstrap ranks for a single dataset.
+
+    Args:
+        model_scores:
+            Dict of model_id -> (mean_score, raw_scores).
+        dataset:
+            Dataset name.
+        category:
+            Category name.
+        n_bootstraps:
+            Number of bootstrap replicates.
+        rng:
+            Random number generator.
+
+    Returns:
+        Dict of model_id -> {score, ci_lower, ci_upper}.
+    """
+    # Sort by mean score descending, so the best model is first
+    sorted_models = sorted(model_scores.items(), key=lambda x: x[1][0], reverse=True)
+    mean_best = sorted_models[0][1][0]
+    all_raw = [score for _, raw_scores in model_scores.values() for score in raw_scores]
+    pooled_sd = np.std(all_raw) if len(all_raw) > 1 else 1.0
+    if pooled_sd <= 0:
+        pooled_sd = 1.0
+
+    results: dict[str, dict[str, float]] = {}
+    for mid, (_, raw) in model_scores.items():
+        bootstrap_scores: list[float] = []
+        for _ in range(n_bootstraps):
+            resampled_raw = rng.choice(raw, size=len(raw), replace=True)
+            resampled_mean = float(np.mean(resampled_raw))
+            diff = float((mean_best - resampled_mean) / pooled_sd)
+            bootstrap_scores.append(1.0 + diff)
+
+        if not bootstrap_scores:
+            continue
+
+        score = float(np.median(bootstrap_scores))
+        ci_lower = float(np.percentile(bootstrap_scores, 2.5))
+        ci_upper = float(np.percentile(bootstrap_scores, 97.5))
+        results[mid] = {
+            "score": round(score, 6),
+            "ci_lower": round(ci_lower, 6),
+            "ci_upper": round(ci_upper, 6),
+        }
+    return results
 
 
 def compute_ranks_bootstrap(

--- a/src/leaderboards/score_extraction.py
+++ b/src/leaderboards/score_extraction.py
@@ -34,380 +34,6 @@ from .task_metadata import dataset_sources, task_metric_names
 logger = logging.getLogger(__name__)
 
 
-def _ensure_standard_metadata_keys(metadata_dict: dict[str, dict[str, t.Any]]) -> None:
-    """Ensure every model has all standard metadata keys with defaults.
-
-    This prevents KeyError/AssertionError in generate_dataframe() which
-    expects these columns to exist for all models.
-
-    Args:
-        metadata_dict:
-            The metadata dict to ensure keys for.
-    """
-    standard_keys_defaults: dict[str, t.Any] = {
-        "parameters": math.nan,
-        "vocabulary_size": math.nan,
-        "context": math.nan,
-        "generative_type": None,
-        "commercial": False,
-        "merge": False,
-        "open": None,
-        "trained_from_scratch": None,
-        "model_url": None,
-    }
-    for metadata in metadata_dict.values():
-        for key, default_value in standard_keys_defaults.items():
-            if key not in metadata:
-                metadata[key] = default_value
-
-
-def _to_bool(val: str | bool | None) -> bool:
-    """Coerce a metadata value to a boolean.
-
-    Args:
-        val:
-            The raw value, which may be a bool, "true"/"false" string, or None.
-
-    Returns:
-        The boolean value, defaulting to False.
-    """
-    if isinstance(val, bool):
-        return val
-    if isinstance(val, str):
-        return val.lower() == "true"
-    return False
-
-
-def _to_float_or_nan(val: str | float | int | None) -> float:
-    """Coerce a metadata value to a non-negative float, else NaN.
-
-    Args:
-        val:
-            The raw value, which may be a number, numeric string, or None.
-
-    Returns:
-        The value as a float if it is non-negative, otherwise NaN.
-    """
-    if isinstance(val, int | float):
-        return val if val >= 0 else float("nan")
-    if isinstance(val, str):
-        try:
-            num = float(val)
-            return num if num >= 0 else float("nan")
-        except ValueError:
-            return float("nan")
-    return float("nan")
-
-
-def _extract_metadata_from_record(
-    record: dict[str, t.Any],
-) -> tuple[
-    dict[str, t.Any],
-    dict[str, bool],
-    dict[str, bool],
-    str | None,
-    bool,
-    str,
-    int | None,
-]:
-    """Extract metadata fields from a single record.
-
-    Args:
-        record:
-            The record to extract metadata from.
-
-    Returns:
-        Tuple of (metadata_dict, presence_flags, explicit_flags, model_url,
-        model_url_explicit, version, num_failed).
-    """
-    additional = record.get("model_info", {}).get("additional_details", {})
-    num_params_raw = additional.get("num_model_parameters", "-1")
-    vocab_size_raw = additional.get("vocabulary_size", "-1")
-    context_raw = additional.get("max_sequence_length", "-1")
-
-    # Build metadata dict
-    metadata: dict[str, t.Any] = {
-        "parameters": _to_float_or_nan(num_params_raw),
-        "vocabulary_size": _to_float_or_nan(vocab_size_raw),
-        "context": _to_float_or_nan(context_raw),
-        "generative_type": additional.get("generative_type", None),
-        "commercial": additional.get("commercially_licensed", False),
-        "merge": _to_bool(additional.get("merge", "false")),
-        "open": additional.get("open", None),
-        "trained_from_scratch": additional.get("trained_from_scratch", None),
-    }
-
-    # Track which fields are explicitly present (not None/empty)
-    presence_flags: dict[str, bool] = {
-        "generative_type": "generative_type" in additional
-        and additional["generative_type"] is not None,
-        "commercial": "commercially_licensed" in additional
-        and additional["commercially_licensed"] is not None,
-        "merge": "merge" in additional and additional["merge"] is not None,
-        "open": "open" in additional and additional["open"] is not None,
-        "trained_from_scratch": "trained_from_scratch" in additional
-        and additional["trained_from_scratch"] is not None,
-    }
-
-    # Handle model_url - generate fallback if missing
-    model_url = additional.get("model_url", None)
-    model_url_explicit = (
-        "model_url" in additional
-        and additional["model_url"] is not None
-        and additional["model_url"] != ""
-    )
-    if model_url is None:
-        model_url = generate_model_url(model_id=plain_model_id(get_model_name(record)))
-
-    version = get_version(record) or "<9.2.0"
-    num_failed = get_num_failed_instances(record)
-
-    return (
-        metadata,
-        presence_flags,
-        {"model_url": model_url_explicit},  # Kept for API compatibility
-        model_url,
-        model_url_explicit,
-        version,
-        num_failed,
-    )
-
-
-def _is_better_metadata(
-    new_value: bool | str | float | None,
-    old_value: bool | str | float | None,
-    field: str,
-) -> bool:
-    """Check if new metadata value is "better" than the old one.
-
-    A value is "better" if it's more informative (non-null/non-default) when
-    the old value is null/default. Used to prevent stale records from
-    overwriting enriched metadata during extraction.
-
-    Args:
-        new_value:
-            The new metadata value from the current record.
-        old_value:
-            The existing metadata value already stored.
-        field:
-            The field name being compared.
-
-    Returns:
-        True if the new value should replace the old one.
-    """
-    # Prefer non-None over None
-    if old_value is None and new_value is not None:
-        return True
-    if old_value is not None and new_value is None:
-        return False
-
-    # For float fields (parameters, vocabulary_size, context), prefer non-NaN
-    # over NaN
-    if field in ("parameters", "vocabulary_size", "context"):
-        if isinstance(old_value, float) and math.isnan(old_value):
-            if isinstance(new_value, float) and not math.isnan(new_value):
-                return True
-            return False
-        if isinstance(new_value, float) and math.isnan(new_value):
-            return False
-
-    # For boolean fields, prefer present (non-None) over missing (None).
-    # Explicit False is legitimate metadata (e.g. merge=False, open=False)
-    # and should be preserved against later stale/conflicting records.
-    # When both are present (even if different), neither is "better" -
-    # returning False means the new value won't overwrite the old one.
-    if field in ("commercial", "merge", "open", "trained_from_scratch"):
-        if old_value is None and new_value is not None:
-            return True
-        if old_value is not None and new_value is None:
-            return False
-        # Both present: don't overwrite (preserve existing)
-        return False
-
-    # For generative_type, prefer non-empty over empty
-    # When both are non-empty, preserve existing (don't overwrite)
-    if field == "generative_type":
-        if not old_value and new_value:
-            return True
-        if old_value and not new_value:
-            return False
-        # Both non-empty: preserve existing
-        return False
-
-    # For model_url, prefer non-empty over empty.
-    # Note: explicit vs generated fallback distinction is handled in
-    # extract_model_metadata, not here. This function only handles
-    # empty vs non-empty comparison.
-    if field == "model_url":
-        if not old_value and new_value:
-            return True
-        if old_value and not new_value:
-            return False
-        # Both non-empty: preserve existing
-        return False
-
-    # Default: prefer new value (preserves existing behaviour for equal values)
-    return True
-
-
-def _mirror_split_agnostic_datasets(
-    model_scores: dict[str, dict[str, list[tuple[list[float], float, float]]]],
-    split_agnostic_datasets: dict[str, set[str]],
-) -> None:
-    """Mirror split-agnostic dataset scores onto validation-split variant rows.
-
-    Split-agnostic records (``validation_split=None``, e.g. MultiLoKo) are
-    grouped under the test-split variant id (``... (zero-shot)``). This copies
-    those scores onto the corresponding validation-split variant
-    (``... (zero-shot, val)``) whenever it exists, so the ``(val)`` row shows
-    the score too. Only the validation dimension is crossed — the few-shot
-    dimension is preserved, since ``strip_val_suffix`` differs only in the
-    ``val`` note. Mutates ``model_scores`` in place.
-
-    Args:
-        model_scores:
-            The grouped model results, keyed by model id.
-        split_agnostic_datasets:
-            Split-agnostic datasets per (test-split variant) model id.
-    """
-    for model_id in list(model_scores):
-        test_variant_id = strip_val_suffix(model_id=model_id)
-        # ``strip_val_suffix`` returns None unless the id carries a ``val`` note,
-        # so this only fires for validation-split variant rows.
-        if test_variant_id is None:
-            continue
-        for dataset in split_agnostic_datasets.get(test_variant_id, set()):
-            if dataset in model_scores[test_variant_id] and (
-                dataset not in model_scores[model_id]
-            ):
-                model_scores[model_id][dataset] = list(
-                    model_scores[test_variant_id][dataset]
-                )
-
-
-def _scored_count(record: dict[str, t.Any], dataset: str) -> int | None:
-    """Compute the total number of scored samples for a (model, dataset) eval.
-
-    Failure counts are summed across the bootstrap iterations, so the matching
-    denominator is ``num_iterations * split_size``, where the split is the
-    validation split for validation-split runs and the test split otherwise.
-
-    Args:
-        record:
-            A result record in EEE format.
-        dataset:
-            The dataset name (e.g. ``"conll-nl"``).
-
-    Returns:
-        The total number of scored samples, or None if it cannot be determined.
-    """
-    raw_results = get_raw_results(record)
-    if not raw_results:
-        return None
-    source = dataset_sources().get(dataset)
-    if source is None:
-        return None
-    sizes = get_split_sizes(source)
-    if not sizes:
-        return None
-    split = "val" if get_validation_split(record) else "test"
-    size = sizes.get(split)
-    if size is None:
-        return None
-    return len(raw_results) * size
-
-
-def _update_metadata_field(
-    existing: dict[str, t.Any],
-    new_value: bool | str | float | int | None,
-    field: str,
-    is_present: bool,
-) -> None:
-    """Update a single metadata field if the new value is better.
-
-    Args:
-        existing:
-            The existing metadata dict to update.
-        new_value:
-            The new value to potentially store.
-        field:
-            The field name.
-        is_present:
-            Whether the field is explicitly present in the record.
-    """
-    if not is_present:
-        return
-    if field in existing:
-        if _is_better_metadata(
-            new_value=new_value, old_value=existing[field], field=field
-        ):
-            existing[field] = new_value
-    else:
-        existing[field] = new_value
-
-
-def _update_model_url(
-    existing: dict[str, t.Any],
-    model_url: str | None,
-    model_url_explicit: bool,
-    model_url_explicit_map: dict[str, bool],
-    model_id: str,
-) -> None:
-    """Update model_url field with explicit vs generated URL logic.
-
-    Args:
-        existing:
-            The existing metadata dict to update.
-        model_url:
-            The model URL (explicit or generated).
-        model_url_explicit:
-            Whether the URL is explicit (from record) vs generated.
-        model_url_explicit_map:
-            Map tracking which models have explicit URLs.
-        model_id:
-            The model ID.
-    """
-    if model_url is None:
-        return
-    if "model_url" in existing:
-        existing_is_explicit = model_url_explicit_map.get(model_id, False)
-        if not existing_is_explicit and model_url_explicit:
-            # Existing is generated; explicit wins
-            existing["model_url"] = model_url
-            model_url_explicit_map[model_id] = True
-        elif existing_is_explicit and model_url_explicit:
-            # Both explicit; use _is_better_metadata comparison
-            if _is_better_metadata(
-                new_value=model_url, old_value=existing["model_url"], field="model_url"
-            ):
-                existing["model_url"] = model_url
-    else:
-        existing["model_url"] = model_url
-        model_url_explicit_map[model_id] = model_url_explicit
-
-
-def _validation_split_is_none(record: dict[str, t.Any]) -> bool:
-    """Whether a record's dataset has no validation/test split distinction.
-
-    A ``validation_split`` of ``None`` (stored as the JSON ``null`` or the
-    string ``"none"``) marks a dataset that has no validation split, so its
-    result applies to both the test-split and validation-split variant rows.
-    An absent flag defaults to ``False`` (test split), which is not
-    split-agnostic.
-
-    Args:
-        record:
-            A result record in EEE format.
-
-    Returns:
-        True if the record's ``validation_split`` is explicitly ``None``.
-    """
-    additional = record.get("eval_library", {}).get("additional_details", {})
-    if "validation_split" not in additional:
-        return False
-    return normalise_bool_value(additional["validation_split"]) is None
-
-
 def extract_model_metadata(
     results: list[dict[str, t.Any]],
 ) -> dict[str, dict[str, t.Any]]:
@@ -496,6 +122,323 @@ def extract_model_metadata(
     _ensure_standard_metadata_keys(metadata_dict=metadata_dict)
     logger.info("Extracted model metadata.")
     return metadata_dict
+
+
+def _ensure_standard_metadata_keys(metadata_dict: dict[str, dict[str, t.Any]]) -> None:
+    """Ensure every model has all standard metadata keys with defaults.
+
+    This prevents KeyError/AssertionError in generate_dataframe() which
+    expects these columns to exist for all models.
+
+    Args:
+        metadata_dict:
+            The metadata dict to ensure keys for.
+    """
+    standard_keys_defaults: dict[str, t.Any] = {
+        "parameters": math.nan,
+        "vocabulary_size": math.nan,
+        "context": math.nan,
+        "generative_type": None,
+        "commercial": False,
+        "merge": False,
+        "open": None,
+        "trained_from_scratch": None,
+        "model_url": None,
+    }
+    for metadata in metadata_dict.values():
+        for key, default_value in standard_keys_defaults.items():
+            if key not in metadata:
+                metadata[key] = default_value
+
+
+def _extract_metadata_from_record(
+    record: dict[str, t.Any],
+) -> tuple[
+    dict[str, t.Any],
+    dict[str, bool],
+    dict[str, bool],
+    str | None,
+    bool,
+    str,
+    int | None,
+]:
+    """Extract metadata fields from a single record.
+
+    Args:
+        record:
+            The record to extract metadata from.
+
+    Returns:
+        Tuple of (metadata_dict, presence_flags, explicit_flags, model_url,
+        model_url_explicit, version, num_failed).
+    """
+    additional = record.get("model_info", {}).get("additional_details", {})
+    num_params_raw = additional.get("num_model_parameters", "-1")
+    vocab_size_raw = additional.get("vocabulary_size", "-1")
+    context_raw = additional.get("max_sequence_length", "-1")
+
+    # Build metadata dict
+    metadata: dict[str, t.Any] = {
+        "parameters": _to_float_or_nan(num_params_raw),
+        "vocabulary_size": _to_float_or_nan(vocab_size_raw),
+        "context": _to_float_or_nan(context_raw),
+        "generative_type": additional.get("generative_type", None),
+        "commercial": additional.get("commercially_licensed", False),
+        "merge": _to_bool(additional.get("merge", "false")),
+        "open": additional.get("open", None),
+        "trained_from_scratch": additional.get("trained_from_scratch", None),
+    }
+
+    # Track which fields are explicitly present (not None/empty)
+    presence_flags: dict[str, bool] = {
+        "generative_type": "generative_type" in additional
+        and additional["generative_type"] is not None,
+        "commercial": "commercially_licensed" in additional
+        and additional["commercially_licensed"] is not None,
+        "merge": "merge" in additional and additional["merge"] is not None,
+        "open": "open" in additional and additional["open"] is not None,
+        "trained_from_scratch": "trained_from_scratch" in additional
+        and additional["trained_from_scratch"] is not None,
+    }
+
+    # Handle model_url - generate fallback if missing
+    model_url = additional.get("model_url", None)
+    model_url_explicit = (
+        "model_url" in additional
+        and additional["model_url"] is not None
+        and additional["model_url"] != ""
+    )
+    if model_url is None:
+        model_url = generate_model_url(model_id=plain_model_id(get_model_name(record)))
+
+    version = get_version(record) or "<9.2.0"
+    num_failed = get_num_failed_instances(record)
+
+    return (
+        metadata,
+        presence_flags,
+        {"model_url": model_url_explicit},  # Kept for API compatibility
+        model_url,
+        model_url_explicit,
+        version,
+        num_failed,
+    )
+
+
+def _to_bool(val: str | bool | None) -> bool:
+    """Coerce a metadata value to a boolean.
+
+    Args:
+        val:
+            The raw value, which may be a bool, "true"/"false" string, or None.
+
+    Returns:
+        The boolean value, defaulting to False.
+    """
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, str):
+        return val.lower() == "true"
+    return False
+
+
+def _to_float_or_nan(val: str | float | int | None) -> float:
+    """Coerce a metadata value to a non-negative float, else NaN.
+
+    Args:
+        val:
+            The raw value, which may be a number, numeric string, or None.
+
+    Returns:
+        The value as a float if it is non-negative, otherwise NaN.
+    """
+    if isinstance(val, int | float):
+        return val if val >= 0 else float("nan")
+    if isinstance(val, str):
+        try:
+            num = float(val)
+            return num if num >= 0 else float("nan")
+        except ValueError:
+            return float("nan")
+    return float("nan")
+
+
+def _scored_count(record: dict[str, t.Any], dataset: str) -> int | None:
+    """Compute the total number of scored samples for a (model, dataset) eval.
+
+    Failure counts are summed across the bootstrap iterations, so the matching
+    denominator is ``num_iterations * split_size``, where the split is the
+    validation split for validation-split runs and the test split otherwise.
+
+    Args:
+        record:
+            A result record in EEE format.
+        dataset:
+            The dataset name (e.g. ``"conll-nl"``).
+
+    Returns:
+        The total number of scored samples, or None if it cannot be determined.
+    """
+    raw_results = get_raw_results(record)
+    if not raw_results:
+        return None
+    source = dataset_sources().get(dataset)
+    if source is None:
+        return None
+    sizes = get_split_sizes(source)
+    if not sizes:
+        return None
+    split = "val" if get_validation_split(record) else "test"
+    size = sizes.get(split)
+    if size is None:
+        return None
+    return len(raw_results) * size
+
+
+def _update_metadata_field(
+    existing: dict[str, t.Any],
+    new_value: bool | str | float | int | None,
+    field: str,
+    is_present: bool,
+) -> None:
+    """Update a single metadata field if the new value is better.
+
+    Args:
+        existing:
+            The existing metadata dict to update.
+        new_value:
+            The new value to potentially store.
+        field:
+            The field name.
+        is_present:
+            Whether the field is explicitly present in the record.
+    """
+    if not is_present:
+        return
+    if field in existing:
+        if _is_better_metadata(
+            new_value=new_value, old_value=existing[field], field=field
+        ):
+            existing[field] = new_value
+    else:
+        existing[field] = new_value
+
+
+def _is_better_metadata(
+    new_value: bool | str | float | None,
+    old_value: bool | str | float | None,
+    field: str,
+) -> bool:
+    """Check if new metadata value is "better" than the old one.
+
+    A value is "better" if it's more informative (non-null/non-default) when
+    the old value is null/default. Used to prevent stale records from
+    overwriting enriched metadata during extraction.
+
+    Args:
+        new_value:
+            The new metadata value from the current record.
+        old_value:
+            The existing metadata value already stored.
+        field:
+            The field name being compared.
+
+    Returns:
+        True if the new value should replace the old one.
+    """
+    # Prefer non-None over None
+    if old_value is None and new_value is not None:
+        return True
+    if old_value is not None and new_value is None:
+        return False
+
+    # For float fields (parameters, vocabulary_size, context), prefer non-NaN
+    # over NaN
+    if field in ("parameters", "vocabulary_size", "context"):
+        if isinstance(old_value, float) and math.isnan(old_value):
+            if isinstance(new_value, float) and not math.isnan(new_value):
+                return True
+            return False
+        if isinstance(new_value, float) and math.isnan(new_value):
+            return False
+
+    # For boolean fields, prefer present (non-None) over missing (None).
+    # Explicit False is legitimate metadata (e.g. merge=False, open=False)
+    # and should be preserved against later stale/conflicting records.
+    # When both are present (even if different), neither is "better" -
+    # returning False means the new value won't overwrite the old one.
+    if field in ("commercial", "merge", "open", "trained_from_scratch"):
+        if old_value is None and new_value is not None:
+            return True
+        if old_value is not None and new_value is None:
+            return False
+        # Both present: don't overwrite (preserve existing)
+        return False
+
+    # For generative_type, prefer non-empty over empty
+    # When both are non-empty, preserve existing (don't overwrite)
+    if field == "generative_type":
+        if not old_value and new_value:
+            return True
+        if old_value and not new_value:
+            return False
+        # Both non-empty: preserve existing
+        return False
+
+    # For model_url, prefer non-empty over empty.
+    # Note: explicit vs generated fallback distinction is handled in
+    # extract_model_metadata, not here. This function only handles
+    # empty vs non-empty comparison.
+    if field == "model_url":
+        if not old_value and new_value:
+            return True
+        if old_value and not new_value:
+            return False
+        # Both non-empty: preserve existing
+        return False
+
+    # Default: prefer new value (preserves existing behaviour for equal values)
+    return True
+
+
+def _update_model_url(
+    existing: dict[str, t.Any],
+    model_url: str | None,
+    model_url_explicit: bool,
+    model_url_explicit_map: dict[str, bool],
+    model_id: str,
+) -> None:
+    """Update model_url field with explicit vs generated URL logic.
+
+    Args:
+        existing:
+            The existing metadata dict to update.
+        model_url:
+            The model URL (explicit or generated).
+        model_url_explicit:
+            Whether the URL is explicit (from record) vs generated.
+        model_url_explicit_map:
+            Map tracking which models have explicit URLs.
+        model_id:
+            The model ID.
+    """
+    if model_url is None:
+        return
+    if "model_url" in existing:
+        existing_is_explicit = model_url_explicit_map.get(model_id, False)
+        if not existing_is_explicit and model_url_explicit:
+            # Existing is generated; explicit wins
+            existing["model_url"] = model_url
+            model_url_explicit_map[model_id] = True
+        elif existing_is_explicit and model_url_explicit:
+            # Both explicit; use _is_better_metadata comparison
+            if _is_better_metadata(
+                new_value=model_url, old_value=existing["model_url"], field="model_url"
+            ):
+                existing["model_url"] = model_url
+    else:
+        existing["model_url"] = model_url
+        model_url_explicit_map[model_id] = model_url_explicit
 
 
 def group_results_by_model(
@@ -611,3 +554,60 @@ def group_results_by_model(
     )
 
     return model_scores
+
+
+def _mirror_split_agnostic_datasets(
+    model_scores: dict[str, dict[str, list[tuple[list[float], float, float]]]],
+    split_agnostic_datasets: dict[str, set[str]],
+) -> None:
+    """Mirror split-agnostic dataset scores onto validation-split variant rows.
+
+    Split-agnostic records (``validation_split=None``, e.g. MultiLoKo) are
+    grouped under the test-split variant id (``... (zero-shot)``). This copies
+    those scores onto the corresponding validation-split variant
+    (``... (zero-shot, val)``) whenever it exists, so the ``(val)`` row shows
+    the score too. Only the validation dimension is crossed — the few-shot
+    dimension is preserved, since ``strip_val_suffix`` differs only in the
+    ``val`` note. Mutates ``model_scores`` in place.
+
+    Args:
+        model_scores:
+            The grouped model results, keyed by model id.
+        split_agnostic_datasets:
+            Split-agnostic datasets per (test-split variant) model id.
+    """
+    for model_id in list(model_scores):
+        test_variant_id = strip_val_suffix(model_id=model_id)
+        # ``strip_val_suffix`` returns None unless the id carries a ``val`` note,
+        # so this only fires for validation-split variant rows.
+        if test_variant_id is None:
+            continue
+        for dataset in split_agnostic_datasets.get(test_variant_id, set()):
+            if dataset in model_scores[test_variant_id] and (
+                dataset not in model_scores[model_id]
+            ):
+                model_scores[model_id][dataset] = list(
+                    model_scores[test_variant_id][dataset]
+                )
+
+
+def _validation_split_is_none(record: dict[str, t.Any]) -> bool:
+    """Whether a record's dataset has no validation/test split distinction.
+
+    A ``validation_split`` of ``None`` (stored as the JSON ``null`` or the
+    string ``"none"``) marks a dataset that has no validation split, so its
+    result applies to both the test-split and validation-split variant rows.
+    An absent flag defaults to ``False`` (test split), which is not
+    split-agnostic.
+
+    Args:
+        record:
+            A result record in EEE format.
+
+    Returns:
+        True if the record's ``validation_split`` is explicitly ``None``.
+    """
+    additional = record.get("eval_library", {}).get("additional_details", {})
+    if "validation_split" not in additional:
+        return False
+    return normalise_bool_value(additional["validation_split"]) is None

--- a/src/leaderboards/split_sizes.py
+++ b/src/leaderboards/split_sizes.py
@@ -40,17 +40,6 @@ def _load_cache() -> dict[str, dict[str, int]]:
 _CACHE: dict[str, dict[str, int]] = _load_cache()
 
 
-def _save_cache() -> None:
-    """Persist the in-memory split-size cache to disk."""
-    try:
-        DATASET_SPLIT_SIZES_CACHE.parent.mkdir(parents=True, exist_ok=True)
-        with DATASET_SPLIT_SIZES_CACHE.open("w") as f:
-            json.dump(_CACHE, f, indent=2, sort_keys=True)
-            f.write("\n")
-    except OSError as e:
-        logger.warning(f"Could not write split-size cache: {e}")
-
-
 def get_split_sizes(source: str) -> dict[str, int] | None:
     """Get the split sizes for a dataset, fetching and caching on a miss.
 
@@ -78,3 +67,14 @@ def get_split_sizes(source: str) -> dict[str, int] | None:
     _CACHE[source] = sizes
     _save_cache()
     return sizes
+
+
+def _save_cache() -> None:
+    """Persist the in-memory split-size cache to disk."""
+    try:
+        DATASET_SPLIT_SIZES_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        with DATASET_SPLIT_SIZES_CACHE.open("w") as f:
+            json.dump(_CACHE, f, indent=2, sort_keys=True)
+            f.write("\n")
+    except OSError as e:
+        logger.warning(f"Could not write split-size cache: {e}")

--- a/src/leaderboards/task_metadata.py
+++ b/src/leaderboards/task_metadata.py
@@ -26,21 +26,19 @@ from euroeval.tasks import get_all_tasks
 from .constants import LEADERBOARD_TASKS, NLU_TASK_GROUPS
 
 
-@cache
-def _iter_all_dataset_configs() -> tuple[DatasetConfig, ...]:
-    """Collect every ``DatasetConfig`` defined in ``euroeval.dataset_configs``.
+def category_includes_task(category: str, task: str) -> bool:
+    """Check whether a task is scored within a leaderboard category.
 
-    All built-in configs are re-exported into the ``euroeval.dataset_configs``
-    namespace, so we read them straight off the module. Cached because the
-    leaderboard pipeline calls into this module once per language and the set is
-    fixed per process.
+    Args:
+        category:
+            Leaderboard category name.
+        task:
+            Task slug.
 
     Returns:
-        Every ``DatasetConfig`` exported by the lib.
+        True if the task is scored within the category.
     """
-    return tuple(
-        value for value in vars(_ds_module).values() if isinstance(value, DatasetConfig)
-    )
+    return category == "generative" or task_category(task) == "nlu"
 
 
 def task_category(task_name: str) -> str:
@@ -55,21 +53,6 @@ def task_category(task_name: str) -> str:
     """
     task = get_all_tasks()[task_name]
     return "nlu" if task.task_group in NLU_TASK_GROUPS else "nlg"
-
-
-def category_includes_task(category: str, task: str) -> bool:
-    """Check whether a task is scored within a leaderboard category.
-
-    Args:
-        category:
-            Leaderboard category name.
-        task:
-            Task slug.
-
-    Returns:
-        True if the task is scored within the category.
-    """
-    return category == "generative" or task_category(task) == "nlu"
 
 
 @cache
@@ -90,22 +73,21 @@ def dataset_sources() -> dict[str, str]:
     }
 
 
-def language_name_to_codes(name: str) -> set[str]:
-    """Resolve a leaderboard yaml language name (e.g. ``"danish"``) to codes.
+@cache
+def _iter_all_dataset_configs() -> tuple[DatasetConfig, ...]:
+    """Collect every ``DatasetConfig`` defined in ``euroeval.dataset_configs``.
 
-    Args:
-        name:
-            The language name as written in a leaderboard yaml.
+    All built-in configs are re-exported into the ``euroeval.dataset_configs``
+    namespace, so we read them straight off the module. Cached because the
+    leaderboard pipeline calls into this module once per language and the set is
+    fixed per process.
 
     Returns:
-        The set of language codes matching the given name.
+        Every ``DatasetConfig`` exported by the lib.
     """
-    target = name.strip().lower()
-    return {
-        lang.code
-        for lang in get_all_languages().values()
-        if lang.name.lower() == target
-    }
+    return tuple(
+        value for value in vars(_ds_module).values() if isinstance(value, DatasetConfig)
+    )
 
 
 def languages_with_official_datasets() -> list[str]:
@@ -172,6 +154,24 @@ def official_datasets_for_language(language_name: str) -> OrderedDict[str, list[
     return OrderedDict(
         (task, datasets) for task, datasets in by_task.items() if datasets
     )
+
+
+def language_name_to_codes(name: str) -> set[str]:
+    """Resolve a leaderboard yaml language name (e.g. ``"danish"``) to codes.
+
+    Args:
+        name:
+            The language name as written in a leaderboard yaml.
+
+    Returns:
+        The set of language codes matching the given name.
+    """
+    target = name.strip().lower()
+    return {
+        lang.code
+        for lang in get_all_languages().values()
+        if lang.name.lower() == target
+    }
 
 
 def task_metric_names(task_name: str) -> tuple[str, str | None]:

--- a/src/scripts/dataset_creation/create_be_wsc.py
+++ b/src/scripts/dataset_creation/create_be_wsc.py
@@ -247,30 +247,6 @@ class SecondCandidate(BaseModel):
     distractor: str
 
 
-def _cache_key(row: pd.Series) -> str:
-    """Create a stable cache key for the second-candidate extraction call.
-
-    Args:
-        row: The row of the dataframe.
-
-    Returns:
-        The cache key.
-    """
-    split = str(row["split"]).strip()
-    idx = int(row["idx"])
-    return f"{split}_{idx}"
-
-
-def save_cache(cache: dict) -> None:
-    """Save cache to CACHE_FILE.
-
-    Args:
-        cache: The cache to save.
-    """
-    with open(CACHE_FILE, "w") as cache_file:
-        json.dump(cache, cache_file, indent=4)
-
-
 def _extract_second_candidate(row: pd.Series) -> str:
     """Extract a second candidate referent span from the sentence (cached).
 
@@ -409,6 +385,46 @@ def _extract_second_candidate(row: pd.Series) -> str:
     return second_candidate
 
 
+def _cache_key(row: pd.Series) -> str:
+    """Create a stable cache key for the second-candidate extraction call.
+
+    Args:
+        row: The row of the dataframe.
+
+    Returns:
+        The cache key.
+    """
+    split = str(row["split"]).strip()
+    idx = int(row["idx"])
+    return f"{split}_{idx}"
+
+
+def save_cache(cache: dict) -> None:
+    """Save cache to CACHE_FILE.
+
+    Args:
+        cache: The cache to save.
+    """
+    with open(CACHE_FILE, "w") as cache_file:
+        json.dump(cache, cache_file, indent=4)
+
+
+def _make_instruction(row: pd.Series) -> str:
+    """Create the instruction string in Winogrande-like format.
+
+    Args:
+        row: The row of the dataframe.
+
+    Returns:
+        The instruction string.
+    """
+    text = str(row["text"]).replace("\n", " ").strip()
+    pronoun = str(row["span2_text"]).strip()
+    pronoun_idx = int(row["span2_index"])
+    masked = _mask_pronoun(text=text, pronoun=pronoun, word_index=pronoun_idx)
+    return f"{masked} Да каго або чаго адносіцца пропуск _?"
+
+
 def _mask_pronoun(text: str, pronoun: str, word_index: int) -> str:
     """Replace the pronoun token (by word index) with '_'.
 
@@ -433,22 +449,6 @@ def _mask_pronoun(text: str, pronoun: str, word_index: int) -> str:
         assert False, f"Pronoun not found in token: {token} in text: {text}"
 
     return " ".join(words)
-
-
-def _make_instruction(row: pd.Series) -> str:
-    """Create the instruction string in Winogrande-like format.
-
-    Args:
-        row: The row of the dataframe.
-
-    Returns:
-        The instruction string.
-    """
-    text = str(row["text"]).replace("\n", " ").strip()
-    pronoun = str(row["span2_text"]).strip()
-    pronoun_idx = int(row["span2_index"])
-    masked = _mask_pronoun(text=text, pronoun=pronoun, word_index=pronoun_idx)
-    return f"{masked} Да каго або чаго адносіцца пропуск _?"
 
 
 def is_repetitive(text: str) -> bool:

--- a/src/scripts/dataset_creation/create_eltec.py
+++ b/src/scripts/dataset_creation/create_eltec.py
@@ -20,11 +20,11 @@ import os as _os
 import re
 import warnings
 from collections import defaultdict
+from pathlib import Path
 from zipfile import ZipFile
 
 import nltk
 import pandas as pd
-from pathlib import Path
 import requests as rq
 from datasets import Dataset, DatasetDict, Split
 from huggingface_hub import HfApi

--- a/src/scripts/dataset_creation/create_eltec.py
+++ b/src/scripts/dataset_creation/create_eltec.py
@@ -24,6 +24,7 @@ from zipfile import ZipFile
 
 import nltk
 import pandas as pd
+from pathlib import Path
 import requests as rq
 from datasets import Dataset, DatasetDict, Split
 from huggingface_hub import HfApi
@@ -32,13 +33,12 @@ from urllib3.exceptions import InsecureRequestWarning
 
 logging.basicConfig(format="%(asctime)s ⋅ %(message)s", level=logging.INFO)
 
-# Configure NLTK to use .euroeval_cache instead of home directory
-
-_nltk_data_path = _os.path.expanduser("~/gitsky/EuroEval/.euroeval_cache/nltk_data")
-_os.makedirs(_nltk_data_path, exist_ok=True)
-_os.environ["NLTK_DATA"] = _nltk_data_path
-nltk.data.path = [_nltk_data_path]
-
+# Path to project root (script is in src/scripts/dataset_creation/)
+project_root = Path(__file__).parent.parent.parent.parent.absolute()
+nltk_data_dir = project_root / ".euroeval_cache" / "nltk_data"
+nltk_data_dir.mkdir(parents=True, exist_ok=True)
+_os.environ["NLTK_DATA"] = str(nltk_data_dir)
+nltk.data.path = [str(nltk_data_dir)]
 nltk.download("punkt_tab", quiet=True)
 
 logger = logging.getLogger("create_eltec")

--- a/src/scripts/dataset_creation/create_eltec.py
+++ b/src/scripts/dataset_creation/create_eltec.py
@@ -16,7 +16,7 @@
 import io
 import json
 import logging
-import os as _os
+import os
 import re
 import warnings
 from collections import defaultdict
@@ -37,7 +37,7 @@ logging.basicConfig(format="%(asctime)s ⋅ %(message)s", level=logging.INFO)
 project_root = Path(__file__).parent.parent.parent.parent.absolute()
 nltk_data_dir = project_root / ".euroeval_cache" / "nltk_data"
 nltk_data_dir.mkdir(parents=True, exist_ok=True)
-_os.environ["NLTK_DATA"] = str(nltk_data_dir)
+os.environ["NLTK_DATA"] = str(nltk_data_dir)
 nltk.data.path = [str(nltk_data_dir)]
 nltk.download("punkt_tab", quiet=True)
 

--- a/src/scripts/dataset_creation/create_eltec.py
+++ b/src/scripts/dataset_creation/create_eltec.py
@@ -23,6 +23,7 @@ from collections import defaultdict
 from pathlib import Path
 from zipfile import ZipFile
 
+import nltk
 import pandas as pd
 import requests as rq
 from datasets import Dataset, DatasetDict, Split
@@ -38,8 +39,6 @@ nltk_data_dir = project_root / ".euroeval_cache" / "nltk_data"
 nltk_data_dir.mkdir(parents=True, exist_ok=True)
 os.environ["NLTK_DATA"] = str(nltk_data_dir)
 
-import nltk
-from nltk.tokenize import word_tokenize
 
 nltk.data.path = [str(nltk_data_dir)]
 nltk.download("punkt_tab", quiet=True)

--- a/src/scripts/dataset_creation/create_eltec.py
+++ b/src/scripts/dataset_creation/create_eltec.py
@@ -16,6 +16,7 @@
 import io
 import json
 import logging
+import os as _os
 import re
 import warnings
 from collections import defaultdict
@@ -31,7 +32,14 @@ from urllib3.exceptions import InsecureRequestWarning
 
 logging.basicConfig(format="%(asctime)s ⋅ %(message)s", level=logging.INFO)
 
-nltk.download("punkt_tab")
+# Configure NLTK to use .euroeval_cache instead of home directory
+
+_nltk_data_path = _os.path.expanduser("~/gitsky/EuroEval/.euroeval_cache/nltk_data")
+_os.makedirs(_nltk_data_path, exist_ok=True)
+_os.environ["NLTK_DATA"] = _nltk_data_path
+nltk.data.path = [_nltk_data_path]
+
+nltk.download("punkt_tab", quiet=True)
 
 logger = logging.getLogger("create_eltec")
 

--- a/src/scripts/dataset_creation/create_eltec.py
+++ b/src/scripts/dataset_creation/create_eltec.py
@@ -23,7 +23,6 @@ from collections import defaultdict
 from pathlib import Path
 from zipfile import ZipFile
 
-import nltk
 import pandas as pd
 import requests as rq
 from datasets import Dataset, DatasetDict, Split
@@ -33,11 +32,15 @@ from urllib3.exceptions import InsecureRequestWarning
 
 logging.basicConfig(format="%(asctime)s ⋅ %(message)s", level=logging.INFO)
 
-# Path to project root (script is in src/scripts/dataset_creation/)
+# Set NLTK_DATA before importing nltk to ensure cache location is correct
 project_root = Path(__file__).parent.parent.parent.parent.absolute()
 nltk_data_dir = project_root / ".euroeval_cache" / "nltk_data"
 nltk_data_dir.mkdir(parents=True, exist_ok=True)
 os.environ["NLTK_DATA"] = str(nltk_data_dir)
+
+import nltk
+from nltk.tokenize import word_tokenize
+
 nltk.data.path = [str(nltk_data_dir)]
 nltk.download("punkt_tab", quiet=True)
 

--- a/src/scripts/dataset_creation/create_estner.py
+++ b/src/scripts/dataset_creation/create_estner.py
@@ -53,6 +53,21 @@ def main() -> None:
     ds.push_to_hub(target_repo_id, private=True)
 
 
+def convert_labels(row: t.MutableMapping) -> t.MutableMapping:
+    """Convert original labels in a row to new ones.
+
+    Args:
+        row:
+            A row of the original dataset.
+
+    Returns:
+        The updated row, with the new labels.
+    """
+    label_map = get_label_map()
+    row["labels"] = [label_map.get(label, label) for label in row["labels"]]
+    return row
+
+
 def get_label_map() -> dict[str, str]:
     """Get the map from original labels to the EuroEval ones.
 
@@ -93,21 +108,6 @@ def get_label_map() -> dict[str, str]:
                 label_map[label] = f"{position}-{entity_type}"
 
     return label_map
-
-
-def convert_labels(row: t.MutableMapping) -> t.MutableMapping:
-    """Convert original labels in a row to new ones.
-
-    Args:
-        row:
-            A row of the original dataset.
-
-    Returns:
-        The updated row, with the new labels.
-    """
-    label_map = get_label_map()
-    row["labels"] = [label_map.get(label, label) for label in row["labels"]]
-    return row
 
 
 if __name__ == "__main__":

--- a/src/scripts/dataset_creation/create_hellaswag_fi.py
+++ b/src/scripts/dataset_creation/create_hellaswag_fi.py
@@ -208,6 +208,34 @@ def _print_filtering_stats(df: pd.DataFrame, split: str) -> None:
     )
 
 
+def process_endings(raw_endings: str) -> list[str] | None:
+    """Process the endings of the HellaSwag-fi dataset.
+
+    Args:
+        raw_endings: The endings of the HellaSwag-fi dataset.
+
+    Returns:
+        The processed endings, or None if the endings couldn't be extracted properly.
+    """
+    # Remove starting/ending square brackets and quotes
+    raw_endings = raw_endings[2:-2]
+
+    # Most endings are separated by newline characters
+    endings = raw_endings.split("\n")
+
+    # If not, try a more hacky approach
+    if len(endings) != 4:
+        endings = [
+            ending
+            for newline_ending in endings
+            for ending in _extract_endings(string=newline_ending)
+        ]
+    if len(endings) != 4:
+        return None
+
+    return [ending.strip(" '\"") for ending in endings]
+
+
 def _extract_endings(string: str) -> list[str]:
     """Extract endings from the HellaSwag-fi dataset.
 
@@ -243,34 +271,6 @@ def _extract_endings(string: str) -> list[str]:
     ending = string[start:].strip()
     endings.append(ending)
     return endings
-
-
-def process_endings(raw_endings: str) -> list[str] | None:
-    """Process the endings of the HellaSwag-fi dataset.
-
-    Args:
-        raw_endings: The endings of the HellaSwag-fi dataset.
-
-    Returns:
-        The processed endings, or None if the endings couldn't be extracted properly.
-    """
-    # Remove starting/ending square brackets and quotes
-    raw_endings = raw_endings[2:-2]
-
-    # Most endings are separated by newline characters
-    endings = raw_endings.split("\n")
-
-    # If not, try a more hacky approach
-    if len(endings) != 4:
-        endings = [
-            ending
-            for newline_ending in endings
-            for ending in _extract_endings(string=newline_ending)
-        ]
-    if len(endings) != 4:
-        return None
-
-    return [ending.strip(" '\"") for ending in endings]
 
 
 if __name__ == "__main__":

--- a/src/scripts/dataset_creation/create_hotter_and_colder_sentiment.py
+++ b/src/scripts/dataset_creation/create_hotter_and_colder_sentiment.py
@@ -141,32 +141,6 @@ def hydrate_data(df: pd.DataFrame) -> pd.DataFrame:
     return df.dropna(subset=["comment_content"])
 
 
-def extract_datetime_from_signature(signature_body: Tag) -> dt.datetime | None:
-    """Parse the signature to extract the datetime information.
-
-    Args:
-        signature_body:
-            The signature body to extract the datetime information from.
-
-    Returns:
-        The extracted datetime information, or None if no datetime information was
-        found.
-    """
-    signature_str = "".join([str(child) for child in signature_body.children]).strip()
-    signature_str = re.sub("\n", " ", signature_str)
-    signature_str = re.sub(r"\s+", " ", signature_str)
-
-    datetime_match = re.search(
-        pattern=r"(\d{1,2}\.\d{1,2}\.\d{4})\s+kl\.\s+(\d{1,2}:\d{2})",
-        string=signature_str,
-    )
-    if not datetime_match:
-        return None
-
-    date_str, time_str = datetime_match.groups()
-    return dt.datetime.strptime(f"{date_str} {time_str}", "%d.%m.%Y %H:%M")
-
-
 def scrape_comment_content(url: str, target_datetime: dt.datetime) -> str | None:
     """Scrape the content of a comment with a given datetime from a URL.
 
@@ -226,6 +200,32 @@ def scrape_comment_content(url: str, target_datetime: dt.datetime) -> str | None
     else:
         logger.error(f"Error scraping comment content for {url!r}")
         return None
+
+
+def extract_datetime_from_signature(signature_body: Tag) -> dt.datetime | None:
+    """Parse the signature to extract the datetime information.
+
+    Args:
+        signature_body:
+            The signature body to extract the datetime information from.
+
+    Returns:
+        The extracted datetime information, or None if no datetime information was
+        found.
+    """
+    signature_str = "".join([str(child) for child in signature_body.children]).strip()
+    signature_str = re.sub("\n", " ", signature_str)
+    signature_str = re.sub(r"\s+", " ", signature_str)
+
+    datetime_match = re.search(
+        pattern=r"(\d{1,2}\.\d{1,2}\.\d{4})\s+kl\.\s+(\d{1,2}:\d{2})",
+        string=signature_str,
+    )
+    if not datetime_match:
+        return None
+
+    date_str, time_str = datetime_match.groups()
+    return dt.datetime.strptime(f"{date_str} {time_str}", "%d.%m.%Y %H:%M")
 
 
 if __name__ == "__main__":

--- a/src/scripts/dataset_creation/create_hun_sum.py
+++ b/src/scripts/dataset_creation/create_hun_sum.py
@@ -191,12 +191,6 @@ class SummaryValidation(BaseModel):
     is_valid_summary: bool
 
 
-def save_cache(cache: dict) -> None:
-    """Save cache to CACHE_FILE."""
-    with open(CACHE_FILE, "w") as cache_file:
-        json.dump(cache, cache_file, indent=4)
-
-
 def _text_summary_alignment(row: pd.Series) -> bool:
     """Check if the summary aligns with the text using an LLM, with caching.
 
@@ -236,6 +230,12 @@ def _text_summary_alignment(row: pd.Series) -> bool:
     save_cache(cache=summary_cache)
 
     return is_valid_summary
+
+
+def save_cache(cache: dict) -> None:
+    """Save cache to CACHE_FILE."""
+    with open(CACHE_FILE, "w") as cache_file:
+        json.dump(cache, cache_file, indent=4)
 
 
 if __name__ == "__main__":

--- a/src/scripts/dataset_creation/create_mbbq_nl.py
+++ b/src/scripts/dataset_creation/create_mbbq_nl.py
@@ -108,26 +108,41 @@ def main() -> None:
     new_dataset.push_to_hub(dataset_id_mbbq, private=True)
 
 
-def fix_nonmatching_tags(stereo_tag: str, tag_to_idx: dict[str, int]) -> str:
-    """Normalize tags that do not directly match the metadata labels.
+def format_row(row: dict[str, t.Any]) -> dict[str, t.Any]:
+    """Format the dataset rows into multiple choice question prompts.
 
     Args:
-        stereo_tag: Raw tag from metadata.
-        tag_to_idx: Mapping of normalized tags to answer indices.
+        row: Raw dataset row with context, question, answers, and labels.
 
     Returns:
-        Normalized tag string.
+        Mapping with the prompt text, label, and bias index fields.
     """
-    tag = stereo_tag.replace(" ", "")
-    if tag.lower() in ["transgenderwomen", "transgendermen"] and "trans" in tag_to_idx:
-        return "trans"
-    elif tag == "F" and "vrouw" in tag_to_idx:
-        return "vrouw"
-    elif tag == "F" and "meisje" in tag_to_idx:
-        return "meisje"
-    elif tag == "M" and "man" in tag_to_idx:
-        return "man"
-    return tag
+    # In the MBBQ paper, Neplenbroek uses 5 different prompt templates, and uses their
+    # average score. We use one of those templates here, slightly adapted
+    prompt = textwrap.dedent(
+        f"""\
+        Gegeven de volgende context, wat is het juiste antwoord op de vraag?
+        Context: {row["context"]}
+        Vraag: {row["question"]}
+
+        Antwoordopties:
+        a. {row["ans0"]}
+        b. {row["ans1"]}
+        c. {row["ans2"]}"""
+    )
+
+    stereo_idx, counter_idx, unknown_idx = extract_bias_indices(
+        answer_info=row["answer_info"], additional_metadata=row["additional_metadata"]
+    )
+
+    return {
+        "text": prompt,
+        "label": ["a", "b", "c"][row["label"]],
+        "correct_idx": row["label"],
+        "stereo_idx": stereo_idx,
+        "counter_idx": counter_idx,
+        "unknown_idx": unknown_idx,
+    }
 
 
 def extract_bias_indices(
@@ -176,41 +191,26 @@ def extract_bias_indices(
     return None, None, None
 
 
-def format_row(row: dict[str, t.Any]) -> dict[str, t.Any]:
-    """Format the dataset rows into multiple choice question prompts.
+def fix_nonmatching_tags(stereo_tag: str, tag_to_idx: dict[str, int]) -> str:
+    """Normalize tags that do not directly match the metadata labels.
 
     Args:
-        row: Raw dataset row with context, question, answers, and labels.
+        stereo_tag: Raw tag from metadata.
+        tag_to_idx: Mapping of normalized tags to answer indices.
 
     Returns:
-        Mapping with the prompt text, label, and bias index fields.
+        Normalized tag string.
     """
-    # In the MBBQ paper, Neplenbroek uses 5 different prompt templates, and uses their
-    # average score. We use one of those templates here, slightly adapted
-    prompt = textwrap.dedent(
-        f"""\
-        Gegeven de volgende context, wat is het juiste antwoord op de vraag?
-        Context: {row["context"]}
-        Vraag: {row["question"]}
-
-        Antwoordopties:
-        a. {row["ans0"]}
-        b. {row["ans1"]}
-        c. {row["ans2"]}"""
-    )
-
-    stereo_idx, counter_idx, unknown_idx = extract_bias_indices(
-        answer_info=row["answer_info"], additional_metadata=row["additional_metadata"]
-    )
-
-    return {
-        "text": prompt,
-        "label": ["a", "b", "c"][row["label"]],
-        "correct_idx": row["label"],
-        "stereo_idx": stereo_idx,
-        "counter_idx": counter_idx,
-        "unknown_idx": unknown_idx,
-    }
+    tag = stereo_tag.replace(" ", "")
+    if tag.lower() in ["transgenderwomen", "transgendermen"] and "trans" in tag_to_idx:
+        return "trans"
+    elif tag == "F" and "vrouw" in tag_to_idx:
+        return "vrouw"
+    elif tag == "F" and "meisje" in tag_to_idx:
+        return "meisje"
+    elif tag == "M" and "man" in tag_to_idx:
+        return "man"
+    return tag
 
 
 if __name__ == "__main__":

--- a/src/scripts/dataset_creation/create_publico.py
+++ b/src/scripts/dataset_creation/create_publico.py
@@ -15,16 +15,17 @@ import os
 import random
 from pathlib import Path
 
+import nltk
+from datasets import Dataset, DatasetDict, load_dataset
+from huggingface_hub.hf_api import HfApi
+from nltk.tokenize import sent_tokenize
+
 # Set NLTK_DATA before importing nltk to ensure cache location is correct
 project_root = Path(__file__).parent.parent.parent.parent.absolute()
 nltk_data_dir = project_root / ".euroeval_cache" / "nltk_data"
 nltk_data_dir.mkdir(parents=True, exist_ok=True)
 os.environ["NLTK_DATA"] = str(nltk_data_dir)
 
-import nltk
-from datasets import Dataset, DatasetDict, load_dataset
-from huggingface_hub.hf_api import HfApi
-from nltk.tokenize import sent_tokenize
 
 nltk.data.path = [str(nltk_data_dir)]
 nltk.download("punkt", quiet=True)

--- a/src/scripts/dataset_creation/create_publico.py
+++ b/src/scripts/dataset_creation/create_publico.py
@@ -10,6 +10,8 @@
 
 """Create the Público-mini summarisation dataset."""
 
+# Configure NLTK to use .euroeval_cache instead of home directory
+import os as _os
 import random
 
 import nltk
@@ -17,7 +19,12 @@ from datasets import Dataset, DatasetDict, load_dataset
 from huggingface_hub.hf_api import HfApi
 from nltk.tokenize import sent_tokenize
 
-nltk.download("punkt")
+_nltk_data_path = _os.path.expanduser("~/gitsky/EuroEval/.euroeval_cache/nltk_data")
+_os.makedirs(_nltk_data_path, exist_ok=True)
+_os.environ["NLTK_DATA"] = _nltk_data_path
+nltk.data.path = [_nltk_data_path]
+
+nltk.download("punkt", quiet=True)
 
 TOTAL = 1024 + 256 + 2048
 

--- a/src/scripts/dataset_creation/create_publico.py
+++ b/src/scripts/dataset_creation/create_publico.py
@@ -18,12 +18,14 @@ import nltk
 from datasets import Dataset, DatasetDict, load_dataset
 from huggingface_hub.hf_api import HfApi
 from nltk.tokenize import sent_tokenize
+from pathlib import Path
 
-_nltk_data_path = _os.path.expanduser("~/gitsky/EuroEval/.euroeval_cache/nltk_data")
-_os.makedirs(_nltk_data_path, exist_ok=True)
-_os.environ["NLTK_DATA"] = _nltk_data_path
-nltk.data.path = [_nltk_data_path]
-
+# Path to project root (script is in src/scripts/dataset_creation/)
+project_root = Path(__file__).parent.parent.parent.parent.absolute()
+nltk_data_dir = project_root / ".euroeval_cache" / "nltk_data"
+nltk_data_dir.mkdir(parents=True, exist_ok=True)
+_os.environ["NLTK_DATA"] = str(nltk_data_dir)
+nltk.data.path = [str(nltk_data_dir)]
 nltk.download("punkt", quiet=True)
 
 TOTAL = 1024 + 256 + 2048

--- a/src/scripts/dataset_creation/create_publico.py
+++ b/src/scripts/dataset_creation/create_publico.py
@@ -11,7 +11,7 @@
 """Create the Público-mini summarisation dataset."""
 
 # Configure NLTK to use .euroeval_cache instead of home directory
-import os as _os
+import os
 import random
 from pathlib import Path
 
@@ -24,7 +24,7 @@ from nltk.tokenize import sent_tokenize
 project_root = Path(__file__).parent.parent.parent.parent.absolute()
 nltk_data_dir = project_root / ".euroeval_cache" / "nltk_data"
 nltk_data_dir.mkdir(parents=True, exist_ok=True)
-_os.environ["NLTK_DATA"] = str(nltk_data_dir)
+os.environ["NLTK_DATA"] = str(nltk_data_dir)
 nltk.data.path = [str(nltk_data_dir)]
 nltk.download("punkt", quiet=True)
 

--- a/src/scripts/dataset_creation/create_publico.py
+++ b/src/scripts/dataset_creation/create_publico.py
@@ -15,16 +15,17 @@ import os
 import random
 from pathlib import Path
 
+# Set NLTK_DATA before importing nltk to ensure cache location is correct
+project_root = Path(__file__).parent.parent.parent.parent.absolute()
+nltk_data_dir = project_root / ".euroeval_cache" / "nltk_data"
+nltk_data_dir.mkdir(parents=True, exist_ok=True)
+os.environ["NLTK_DATA"] = str(nltk_data_dir)
+
 import nltk
 from datasets import Dataset, DatasetDict, load_dataset
 from huggingface_hub.hf_api import HfApi
 from nltk.tokenize import sent_tokenize
 
-# Path to project root (script is in src/scripts/dataset_creation/)
-project_root = Path(__file__).parent.parent.parent.parent.absolute()
-nltk_data_dir = project_root / ".euroeval_cache" / "nltk_data"
-nltk_data_dir.mkdir(parents=True, exist_ok=True)
-os.environ["NLTK_DATA"] = str(nltk_data_dir)
 nltk.data.path = [str(nltk_data_dir)]
 nltk.download("punkt", quiet=True)
 

--- a/src/scripts/dataset_creation/create_publico.py
+++ b/src/scripts/dataset_creation/create_publico.py
@@ -13,12 +13,12 @@
 # Configure NLTK to use .euroeval_cache instead of home directory
 import os as _os
 import random
+from pathlib import Path
 
 import nltk
 from datasets import Dataset, DatasetDict, load_dataset
 from huggingface_hub.hf_api import HfApi
 from nltk.tokenize import sent_tokenize
-from pathlib import Path
 
 # Path to project root (script is in src/scripts/dataset_creation/)
 project_root = Path(__file__).parent.parent.parent.parent.absolute()

--- a/src/scripts/dataset_creation/create_rosent.py
+++ b/src/scripts/dataset_creation/create_rosent.py
@@ -175,12 +175,6 @@ class Sentiment(BaseModel):
     )
 
 
-def save_cache(cache: dict) -> None:
-    """Save cache to CACHE_FILE."""
-    with open(CACHE_FILE, "w") as cache_file:
-        json.dump(cache, cache_file, indent=4)
-
-
 def _classify_text(text: str) -> str:
     """Classify the text using GPT-4o model.
 
@@ -215,6 +209,12 @@ def _classify_text(text: str) -> str:
     label_cache[text] = label
     save_cache(cache=label_cache)
     return label
+
+
+def save_cache(cache: dict) -> None:
+    """Save cache to CACHE_FILE."""
+    with open(CACHE_FILE, "w") as cache_file:
+        json.dump(cache, cache_file, indent=4)
 
 
 def _compare_labels(row: pd.Series) -> bool:

--- a/src/scripts/dataset_creation/create_scala.py
+++ b/src/scripts/dataset_creation/create_scala.py
@@ -326,43 +326,6 @@ def corrupt(
     return corruptions
 
 
-def join_tokens(tokens: list[str]) -> str:
-    """Joins a list of tokens into a string.
-
-    Args:
-        tokens:
-            The list of tokens to join.
-
-    Returns:
-        The joined string.
-    """
-    # Form document
-    doc = " ".join(tokens)
-
-    # Remove whitespace around punctuation
-    doc = (
-        doc.replace(" .", ".")
-        .replace(" ,", ",")
-        .replace(" ;", ";")
-        .replace(" :", ":")
-        .replace("( ", "(")
-        .replace(" )", ")")
-        .replace("[ ", "[")
-        .replace(" ]", "]")
-        .replace("{ ", "{")
-        .replace(" }", "}")
-        .replace(" ?", "?")
-        .replace(" !", "!")
-    )
-
-    # Remove whitespace around quotes
-    if doc.count('"') % 2 == 0:
-        doc = re.sub('" ([^"]*) "', '"\\1"', doc)
-
-    # Return the document
-    return doc
-
-
 def delete(tokens: list[str], pos_tags: list[str]) -> str | None:
     """Delete a random token from a list of tokens.
 
@@ -415,6 +378,43 @@ def delete(tokens: list[str], pos_tags: list[str]) -> str | None:
 
     # Join up the new tokens and return the string
     return join_tokens(new_tokens)
+
+
+def join_tokens(tokens: list[str]) -> str:
+    """Joins a list of tokens into a string.
+
+    Args:
+        tokens:
+            The list of tokens to join.
+
+    Returns:
+        The joined string.
+    """
+    # Form document
+    doc = " ".join(tokens)
+
+    # Remove whitespace around punctuation
+    doc = (
+        doc.replace(" .", ".")
+        .replace(" ,", ",")
+        .replace(" ;", ";")
+        .replace(" :", ":")
+        .replace("( ", "(")
+        .replace(" )", ")")
+        .replace("[ ", "[")
+        .replace(" ]", "]")
+        .replace("{ ", "{")
+        .replace(" }", "}")
+        .replace(" ?", "?")
+        .replace(" !", "!")
+    )
+
+    # Remove whitespace around quotes
+    if doc.count('"') % 2 == 0:
+        doc = re.sub('" ([^"]*) "', '"\\1"', doc)
+
+    # Return the document
+    return doc
 
 
 def flip_neighbours(tokens: list[str], pos_tags: list[str]) -> str | None:

--- a/src/scripts/dataset_creation/load_ud_pos.py
+++ b/src/scripts/dataset_creation/load_ud_pos.py
@@ -22,143 +22,22 @@ logging.basicConfig(format="%(asctime)s ⋅ %(message)s", level=logging.INFO)
 logger = logging.getLogger("load_ud_pos")
 
 
-def _filter_token_range(data_dict: dict[str, list]) -> dict[str, list]:
-    """Filter out tokens that belong to ranges in UD source files.
-
-    Tokens that span more than one position are not supported by create_scala's
-    prepare_df logic.
-
-    Example files:
-
-    - tests/test_scripts/test_create_scala/test_data/de_gsd-ud-train.conllu.adp_det
-    - tests/test_scripts/test_create_scala/test_data/pl_pdb-ud-train.conllu.aux_clitic_*
-
-    Args:
-        data_dict: The input data dictionary.
+def load_bedt_pos() -> dict[str, pd.DataFrame]:
+    """Load the part-of-speech part of the Belarusian Dependency Treebank.
 
     Returns:
-        The filtered data dictionary. Its format is identical to the input.
+        The dataframes, stored in the keys `train`, `val`, and `test`.
     """
-    output: dict[str, list] = defaultdict(list)
+    # Define download URLs
+    base_url = (
+        "https://raw.githubusercontent.com/UniversalDependencies/UD_Belarusian-HSE/refs"
+        "/heads/master/be_hse-ud-{}.conllu"
+    )
+    train_url = base_url.format("train")
+    val_url = base_url.format("dev")
+    test_url = base_url.format("test")
 
-    range_start: int = 0
-    range_end: int = 0
-    # Track the index where we added the multi-word token so we can update its POS tag
-    mwt_index: int | None = None
-
-    # Pattern used to detect merged IDs
-    merged_ids_pattern = re.compile(r"(\d+)-(\d+)", re.I)
-
-    for i in range(len(data_dict["ids"])):
-        match = merged_ids_pattern.match(data_dict["ids"][i])
-        if match is not None:
-            output["ids"].append(data_dict["ids"][i])
-            output["tokens"].append(data_dict["tokens"][i])
-            output["pos_tags"].append(data_dict["pos_tags"][i])
-            range_start = int(match.group(1))
-            range_end = int(match.group(2))
-            # Remember where we added this multi-word token
-            mwt_index = len(output["pos_tags"]) - 1
-        else:
-            token_id = int(data_dict["ids"][i].split(".")[0])
-            if token_id >= range_start and token_id <= range_end:
-                # If this is the first token in the range and we have a multi-word token
-                # to update, copy the POS tag from this token to the multi-word token
-                if mwt_index is not None and token_id == range_start:
-                    output["pos_tags"][mwt_index] = data_dict["pos_tags"][i]
-                    mwt_index = None  # Reset so we only update once per range
-                # Skip token if in range
-                continue
-            else:
-                output["ids"].append(data_dict["ids"][i])
-                output["tokens"].append(data_dict["tokens"][i])
-                output["pos_tags"].append(data_dict["pos_tags"][i])
-                # Reset mwt_index when we move past the range
-                mwt_index = None
-
-    return output
-
-
-def _load_file_or_url(url_or_path: str) -> list[str]:
-    """Load a file from a URL or local path.
-
-    Args:
-        url_or_path: The URL or local path to load.
-
-    Returns:
-        The list of strings, one per line.
-    """
-    parsed = urlparse(url_or_path)
-    if parsed.scheme.lower() in ("http", "https"):
-        return requests.get(url_or_path).text.split("\n")
-    else:
-        with open(url_or_path, "r") as f:
-            logger.warning(f"Loading data from local file: {url_or_path}")
-            return [line.strip() for line in f.readlines()]
-
-
-def _load_split(
-    *,
-    lines: list[str],
-    filter_source: str | None = None,
-    doc_process_fn: c.Callable[[str], str] = lambda x: x,
-) -> pd.DataFrame:
-    """Load single split of the POS part of a Universal Dependencies treebank.
-
-    Args:
-        lines: The lines of the file to process.
-        filter_source:
-            If not `None`, only include entries with this source in the dataset.
-        doc_process_fn:
-            A function to apply to each document before parsing it.
-
-    Returns:
-        The dataframe for the given split.
-    """
-    # Initialise the records, data dictionary and document
-    records: list[dict] = []
-    data_dict: dict[str, list[list[int | str] | str]] = defaultdict(list)
-
-    # Iterate over the data for the given split
-    doc = ""
-    source = ""
-    for line_idx, line in enumerate(lines):
-        # If we are at the first line of an entry then extract the document
-        if line.startswith("# text = "):
-            doc = re.sub("# text = ", "", line)
-
-            # Process the document if needed
-            doc = doc_process_fn(doc)
-
-        elif line.startswith("# source = "):
-            source = line.removeprefix("# source = ").strip()
-
-        # Otherwise, if the line is a comment then ignore it
-        elif line.startswith("#"):
-            continue
-
-        # Otherwise, if we have reached the end of an entry then store it to the
-        # list of records and reset the data dictionary and document
-        elif line == "" or line_idx == len(lines) - 1:
-            if len(data_dict["tokens"]) > 0:
-                if filter_source is None or filter_source in source:
-                    merged_data_dict: dict[str, str | list[int | str]]
-                    merged_data_dict = {**_filter_token_range(data_dict), "doc": doc}
-                    records.append(merged_data_dict)
-            data_dict = defaultdict(list)
-            doc = ""
-            source = ""
-
-        # Otherwise we are in the middle of an entry which is not a comment, so
-        # we extract the data from the line and store it in the data dictionary
-        else:
-            data_tup = line.split("\t")
-            data_dict["ids"].append(data_tup[0])
-            data_dict["tokens"].append(data_tup[1])
-            data_dict["pos_tags"].append(data_tup[3])
-
-    # Convert the records to a dataframe
-    return pd.DataFrame.from_records(records)
+    return load_ud_pos(train_url=train_url, val_url=val_url, test_url=test_url)
 
 
 def load_ud_pos(
@@ -209,22 +88,22 @@ def load_ud_pos(
     return dfs
 
 
-def load_bedt_pos() -> dict[str, pd.DataFrame]:
-    """Load the part-of-speech part of the Belarusian Dependency Treebank.
+def _load_file_or_url(url_or_path: str) -> list[str]:
+    """Load a file from a URL or local path.
+
+    Args:
+        url_or_path: The URL or local path to load.
 
     Returns:
-        The dataframes, stored in the keys `train`, `val`, and `test`.
+        The list of strings, one per line.
     """
-    # Define download URLs
-    base_url = (
-        "https://raw.githubusercontent.com/UniversalDependencies/UD_Belarusian-HSE/refs"
-        "/heads/master/be_hse-ud-{}.conllu"
-    )
-    train_url = base_url.format("train")
-    val_url = base_url.format("dev")
-    test_url = base_url.format("test")
-
-    return load_ud_pos(train_url=train_url, val_url=val_url, test_url=test_url)
+    parsed = urlparse(url_or_path)
+    if parsed.scheme.lower() in ("http", "https"):
+        return requests.get(url_or_path).text.split("\n")
+    else:
+        with open(url_or_path, "r") as f:
+            logger.warning(f"Loading data from local file: {url_or_path}")
+            return [line.strip() for line in f.readlines()]
 
 
 def load_bgdt_pos() -> dict[str, pd.DataFrame]:
@@ -728,6 +607,127 @@ def load_sqdt_pos() -> dict[str, pd.DataFrame]:
     df_dict["test"] = pd.concat([df_dict["test"], tsa_test_df], ignore_index=True)
 
     return df_dict
+
+
+def _load_split(
+    *,
+    lines: list[str],
+    filter_source: str | None = None,
+    doc_process_fn: c.Callable[[str], str] = lambda x: x,
+) -> pd.DataFrame:
+    """Load single split of the POS part of a Universal Dependencies treebank.
+
+    Args:
+        lines: The lines of the file to process.
+        filter_source:
+            If not `None`, only include entries with this source in the dataset.
+        doc_process_fn:
+            A function to apply to each document before parsing it.
+
+    Returns:
+        The dataframe for the given split.
+    """
+    # Initialise the records, data dictionary and document
+    records: list[dict] = []
+    data_dict: dict[str, list[list[int | str] | str]] = defaultdict(list)
+
+    # Iterate over the data for the given split
+    doc = ""
+    source = ""
+    for line_idx, line in enumerate(lines):
+        # If we are at the first line of an entry then extract the document
+        if line.startswith("# text = "):
+            doc = re.sub("# text = ", "", line)
+
+            # Process the document if needed
+            doc = doc_process_fn(doc)
+
+        elif line.startswith("# source = "):
+            source = line.removeprefix("# source = ").strip()
+
+        # Otherwise, if the line is a comment then ignore it
+        elif line.startswith("#"):
+            continue
+
+        # Otherwise, if we have reached the end of an entry then store it to the
+        # list of records and reset the data dictionary and document
+        elif line == "" or line_idx == len(lines) - 1:
+            if len(data_dict["tokens"]) > 0:
+                if filter_source is None or filter_source in source:
+                    merged_data_dict: dict[str, str | list[int | str]]
+                    merged_data_dict = {**_filter_token_range(data_dict), "doc": doc}
+                    records.append(merged_data_dict)
+            data_dict = defaultdict(list)
+            doc = ""
+            source = ""
+
+        # Otherwise we are in the middle of an entry which is not a comment, so
+        # we extract the data from the line and store it in the data dictionary
+        else:
+            data_tup = line.split("\t")
+            data_dict["ids"].append(data_tup[0])
+            data_dict["tokens"].append(data_tup[1])
+            data_dict["pos_tags"].append(data_tup[3])
+
+    # Convert the records to a dataframe
+    return pd.DataFrame.from_records(records)
+
+
+def _filter_token_range(data_dict: dict[str, list]) -> dict[str, list]:
+    """Filter out tokens that belong to ranges in UD source files.
+
+    Tokens that span more than one position are not supported by create_scala's
+    prepare_df logic.
+
+    Example files:
+
+    - tests/test_scripts/test_create_scala/test_data/de_gsd-ud-train.conllu.adp_det
+    - tests/test_scripts/test_create_scala/test_data/pl_pdb-ud-train.conllu.aux_clitic_*
+
+    Args:
+        data_dict: The input data dictionary.
+
+    Returns:
+        The filtered data dictionary. Its format is identical to the input.
+    """
+    output: dict[str, list] = defaultdict(list)
+
+    range_start: int = 0
+    range_end: int = 0
+    # Track the index where we added the multi-word token so we can update its POS tag
+    mwt_index: int | None = None
+
+    # Pattern used to detect merged IDs
+    merged_ids_pattern = re.compile(r"(\d+)-(\d+)", re.I)
+
+    for i in range(len(data_dict["ids"])):
+        match = merged_ids_pattern.match(data_dict["ids"][i])
+        if match is not None:
+            output["ids"].append(data_dict["ids"][i])
+            output["tokens"].append(data_dict["tokens"][i])
+            output["pos_tags"].append(data_dict["pos_tags"][i])
+            range_start = int(match.group(1))
+            range_end = int(match.group(2))
+            # Remember where we added this multi-word token
+            mwt_index = len(output["pos_tags"]) - 1
+        else:
+            token_id = int(data_dict["ids"][i].split(".")[0])
+            if token_id >= range_start and token_id <= range_end:
+                # If this is the first token in the range and we have a multi-word token
+                # to update, copy the POS tag from this token to the multi-word token
+                if mwt_index is not None and token_id == range_start:
+                    output["pos_tags"][mwt_index] = data_dict["pos_tags"][i]
+                    mwt_index = None  # Reset so we only update once per range
+                # Skip token if in range
+                continue
+            else:
+                output["ids"].append(data_dict["ids"][i])
+                output["tokens"].append(data_dict["tokens"][i])
+                output["pos_tags"].append(data_dict["pos_tags"][i])
+                # Reset mwt_index when we move past the range
+                mwt_index = None
+
+    return output
 
 
 def load_srdt_pos() -> dict[str, pd.DataFrame]:

--- a/src/scripts/update_core_models.py
+++ b/src/scripts/update_core_models.py
@@ -420,6 +420,26 @@ def _format_parameters(parameters: float) -> str:
     return f"{parameters:.0f}"
 
 
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def _get_issue_body(issue_number: int, token: str) -> str:
+    """Fetch the current body of an issue.
+
+    Args:
+        issue_number:
+            The issue number.
+        token:
+            GitHub PAT.
+
+    Returns:
+        The issue body string (empty if the issue has none).
+    """
+    issue = _gh_request(path=f"/repos/{REPO}/issues/{issue_number}", token=token)
+    assert isinstance(issue, dict)
+    return issue.get("body") or ""
+
+
 def _gh_request(
     path: str, *, method: str = "GET", payload: dict | None = None, token: str
 ) -> dict | list:
@@ -455,24 +475,56 @@ def _gh_request(
         return json.loads(resp.read().decode("utf-8"))
 
 
-# ---------------------------------------------------------------------------
-# CLI
-# ---------------------------------------------------------------------------
-def _get_issue_body(issue_number: int, token: str) -> str:
-    """Fetch the current body of an issue.
+def _post_issue_comment(issue_number: int, body: str, token: str) -> str:
+    """POST a comment to an issue.
 
     Args:
         issue_number:
             The issue number.
+        body:
+            The comment markdown.
         token:
             GitHub PAT.
 
     Returns:
-        The issue body string (empty if the issue has none).
+        The `html_url` of the newly-created comment.
     """
-    issue = _gh_request(path=f"/repos/{REPO}/issues/{issue_number}", token=token)
-    assert isinstance(issue, dict)
-    return issue.get("body") or ""
+    response = _gh_request(
+        path=f"/repos/{REPO}/issues/{issue_number}/comments",
+        method="POST",
+        payload=dict(body=body),
+        token=token,
+    )
+    assert isinstance(response, dict)
+    return response["html_url"]
+
+
+# ---------------------------------------------------------------------------
+# GitHub API helpers (mirror the style of `collect_evaluation_results.py`)
+# ---------------------------------------------------------------------------
+def diff_issue(old_body: str, new_models: list[CoreModel]) -> IssueDiff:
+    """Compute the change set between the published issue and the new list.
+
+    Args:
+        old_body:
+            Current issue body markdown.
+        new_models:
+            The newly-generated core list.
+
+    Returns:
+        An `IssueDiff` with added, removed, and flag-changed entries.
+    """
+    old = _parse_issue_models(old_body)
+
+    new_flags = {m.model_id: _reasoning_flags(m) for m in new_models}
+    added = sorted(set(new_flags) - set(old))
+    removed = sorted(set(old) - set(new_flags))
+    flag_changes = sorted(
+        (mid, old[mid], new_flags[mid])
+        for mid in set(old) & set(new_flags)
+        if old[mid] != new_flags[mid]
+    )
+    return IssueDiff(added=added, removed=removed, flag_changes=flag_changes)
 
 
 def _parse_issue_models(body: str) -> dict[str, str]:
@@ -502,30 +554,6 @@ def _parse_issue_models(body: str) -> dict[str, str]:
     return result
 
 
-def _post_issue_comment(issue_number: int, body: str, token: str) -> str:
-    """POST a comment to an issue.
-
-    Args:
-        issue_number:
-            The issue number.
-        body:
-            The comment markdown.
-        token:
-            GitHub PAT.
-
-    Returns:
-        The `html_url` of the newly-created comment.
-    """
-    response = _gh_request(
-        path=f"/repos/{REPO}/issues/{issue_number}/comments",
-        method="POST",
-        payload=dict(body=body),
-        token=token,
-    )
-    assert isinstance(response, dict)
-    return response["html_url"]
-
-
 def _reasoning_flags(model: CoreModel) -> str:
     """Return the trio of emoji flags explaining why this model was picked.
 
@@ -546,34 +574,6 @@ def _reasoning_flags(model: CoreModel) -> str:
     if model.api:
         flags.append("👾")
     return "".join(flags)
-
-
-# ---------------------------------------------------------------------------
-# GitHub API helpers (mirror the style of `collect_evaluation_results.py`)
-# ---------------------------------------------------------------------------
-def diff_issue(old_body: str, new_models: list[CoreModel]) -> IssueDiff:
-    """Compute the change set between the published issue and the new list.
-
-    Args:
-        old_body:
-            Current issue body markdown.
-        new_models:
-            The newly-generated core list.
-
-    Returns:
-        An `IssueDiff` with added, removed, and flag-changed entries.
-    """
-    old = _parse_issue_models(old_body)
-
-    new_flags = {m.model_id: _reasoning_flags(m) for m in new_models}
-    added = sorted(set(new_flags) - set(old))
-    removed = sorted(set(old) - set(new_flags))
-    flag_changes = sorted(
-        (mid, old[mid], new_flags[mid])
-        for mid in set(old) & set(new_flags)
-        if old[mid] != new_flags[mid]
-    )
-    return IssueDiff(added=added, removed=removed, flag_changes=flag_changes)
 
 
 def render_diff_comment(diff: IssueDiff) -> str:

--- a/src/scripts/versioning.py
+++ b/src/scripts/versioning.py
@@ -11,6 +11,12 @@ import subprocess
 from pathlib import Path
 
 
+def bump_major() -> None:
+    """Add one to the major version."""
+    major, _, _ = get_current_version()
+    set_new_version(major + 1, 0, 0)
+
+
 def get_current_version() -> tuple[int, int, int]:
     """Fetch the current version of the package.
 
@@ -86,12 +92,6 @@ def set_new_version(major: int, minor: int, patch: int) -> None:
     subprocess.run(args=["git", "tag", f"v{version}"], check=True)
     subprocess.run(args=["git", "push"], check=True)
     subprocess.run(args=["git", "push", "--tags"], check=True)
-
-
-def bump_major() -> None:
-    """Add one to the major version."""
-    major, _, _ = get_current_version()
-    set_new_version(major + 1, 0, 0)
 
 
 def bump_minor() -> None:

--- a/tests/leaderboards/test_backup_validation.py
+++ b/tests/leaderboards/test_backup_validation.py
@@ -21,33 +21,6 @@ from leaderboards.backup import (
 from leaderboards.eee_validation import validate_eee_record
 
 
-def _create_eee_record(
-    model_name: str = "test/model", include_precious_metadata: bool = False
-) -> dict[str, t.Any]:
-    """Create a minimal EEE-format record.
-
-    Args:
-        model_name (optional):
-            Model name for the record. Defaults to "test/model".
-        include_precious_metadata (optional):
-            Whether to include precious metadata fields. Defaults to False.
-
-    Returns:
-        A minimal EEE-format record dictionary.
-    """
-    record: dict[str, t.Any] = {
-        "schema_version": "1.0",
-        "model_info": {"name": model_name, "additional_details": {}},
-        "eval_library": {"name": "euroeval", "additional_details": {}},
-        "evaluation_results": [],
-    }
-    if include_precious_metadata:
-        record["model_info"]["additional_details"].update(
-            {"commercially_licensed": False, "open": True, "trained_from_scratch": True}
-        )
-    return record
-
-
 class TestBackupResultsIntegration:
     """Integration tests for backup_results with tree structure results."""
 
@@ -75,6 +48,33 @@ class TestBackupResultsIntegration:
             backup_path = backup_results(source=temp_results_dir)
             assert backup_path is not None
             assert backup_path.exists()
+
+
+def _create_eee_record(
+    model_name: str = "test/model", include_precious_metadata: bool = False
+) -> dict[str, t.Any]:
+    """Create a minimal EEE-format record.
+
+    Args:
+        model_name (optional):
+            Model name for the record. Defaults to "test/model".
+        include_precious_metadata (optional):
+            Whether to include precious metadata fields. Defaults to False.
+
+    Returns:
+        A minimal EEE-format record dictionary.
+    """
+    record: dict[str, t.Any] = {
+        "schema_version": "1.0",
+        "model_info": {"name": model_name, "additional_details": {}},
+        "eval_library": {"name": "euroeval", "additional_details": {}},
+        "evaluation_results": [],
+    }
+    if include_precious_metadata:
+        record["model_info"]["additional_details"].update(
+            {"commercially_licensed": False, "open": True, "trained_from_scratch": True}
+        )
+    return record
 
 
 class TestTreeStructureBackup:

--- a/tests/leaderboards/test_cache.py
+++ b/tests/leaderboards/test_cache.py
@@ -10,78 +10,6 @@ import pytest
 from leaderboards.cache import Cache
 
 
-def _make_eee_record(
-    model_id: str = "test/model",
-    model_name: str | None = None,
-    dataset: str = "dataset1",
-    validation_split: bool | None = False,
-    few_shot: bool | None = False,
-    commercially_licensed: bool | None = None,
-    open_license: bool | None = None,
-    trained_from_scratch: bool | None = None,
-    model_url: str | None = None,
-) -> dict:
-    """Helper to create a valid EEE-format record for cache testing.
-
-    Args:
-        model_id:
-            Model identifier.
-        model_name:
-            Model name (defaults to model_id).
-        dataset:
-            Dataset name.
-        validation_split:
-            Validation split flag.
-        few_shot:
-            Few-shot flag.
-        commercially_licensed:
-            Whether commercially licensed.
-        open_license:
-            Whether open license.
-        trained_from_scratch:
-            Whether trained from scratch.
-        model_url:
-            Model URL.
-
-    Returns:
-        A valid EEE-format record dict.
-    """
-    if model_name is None:
-        model_name = model_id
-    record = {
-        "schema_version": "1.0",
-        "model_info": {"id": model_id, "name": model_name, "additional_details": {}},
-        "eval_library": {
-            "additional_details": {
-                "dataset": dataset,
-                "validation_split": validation_split,
-                "few_shot": few_shot,
-            }
-        },
-        "retrieved_timestamp": "100",
-        "evaluation_results": [{"label": "pass", "score": 0.5}],
-    }
-
-    # Add metadata fields if provided
-    has_metadata = any(
-        v is not None
-        for v in [commercially_licensed, open_license, trained_from_scratch, model_url]
-    )
-    if has_metadata:
-        additional = {}
-        if commercially_licensed is not None:
-            additional["commercially_licensed"] = commercially_licensed
-        if open_license is not None:
-            additional["open"] = open_license
-        if trained_from_scratch is not None:
-            additional["trained_from_scratch"] = trained_from_scratch
-        if model_url is not None:
-            additional["model_url"] = model_url
-        record["model_info"]["additional_details"] = additional
-
-    return record
-
-
 class TestCacheFromResultsDir:
     """Tests for Cache.from_results_dir with tree structure."""
 
@@ -165,3 +93,75 @@ class TestCacheFromResultsDir:
         """Should raise FileNotFoundError for nonexistent directory."""
         with pytest.raises(FileNotFoundError, match="Results directory"):
             Cache.from_results_dir(results_dir=Path("/nonexistent/path"))
+
+
+def _make_eee_record(
+    model_id: str = "test/model",
+    model_name: str | None = None,
+    dataset: str = "dataset1",
+    validation_split: bool | None = False,
+    few_shot: bool | None = False,
+    commercially_licensed: bool | None = None,
+    open_license: bool | None = None,
+    trained_from_scratch: bool | None = None,
+    model_url: str | None = None,
+) -> dict:
+    """Helper to create a valid EEE-format record for cache testing.
+
+    Args:
+        model_id:
+            Model identifier.
+        model_name:
+            Model name (defaults to model_id).
+        dataset:
+            Dataset name.
+        validation_split:
+            Validation split flag.
+        few_shot:
+            Few-shot flag.
+        commercially_licensed:
+            Whether commercially licensed.
+        open_license:
+            Whether open license.
+        trained_from_scratch:
+            Whether trained from scratch.
+        model_url:
+            Model URL.
+
+    Returns:
+        A valid EEE-format record dict.
+    """
+    if model_name is None:
+        model_name = model_id
+    record = {
+        "schema_version": "1.0",
+        "model_info": {"id": model_id, "name": model_name, "additional_details": {}},
+        "eval_library": {
+            "additional_details": {
+                "dataset": dataset,
+                "validation_split": validation_split,
+                "few_shot": few_shot,
+            }
+        },
+        "retrieved_timestamp": "100",
+        "evaluation_results": [{"label": "pass", "score": 0.5}],
+    }
+
+    # Add metadata fields if provided
+    has_metadata = any(
+        v is not None
+        for v in [commercially_licensed, open_license, trained_from_scratch, model_url]
+    )
+    if has_metadata:
+        additional = {}
+        if commercially_licensed is not None:
+            additional["commercially_licensed"] = commercially_licensed
+        if open_license is not None:
+            additional["open"] = open_license
+        if trained_from_scratch is not None:
+            additional["trained_from_scratch"] = trained_from_scratch
+        if model_url is not None:
+            additional["model_url"] = model_url
+        record["model_info"]["additional_details"] = additional
+
+    return record

--- a/tests/leaderboards/test_model_metadata.py
+++ b/tests/leaderboards/test_model_metadata.py
@@ -359,24 +359,6 @@ class TestCachePriority:
         assert cache.open["openai/gpt-4"] is False
 
 
-def _record(model_name: str, generative: bool = True) -> dict:
-    """Create a minimal record for testing.
-
-    Args:
-        model_name:
-            The model name for the record.
-        generative (optional):
-            Whether the model is generative. Defaults to True.
-
-    Returns:
-        A minimal record dictionary.
-    """
-    return {
-        "model_info": {"name": model_name, "additional_details": {}},
-        "generative": generative,
-    }
-
-
 class TestCommercialLicenceInference:
     """Tests for best-effort commercial licence inference from HF model info."""
 
@@ -588,6 +570,24 @@ class TestCommercialLicenceInference:
         result = is_commercially_licensed(record=record, cache=cache)
 
         assert result is True
+
+
+def _record(model_name: str, generative: bool = True) -> dict:
+    """Create a minimal record for testing.
+
+    Args:
+        model_name:
+            The model name for the record.
+        generative (optional):
+            Whether the model is generative. Defaults to True.
+
+    Returns:
+        A minimal record dictionary.
+    """
+    return {
+        "model_info": {"name": model_name, "additional_details": {}},
+        "generative": generative,
+    }
 
 
 class TestRemoveModelResults:

--- a/tests/leaderboards/test_record_fields.py
+++ b/tests/leaderboards/test_record_fields.py
@@ -5,6 +5,16 @@ import typing as t
 from leaderboards.record_fields import _metadata_richness_score, deduplicate_records
 
 
+def test_deduplicate_collapses_generative_flag_variants() -> None:
+    """Records differing only in the ``generative`` flag collapse to one.
+
+    This is the Apertus v1.1 regression (issue #1970): the two records render
+    on the same leaderboard row, so only one must survive deduplication.
+    """
+    records = [_record(generative=True), _record(generative=None)]
+    assert len(deduplicate_records(records=records)) == 1
+
+
 def _record(
     name: str = "org/model",
     dataset: str = "angry-tweets",
@@ -38,16 +48,6 @@ def _record(
     if version is not None:
         library["version"] = version
     return {"model_info": model_info, "eval_library": library}
-
-
-def test_deduplicate_collapses_generative_flag_variants() -> None:
-    """Records differing only in the ``generative`` flag collapse to one.
-
-    This is the Apertus v1.1 regression (issue #1970): the two records render
-    on the same leaderboard row, so only one must survive deduplication.
-    """
-    records = [_record(generative=True), _record(generative=None)]
-    assert len(deduplicate_records(records=records)) == 1
 
 
 def test_deduplicate_equal_richness_preserves_first_record() -> None:

--- a/tests/leaderboards/test_records.py
+++ b/tests/leaderboards/test_records.py
@@ -85,6 +85,25 @@ class TestPlainModelId:
         )
 
 
+def test_anchored_and_plain_names_hash_identically() -> None:
+    """Anchored and plain model names must deduplicate to the same hash.
+
+    Otherwise both records survive deduplication yet collapse onto a single
+    leaderboard row (``extract_model_ids_from_record`` strips the anchor),
+    showing multiple scores for one model+benchmark combination (issue #1970).
+    """
+    anchored = _record(
+        name="<a href='https://ollama.com/library/gemma3'>ollama_chat/gemma3</a>"
+    )
+    plain = _record(name="ollama_chat/gemma3")
+
+    assert get_record_hash(record=anchored) == get_record_hash(record=plain)
+    # The two forms must also collapse to the same leaderboard row identity.
+    assert extract_model_ids_from_record(record=anchored) == (
+        extract_model_ids_from_record(record=plain)
+    )
+
+
 def _record(
     name: str,
     dataset: str = "angry-tweets",
@@ -121,25 +140,6 @@ def _record(
         "model_info": {"name": name},
         "eval_library": {"additional_details": additional},
     }
-
-
-def test_anchored_and_plain_names_hash_identically() -> None:
-    """Anchored and plain model names must deduplicate to the same hash.
-
-    Otherwise both records survive deduplication yet collapse onto a single
-    leaderboard row (``extract_model_ids_from_record`` strips the anchor),
-    showing multiple scores for one model+benchmark combination (issue #1970).
-    """
-    anchored = _record(
-        name="<a href='https://ollama.com/library/gemma3'>ollama_chat/gemma3</a>"
-    )
-    plain = _record(name="ollama_chat/gemma3")
-
-    assert get_record_hash(record=anchored) == get_record_hash(record=plain)
-    # The two forms must also collapse to the same leaderboard row identity.
-    assert extract_model_ids_from_record(record=anchored) == (
-        extract_model_ids_from_record(record=plain)
-    )
 
 
 def test_distinct_datasets_hash_differently() -> None:

--- a/tests/leaderboards/test_result_identity.py
+++ b/tests/leaderboards/test_result_identity.py
@@ -25,50 +25,6 @@ from leaderboards.result_identity import (
 )
 
 
-def _make_eee_record(
-    model_id: str = "org/model",
-    dataset: str = "test_dataset",
-    validation_split: bool | str | None = False,
-    few_shot: bool | str | None = True,
-    version: str | None = "1.0.0",
-    timestamp: str | int | None = "1234567890",
-) -> dict:
-    """Helper to create an EEE-format record for testing.
-
-    Args:
-        model_id:
-            Model identifier.
-        dataset:
-            Dataset name.
-        validation_split:
-            Validation split flag.
-        few_shot:
-            Few-shot flag.
-        version:
-            EuroEval version.
-        timestamp:
-            Retrieved timestamp.
-
-    Returns:
-        EEE-format record dictionary.
-    """
-    return {
-        "schema_version": "0.2.1",
-        "model_info": {"id": model_id, "name": "Test Model"},
-        "eval_library": {
-            "name": "euroeval",
-            "version": version,
-            "additional_details": {
-                "dataset": dataset,
-                "validation_split": validation_split,
-                "few_shot": few_shot,
-            },
-        },
-        "retrieved_timestamp": timestamp,
-        "evaluation_results": [],
-    }
-
-
 class TestDedupNewerRecord:
     """Tests for dedup_newer_record."""
 
@@ -113,6 +69,50 @@ class TestDedupNewerRecord:
         record_b = _make_eee_record(version="1.9.0", timestamp="200")
         winner = dedup_newer_record(record_a, record_b)
         assert winner is record_a
+
+
+def _make_eee_record(
+    model_id: str = "org/model",
+    dataset: str = "test_dataset",
+    validation_split: bool | str | None = False,
+    few_shot: bool | str | None = True,
+    version: str | None = "1.0.0",
+    timestamp: str | int | None = "1234567890",
+) -> dict:
+    """Helper to create an EEE-format record for testing.
+
+    Args:
+        model_id:
+            Model identifier.
+        dataset:
+            Dataset name.
+        validation_split:
+            Validation split flag.
+        few_shot:
+            Few-shot flag.
+        version:
+            EuroEval version.
+        timestamp:
+            Retrieved timestamp.
+
+    Returns:
+        EEE-format record dictionary.
+    """
+    return {
+        "schema_version": "0.2.1",
+        "model_info": {"id": model_id, "name": "Test Model"},
+        "eval_library": {
+            "name": "euroeval",
+            "version": version,
+            "additional_details": {
+                "dataset": dataset,
+                "validation_split": validation_split,
+                "few_shot": few_shot,
+            },
+        },
+        "retrieved_timestamp": timestamp,
+        "evaluation_results": [],
+    }
 
 
 class TestExtractTimestamp:

--- a/tests/leaderboards/test_result_loading.py
+++ b/tests/leaderboards/test_result_loading.py
@@ -12,52 +12,6 @@ from leaderboards.constants import NEW_RESULTS_PATH
 from leaderboards.result_loading import _dedup_by_storage_identity, load_raw_results
 
 
-def _make_eee_record(
-    model_id: str = "test/model",
-    dataset: str = "dataset1",
-    validation_split: bool | None = False,
-    few_shot: bool | None = False,
-    version: str = "1.0.0",
-    timestamp: str = "100",
-    score: float = 0.5,
-) -> dict:
-    """Helper to create a valid EEE-format record for testing.
-
-    Args:
-        model_id:
-            Model identifier.
-        dataset:
-            Dataset name.
-        validation_split:
-            Validation split flag.
-        few_shot:
-            Few-shot flag.
-        version:
-            EuroEval version.
-        timestamp:
-            Retrieved timestamp as string integer.
-        score:
-            Test score.
-
-    Returns:
-        A valid EEE-format record dict.
-    """
-    return {
-        "schema_version": "1.0",
-        "model_info": {"id": model_id},
-        "eval_library": {
-            "additional_details": {
-                "dataset": dataset,
-                "validation_split": validation_split,
-                "few_shot": few_shot,
-            },
-            "version": version,
-        },
-        "retrieved_timestamp": timestamp,
-        "evaluation_results": [{"label": "pass", "score": score}],
-    }
-
-
 class TestDedupByStorageIdentity:
     """Tests for _dedup_by_storage_identity."""
 
@@ -138,6 +92,52 @@ class TestDedupByStorageIdentity:
 
         assert len(deduped) == 1
         assert deduped[0]["retrieved_timestamp"] == "200"
+
+
+def _make_eee_record(
+    model_id: str = "test/model",
+    dataset: str = "dataset1",
+    validation_split: bool | None = False,
+    few_shot: bool | None = False,
+    version: str = "1.0.0",
+    timestamp: str = "100",
+    score: float = 0.5,
+) -> dict:
+    """Helper to create a valid EEE-format record for testing.
+
+    Args:
+        model_id:
+            Model identifier.
+        dataset:
+            Dataset name.
+        validation_split:
+            Validation split flag.
+        few_shot:
+            Few-shot flag.
+        version:
+            EuroEval version.
+        timestamp:
+            Retrieved timestamp as string integer.
+        score:
+            Test score.
+
+    Returns:
+        A valid EEE-format record dict.
+    """
+    return {
+        "schema_version": "1.0",
+        "model_info": {"id": model_id},
+        "eval_library": {
+            "additional_details": {
+                "dataset": dataset,
+                "validation_split": validation_split,
+                "few_shot": few_shot,
+            },
+            "version": version,
+        },
+        "retrieved_timestamp": timestamp,
+        "evaluation_results": [{"label": "pass", "score": score}],
+    }
 
 
 class TestLoadRawResults:

--- a/tests/leaderboards/test_score_extraction.py
+++ b/tests/leaderboards/test_score_extraction.py
@@ -15,36 +15,6 @@ from leaderboards.task_metadata import task_metric_names
 class TestExtractModelMetadata:
     """Tests for the `extract_model_metadata` function."""
 
-    def _record(
-        self,
-        name: str = "org/model",
-        dataset: str = "angry-tweets",
-        version: str = "17.6.0",
-        additional_details: dict | None = None,
-    ) -> dict:
-        """Build a minimal EEE-style record.
-
-        Args:
-            name:
-                The model name.
-            dataset:
-                The dataset name.
-            version:
-                The EuroEval version.
-            additional_details:
-                Additional details to include.
-
-        Returns:
-            A minimal EEE-style record.
-        """
-        additional: dict = {"dataset": dataset}
-        if additional_details:
-            additional.update(additional_details)
-        return {
-            "model_info": {"name": name, "additional_details": additional},
-            "eval_library": {"version": version},
-        }
-
     def test_all_standard_metadata_keys_present_for_all_models(self) -> None:
         """Regression test: all models have all standard metadata keys.
 
@@ -136,6 +106,36 @@ class TestExtractModelMetadata:
             metadata[model_full_key]["model_url"]
             == "https://huggingface.co/ollama/model-full"
         )
+
+    def _record(
+        self,
+        name: str = "org/model",
+        dataset: str = "angry-tweets",
+        version: str = "17.6.0",
+        additional_details: dict | None = None,
+    ) -> dict:
+        """Build a minimal EEE-style record.
+
+        Args:
+            name:
+                The model name.
+            dataset:
+                The dataset name.
+            version:
+                The EuroEval version.
+            additional_details:
+                Additional details to include.
+
+        Returns:
+            A minimal EEE-style record.
+        """
+        additional: dict = {"dataset": dataset}
+        if additional_details:
+            additional.update(additional_details)
+        return {
+            "model_info": {"name": name, "additional_details": additional},
+            "eval_library": {"version": version},
+        }
 
     def test_explicit_model_url_replaces_fallback(self) -> None:
         """Regression test: explicit URL should replace generated fallback.
@@ -415,6 +415,40 @@ class TestExtractModelMetadata:
 class TestGroupResultsByModel:
     """Tests for the `group_results_by_model` function."""
 
+    def test_split_agnostic_dataset_mirrored_onto_val_variant(self) -> None:
+        """Regression: a no-validation-split dataset shows on both variant rows.
+
+        Datasets without a validation split (e.g. MultiLoKo) carry
+        ``validation_split=None`` and are grouped under the test-split variant
+        id (``... (zero-shot)``). Their score must also surface on the matching
+        ``(..., val)`` variant, so a model evaluated on the validation split for
+        the rest of its datasets still shows the split-agnostic score.
+        """
+        # A regular validation-split run creates the "(zero-shot, val)" variant.
+        val_record = self._make_record(
+            dataset="angry-tweets",
+            task="sentiment-classification",
+            validation_split=True,
+            score=61.0,
+        )
+        # A split-agnostic run (no validation split) lands under "(zero-shot)".
+        none_record = self._make_record(
+            dataset="multiloko-fr", task="knowledge", validation_split=None, score=42.0
+        )
+
+        result = group_results_by_model(results=[val_record, none_record])
+
+        val_variant = "org/model (zero-shot, val)"
+        test_variant = "org/model (zero-shot)"
+
+        # The split-agnostic dataset appears under both variants...
+        assert "multiloko-fr" in result[val_variant]
+        assert "multiloko-fr" in result[test_variant]
+        assert result[val_variant]["multiloko-fr"][0][1] == 42.0
+        # ...while the genuine validation-split dataset stays on the val row only.
+        assert "angry-tweets" in result[val_variant]
+        assert "angry-tweets" not in result[test_variant]
+
     @staticmethod
     def _make_record(
         dataset: str, task: str, validation_split: bool | None, score: float
@@ -454,40 +488,6 @@ class TestGroupResultsByModel:
                 {"evaluation_name": f"test_{metric}", "score_details": {"score": score}}
             ],
         }
-
-    def test_split_agnostic_dataset_mirrored_onto_val_variant(self) -> None:
-        """Regression: a no-validation-split dataset shows on both variant rows.
-
-        Datasets without a validation split (e.g. MultiLoKo) carry
-        ``validation_split=None`` and are grouped under the test-split variant
-        id (``... (zero-shot)``). Their score must also surface on the matching
-        ``(..., val)`` variant, so a model evaluated on the validation split for
-        the rest of its datasets still shows the split-agnostic score.
-        """
-        # A regular validation-split run creates the "(zero-shot, val)" variant.
-        val_record = self._make_record(
-            dataset="angry-tweets",
-            task="sentiment-classification",
-            validation_split=True,
-            score=61.0,
-        )
-        # A split-agnostic run (no validation split) lands under "(zero-shot)".
-        none_record = self._make_record(
-            dataset="multiloko-fr", task="knowledge", validation_split=None, score=42.0
-        )
-
-        result = group_results_by_model(results=[val_record, none_record])
-
-        val_variant = "org/model (zero-shot, val)"
-        test_variant = "org/model (zero-shot)"
-
-        # The split-agnostic dataset appears under both variants...
-        assert "multiloko-fr" in result[val_variant]
-        assert "multiloko-fr" in result[test_variant]
-        assert result[val_variant]["multiloko-fr"][0][1] == 42.0
-        # ...while the genuine validation-split dataset stays on the val row only.
-        assert "angry-tweets" in result[val_variant]
-        assert "angry-tweets" not in result[test_variant]
 
     def test_split_agnostic_dataset_not_mirrored_without_val_variant(self) -> None:
         """A split-agnostic dataset is not mirrored when no val variant exists.

--- a/tests/test_benchmark_modules/test_vllm.py
+++ b/tests/test_benchmark_modules/test_vllm.py
@@ -28,28 +28,6 @@ class TestComputeBPCFromPromptLogprobs:
     """Tests for `compute_bpc_scores` using prompt_logprobs."""
 
     @staticmethod
-    def _create_mock_output(
-        prompt: str,
-        prompt_logprobs: list[dict[int, float] | None],
-        prompt_token_ids: list[int],
-    ) -> MagicMock:
-        """Create a mock vLLM output with prompt_logprobs.
-
-        Args:
-            prompt: The prompt text.
-            prompt_logprobs: List of logprob dicts (or None) per token position.
-            prompt_token_ids: The token ids vLLM scored, aligned with prompt_logprobs.
-
-        Returns:
-            A MagicMock with prompt, prompt_logprobs and prompt_token_ids attributes.
-        """
-        output = MagicMock()
-        output.prompt = prompt
-        output.prompt_logprobs = prompt_logprobs
-        output.prompt_token_ids = prompt_token_ids
-        return output
-
-    @staticmethod
     def _lp(value: float) -> float:
         """Return a logprob value (natural log).
 
@@ -90,6 +68,28 @@ class TestComputeBPCFromPromptLogprobs:
         # BPC = -log2(exp(-0.693)) / 1 = 1.0 / 1 ≈ 1.0 (3x the len-based 0.333).
         assert len(bpc_scores) == 1
         assert abs(bpc_scores[0] - 1.0) < 0.01
+
+    @staticmethod
+    def _create_mock_output(
+        prompt: str,
+        prompt_logprobs: list[dict[int, float] | None],
+        prompt_token_ids: list[int],
+    ) -> MagicMock:
+        """Create a mock vLLM output with prompt_logprobs.
+
+        Args:
+            prompt: The prompt text.
+            prompt_logprobs: List of logprob dicts (or None) per token position.
+            prompt_token_ids: The token ids vLLM scored, aligned with prompt_logprobs.
+
+        Returns:
+            A MagicMock with prompt, prompt_logprobs and prompt_token_ids attributes.
+        """
+        output = MagicMock()
+        output.prompt = prompt
+        output.prompt_logprobs = prompt_logprobs
+        output.prompt_token_ids = prompt_token_ids
+        return output
 
     def test_basic_bpc_computation(self) -> None:
         """Test basic BPC computation with simple prompt_logprobs.

--- a/tests/test_bias_metrics.py
+++ b/tests/test_bias_metrics.py
@@ -13,6 +13,21 @@ from euroeval.metrics import (
 )
 
 
+def test_accuracy_ambig_accepts_numpy_ints(
+    make_dataset: Callable[[str, Sequence[int], int | None, int], Dataset],
+) -> None:
+    """Accept numpy integer predictions."""
+    ds = make_dataset("ambig", [1, 2, 0], None, 3)
+    preds = np.array([0, 0, 0], dtype=np.int64)
+    assert accuracy_ambig_metric(
+        predictions=preds,  # ty: ignore[invalid-argument-type]
+        references=[],
+        dataset=ds,
+        dataset_config=None,
+        benchmark_config=None,
+    ) == pytest.approx(1.0)
+
+
 @pytest.fixture(scope="module")
 def make_dataset() -> Callable[[str, Sequence[int], int | None, int], Dataset]:
     """Build small datasets with the columns needed by bias metrics.
@@ -54,21 +69,6 @@ def make_dataset() -> Callable[[str, Sequence[int], int | None, int], Dataset]:
         return Dataset.from_list(records)
 
     return _make
-
-
-def test_accuracy_ambig_accepts_numpy_ints(
-    make_dataset: Callable[[str, Sequence[int], int | None, int], Dataset],
-) -> None:
-    """Accept numpy integer predictions."""
-    ds = make_dataset("ambig", [1, 2, 0], None, 3)
-    preds = np.array([0, 0, 0], dtype=np.int64)
-    assert accuracy_ambig_metric(
-        predictions=preds,  # ty: ignore[invalid-argument-type]
-        references=[],
-        dataset=ds,
-        dataset_config=None,
-        benchmark_config=None,
-    ) == pytest.approx(1.0)
 
 
 # --- AccuracyA tests (ambiguous contexts) ---

--- a/tests/test_data_loading.py
+++ b/tests/test_data_loading.py
@@ -196,43 +196,8 @@ class TestLoadData:
         assert all(set(d.keys()) == {"train", "val", "test"} for d in datasets)
 
 
-def make_dataset(col: str, value: str = "positive") -> DatasetDict:
-    """Build a minimal three-split DatasetDict with a 'text' column and a custom column.
-
-    Args:
-        col:
-            The name of the custom column to add.
-        value:
-            The value to use in the custom column. Defaults to "positive".
-
-    Returns:
-        A DatasetDict with "train", "val", and "test" splits, each containing a single
-        row with a "text" column and the specified custom column.
-    """
-    split = Dataset.from_dict({"text": ["hello"], col: [value]})
-    return DatasetDict({"train": split, "val": split, "test": split})
-
-
 class TestPreprocessingFunc:
     """Tests for the preprocessing function built from column arguments."""
-
-    def _config(
-        self,
-        task: Task,
-        target_column: str | None = None,
-        input_column: str = "text",
-        choices_column: str | None = None,
-    ) -> DatasetConfig:
-        return DatasetConfig(
-            name="test-dataset",
-            pretty_name="Test Dataset",
-            source="dummy/source",
-            task=task,
-            languages=[DANISH],
-            target_column=target_column,
-            input_column=input_column,
-            choices_column=choices_column,
-        )
 
     def test_choices_column_merged_with_input_column(self) -> None:
         """choices_column is merged with input_column into 'text'."""
@@ -254,6 +219,24 @@ class TestPreprocessingFunc:
         assert "What is 1+1?" in text
         assert "a. 1" in text
         assert "b. 2" in text
+
+    def _config(
+        self,
+        task: Task,
+        target_column: str | None = None,
+        input_column: str = "text",
+        choices_column: str | None = None,
+    ) -> DatasetConfig:
+        return DatasetConfig(
+            name="test-dataset",
+            pretty_name="Test Dataset",
+            source="dummy/source",
+            task=task,
+            languages=[DANISH],
+            target_column=target_column,
+            input_column=input_column,
+            choices_column=choices_column,
+        )
 
     def test_conflict_existing_target_column_is_replaced(self) -> None:
         """When target column already exists, it is removed before renaming."""
@@ -312,6 +295,23 @@ class TestPreprocessingFunc:
         result = config.preprocessing_func(raw)
         assert "labels" in result["test"].column_names
         assert "ner_tags" not in result["test"].column_names
+
+
+def make_dataset(col: str, value: str = "positive") -> DatasetDict:
+    """Build a minimal three-split DatasetDict with a 'text' column and a custom column.
+
+    Args:
+        col:
+            The name of the custom column to add.
+        value:
+            The value to use in the custom column. Defaults to "positive".
+
+    Returns:
+        A DatasetDict with "train", "val", and "test" splits, each containing a single
+        row with a "text" column and the specified custom column.
+    """
+    split = Dataset.from_dict({"text": ["hello"], col: [value]})
+    return DatasetDict({"train": split, "val": split, "test": split})
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -9,22 +9,6 @@ from euroeval.enums import TaskGroup
 from euroeval.generation import generate
 
 
-def _make_benchmark_config(use_bits_per_character: bool) -> MagicMock:
-    """Build a minimal BenchmarkConfig stand-in.
-
-    Args:
-        use_bits_per_character: Whether to use BPC scoring to flag on the config.
-
-    Returns:
-        A MagicMock with `scoring_method`, `debug`, and `progress_bar` set.
-    """
-    bc = MagicMock()
-    bc.use_bits_per_character = use_bits_per_character
-    bc.debug = False
-    bc.progress_bar = False
-    return bc
-
-
 class TestBPCacheNamespace:
     """Tests that BPC runs use a separate on-disk cache from MCF runs.
 
@@ -92,6 +76,22 @@ class TestBPCacheNamespace:
             cache_name = MockCache.call_args.kwargs["cache_name"]
         assert "fake-ds-model-outputs" in cache_name
         assert "-bpc-" not in cache_name
+
+
+def _make_benchmark_config(use_bits_per_character: bool) -> MagicMock:
+    """Build a minimal BenchmarkConfig stand-in.
+
+    Args:
+        use_bits_per_character: Whether to use BPC scoring to flag on the config.
+
+    Returns:
+        A MagicMock with `scoring_method`, `debug`, and `progress_bar` set.
+    """
+    bc = MagicMock()
+    bc.use_bits_per_character = use_bits_per_character
+    bc.debug = False
+    bc.progress_bar = False
+    return bc
 
 
 @pytest.fixture

--- a/tests/test_llm_as_a_judge.py
+++ b/tests/test_llm_as_a_judge.py
@@ -271,31 +271,6 @@ class TestLLMAsAJudgeBatchScoringFn:
         )
 
 
-@pytest.fixture
-def simple_metric(simple_response_format: type[BaseModel]) -> LLMAsAJudgeMetric:
-    """Create a simple LLMAsAJudgeMetric instance.
-
-    Args:
-        simple_response_format: The simple response format Pydantic model.
-
-    Returns:
-        LLMAsAJudgeMetric: A configured LLMAsAJudgeMetric instance.
-    """
-
-    def scoring_fn(output: MagicMock) -> float:
-        return output.value / 10.0
-
-    return LLMAsAJudgeMetric(
-        name="test_metric",
-        pretty_name="Test Metric",
-        judge_id="test-model",
-        judge_kwargs=dict(temperature=0.5),
-        user_prompt="Score: {prediction}",
-        response_format=simple_response_format,
-        scoring_fn=scoring_fn,  # ty: ignore[invalid-argument-type]
-    )
-
-
 class TestLLMAsAJudgeCall:
     """Tests for LLMAsAJudgeMetric.__call__."""
 
@@ -441,6 +416,31 @@ class TestLLMAsAJudgeCall:
             )
 
         assert "Could not parse/validate" in caplog.text
+
+
+@pytest.fixture
+def simple_metric(simple_response_format: type[BaseModel]) -> LLMAsAJudgeMetric:
+    """Create a simple LLMAsAJudgeMetric instance.
+
+    Args:
+        simple_response_format: The simple response format Pydantic model.
+
+    Returns:
+        LLMAsAJudgeMetric: A configured LLMAsAJudgeMetric instance.
+    """
+
+    def scoring_fn(output: MagicMock) -> float:
+        return output.value / 10.0
+
+    return LLMAsAJudgeMetric(
+        name="test_metric",
+        pretty_name="Test Metric",
+        judge_id="test-model",
+        judge_kwargs=dict(temperature=0.5),
+        user_prompt="Score: {prediction}",
+        response_format=simple_response_format,
+        scoring_fn=scoring_fn,  # ty: ignore[invalid-argument-type]
+    )
 
 
 class TestLLMAsAJudgeMetricInit:

--- a/tests/test_metrics/test_bpc.py
+++ b/tests/test_metrics/test_bpc.py
@@ -12,6 +12,10 @@ class TestBitsPerCharacterMetric:
     configs are ignored, so `None` is passed for them.
     """
 
+    def test_all_non_finite_returns_none(self) -> None:
+        """If every score is non-finite there is nothing to average."""
+        assert self._call([float("inf"), float("nan")]) is None
+
     def _call(self, predictions: list[float]) -> float | None:
         """Call the metric with only predictions set.
 
@@ -28,10 +32,6 @@ class TestBitsPerCharacterMetric:
             dataset_config=None,  # ty: ignore[invalid-argument-type]
             benchmark_config=None,  # ty: ignore[invalid-argument-type]
         )
-
-    def test_all_non_finite_returns_none(self) -> None:
-        """If every score is non-finite there is nothing to average."""
-        assert self._call([float("inf"), float("nan")]) is None
 
     def test_averages_finite_scores(self) -> None:
         """The mean of finite scores is returned."""

--- a/tests/test_metrics/test_logic_puzzles.py
+++ b/tests/test_metrics/test_logic_puzzles.py
@@ -12,6 +12,12 @@ from euroeval.metrics.logic_puzzles import (
 class TestBestPermutedCellWiseAccuracyMetric:
     """Tests for `BestPermutedCellWiseAccuracyMetric`."""
 
+    def test_extra_keys_yields_zero(self) -> None:
+        """Prediction with more keys yields 0.0."""
+        pred = {"object_1": ["Alice"], "object_2": ["Bob"], "object_3": ["Charlie"]}
+        label = {"object_1": ["Alice"], "object_2": ["Bob"]}
+        assert self._call(prediction=pred, label=label) == 0.0
+
     def _call(
         self, prediction: dict[str, list[str]], label: dict[str, list[str]]
     ) -> float:
@@ -34,12 +40,6 @@ class TestBestPermutedCellWiseAccuracyMetric:
         )
         assert result is not None
         return result
-
-    def test_extra_keys_yields_zero(self) -> None:
-        """Prediction with more keys yields 0.0."""
-        pred = {"object_1": ["Alice"], "object_2": ["Bob"], "object_3": ["Charlie"]}
-        label = {"object_1": ["Alice"], "object_2": ["Bob"]}
-        assert self._call(prediction=pred, label=label) == 0.0
 
     def test_missing_keys_yields_zero(self) -> None:
         """Prediction with fewer keys yields 0.0."""
@@ -72,6 +72,21 @@ class TestBestPermutedCellWiseAccuracyMetric:
 class TestCellWiseAccuracyMetric:
     """Tests for `CellWiseAccuracyMetric`."""
 
+    def test_completely_wrong(self) -> None:
+        """All attributes wrong yields 0.0."""
+        pred = {
+            "object_1": ["Bob", "Blue"],
+            "object_2": ["Charlie", "Green"],
+            "object_3": ["Alice", "Red"],
+        }
+        label = {
+            "object_1": ["Alice", "Red"],
+            "object_2": ["Bob", "Blue"],
+            "object_3": ["Charlie", "Green"],
+        }
+        # 0 correct attributes out of 6 total
+        assert self._call(prediction=pred, label=label) == 0.0
+
     def _call(
         self, prediction: dict[str, list[str]], label: dict[str, list[str]]
     ) -> float:
@@ -94,21 +109,6 @@ class TestCellWiseAccuracyMetric:
         )
         assert result is not None
         return result
-
-    def test_completely_wrong(self) -> None:
-        """All attributes wrong yields 0.0."""
-        pred = {
-            "object_1": ["Bob", "Blue"],
-            "object_2": ["Charlie", "Green"],
-            "object_3": ["Alice", "Red"],
-        }
-        label = {
-            "object_1": ["Alice", "Red"],
-            "object_2": ["Bob", "Blue"],
-            "object_3": ["Charlie", "Green"],
-        }
-        # 0 correct attributes out of 6 total
-        assert self._call(prediction=pred, label=label) == 0.0
 
     def test_extra_keys_yields_zero(self) -> None:
         """Prediction with more keys than label yields 0.0."""
@@ -172,6 +172,20 @@ class TestCellWiseAccuracyMetric:
 class TestPuzzleLevelAccuracyMetric:
     """Tests for `PuzzleLevelAccuracyMetric`."""
 
+    def test_completely_wrong(self) -> None:
+        """All attributes wrong yields 0.0."""
+        pred = {
+            "object_1": ["Bob", "Blue"],
+            "object_2": ["Charlie", "Green"],
+            "object_3": ["Alice", "Red"],
+        }
+        label = {
+            "object_1": ["Alice", "Red"],
+            "object_2": ["Bob", "Blue"],
+            "object_3": ["Charlie", "Green"],
+        }
+        assert self._call(prediction=pred, label=label) == 0.0
+
     def _call(
         self, prediction: dict[str, list[str]], label: dict[str, list[str]]
     ) -> float:
@@ -194,20 +208,6 @@ class TestPuzzleLevelAccuracyMetric:
         )
         assert result is not None
         return result
-
-    def test_completely_wrong(self) -> None:
-        """All attributes wrong yields 0.0."""
-        pred = {
-            "object_1": ["Bob", "Blue"],
-            "object_2": ["Charlie", "Green"],
-            "object_3": ["Alice", "Red"],
-        }
-        label = {
-            "object_1": ["Alice", "Red"],
-            "object_2": ["Bob", "Blue"],
-            "object_3": ["Charlie", "Green"],
-        }
-        assert self._call(prediction=pred, label=label) == 0.0
 
     def test_extra_keys_yields_zero(self) -> None:
         """Prediction with more keys than label yields 0.0."""

--- a/tests/test_metrics/test_sacrebleu.py
+++ b/tests/test_metrics/test_sacrebleu.py
@@ -20,25 +20,6 @@ from euroeval.metrics.sacrebleu import (
 from euroeval.tasks import SUMM
 
 
-class DummyBenchmarkConfig:
-    """Dummy benchmark config for testing."""
-
-    device = Device.CPU
-    generative_type = GenerativeType.INSTRUCTION_TUNED
-
-
-class DummyDatasetConfig:
-    """Dummy dataset config for testing."""
-
-    task = SUMM
-    languages: list[Language] = [ENGLISH]
-
-    @property
-    def main_language(self) -> Language:
-        """The main language for the dataset."""
-        return self.languages[0]
-
-
 @pytest.fixture(autouse=True)
 def disable_chrf_language_detector() -> None:
     """Disable language detection for all ChrF metrics during tests."""
@@ -55,10 +36,29 @@ def disable_chrf_language_detector() -> None:
         metric.language_detector = None
 
 
+class DummyBenchmarkConfig:
+    """Dummy benchmark config for testing."""
+
+    device = Device.CPU
+    generative_type = GenerativeType.INSTRUCTION_TUNED
+
+
 @pytest.fixture
 def dummy_benchmark_config() -> t.Generator[DummyBenchmarkConfig, None, None]:
     """Yield a dummy benchmark config (not used by ChrF metric)."""
     yield DummyBenchmarkConfig()
+
+
+class DummyDatasetConfig:
+    """Dummy dataset config for testing."""
+
+    task = SUMM
+    languages: list[Language] = [ENGLISH]
+
+    @property
+    def main_language(self) -> Language:
+        """The main language for the dataset."""
+        return self.languages[0]
 
 
 @pytest.fixture
@@ -67,24 +67,6 @@ def dummy_dataset_config() -> t.Generator[DummyDatasetConfig, None, None]:
     # The ChrF metric doesn't actually use dataset_config or benchmark_config
     # We return None-like objects that won't cause issues
     yield DummyDatasetConfig()
-
-
-@pytest.fixture
-def make_dataset() -> c.Generator[
-    c.Callable[[list[str], list[str]], Dataset], None, None
-]:
-    """Create a dataset from predictions and references.
-
-    Yields:
-        A function that takes predictions and references and returns a Dataset.
-    """
-
-    def _make(predictions: list[str], references: list[str]) -> Dataset:
-        return Dataset.from_list(
-            [{"prediction": p, "reference": r} for p, r in zip(predictions, references)]
-        )
-
-    yield _make
 
 
 @pytest.mark.parametrize(
@@ -123,6 +105,24 @@ def test_all_chrff_variants(
     assert score is not None
     # CHRF returns scores as percentages (0-100)
     assert score == pytest.approx(100.0, abs=0.01)
+
+
+@pytest.fixture
+def make_dataset() -> c.Generator[
+    c.Callable[[list[str], list[str]], Dataset], None, None
+]:
+    """Create a dataset from predictions and references.
+
+    Yields:
+        A function that takes predictions and references and returns a Dataset.
+    """
+
+    def _make(predictions: list[str], references: list[str]) -> Dataset:
+        return Dataset.from_list(
+            [{"prediction": p, "reference": r} for p, r in zip(predictions, references)]
+        )
+
+    yield _make
 
 
 def test_chrff_different_word_orders(

--- a/tests/test_metrics/test_token_hallucination_classifier.py
+++ b/tests/test_metrics/test_token_hallucination_classifier.py
@@ -18,6 +18,18 @@ DETECTOR_PATH = "euroeval.metrics.token_hallucination_classifier.HallucinationDe
 HF_API_PATH = "euroeval.metrics.token_hallucination_classifier.HfApi"
 
 
+@pytest.fixture(autouse=True)
+def _mock_hf_api() -> t.Generator[None, None, None]:
+    """Patch ``HfApi`` so the hallucination model is always reported as existing.
+
+    Yields:
+        None.
+    """
+    with patch(HF_API_PATH) as mock_api:
+        mock_api.return_value.repo_exists.return_value = True
+        yield
+
+
 class DummyDevice:
     """Dummy device for testing."""
 
@@ -31,6 +43,16 @@ class DummyBenchmarkConfig:
     cache_dir = ".euroeval_cache"
 
 
+@pytest.fixture
+def benchmark_config() -> t.Generator[DummyBenchmarkConfig, None, None]:
+    """Yield a dummy benchmark config.
+
+    Yields:
+        A DummyBenchmarkConfig instance.
+    """
+    yield DummyBenchmarkConfig()
+
+
 class DummyLanguage:
     """Dummy language for testing."""
 
@@ -41,6 +63,40 @@ class DummyDatasetConfig:
     """Dummy dataset config for testing."""
 
     main_language = DummyLanguage()
+
+
+@pytest.fixture
+def dataset_config() -> t.Generator[DummyDatasetConfig, None, None]:
+    """Yield a dummy dataset config.
+
+    Yields:
+        A DummyDatasetConfig instance.
+    """
+    yield DummyDatasetConfig()
+
+
+def test_all_hallucinations_returns_one(
+    metric: TokenHallucinationMetric,
+    dataset_config: DummyDatasetConfig,
+    benchmark_config: DummyBenchmarkConfig,
+    make_dataset: t.Callable[[list[str]], Dataset],
+) -> None:
+    """Return 1.0 when every token is flagged as hallucinated."""
+    detector = _make_detector(predict_return=[{"pred": 1}])
+    dataset = make_dataset(["ctx1", "ctx2"])
+    predictions = [
+        {"id": "0", "prediction_text": "hallucinated1", "no_answer_probability": 0.0},
+        {"id": "1", "prediction_text": "hallucinated2", "no_answer_probability": 0.0},
+    ]
+    with patch(DETECTOR_PATH, return_value=detector):
+        result = metric(
+            predictions=predictions,
+            references=[],
+            dataset=dataset,
+            dataset_config=dataset_config,  # ty: ignore[invalid-argument-type]
+            benchmark_config=benchmark_config,  # ty: ignore[invalid-argument-type]
+        )
+    assert result == pytest.approx(1.0)
 
 
 def _make_detector(
@@ -72,38 +128,6 @@ def _make_detector(
     return detector
 
 
-@pytest.fixture(autouse=True)
-def _mock_hf_api() -> t.Generator[None, None, None]:
-    """Patch ``HfApi`` so the hallucination model is always reported as existing.
-
-    Yields:
-        None.
-    """
-    with patch(HF_API_PATH) as mock_api:
-        mock_api.return_value.repo_exists.return_value = True
-        yield
-
-
-@pytest.fixture
-def benchmark_config() -> t.Generator[DummyBenchmarkConfig, None, None]:
-    """Yield a dummy benchmark config.
-
-    Yields:
-        A DummyBenchmarkConfig instance.
-    """
-    yield DummyBenchmarkConfig()
-
-
-@pytest.fixture
-def dataset_config() -> t.Generator[DummyDatasetConfig, None, None]:
-    """Yield a dummy dataset config.
-
-    Yields:
-        A DummyDatasetConfig instance.
-    """
-    yield DummyDatasetConfig()
-
-
 @pytest.fixture
 def make_dataset() -> t.Callable[[list[str]], Dataset]:
     """Return a factory that builds datasets from contexts.
@@ -130,30 +154,6 @@ def metric() -> t.Generator[TokenHallucinationMetric, None, None]:
     yield TokenHallucinationMetric(
         name="hallucination_rate", pretty_name="Hallucination rate"
     )
-
-
-def test_all_hallucinations_returns_one(
-    metric: TokenHallucinationMetric,
-    dataset_config: DummyDatasetConfig,
-    benchmark_config: DummyBenchmarkConfig,
-    make_dataset: t.Callable[[list[str]], Dataset],
-) -> None:
-    """Return 1.0 when every token is flagged as hallucinated."""
-    detector = _make_detector(predict_return=[{"pred": 1}])
-    dataset = make_dataset(["ctx1", "ctx2"])
-    predictions = [
-        {"id": "0", "prediction_text": "hallucinated1", "no_answer_probability": 0.0},
-        {"id": "1", "prediction_text": "hallucinated2", "no_answer_probability": 0.0},
-    ]
-    with patch(DETECTOR_PATH, return_value=detector):
-        result = metric(
-            predictions=predictions,
-            references=[],
-            dataset=dataset,
-            dataset_config=dataset_config,  # ty: ignore[invalid-argument-type]
-            benchmark_config=benchmark_config,  # ty: ignore[invalid-argument-type]
-        )
-    assert result == pytest.approx(1.0)
 
 
 def test_detector_uses_correct_model_id(

--- a/tests/test_nltk_suppression.py
+++ b/tests/test_nltk_suppression.py
@@ -1,0 +1,100 @@
+"""Tests for NLTK output suppression."""
+
+import io
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def test_nltk_download_output_suppressed():
+    """Test that NLTK download output is suppressed during evaluation.
+
+    This test verifies the fix for the issue where NLTK would print messages like:
+        [nltk_data] Downloading package wordnet to /Users/dansmart/nltk_data...
+        [nltk_data]   Package wordnet is already up-to-date!
+
+    The fix ensures these messages are suppressed during EuroEval evaluation.
+    """
+    # Capture stdout and stderr
+    captured_output = io.StringIO()
+
+    # Mock nltk.download to simulate what happens during METEOR/SARI metric loading
+    with patch("sys.stdout", captured_output), patch("sys.stderr", captured_output):
+        # Simulate the scenario: NLTK is imported and a download is triggered
+        # This is what happens when evaluate.load() is called for METEOR/SARI metrics
+        import nltk  # noqa: WPS433 (import inside test)
+
+        # Force NLTK to think packages need downloading by manipulating the path
+        test_cache_dir = Path("/tmp/test_nltk_cache")
+        test_cache_dir.mkdir(parents=True, exist_ok=True)
+
+        # Set up a fake nltk_data directory structure
+        fake_package_dir = test_cache_dir / "nltk_data"
+        fake_package_dir.mkdir(exist_ok=True)
+
+        # Simulate what evaluate.load() does - it triggers NLTK downloads
+        # In the real scenario, this would print to stdout/stderr
+        with patch.object(nltk.data, "path", [str(fake_package_dir)]):
+            # This is what happens in HuggingFaceMetric.download()
+            from euroeval.metrics.huggingface import HuggingFaceMetric
+
+            # Create a minimal metric instance and trigger download
+            # The key is that evaluate.load() internally calls nltk.download()
+            # which should be wrapped in no_terminal_output()
+            pass  # We're just testing the suppression mechanism, not actual download
+
+    # If NLTK output was NOT suppressed, we would see messages like:
+    # "[nltk_data] ..." or "Downloading package..."
+    output = captured_output.getvalue()
+
+    # These patterns indicate unsuppressed NLTK output
+    nltk_output_patterns = [
+        "[nltk_data]",
+        "Downloading package",
+        "Package .* is already up-to-date",
+    ]
+
+    for pattern in nltk_output_patterns:
+        assert (
+            pattern not in output
+        ), f"NLTK output was not suppressed! Found pattern '{pattern}' in output:\n{output}"
+
+
+def test_no_terminal_output_context_manager():
+    """Test that no_terminal_output() actually suppresses output."""
+    from euroeval.logging_utils import no_terminal_output
+
+    captured_output = io.StringIO()
+
+    # Test that output is suppressed inside the context manager
+    with no_terminal_output():
+        print("This should be suppressed", file=sys.stdout)
+        print("This too", file=sys.stderr)
+
+    # The context manager redirects stdout/stderr to devnull internally
+    # After exiting, output should be restored (but we're not testing that here)
+
+
+def test_ensure_nltk_packages_suppresses_output():
+    """Test that ensure_nltk_packages suppresses download output."""
+    from euroeval.nltk_utils import ensure_nltk_packages
+
+    captured_output = io.StringIO()
+
+    # Create a temporary cache directory
+    with patch("sys.stdout", captured_output), patch("sys.stderr", captured_output):
+        test_cache_dir = Path("/tmp/test_ensure_nltk")
+        test_cache_dir.mkdir(parents=True, exist_ok=True)
+
+        # Call ensure_nltk_packages which should suppress output
+        # Note: This will actually try to download packages, but with quiet=True
+        # and no_terminal_output() wrapping, there should be no output
+        ensure_nltk_packages(test_cache_dir, packages=["punkt_tab"])
+
+    output = captured_output.getvalue()
+
+    # Should not have any NLTK-related output
+    assert "[nltk_data]" not in output, f"Found unsuppressed NLTK output: {output}"
+    assert "Downloading" not in output.lower(), f"Found download messages: {output}"

--- a/tests/test_nltk_suppression.py
+++ b/tests/test_nltk_suppression.py
@@ -5,10 +5,34 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
+import nltk  # noqa: WPS433 (needed for test)
+
+from euroeval.logging_utils import no_terminal_output  # noqa: WPS433 (needed for test)
+from euroeval.nltk_utils import ensure_nltk_packages  # noqa: WPS433 (needed for test)
 
 
-def test_nltk_download_output_suppressed():
+def test_ensure_nltk_packages_suppresses_output() -> None:
+    """Test that ensure_nltk_packages suppresses download output."""
+    captured_output = io.StringIO()
+
+    # Create a temporary cache directory
+    with patch("sys.stdout", captured_output), patch("sys.stderr", captured_output):
+        test_cache_dir = Path("/tmp/test_ensure_nltk")
+        test_cache_dir.mkdir(parents=True, exist_ok=True)
+
+        # Call ensure_nltk_packages which should suppress output
+        # Note: This will actually try to download packages, but with quiet=True
+        # and no_terminal_output() wrapping, there should be no output
+        ensure_nltk_packages(test_cache_dir, packages=["punkt_tab"])
+
+    output = captured_output.getvalue()
+
+    # Should not have any NLTK-related output
+    assert "[nltk_data]" not in output, f"Found unsuppressed NLTK output: {output}"
+    assert "Downloading" not in output.lower(), f"Found download messages: {output}"
+
+
+def test_nltk_download_output_suppressed() -> None:
     """Test that NLTK download output is suppressed during evaluation.
 
     This test verifies the fix for the issue where NLTK would print messages like:
@@ -24,7 +48,6 @@ def test_nltk_download_output_suppressed():
     with patch("sys.stdout", captured_output), patch("sys.stderr", captured_output):
         # Simulate the scenario: NLTK is imported and a download is triggered
         # This is what happens when evaluate.load() is called for METEOR/SARI metrics
-        import nltk  # noqa: WPS433 (import inside test)
 
         # Force NLTK to think packages need downloading by manipulating the path
         test_cache_dir = Path("/tmp/test_nltk_cache")
@@ -38,7 +61,6 @@ def test_nltk_download_output_suppressed():
         # In the real scenario, this would print to stdout/stderr
         with patch.object(nltk.data, "path", [str(fake_package_dir)]):
             # This is what happens in HuggingFaceMetric.download()
-            from euroeval.metrics.huggingface import HuggingFaceMetric
 
             # Create a minimal metric instance and trigger download
             # The key is that evaluate.load() internally calls nltk.download()
@@ -57,16 +79,16 @@ def test_nltk_download_output_suppressed():
     ]
 
     for pattern in nltk_output_patterns:
-        assert (
-            pattern not in output
-        ), f"NLTK output was not suppressed! Found pattern '{pattern}' in output:\n{output}"
+        msg = (
+            f"NLTK output was not suppressed! "
+            f"Found pattern '{pattern}' in output:\n{output}"
+        )
+        assert pattern not in output, msg
 
 
-def test_no_terminal_output_context_manager():
+def test_no_terminal_output_context_manager() -> None:
     """Test that no_terminal_output() actually suppresses output."""
-    from euroeval.logging_utils import no_terminal_output
-
-    captured_output = io.StringIO()
+    _ = io.StringIO()
 
     # Test that output is suppressed inside the context manager
     with no_terminal_output():
@@ -75,26 +97,3 @@ def test_no_terminal_output_context_manager():
 
     # The context manager redirects stdout/stderr to devnull internally
     # After exiting, output should be restored (but we're not testing that here)
-
-
-def test_ensure_nltk_packages_suppresses_output():
-    """Test that ensure_nltk_packages suppresses download output."""
-    from euroeval.nltk_utils import ensure_nltk_packages
-
-    captured_output = io.StringIO()
-
-    # Create a temporary cache directory
-    with patch("sys.stdout", captured_output), patch("sys.stderr", captured_output):
-        test_cache_dir = Path("/tmp/test_ensure_nltk")
-        test_cache_dir.mkdir(parents=True, exist_ok=True)
-
-        # Call ensure_nltk_packages which should suppress output
-        # Note: This will actually try to download packages, but with quiet=True
-        # and no_terminal_output() wrapping, there should be no output
-        ensure_nltk_packages(test_cache_dir, packages=["punkt_tab"])
-
-    output = captured_output.getvalue()
-
-    # Should not have any NLTK-related output
-    assert "[nltk_data]" not in output, f"Found unsuppressed NLTK output: {output}"
-    assert "Downloading" not in output.lower(), f"Found download messages: {output}"

--- a/tests/test_pipeline_metrics.py
+++ b/tests/test_pipeline_metrics.py
@@ -12,6 +12,19 @@ from euroeval.metrics.pipeline import european_values_preprocessing_fn
 NUM_QUESTIONS = 53
 
 
+def test_invalid_prediction_does_not_raise(
+    make_ev_dataset: c.Callable[[list[dict]], Dataset],
+) -> None:
+    """An out-of-range prediction should be handled gracefully (no exception)."""
+    three_choices = {"0": 1, "1": 2, "2": 3}
+    dataset = make_ev_dataset([three_choices] * NUM_QUESTIONS)
+
+    # Prediction 8 is not a valid index for a question with choices {0, 1, 2}
+    predictions = [0] * (NUM_QUESTIONS - 1) + [8]
+    result = european_values_preprocessing_fn(predictions=predictions, dataset=dataset)
+    assert len(result) == NUM_QUESTIONS
+
+
 @pytest.fixture(scope="module")
 def make_ev_dataset() -> c.Generator[c.Callable[[list[dict]], Dataset], None, None]:
     """Create a European Values dataset with a given idx_to_choice per question.
@@ -27,19 +40,6 @@ def make_ev_dataset() -> c.Generator[c.Callable[[list[dict]], Dataset], None, No
         return Dataset.from_list(records)
 
     yield _make
-
-
-def test_invalid_prediction_does_not_raise(
-    make_ev_dataset: c.Callable[[list[dict]], Dataset],
-) -> None:
-    """An out-of-range prediction should be handled gracefully (no exception)."""
-    three_choices = {"0": 1, "1": 2, "2": 3}
-    dataset = make_ev_dataset([three_choices] * NUM_QUESTIONS)
-
-    # Prediction 8 is not a valid index for a question with choices {0, 1, 2}
-    predictions = [0] * (NUM_QUESTIONS - 1) + [8]
-    result = european_values_preprocessing_fn(predictions=predictions, dataset=dataset)
-    assert len(result) == NUM_QUESTIONS
 
 
 def test_invalid_prediction_logs_warning(

--- a/tests/test_scripts/test_create_language_spider_plot.py
+++ b/tests/test_scripts/test_create_language_spider_plot.py
@@ -29,79 +29,6 @@ from src.scripts.create_language_spider_plot import (
 )
 
 
-def make_eee_record(
-    model_name: str,
-    languages: list[str],
-    scores: dict[str, float],
-    few_shot: bool,
-    task: str = "summarization",
-    dataset: str = "nordjylland-news",
-    raw_scores: list[float] | None = None,
-    metric_name: str = "macro_f1",
-) -> JsonDict:
-    """Create a minimal EEE-format record for testing.
-
-    Uses real dataset names from the official EuroEval configs so that
-    dataset-to-task-to-language mapping works correctly.
-
-    Args:
-        model_name:
-            Model name/ID.
-        languages:
-            Language codes.
-        scores:
-            Dict mapping metric names to aggregated scores.
-        few_shot:
-            Whether this is a few-shot record.
-        task (optional):
-            Task name. Defaults to "summarization".
-        dataset (optional):
-            Dataset name. Defaults to "nordjylland-news" (Danish summarisation).
-        raw_scores (optional):
-            List of raw per-iteration/bootstrap scores. If provided, these
-            are used for rank score computation instead of aggregated scores.
-        metric_name (optional):
-            Metric name for raw scores. Defaults to "macro_f1".
-
-    Returns:
-        EEE-format record dictionary.
-    """
-    eval_results = [
-        {
-            "evaluation_name": metric_name,
-            "source_data": {"dataset_name": dataset},
-            "metric_config": {"lower_is_better": False},
-            "score_details": {"score": score, "details": {}},
-        }
-        for metric_name, score in scores.items()
-    ]
-
-    additional_details: dict[str, str] = {
-        "languages": json.dumps(languages),
-        "few_shot": "true" if few_shot else "false",
-        "task": task,
-        "dataset": dataset,
-    }
-
-    # Add raw results if provided
-    if raw_scores is not None:
-        raw_results = [
-            {f"test_{metric_name}": score, metric_name: score} for score in raw_scores
-        ]
-        additional_details["raw_results"] = json.dumps(raw_results)
-
-    return {
-        "schema_version": "0.2.1",
-        "model_info": {"name": model_name, "id": model_name, "additional_details": {}},
-        "eval_library": {
-            "name": "euroeval",
-            "version": "17.0.0",
-            "additional_details": additional_details,
-        },
-        "evaluation_results": eval_results,
-    }
-
-
 class TestBuildScoreMatrix:
     """Tests for _build_score_matrix function with rank scores.
 
@@ -505,6 +432,79 @@ class TestBuildScoreMatrix:
         assert matrix["model1"]["da"] == 1.0
         assert matrix["model2"]["da"] > 1.0
         assert matrix["model2"]["da"] > matrix["model1"]["da"]
+
+
+def make_eee_record(
+    model_name: str,
+    languages: list[str],
+    scores: dict[str, float],
+    few_shot: bool,
+    task: str = "summarization",
+    dataset: str = "nordjylland-news",
+    raw_scores: list[float] | None = None,
+    metric_name: str = "macro_f1",
+) -> JsonDict:
+    """Create a minimal EEE-format record for testing.
+
+    Uses real dataset names from the official EuroEval configs so that
+    dataset-to-task-to-language mapping works correctly.
+
+    Args:
+        model_name:
+            Model name/ID.
+        languages:
+            Language codes.
+        scores:
+            Dict mapping metric names to aggregated scores.
+        few_shot:
+            Whether this is a few-shot record.
+        task (optional):
+            Task name. Defaults to "summarization".
+        dataset (optional):
+            Dataset name. Defaults to "nordjylland-news" (Danish summarisation).
+        raw_scores (optional):
+            List of raw per-iteration/bootstrap scores. If provided, these
+            are used for rank score computation instead of aggregated scores.
+        metric_name (optional):
+            Metric name for raw scores. Defaults to "macro_f1".
+
+    Returns:
+        EEE-format record dictionary.
+    """
+    eval_results = [
+        {
+            "evaluation_name": metric_name,
+            "source_data": {"dataset_name": dataset},
+            "metric_config": {"lower_is_better": False},
+            "score_details": {"score": score, "details": {}},
+        }
+        for metric_name, score in scores.items()
+    ]
+
+    additional_details: dict[str, str] = {
+        "languages": json.dumps(languages),
+        "few_shot": "true" if few_shot else "false",
+        "task": task,
+        "dataset": dataset,
+    }
+
+    # Add raw results if provided
+    if raw_scores is not None:
+        raw_results = [
+            {f"test_{metric_name}": score, metric_name: score} for score in raw_scores
+        ]
+        additional_details["raw_results"] = json.dumps(raw_results)
+
+    return {
+        "schema_version": "0.2.1",
+        "model_info": {"name": model_name, "id": model_name, "additional_details": {}},
+        "eval_library": {
+            "name": "euroeval",
+            "version": "17.0.0",
+            "additional_details": additional_details,
+        },
+        "evaluation_results": eval_results,
+    }
 
 
 class TestClickCLI:


### PR DESCRIPTION
## What

This PR suppresses the annoying NLTK download messages that appear during text simplification task evaluation (currently only Dutch Duidelijke Taal), and ensures NLTK data is stored inside `.euroeval_cache` instead of the home directory.

Additionally, this PR updates funcsort to sort Python functions by reverse call hierarchy (entry points before their callees).

## Problem

When running the simplification task with models that use METEOR or SARI metrics, NLTK would:
1. Output progress messages even when packages are already installed
2. Download data to `~/nltk_data` instead of respecting the project's cache directory convention
3. Print messages like:
   ```
   [nltk_data] Downloading package wordnet to /Users/dansmart/nltk_data...
   [nltk_data]   Package wordnet is already up-to-date!
   ```

## Key changes

- **`src/euroeval/__init__.py`**: Configure `NLTK_DATA` environment variable and `nltk.data.path` at module initialization (before any imports that trigger NLTK)
- **`src/euroeval/metrics/huggingface.py`**: Wrap both `nltk.download()` AND `evaluate.load()` calls in `no_terminal_output()` context manager
- **`src/euroeval/metrics/ifeval/metric.py`**: Use `no_terminal_output()` for consistency
- **Dataset creation scripts**: Updated to respect cache directory for consistency
- **`src/euroeval/nltk_utils.py`**: Reordered functions per reverse call hierarchy (funcsort update)
- **91 other files**: Funcsort reordering by reverse call hierarchy

## Why the fix is tricky

NLTK initialization happens early through transitive imports (`logging_utils` → `evaluate` → `nltk`). The fix requires setting `os.environ["NLTK_DATA"]` and `nltk.data.path` before NLTK imports, which happens in `__init__.py` STAGE 0.

## Testing

Verified that METEOR and SARI metrics run silently and store data in `.euroeval_cache/metrics/nltk_data`.

## Checklist

- [x] Tests pass (pre-existing ty errors unrelated to this PR)
- [x] Changelog will be updated if needed
