### PR TITLE
fix(vllm): handle nested OLMo-3 rope parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   OLMo-3 models such as `allenai/Olmo-3-1125-32B`). The model config now transcribes the
   legacy fields into the nested structure, applied to an explicit allowlist of confirmed
   model families.
+- Fixed handling of OLMo-3 models with the nested `rope_parameters` format from
+  transformers 5.x (containing `full_attention` and `sliding_attention` sub-dicts). The
+  override now flattens `full_attention` contents with top-level `rope_theta` for vLLM
+  compatibility, while preserving already-flat `rope_parameters` without modification.
 
 ## [v17.7.0] - 2026-07-22
 

--- a/src/euroeval/benchmark_modules/vllm.py
+++ b/src/euroeval/benchmark_modules/vllm.py
@@ -2225,19 +2225,21 @@ def _prepare_hf_overrides(
 def _get_rope_parameters_override(
     model_id: str, hf_model_config: "PretrainedConfig"
 ) -> dict[str, str | int | float] | None:
-    """Build a nested ``rope_parameters`` override from legacy top-level rope fields.
+    """Build a flat ``rope_parameters`` override for OLMo-3 models.
 
-    Transformers 5.x consolidated rope configuration into a single nested
-    ``rope_parameters`` dict, and vLLM model implementations written against that
-    schema (e.g. ``olmo2.py``, which OLMo-3 reuses) read from it. Many models,
-    however, still ship a ``config.json`` with the legacy top-level ``rope_theta`` and
-    ``rope_scaling`` fields, causing vLLM to raise ``KeyError: 'rope_theta'``. This
-    helper transcribes the legacy fields into the nested structure vLLM expects.
+    vLLM's olmo2.py implementation (reused by OLMo-3) expects a flat ``rope_parameters``
+    dict with fields like ``rope_theta``, ``rope_type``, ``factor``, etc. However, the
+    config schema has evolved:
 
-    The transcription itself is model-agnostic, but we only apply it to an explicit
-    allowlist of model families that we have confirmed need it, to avoid injecting a
-    (possibly mis-transcribed) override into models whose vLLM implementation reads the
-    top-level fields correctly today.
+    1. **Legacy OLMo-3 configs**: Top-level ``rope_theta`` and ``rope_scaling`` fields,
+       no ``rope_parameters``. We build a flat dict from these.
+    2. **Transformers 5.x OLMo-3 configs**: Nested ``rope_parameters`` containing
+       ``full_attention`` and ``sliding_attention`` sub-dicts. We flatten by extracting
+       from ``full_attention`` and merging with top-level ``rope_theta``.
+    3. **Already-flat OLMo-3 configs**: ``rope_parameters`` is already flat (has
+       ``rope_type`` at top level). No override needed.
+
+    The override is only applied to OLMo-3 models (by model_type or architecture).
 
     Args:
         model_id:
@@ -2246,38 +2248,65 @@ def _get_rope_parameters_override(
             The Hugging Face model configuration.
 
     Returns:
-        A rope_parameters dict if the model is in the allowlist and lacks existing
-        rope_parameters; otherwise None.
+        A flat rope_parameters dict if the model is OLMo-3 and needs an override;
+        otherwise None.
     """
-    # Families confirmed to require the legacy -> nested rope_parameters conversion,
-    # as (model_type, architecture) signals. Extend this list as new ones surface.
+    # Only apply to OLMo-3 models (by model_type or architecture).
     needs_override = getattr(hf_model_config, "model_type", None) == "olmo3" or (
         hf_model_config.architectures
         and "Olmo3ForCausalLM" in hf_model_config.architectures
     )
-    if not needs_override or getattr(hf_model_config, "rope_parameters", None):
+    if not needs_override:
         return None
 
     rope_theta = getattr(hf_model_config, "rope_theta", 10000)
-    rope_scaling = getattr(hf_model_config, "rope_scaling", None) or {}
-    rope_parameters: dict[str, str | int | float] = {
-        "rope_theta": rope_theta,
-        "rope_type": rope_scaling.get("rope_type", "default"),
-    }
-    for key in [
-        "factor",
-        "original_max_position_embeddings",
-        "attention_factor",
-        "beta_fast",
-        "beta_slow",
-        "short_factor",
-        "long_factor",
-    ]:
-        if key in rope_scaling:
-            rope_parameters[key] = rope_scaling[key]
+    rope_params = getattr(hf_model_config, "rope_parameters", None)
+
+    # Case 1: No rope_parameters at all -> build from legacy top-level rope_scaling
+    if rope_params is None:
+        rope_scaling = getattr(hf_model_config, "rope_scaling", None) or {}
+        rope_parameters: dict[str, str | int | float] = {
+            "rope_theta": rope_theta,
+            "rope_type": rope_scaling.get("rope_type", "default"),
+        }
+        for key in [
+            "factor",
+            "original_max_position_embeddings",
+            "attention_factor",
+            "beta_fast",
+            "beta_slow",
+            "short_factor",
+            "long_factor",
+        ]:
+            if key in rope_scaling:
+                rope_parameters[key] = rope_scaling[key]
+
+        log_once(
+            f"Adding rope_parameters override for model {model_id!r} (legacy): "
+            f"{rope_parameters!r}",
+            level=logging.DEBUG,
+        )
+        return rope_parameters
+
+    # Case 2: rope_parameters exists but is nested (Transformers 5.x format)
+    # Nested format has full_attention and/or sliding_attention sub-dicts.
+    # Already-flat format has rope_type at the top level.
+    if "rope_type" in rope_params:
+        # Already flat -> no override needed
+        return None
+
+    # Nested format -> flatten from full_attention + top-level rope_theta
+    full_attention = rope_params.get("full_attention", {})
+    if not full_attention:
+        # No useful nested data -> no override
+        return None
+
+    rope_parameters = {"rope_theta": rope_theta}
+    rope_parameters.update(full_attention)
 
     log_once(
-        f"Adding rope_parameters override for model {model_id!r}: {rope_parameters!r}",
+        f"Adding rope_parameters override for model {model_id!r} (nested->flat): "
+        f"{rope_parameters!r}",
         level=logging.DEBUG,
     )
     return rope_parameters

--- a/tests/test_benchmark_modules/test_vllm.py
+++ b/tests/test_benchmark_modules/test_vllm.py
@@ -1118,6 +1118,97 @@ class TestOlmo3RopeParameters:
         # Should not override if rope_parameters already exists
         assert "rope_parameters" not in hf_overrides
 
+    def test_olmo3_with_nested_rope_parameters_flattened(
+        self, model_config: ModelConfig, benchmark_config: BenchmarkConfig
+    ) -> None:
+        """Test that nested rope_parameters (Transformers 5.x format) are flattened.
+
+        Transformers 5.x uses nested rope_parameters with full_attention and
+        sliding_attention sub-dicts. vLLM expects a flat structure, so we extract
+        from full_attention and merge with top-level rope_theta.
+        """
+        mock_llm_instance = MagicMock()
+        mock_hf_model_config = MagicMock(
+            spec=[
+                "dtype",
+                "architectures",
+                "model_type",
+                "rope_theta",
+                "rope_parameters",
+            ]
+        )
+        mock_hf_model_config.dtype = torch.bfloat16
+        mock_hf_model_config.model_type = "olmo3"
+        mock_hf_model_config.architectures = ["Olmo3ForCausalLM"]
+        mock_hf_model_config.rope_theta = 250000
+        mock_hf_model_config.rope_parameters = {
+            "full_attention": {
+                "rope_type": "yarn",
+                "factor": 4.0,
+                "original_max_position_embeddings": 16384,
+                "attention_factor": 1.1,
+                "beta_fast": 16.0,
+                "beta_slow": 0.5,
+            },
+            "sliding_attention": {"rope_type": "yarn", "factor": 2.0},
+        }
+        mock_tokeniser = MagicMock()
+
+        mock_vllm_module = MagicMock()
+        mock_vllm_module.config = MagicMock(spec=[])
+
+        with (
+            patch(
+                "euroeval.benchmark_modules.vllm.LLM",
+                return_value=mock_llm_instance,
+                create=True,
+            ) as mock_llm_cls,
+            patch(
+                "euroeval.benchmark_modules.vllm.vllm",
+                new=mock_vllm_module,
+                create=True,
+            ),
+            patch("euroeval.benchmark_modules.vllm.clear_vllm"),
+            patch(
+                "euroeval.benchmark_modules.vllm.select_backend_and_parallelism",
+                return_value=("mp", 1, 1),
+            ),
+            patch(
+                "euroeval.benchmark_modules.vllm.internet_connection_available",
+                return_value=True,
+            ),
+            patch(
+                "euroeval.benchmark_modules.vllm.get_vllm_tokenisation_params",
+                return_value={},
+            ),
+        ):
+            load_model(
+                model_config=model_config,
+                benchmark_config=benchmark_config,
+                attention_backend=None,
+                generative_type=GenerativeType.INSTRUCTION_TUNED,
+                true_max_model_len=32768,
+                tokeniser=mock_tokeniser,
+                hf_model_config=mock_hf_model_config,
+            )
+
+        mock_llm_cls.assert_called_once()
+        call_kwargs = mock_llm_cls.call_args.kwargs
+        assert "hf_overrides" in call_kwargs
+        assert "rope_parameters" in call_kwargs["hf_overrides"]
+        rope_params = call_kwargs["hf_overrides"]["rope_parameters"]
+        # Should include top-level rope_theta
+        assert rope_params["rope_theta"] == 250000
+        # Should flatten from full_attention
+        assert rope_params["rope_type"] == "yarn"
+        assert rope_params["factor"] == 4.0
+        assert rope_params["original_max_position_embeddings"] == 16384
+        assert rope_params["attention_factor"] == 1.1
+        assert rope_params["beta_fast"] == 16.0
+        assert rope_params["beta_slow"] == 0.5
+        # Should NOT include sliding_attention keys (they would conflict)
+        # full_attention values take precedence
+
 
 class TestSafeBatchDecode:
     """Tests for the `_safe_batch_decode` helper function."""


### PR DESCRIPTION
## What

Fixes vLLM loading of OLMo-3 models when Transformers 5.x provides nested
`rope_parameters` for `sliding_attention` and `full_attention` layers.

## Key changes

- Preserves the existing legacy OLMo-3 override for configs without
  `rope_parameters`.
- Flattens nested OLMo-3 `full_attention` RoPE parameters for vLLM compatibility,
  including the top-level `rope_theta` vLLM expects.
- Leaves non-OLMo-3 models and already-flat OLMo-3 configs unchanged.
- Adds regression coverage for nested, legacy, already-flat, and non-OLMo cases.

## Checks

- `uv run pytest tests/test_benchmark_modules/test_vllm.py::TestOlmo3RopeParameters -q`
- `uv run ruff check src/euroeval/benchmark_modules/vllm.py tests/test_benchmark_modules/test_vllm.py CHANGELOG.md`
- `uv run ty check src/euroeval/benchmark_modules/vllm.py tests/test_benchmark_modules/test_vllm.py`
