### PR TITLE
feat: swap official dataset scala-nl -> dutch-cola

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Swapped official dataset for Dutch:
+`scala-nl` → `dutch-cola`.
+
 - Bumped minimum `transformers` version to 5.14.0 (required for XLMRoberta/Camembert
   `ForMultipleChoice` heads; see huggingface/transformers#47147).
 - Swapped official datasets for four languages (all performed by the

--- a/src/euroeval/dataset_configs/dutch.py
+++ b/src/euroeval/dataset_configs/dutch.py
@@ -32,14 +32,6 @@ DBRD_CONFIG = DatasetConfig(
     labels=["negative", "positive"],
 )
 
-SCALA_NL_CONFIG = DatasetConfig(
-    name="scala-nl",
-    pretty_name="ScaLA-nl",
-    source="EuroEval/scala-nl",
-    task=LA,
-    languages=[DUTCH],
-)
-
 CONLL_NL_CONFIG = DatasetConfig(
     name="conll-nl",
     pretty_name="CoNLL-nl",
@@ -137,7 +129,24 @@ HELLASWAG_NL_CONFIG = DatasetConfig(
 )
 
 
+DUTCH_COLA_CONFIG = DatasetConfig(
+    name="dutch-cola",
+    pretty_name="Dutch CoLA",
+    source="EuroEval/dutch-cola",
+    task=LA,
+    languages=[DUTCH],
+)
+
 # Unofficial datasets ###
+
+SCALA_NL_CONFIG = DatasetConfig(
+    name="scala-nl",
+    pretty_name="ScaLA-nl",
+    source="EuroEval/scala-nl",
+    task=LA,
+    languages=[DUTCH],
+    unofficial=True,
+)
 
 WINOGRANDE_NL_CONFIG = DatasetConfig(
     name="winogrande-nl",
@@ -146,15 +155,6 @@ WINOGRANDE_NL_CONFIG = DatasetConfig(
     task=COMMON_SENSE,
     languages=[DUTCH],
     labels=["a", "b"],
-    unofficial=True,
-)
-
-DUTCH_COLA_CONFIG = DatasetConfig(
-    name="dutch-cola",
-    pretty_name="Dutch CoLA",
-    source="EuroEval/dutch-cola",
-    task=LA,
-    languages=[DUTCH],
     unofficial=True,
 )
 


### PR DESCRIPTION
Swaps the official dataset `scala-nl` for `dutch-cola`.

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `dutch-cola`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `scala-nl` is demoted to unofficial and `dutch-cola` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.