### PR TITLE
feat: swap official dataset mmlu-pt -> alba-mcq-pt, cultura-viva-pt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,17 +27,15 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Swapped official dataset for European Portuguese, Portuguese:
-`mmlu-pt` → `alba-mcq-pt`, `cultura-viva-pt`.
-
 - Bumped minimum `transformers` version to 5.14.0 (required for XLMRoberta/Camembert
   `ForMultipleChoice` heads; see huggingface/transformers#47147).
 - Swapped official datasets for four languages (all performed by the
   `swap_leaderboard_dataset.py` script, which now automatically updates this changelog):
   - Croatian: `mmlu-hr` → `include-hr`
   - Dutch: `scala-nl` → `dutch-cola`, `mmlu-nl` → `include-nl`, `multiloko-nl`
-  - French: `mmlu-fr` → `include-fr` and `multiloko-fr`
+  - French: `mmlu-fr` → `include-fr`, `multiloko-fr`
   - German: `hellaswag-de` → `winogrande-de`
+  - Portuguese: `mmlu-pt` → `alba-mcq-pt`, `cultura-viva-pt`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Swapped official dataset for European Portuguese, Portuguese:
+`mmlu-pt` → `alba-mcq-pt`, `cultura-viva-pt`.
+
 - Bumped minimum `transformers` version to 5.14.0 (required for XLMRoberta/Camembert
   `ForMultipleChoice` heads; see huggingface/transformers#47147).
 - Swapped official datasets for four languages (all performed by the

--- a/src/euroeval/dataset_configs/portuguese.py
+++ b/src/euroeval/dataset_configs/portuguese.py
@@ -90,15 +90,34 @@ VALEU_PT_CONFIG = DatasetConfig(
 )
 
 
+ALBA_MCQ_PT_CONFIG = DatasetConfig(
+    name="alba-mcq-pt",
+    pretty_name="ALBA-MCQ",
+    source="EuroEval/euroeval-amalia-alba-mcq-pt",
+    task=KNOW,
+    languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
+    labels=["a", "b", "c"],
+    val_split=None,
+)
+
+CULTURA_VIVA_PT_CONFIG = DatasetConfig(
+    name="cultura-viva-pt",
+    pretty_name="CulturaVivaPT",
+    source="EuroEval/euroeval-amalia-cultura-viva-pt",
+    task=KNOW,
+    languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
+)
+
+# Unofficial datasets ###
+
 MMLU_PT_CONFIG = DatasetConfig(
     name="mmlu-pt",
     pretty_name="MMLU-pt",
     source="EuroEval/mmlu-pt-mini",
     task=KNOW,
     languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
+    unofficial=True,
 )
-
-# Unofficial datasets ###
 
 IFEVAL_PT_CONFIG = DatasetConfig(
     name="ifeval-pt",
@@ -181,26 +200,6 @@ PT_COMPLETIONS_CONFIG = DatasetConfig(
         "Responde à pergunta acima usando só {labels_str}, e nada mais."
     ),
     val_split=None,
-    unofficial=True,
-)
-
-ALBA_MCQ_PT_CONFIG = DatasetConfig(
-    name="alba-mcq-pt",
-    pretty_name="ALBA-MCQ",
-    source="EuroEval/euroeval-amalia-alba-mcq-pt",
-    task=KNOW,
-    languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
-    labels=["a", "b", "c"],
-    val_split=None,
-    unofficial=True,
-)
-
-CULTURA_VIVA_PT_CONFIG = DatasetConfig(
-    name="cultura-viva-pt",
-    pretty_name="CulturaVivaPT",
-    source="EuroEval/euroeval-amalia-cultura-viva-pt",
-    task=KNOW,
-    languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
     unofficial=True,
 )
 

--- a/src/frontend/md/datasets/portuguese.md
+++ b/src/frontend/md/datasets/portuguese.md
@@ -427,7 +427,7 @@ euroeval --model <model-id> --dataset boolq-pt
 
 ## Knowledge
 
-### Unofficial: ALBA-MCQ
+### ALBA-MCQ
 
 [ALBA-MCQ](https://huggingface.co/datasets/amalia-llm/alba_mcq) is the multiple-choice
 adaptation of ALBA, an expert-created benchmark introduced in the
@@ -505,7 +505,7 @@ You can evaluate this dataset directly as follows:
 euroeval --model <model-id> --dataset alba-mcq-pt
 ```
 
-### Unofficial: CulturaVivaPT
+### CulturaVivaPT
 
 [CulturaVivaPT](https://huggingface.co/datasets/amalia-llm/cultura-viva-pt-mcq),
 released as part of the [AMALIA project](https://aclanthology.org/2026.propor-1.38/),
@@ -583,7 +583,7 @@ You can evaluate this dataset directly as follows:
 euroeval --model <model-id> --dataset cultura-viva-pt
 ```
 
-### MMLU-pt
+### Unofficial: MMLU-pt
 
 This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2410.08928)
 and is a machine translated version of the English


### PR DESCRIPTION
Swaps the official dataset `mmlu-pt` for `alba-mcq-pt`, `cultura-viva-pt`.

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `alba-mcq-pt`, `cultura-viva-pt`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `mmlu-pt` is demoted to unofficial and `alba-mcq-pt`, `cultura-viva-pt` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.