### PR TITLE
fix: treat result-less euroeval exits as failures in dataset swap

### DIFF
--- a/src/scripts/swap_leaderboard_dataset.py
+++ b/src/scripts/swap_leaderboard_dataset.py
@@ -229,6 +229,15 @@ DOC_UNOFFICIAL_PREFIX = "Unofficial: "
     "when the evaluations already ran).",
 )
 @click.option(
+    "--allow-eval-failures/--no-allow-eval-failures",
+    "allow_eval_failures",
+    is_flag=True,
+    default=False,
+    help="Proceed with the officiality swap even when some evaluations failed or "
+    "produced no result. By default the swap is aborted so the leaderboard never "
+    "shows a ranked model with no score on the new official dataset.",
+)
+@click.option(
     "--pr/--no-pr",
     is_flag=True,
     default=True,
@@ -264,6 +273,7 @@ def main(
     api_providers: str | None,
     gpu_memory_utilization: float | None,
     skip_eval: bool,
+    allow_eval_failures: bool,
     pr: bool,
     reviewer: str,
     force: bool,
@@ -274,7 +284,9 @@ def main(
     Raises:
         ClickException:
             If --api-providers is set without --include-api, if --pr is set without
-            --reviewer, or if --old-dataset and --add-only are both set or both unset.
+            --reviewer, if --old-dataset and --add-only are both set or both unset,
+            or when evaluations failed or produced no result and
+            --allow-eval-failures is not passed.
     """
     # Validation checks
     if api_providers and not include_api:
@@ -328,10 +340,11 @@ def main(
             target_codes=target_codes,
         )
 
+    eval_failures: list[str] = []
     if skip_eval:
         logger.info("--skip-eval set; skipping the evaluation phase.")
     else:
-        run_evaluations(
+        eval_failures = run_evaluations(
             old_dataset=old_dataset,
             new_datasets=new_datasets,
             swapped_task=old_config.task.name
@@ -346,6 +359,15 @@ def main(
         )
         if not dry_run:
             upload_results_to_bucket(results_file=EUROEVAL_BENCHMARK_RESULTS_PATH)
+
+    if eval_failures and not allow_eval_failures and not dry_run:
+        raise click.ClickException(
+            f"{len(eval_failures)} evaluation(s) failed or produced no result, so "
+            "refusing to flip dataset officiality (the leaderboard would otherwise "
+            "show ranked models with no score on the new official dataset). Re-run to "
+            "retry the failures, or pass --allow-eval-failures to swap anyway. "
+            f"Failed: {', '.join(eval_failures)}."
+        )
 
     changed = apply_swap(
         old_dataset=old_dataset, new_datasets=new_datasets, dry_run=dry_run
@@ -1103,7 +1125,7 @@ def run_evaluations(
     gpu_memory_utilization: float | None,
     force: bool,
     dry_run: bool,
-) -> None:
+) -> list[str]:
     """Evaluate every ranked model on the new dataset(s), mirroring their setup.
 
     Args:
@@ -1125,6 +1147,9 @@ def run_evaluations(
             When True, re-run pairs already holding a new-dataset result.
         dry_run:
             When True, print the plan without running.
+
+    Returns:
+        The list of failed job descriptions (empty on dry-run).
     """
     corpus = load_corpus()
     ranked = ranked_model_language_pairs(
@@ -1173,7 +1198,7 @@ def run_evaluations(
                 f"[{tag}] {job.model_id} :: {job.datasets} :: "
                 f"{', '.join(job.languages)} :: {split}, {shots}"
             )
-        return
+        return []
 
     evaluated, failed = execute_jobs(
         jobs=jobs, datasets=new_datasets, gpu_memory_utilization=gpu_memory_utilization
@@ -1185,6 +1210,7 @@ def run_evaluations(
         skipped_existing=skipped_existing,
         skipped_too_large=skipped_too_large,
     )
+    return failed
 
 
 def _log_summary(
@@ -1403,9 +1429,92 @@ def execute_jobs(
                     f"{output_tail}"
                 )
                 failed.append(f"{job.model_id} (exit {returncode})")
+                continue
+            missing = _job_missing_results(
+                job=job, result_keys=_benchmark_result_keys()
+            )
+            if missing:
+                logger.warning(
+                    f"{job.model_id}: euroeval exited 0 but produced no result for "
+                    f"{', '.join(missing)}; the benchmark(s) likely errored (e.g. an "
+                    "out-of-memory at model load). Counting as failed."
+                )
+                failed.append(f"{job.model_id} (no result)")
             else:
                 evaluated.append(job.model_id)
     return evaluated, failed
+
+
+def _benchmark_result_keys() -> set[tuple[str, str, str]]:
+    """Return the (model, dataset, language) triples in the local CLI results file.
+
+    Reads ``euroeval_benchmark_results.jsonl`` (where ``euroeval`` CLI runs append
+    their records) and returns the set of ``(plain_model_id, dataset, language)``
+    triples it currently holds, so a just-run job can be checked for a real result.
+
+    Returns:
+        The set of triples present, empty when the results file is absent.
+    """
+    if not EUROEVAL_BENCHMARK_RESULTS_PATH.exists():
+        return set()
+    keys: set[tuple[str, str, str]] = set()
+    for record in load_records_from_jsonl_files([EUROEVAL_BENCHMARK_RESULTS_PATH]):
+        model_info = t.cast(dict[str, object], record.get("model_info", {}))
+        model = plain_model_id(str(model_info.get("name") or model_info.get("id", "")))
+        dataset = get_dataset(record=record)
+        if not model or not dataset:
+            continue
+        for language in _record_languages(record=record):
+            keys.add((model, str(dataset), language))
+    return keys
+
+
+def _record_languages(record: dict[str, object]) -> list[str]:
+    """Return the language codes a result record covers.
+
+    Args:
+        record:
+            A result record in EEE format.
+
+    Returns:
+        The list of language codes.
+    """
+    raw = (
+        record.get("eval_library", {})
+        .get("additional_details", {})
+        .get("languages", "[]")
+    )
+    if isinstance(raw, list):
+        return [str(code) for code in raw]
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    return [str(code) for code in parsed] if isinstance(parsed, list) else []
+
+
+def _job_missing_results(
+    job: "Job", result_keys: set[tuple[str, str, str]]
+) -> list[str]:
+    """Return ``"dataset/language"`` labels a job should have produced but didn't.
+
+    Args:
+        job:
+            The job that was run.
+        result_keys:
+            The (model, dataset, language) triples present in the local results file.
+
+    Returns:
+        The ``"dataset/language"`` labels with no result record, empty when every
+        expected result is present.
+    """
+    model = plain_model_id(job.model_id)
+    missing: list[str] = []
+    for dataset in job.datasets:
+        for language in job.languages:
+            if (model, dataset, language) not in result_keys:
+                missing.append(f"{dataset}/{language}")
+    return missing
 
 
 @dataclass(frozen=True)
@@ -1602,30 +1711,6 @@ def load_corpus() -> _Corpus:
         observations=observations,
         eval_configs=eval_configs,
     )
-
-
-def _record_languages(record: dict[str, object]) -> list[str]:
-    """Return the language codes a result record covers.
-
-    Args:
-        record:
-            A result record in EEE format.
-
-    Returns:
-        The list of language codes.
-    """
-    raw = (
-        record.get("eval_library", {})
-        .get("additional_details", {})
-        .get("languages", "[]")
-    )
-    if isinstance(raw, list):
-        return [str(code) for code in raw]
-    try:
-        parsed = json.loads(raw)
-    except (json.JSONDecodeError, TypeError):
-        return []
-    return [str(code) for code in parsed] if isinstance(parsed, list) else []
 
 
 def record_is_api(model_info: dict[str, object]) -> bool:

--- a/src/scripts/swap_leaderboard_dataset.py
+++ b/src/scripts/swap_leaderboard_dataset.py
@@ -56,6 +56,7 @@ from tqdm.auto import tqdm
 from euroeval.constants import ORTHOGONAL_TASKS
 from euroeval.data_models import DatasetConfig
 from euroeval.dataset_configs import get_all_dataset_configs
+from euroeval.jsonl_io import parse_jsonl_lines
 from euroeval.languages import get_all_languages
 from leaderboards.bucket_sync import merge_results, upload_results_to_bucket
 from leaderboards.constants import (
@@ -1381,6 +1382,7 @@ def execute_jobs(
 
     logger.info(f"Evaluation log: {log_path}")
 
+    result_keys = _BenchmarkResultKeys()
     with tqdm(jobs, desc="Evaluating models", unit="model") as progress:
         for idx, job in enumerate(progress, start=1):
             progress.set_postfix_str(job.model_id)
@@ -1430,9 +1432,7 @@ def execute_jobs(
                 )
                 failed.append(f"{job.model_id} (exit {returncode})")
                 continue
-            missing = _job_missing_results(
-                job=job, result_keys=_benchmark_result_keys()
-            )
+            missing = _job_missing_results(job=job, result_keys=result_keys.current())
             if missing:
                 logger.warning(
                     f"{job.model_id}: euroeval exited 0 but produced no result for "
@@ -1445,28 +1445,55 @@ def execute_jobs(
     return evaluated, failed
 
 
-def _benchmark_result_keys() -> set[tuple[str, str, str]]:
-    """Return the (model, dataset, language) triples in the local CLI results file.
+class _BenchmarkResultKeys:
+    """Incrementally collects ``(model, dataset, language)`` result triples.
 
-    Reads ``euroeval_benchmark_results.jsonl`` (where ``euroeval`` CLI runs append
-    their records) and returns the set of ``(plain_model_id, dataset, language)``
-    triples it currently holds, so a just-run job can be checked for a real result.
-
-    Returns:
-        The set of triples present, empty when the results file is absent.
+    Tracks the ``(plain_model_id, dataset, language)`` triples present in the
+    local ``euroeval_benchmark_results.jsonl`` file that ``euroeval`` CLI runs
+    append to. Each :meth:`current` call parses only the bytes appended since the
+    previous call (up to the last complete line), so checking every job's result
+    after it runs stays ``O(results-file-size)`` across a whole run rather than
+    ``O(jobs * results-file-size)``. Malformed or partially written lines are
+    skipped rather than raising, so a corrupt line can never crash the run.
     """
-    if not EUROEVAL_BENCHMARK_RESULTS_PATH.exists():
-        return set()
-    keys: set[tuple[str, str, str]] = set()
-    for record in load_records_from_jsonl_files([EUROEVAL_BENCHMARK_RESULTS_PATH]):
-        model_info = t.cast(dict[str, object], record.get("model_info", {}))
-        model = plain_model_id(str(model_info.get("name") or model_info.get("id", "")))
-        dataset = get_dataset(record=record)
-        if not model or not dataset:
-            continue
-        for language in _record_languages(record=record):
-            keys.add((model, str(dataset), language))
-    return keys
+
+    def __init__(self) -> None:
+        """Initialise an empty tracker at the start of the results file."""
+        self._offset = 0
+        self._keys: set[tuple[str, str, str]] = set()
+
+    def current(self) -> set[tuple[str, str, str]]:
+        """Return the triples seen so far, parsing any newly appended lines.
+
+        Returns:
+            The set of ``(model, dataset, language)`` triples present in the
+            results file, empty when the file is absent.
+        """
+        path = EUROEVAL_BENCHMARK_RESULTS_PATH
+        if not path.exists():
+            return self._keys
+        data = path.read_bytes()
+        # Only consume up to the last newline; a trailing partial line (e.g. one
+        # still being written) is left for a later call. Cutting on ``\n`` is
+        # always a safe UTF-8 boundary.
+        end = data.rfind(b"\n") + 1
+        if end <= self._offset:
+            return self._keys
+        chunk = data[self._offset : end].decode("utf-8", errors="replace")
+        self._offset = end
+        for record in parse_jsonl_lines(
+            lines=chunk.splitlines(), source=str(path), strict=False
+        ):
+            model_info = t.cast(dict[str, object], record.get("model_info", {}))
+            model = plain_model_id(
+                str(model_info.get("name") or model_info.get("id", ""))
+            )
+            dataset = get_dataset(record=record)
+            if not model or not dataset:
+                continue
+            for language in _record_languages(record=record):
+                self._keys.add((model, str(dataset), language))
+        return self._keys
 
 
 def _record_languages(record: dict[str, object]) -> list[str]:

--- a/tests/test_scripts/test_swap_leaderboard_dataset.py
+++ b/tests/test_scripts/test_swap_leaderboard_dataset.py
@@ -408,6 +408,87 @@ class TestExecuteJobsLogging:
         assert re.search(r"eval_log_\d{8}_\d{6}\.log", log_messages[0])
 
 
+class TestExecuteJobsResultDetection:
+    """Tests that execute_jobs counts result-less exit-0 jobs as failed."""
+
+    def test_exit_zero_with_result_counts_as_evaluated(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A job that exits 0 and has a matching result record is evaluated."""
+        Job = swap_leaderboard_dataset.Job
+        benchmark_results = tmp_path / "euroeval_benchmark_results.jsonl"
+        record = {
+            "model_info": {"name": "good-model"},
+            "eval_library": {
+                "additional_details": {"dataset": "dutch-cola", "languages": ["nl"]}
+            },
+        }
+        benchmark_results.write_text(json.dumps(record) + "\n", encoding="utf-8")
+        monkeypatch.setattr(
+            target=swap_leaderboard_dataset, name="REPO_ROOT", value=tmp_path
+        )
+        monkeypatch.setattr(
+            target=swap_leaderboard_dataset,
+            name="EUROEVAL_BENCHMARK_RESULTS_PATH",
+            value=benchmark_results,
+        )
+        monkeypatch.setattr(
+            target=swap_leaderboard_dataset,
+            name="run_euroeval",
+            value=lambda **kwargs: (0, "ok"),
+        )
+        jobs = [
+            Job(
+                model_id="good-model",
+                languages=("nl",),
+                is_api=False,
+                evaluate_test_split=True,
+                zero_shot=False,
+                datasets=("dutch-cola",),
+            )
+        ]
+        evaluated, failed = swap_leaderboard_dataset.execute_jobs(
+            jobs=jobs, datasets=("dutch-cola",), gpu_memory_utilization=None
+        )
+        assert failed == []
+        assert evaluated == ["good-model"]
+
+    def test_exit_zero_without_result_counts_as_failed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A job that exits 0 but writes no result record must be marked failed."""
+        Job = swap_leaderboard_dataset.Job
+        monkeypatch.setattr(
+            target=swap_leaderboard_dataset, name="REPO_ROOT", value=tmp_path
+        )
+        monkeypatch.setattr(
+            target=swap_leaderboard_dataset,
+            name="EUROEVAL_BENCHMARK_RESULTS_PATH",
+            value=tmp_path / "euroeval_benchmark_results.jsonl",
+        )
+        monkeypatch.setattr(
+            target=swap_leaderboard_dataset,
+            name="run_euroeval",
+            value=lambda **kwargs: (0, "errored 1 benchmarks"),
+        )
+        jobs = [
+            Job(
+                model_id="oom-model",
+                languages=("nl",),
+                is_api=False,
+                evaluate_test_split=True,
+                zero_shot=False,
+                datasets=("dutch-cola",),
+            )
+        ]
+        evaluated, failed = swap_leaderboard_dataset.execute_jobs(
+            jobs=jobs, datasets=("dutch-cola",), gpu_memory_utilization=None
+        )
+        assert evaluated == []
+        assert len(failed) == 1
+        assert "oom-model" in failed[0]
+
+
 class TestLoadCorpusAndBuildEvalJobs:
     """Tests for load_corpus and build_eval_jobs functions."""
 


### PR DESCRIPTION
## What

`swap_leaderboard_dataset.py` decided each evaluation's success purely on the `euroeval` subprocess return code. But `euroeval` exits **0** even when a benchmark *errors* (e.g. a CUDA OOM at model load) — it just logs "errored N benchmarks". So failed evals were counted as **evaluated**, and the script would then flip dataset officiality despite no results existing, leaving ranked models with **no score on the new official dataset**.

This was hit in practice on `inference-server`: a run with `--gpu-memory-utilization 0.95` OOM'd every job at KV-cache allocation, yet each was logged `Exit Code: 0`.

## Key changes

- **Result-based success detection** (robust, not text-parsing): after a job runs, check whether a record for each of its `(model, dataset, language)` triples actually landed in `euroeval_benchmark_results.jsonl`. Jobs that exit 0 but produced no result are now counted as **failed** (`"<model> (no result)"`).
- **Refuse to swap on failure**: `main` aborts with a clear `ClickException` before flipping officiality when any evaluation failed…
- **…unless `--allow-eval-failures`** is passed, for the cases where you knowingly want to proceed.

## Notes

- Scoped to `src/scripts` + `src/leaderboards` helpers — **no `src/euroeval` changes**.
- Two new tests cover the exit-0-without-result (→ failed) and exit-0-with-result (→ evaluated) paths. All 20 tests in the file pass; `make check` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)