### PR TITLE
﻿Feat: Add built-in dummy model backend for debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   translators at the European Commission's Directorate-General for Translation and by
   students from the European Master's in Translation network, rather than by machine
   translation. They are marked as `unofficial` for now.
+- Added a built-in `dummy` model backend (`--model dummy`) for debugging EuroEval
+  setups without downloading or running any real model. For tasks with a fixed set
+  of possible answers (e.g. classification, multiple-choice), it predicts a uniform
+  probability across all of them, for named entity recognition it predicts no
+  entities, for everything else it returns a generic placeholder answer. Either way,
+  failures point to dataset/task code rather than the model or inference
+  framework.
 
 ### Changed
 

--- a/src/euroeval/benchmark_modules/__init__.py
+++ b/src/euroeval/benchmark_modules/__init__.py
@@ -1,6 +1,7 @@
 """The different types of modules that can be benchmarked."""
 
 from .base import BenchmarkModule
+from .dummy import DummyModel
 from .fresh import FreshEncoderModel
 from .hf import HuggingFaceEncoderModel
 from .litellm import LiteLLMModel

--- a/src/euroeval/benchmark_modules/dummy.py
+++ b/src/euroeval/benchmark_modules/dummy.py
@@ -176,6 +176,12 @@ class DummyModel(BenchmarkModule):
                 self.dataset_config.prompt_label_mapping[label]
                 for label in self.dataset_config.id2label.values()
             ]
+            if not candidate_labels:
+                raise InvalidBenchmark(
+                    "No candidate labels found for this dataset. "
+                    "Set DatasetConfig.labels/prompt_label_mapping for classification "
+                    "tasks before using the dummy backend."
+                )
             uniform_logprob = math.log(1 / len(candidate_labels))
             scores = [
                 [[(label, uniform_logprob) for label in candidate_labels]]

--- a/src/euroeval/benchmark_modules/dummy.py
+++ b/src/euroeval/benchmark_modules/dummy.py
@@ -1,0 +1,317 @@
+"""A built-in dummy model, used for debugging."""
+
+import math
+import random
+import re
+import typing as t
+from functools import cached_property
+
+from ..data_models import (
+    BenchmarkConfig,
+    DatasetConfig,
+    GenerativeModelOutput,
+    ModelConfig,
+    Task,
+)
+from ..enums import (
+    BatchingPreference,
+    GenerativeType,
+    InferenceBackend,
+    ModelType,
+    TaskGroup,
+)
+from ..exceptions import InvalidBenchmark, NeedsEnvironmentVariable, NeedsExtraInstalled
+from ..generation_utils import raise_if_wrong_params
+from ..model_cache import create_model_cache_dir
+from ..task_group_utils.token_classification import serialise_ner_tags
+from ..tokenisation_utils import get_first_label_token_mapping
+from ..types import ExtractLabelsFunction
+from .base import (
+    BenchmarkModule,
+    _extract_labels_from_generation_helper,
+    _prepare_dataset_helper,
+)
+
+if t.TYPE_CHECKING:
+    from datasets import DatasetDict
+    from transformers.trainer import Trainer
+
+
+DUMMY_MODEL_ID = "dummy"
+
+
+class DummyModel(BenchmarkModule):
+    """A built-in model that predicts an even distribution over labels.
+
+    This model does not download or run any real model, and requires no
+    inference framework (HF `transformers`, vLLM, an API, etc.) at all. It
+    exists to let a user debug a dataset/task pipeline in isolation from any
+    real inference backend, and can also serve as a naive random baseline.
+    """
+
+    fresh_model = False
+    batching_preference = BatchingPreference.ALL_AT_ONCE
+    allowed_params = {re.compile(r".*"): []}
+
+    # Checked before any other backend, so that benchmarking "dummy" never
+    # triggers a real HF Hub lookup for a repo literally named "dummy".
+    high_priority = True
+
+    def __init__(
+        self,
+        model_config: ModelConfig,
+        dataset_config: DatasetConfig,
+        benchmark_config: BenchmarkConfig,
+        log_metadata: bool = True,
+    ) -> None:
+        """Initialise the model.
+
+        Args:
+            model_config:
+                The model configuration.
+            dataset_config:
+                The dataset configuration.
+            benchmark_config:
+                The benchmark configuration.
+            log_metadata:
+                Whether to log the model metadata.
+        """
+        raise_if_wrong_params(
+            model_config=model_config, allowed_params=self.allowed_params
+        )
+
+        super().__init__(
+            model_config=model_config,
+            dataset_config=dataset_config,
+            benchmark_config=benchmark_config,
+            log_metadata=log_metadata,
+        )
+        self.buffer["first_label_token_mapping"] = get_first_label_token_mapping(
+            dataset_config=self.dataset_config,
+            model_config=self.model_config,
+            tokeniser=None,
+            generative_type=self.generative_type,
+            log_metadata=self.log_metadata,
+        )
+
+    @property
+    def data_collator(self) -> t.Callable[[list[dict[str, t.Any]]], dict[str, t.Any]]:
+        """The data collator used to prepare samples during finetuning.
+
+        Returns:
+            The data collator.
+        """
+        raise NotImplementedError(
+            "The `data_collator` property has not been implemented for dummy models."
+        )
+
+    @property
+    def extract_labels_from_generation(self) -> ExtractLabelsFunction:
+        """The function used to extract the labels from the generated output.
+
+        Returns:
+            The function used to extract the labels from the generated output.
+        """
+        return _extract_labels_from_generation_helper(
+            dataset_config=self.dataset_config,
+            model_config=self.model_config,
+            first_label_token_mapping=self.buffer["first_label_token_mapping"],
+        )
+
+    def generate(self, inputs: dict) -> GenerativeModelOutput:
+        """Generate outputs from the model.
+
+        Predicts an even probability distribution across the candidate labels
+        for classification-style tasks, an explicit "no entities" prediction
+        for token classification, and a generic placeholder answer for every
+        other (free-text-answer) task group.
+
+        Args:
+            inputs:
+                A batch of inputs to pass through the model.
+
+        Returns:
+            The generated model outputs.
+
+        Raises:
+            InvalidBenchmark:
+                If the inputs do not contain either 'messages' or 'text' keys.
+        """
+        # Recomputed on every call rather than once in __init__, since
+        # update_dataset_config can swap dataset_config between calls.
+        self.buffer["first_label_token_mapping"] = get_first_label_token_mapping(
+            dataset_config=self.dataset_config,
+            model_config=self.model_config,
+            tokeniser=None,
+            generative_type=self.generative_type,
+            log_metadata=self.log_metadata,
+        )
+
+        if "messages" in inputs:
+            num_samples = len(inputs["messages"])
+        elif "text" in inputs:
+            num_samples = len(inputs["text"])
+        else:
+            raise InvalidBenchmark(
+                "The inputs must contain either 'messages' or 'text' keys."
+            )
+
+        if self.dataset_config.task.task_group == TaskGroup.TOKEN_CLASSIFICATION:
+            # Reuses the same serialiser as the few-shot demonstrations and
+            # gold BPC answers, so the "no entities" shape can't drift out of
+            # sync with it.
+            empty_prediction = serialise_ner_tags(
+                tokens=[],
+                labels=[],
+                prompt_label_mapping=self.dataset_config.prompt_label_mapping,
+            )
+            return GenerativeModelOutput(sequences=[empty_prediction] * num_samples)
+        elif self.dataset_config.task.task_group in (
+            TaskGroup.SEQUENCE_CLASSIFICATION,
+            TaskGroup.MULTIPLE_CHOICE_CLASSIFICATION,
+        ):
+            # For sequence classification and multiple choice classification,
+            # we sample uniformly at random from the available candidate labels.
+            candidate_labels = [
+                self.dataset_config.prompt_label_mapping[label]
+                for label in self.dataset_config.id2label.values()
+            ]
+            uniform_logprob = math.log(1 / len(candidate_labels))
+            scores = [
+                [[(label, uniform_logprob) for label in candidate_labels]]
+                for _ in range(num_samples)
+            ]
+            sequences = [random.choice(candidate_labels) for _ in range(num_samples)]
+            return GenerativeModelOutput(sequences=sequences, scores=scores)
+
+        # A generic non-empty placeholder answer for non-classification tasks.
+        # Some metrics (e.g. in the hallucination task) can't process an empty answer.
+        return GenerativeModelOutput(sequences=["answer"] * num_samples)
+
+    @property
+    def generative_type(self) -> GenerativeType | None:
+        """The generative type of the model.
+
+        Always instruction-tuned: this must not be `REASONING`, since that
+        would make `get_first_label_token_mapping` disable logprob output
+        entirely, while `generate` always populates scores for classification
+        tasks regardless.
+
+        Returns:
+            The generative type of the model.
+        """
+        return GenerativeType.INSTRUCTION_TUNED
+
+    @classmethod
+    def get_model_config(
+        cls, model_id: str, benchmark_config: BenchmarkConfig
+    ) -> ModelConfig:
+        """Fetch the model configuration.
+
+        Args:
+            model_id:
+                The model ID.
+            benchmark_config:
+                The benchmark configuration.
+
+        Returns:
+            The model configuration.
+        """
+        return ModelConfig(
+            model_id=DUMMY_MODEL_ID,
+            revision="main",
+            param=None,
+            task="text-generation",
+            languages=list(),
+            merge=False,
+            inference_backend=InferenceBackend.DUMMY,
+            model_type=ModelType.GENERATIVE,
+            fresh=False,
+            model_cache_dir=create_model_cache_dir(
+                cache_dir=benchmark_config.cache_dir, model_id=DUMMY_MODEL_ID
+            ),
+            adapter_base_model_id=None,
+        )
+
+    @classmethod
+    def model_exists(
+        cls, model_id: str, benchmark_config: BenchmarkConfig
+    ) -> bool | NeedsExtraInstalled | NeedsEnvironmentVariable:
+        """Check if a model exists.
+
+        Args:
+            model_id:
+                The model ID.
+            benchmark_config:
+                The benchmark configuration.
+
+        Returns:
+            Whether the model exists.
+        """
+        return model_id == DUMMY_MODEL_ID
+
+    @cached_property
+    def model_max_length(self) -> int:
+        """The maximum length of the model.
+
+        Returns:
+            The maximum length of the model.
+        """
+        return -1
+
+    @cached_property
+    def num_params(self) -> int:
+        """The number of parameters in the model.
+
+        Returns:
+            The number of parameters in the model.
+        """
+        return -1
+
+    def prepare_dataset(
+        self, dataset: "DatasetDict", task: Task, itr_idx: int
+    ) -> "DatasetDict":
+        """Prepare the dataset for the model.
+
+        Args:
+            dataset:
+                The dataset to prepare.
+            task:
+                The task to prepare the dataset for.
+            itr_idx:
+                The index of the dataset in the iterator.
+
+        Returns:
+            The prepared dataset.
+        """
+        return _prepare_dataset_helper(
+            dataset=dataset,
+            task=task,
+            model_config=self.model_config,
+            dataset_config=self.dataset_config,
+            benchmark_config=self.benchmark_config,
+            generative_type=self.generative_type,
+            itr_idx=itr_idx,
+            always_populate_text_field=False,
+            tokeniser=None,
+        )
+
+    @property
+    def trainer_class(self) -> t.Type["Trainer"]:
+        """The Trainer class to use for finetuning.
+
+        Returns:
+            The Trainer class.
+        """
+        raise NotImplementedError(
+            "The `trainer_class` property has not been implemented for dummy models."
+        )
+
+    @cached_property
+    def vocab_size(self) -> int:
+        """The vocabulary size of the model.
+
+        Returns:
+            The vocabulary size of the model.
+        """
+        return -1

--- a/src/euroeval/enums.py
+++ b/src/euroeval/enums.py
@@ -99,11 +99,14 @@ class InferenceBackend(AutoStrEnum):
             VLLM library.
         LITELLM:
             LiteLLM library.
+        DUMMY:
+            The built-in dummy model, used for debugging.
     """
 
     TRANSFORMERS = auto()
     VLLM = auto()
     LITELLM = auto()
+    DUMMY = auto()
 
 
 class ModelType(AutoStrEnum):

--- a/src/euroeval/model_loading.py
+++ b/src/euroeval/model_loading.py
@@ -4,6 +4,7 @@ import logging
 import typing as t
 
 from .benchmark_modules import (
+    DummyModel,
     FreshEncoderModel,
     HuggingFaceEncoderModel,
     LiteLLMModel,
@@ -121,6 +122,8 @@ def load_model(
             model_class = HuggingFaceEncoderModel
         case (ModelType.GENERATIVE, InferenceBackend.LITELLM, False):
             model_class = LiteLLMModel
+        case (ModelType.GENERATIVE, InferenceBackend.DUMMY, False):
+            model_class = DummyModel
         case (ModelType.ENCODER, InferenceBackend.TRANSFORMERS, True):
             model_class = FreshEncoderModel
         case (_, _, True):

--- a/src/frontend/md/python-package.md
+++ b/src/frontend/md/python-package.md
@@ -212,6 +212,20 @@ Concrete, end-to-end tasks. Each is self-contained — copy, adapt, run.
     This works for both encoder and decoder checkpoints. If you'd rather serve the model
     through an inference server and benchmark over HTTP, see the previous recipe.
 
+??? example "Debug your setup with the dummy model"
+
+    Use the built-in `dummy` model to check that a dataset/task works end-to-end
+    without downloading or running any real model. For tasks with a fixed set of
+    possible answers (e.g. classification, multiple-choice), it predicts a uniform
+    probability across all of them; for named entity recognition it predicts no
+    entities; for everything else it returns a generic placeholder answer. Either
+    way, failures point to your dataset/task code rather than the model or inference
+    framework:
+
+    ```bash
+    euroeval --model dummy --dataset <your-dataset>
+    ```
+
 ??? example "Score a base decoder with bits-per-character (BPC)"
 
     For base (completion-only) decoder models, bits-per-character scoring measures the

--- a/tests/test_benchmark_modules/test_dummy.py
+++ b/tests/test_benchmark_modules/test_dummy.py
@@ -1,0 +1,256 @@
+"""Unit tests for the `dummy` module."""
+
+import dataclasses
+import json
+import math
+
+import pytest
+
+from euroeval.benchmark_modules.dummy import DummyModel
+from euroeval.data_models import BenchmarkConfig, DatasetConfig, ModelConfig, Task
+from euroeval.enums import InferenceBackend, ModelType
+from euroeval.exceptions import InvalidModel
+from euroeval.languages import DANISH
+from euroeval.model_config import get_model_config
+from euroeval.model_loading import load_model
+from euroeval.tasks import HALLU, NER, SUMM
+
+
+class TestBPCGating:
+    """Tests that BPC scoring is rejected for the dummy backend."""
+
+    def test_bpc_rejected_for_dummy(
+        self,
+        dummy_model_config: ModelConfig,
+        dataset_config: DatasetConfig,
+        benchmark_config: BenchmarkConfig,
+    ) -> None:
+        """BPC scoring raises InvalidModel for the dummy backend."""
+        bpc_config = dataclasses.replace(benchmark_config, use_bits_per_character=True)
+        with pytest.raises(InvalidModel, match="vLLM backend"):
+            load_model(
+                model_config=dummy_model_config,
+                dataset_config=dataset_config,
+                benchmark_config=bpc_config,
+            )
+
+
+class TestDispatch:
+    """Tests that the dummy backend is reachable through both dispatch points."""
+
+    def test_get_model_config_resolves_to_dummy(
+        self, benchmark_config: BenchmarkConfig
+    ) -> None:
+        """The reflection-based registry resolves 'dummy' with no network calls."""
+        config = get_model_config(model_id="dummy", benchmark_config=benchmark_config)
+        assert config.inference_backend == InferenceBackend.DUMMY
+
+    def test_load_model_returns_dummy_model(
+        self,
+        dummy_model_config: ModelConfig,
+        dataset_config: DatasetConfig,
+        benchmark_config: BenchmarkConfig,
+    ) -> None:
+        """load_model dispatches to DummyModel for the dummy backend."""
+        model = load_model(
+            model_config=dummy_model_config,
+            dataset_config=dataset_config,
+            benchmark_config=benchmark_config,
+        )
+        assert isinstance(model, DummyModel)
+
+
+class TestGenerate:
+    """Tests for DummyModel.generate."""
+
+    def test_classification_scores_are_uniform(
+        self,
+        dummy_model_config: ModelConfig,
+        dataset_config: DatasetConfig,
+        benchmark_config: BenchmarkConfig,
+    ) -> None:
+        """Classification tasks get an even logprob distribution over labels."""
+        model = DummyModel(
+            model_config=dummy_model_config,
+            dataset_config=dataset_config,
+            benchmark_config=benchmark_config,
+            log_metadata=False,
+        )
+        output = model.generate(inputs=dict(text=["some text", "some other text"]))
+
+        num_labels = len(dataset_config.id2label)
+        expected_logprob = math.log(1 / num_labels)
+
+        assert len(output.sequences) == 2
+        assert output.scores is not None
+        assert len(output.scores) == 2
+        for sample_scores in output.scores:
+            assert len(sample_scores) == 1
+            assert len(sample_scores[0]) == num_labels
+            for _, logprob in sample_scores[0]:
+                assert logprob == pytest.approx(expected_logprob)
+
+    @pytest.mark.parametrize("task", [SUMM, HALLU])
+    def test_free_text_tasks_return_generic_placeholder(
+        self,
+        task: Task,
+        dummy_model_config: ModelConfig,
+        benchmark_config: BenchmarkConfig,
+    ) -> None:
+        """Free-text-answer tasks get a generic non-empty placeholder answer.
+
+        A literally empty answer breaks some metrics (e.g. the hallucination
+        classifier errors with "no tokens found in predictions"), so a
+        non-empty placeholder is used for every free-text-answer task group.
+        """
+        free_text_dataset_config = DatasetConfig(
+            name="dataset",
+            pretty_name="Dataset",
+            source="dataset_id",
+            task=task,
+            languages=[DANISH],
+        )
+        model = DummyModel(
+            model_config=dummy_model_config,
+            dataset_config=free_text_dataset_config,
+            benchmark_config=benchmark_config,
+            log_metadata=False,
+        )
+        output = model.generate(inputs=dict(text=["some text", "some other text"]))
+        assert output.scores is None
+        assert output.sequences == ["answer", "answer"]
+
+    def test_token_classification_extracts_to_all_o_labels(
+        self, dummy_model_config: ModelConfig, benchmark_config: BenchmarkConfig
+    ) -> None:
+        """The correctly-shaped empty prediction round-trips to all-"o" labels."""
+        ner_dataset_config = DatasetConfig(
+            name="dataset",
+            pretty_name="Dataset",
+            source="dataset_id",
+            task=NER,
+            languages=[DANISH],
+        )
+        model = DummyModel(
+            model_config=dummy_model_config,
+            dataset_config=ner_dataset_config,
+            benchmark_config=benchmark_config,
+            log_metadata=False,
+        )
+        output = model.generate(inputs=dict(text=["some text"]))
+        labels = model.extract_labels_from_generation(
+            input_batch=dict(tokens=[["some", "text"]]), model_output=output
+        )
+        assert labels == [["o", "o"]]
+
+    def test_token_classification_returns_canonical_empty_shape(
+        self, dummy_model_config: ModelConfig, benchmark_config: BenchmarkConfig
+    ) -> None:
+        """NER gets the same "no entities" shape used in few-shot demonstrations."""
+        ner_dataset_config = DatasetConfig(
+            name="dataset",
+            pretty_name="Dataset",
+            source="dataset_id",
+            task=NER,
+            languages=[DANISH],
+        )
+        model = DummyModel(
+            model_config=dummy_model_config,
+            dataset_config=ner_dataset_config,
+            benchmark_config=benchmark_config,
+            log_metadata=False,
+        )
+        output = model.generate(inputs=dict(text=["some text", "some other text"]))
+        assert output.scores is None
+
+        expected_categories = set(ner_dataset_config.prompt_label_mapping.values())
+        for sequence in output.sequences:
+            prediction = json.loads(sequence)
+            assert set(prediction.keys()) == expected_categories
+            assert all(entities == [] for entities in prediction.values())
+
+
+class TestGetModelConfig:
+    """Tests for DummyModel.get_model_config."""
+
+    def test_config_fields(self, benchmark_config: BenchmarkConfig) -> None:
+        """The built model config points at the dummy backend."""
+        config = DummyModel.get_model_config(
+            model_id="dummy", benchmark_config=benchmark_config
+        )
+        assert config.model_id == "dummy"
+        assert config.inference_backend == InferenceBackend.DUMMY
+        assert config.model_type == ModelType.GENERATIVE
+        assert config.fresh is False
+        assert config.param is None
+
+
+class TestModelExists:
+    """Tests for DummyModel.model_exists."""
+
+    def test_exact_id_matches(self, benchmark_config: BenchmarkConfig) -> None:
+        """The exact 'dummy' id is recognised."""
+        assert DummyModel.model_exists(
+            model_id="dummy", benchmark_config=benchmark_config
+        )
+
+    @pytest.mark.parametrize("model_id", ["dummy-2", "dummy#thinking", "Dummy", ""])
+    def test_other_ids_do_not_match(
+        self, model_id: str, benchmark_config: BenchmarkConfig
+    ) -> None:
+        """IDs other than the exact string 'dummy' are not recognised."""
+        assert not DummyModel.model_exists(
+            model_id=model_id, benchmark_config=benchmark_config
+        )
+
+
+class TestUnimplementedProperties:
+    """Tests for the properties the dummy backend deliberately doesn't support."""
+
+    def test_data_collator_raises(
+        self,
+        dummy_model_config: ModelConfig,
+        dataset_config: DatasetConfig,
+        benchmark_config: BenchmarkConfig,
+    ) -> None:
+        """The dummy backend does not support finetuning."""
+        model = DummyModel(
+            model_config=dummy_model_config,
+            dataset_config=dataset_config,
+            benchmark_config=benchmark_config,
+            log_metadata=False,
+        )
+        with pytest.raises(NotImplementedError):
+            _ = model.data_collator
+
+    def test_trainer_class_raises(
+        self,
+        dummy_model_config: ModelConfig,
+        dataset_config: DatasetConfig,
+        benchmark_config: BenchmarkConfig,
+    ) -> None:
+        """The dummy backend does not support finetuning."""
+        model = DummyModel(
+            model_config=dummy_model_config,
+            dataset_config=dataset_config,
+            benchmark_config=benchmark_config,
+            log_metadata=False,
+        )
+        with pytest.raises(NotImplementedError):
+            _ = model.trainer_class
+
+
+@pytest.fixture
+def dummy_model_config(model_config: ModelConfig) -> ModelConfig:
+    """Yields a model configuration pointing at the dummy backend.
+
+    Returns:
+        A model configuration pointing at the dummy backend.
+    """
+    return dataclasses.replace(
+        model_config,
+        model_id="dummy",
+        inference_backend=InferenceBackend.DUMMY,
+        model_type=ModelType.GENERATIVE,
+        fresh=False,
+    )

--- a/tests/test_benchmark_modules/test_litellm.py
+++ b/tests/test_benchmark_modules/test_litellm.py
@@ -18,7 +18,7 @@ class TestBPCGating:
     BPC validation happens in load_model() before backend initialization.
     """
 
-    def test_bpc_reJECTED_for_litellm(
+    def test_bpc_rejected_for_litellm(
         self,
         model_config: ModelConfig,
         dataset_config: DatasetConfig,

--- a/tests/test_benchmarker.py
+++ b/tests/test_benchmarker.py
@@ -78,6 +78,18 @@ def test_adjust_logging_level(verbose: bool, expected_logging_level: int) -> Non
     assert logging_level == expected_logging_level
 
 
+@pytest.mark.depends(on=["tests/test_model_loading.py::test_load_dummy_model"])
+def test_benchmark_dummy(
+    benchmarker: Benchmarker, task: Task, language: Language
+) -> None:
+    """Test that the dummy model can be benchmarked."""
+    benchmark_result = benchmarker.benchmark(
+        model="dummy", task=task.name, language=language.code
+    )
+    assert isinstance(benchmark_result, list)
+    assert all(isinstance(result, BenchmarkResult) for result in benchmark_result)
+
+
 @pytest.mark.depends(on=["tests/test_model_loading.py::test_load_non_generative_model"])
 def test_benchmark_encoder(
     benchmarker: Benchmarker, task: Task, language: Language, encoder_model_id: str

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -14,6 +14,28 @@ from euroeval.model_config import get_model_config
 from euroeval.model_loading import load_model
 
 
+def test_load_dummy_model(benchmark_config: BenchmarkConfig) -> None:
+    """Test loading the dummy model.
+
+    Unlike the other model types, this needs no GPU or HF_TOKEN, since it never
+    downloads or runs any real model.
+    """
+    model_config = get_model_config(model_id="dummy", benchmark_config=benchmark_config)
+    model = load_model(
+        model_config=model_config,
+        dataset_config=get_all_dataset_configs(
+            custom_datasets_file=Path("custom_datasets.py"),
+            dataset_ids=[],
+            api_key=os.getenv("HF_TOKEN"),
+            cache_dir=Path(".euroeval_cache"),
+            trust_remote_code=True,
+            run_with_cli=True,
+        )["multi-wiki-qa-da"],
+        benchmark_config=benchmark_config,
+    )
+    assert model is not None
+
+
 @pytest.mark.skipif(
     condition=torch.cuda.is_available() is False, reason="CUDA not available"
 )


### PR DESCRIPTION
This PR adds a built-in `dummy` model backend for debugging EuroEval setups without downloading or running any real model (closes #1504).

- For classification/multiple-choice tasks, it predicts a label with a uniform probability across candidate labels
- For NER, it predicts no entities, i.e., `[]` for all entities in the sample
- For everything else (QA, summarization, hallucination, etc.), it returns the generic placeholder answer "answer"

﻿All tests pass, and I've also manually tested the model for Danish across every task type, which also completes successfully.