### PR TITLE
feat: swap official dataset mmlu-de -> include-de, multiloko-de

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Swapped official dataset for German:
+`mmlu-de` → `include-de`, `multiloko-de`.
+
 - Bumped minimum `transformers` version to 5.14.0 (required for XLMRoberta/Camembert
   `ForMultipleChoice` heads; see huggingface/transformers#47147).
 - Swapped official datasets for four languages (all performed by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,6 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Swapped official dataset for German:
-`mmlu-de` → `include-de`, `multiloko-de`.
-
 - Bumped minimum `transformers` version to 5.14.0 (required for XLMRoberta/Camembert
   `ForMultipleChoice` heads; see huggingface/transformers#47147).
 - Swapped official datasets for four languages (all performed by the
@@ -37,7 +34,7 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   - Croatian: `mmlu-hr` → `include-hr`
   - Dutch: `scala-nl` → `dutch-cola`, `mmlu-nl` → `include-nl`, `multiloko-nl`
   - French: `mmlu-fr` → `include-fr`, `multiloko-fr`
-  - German: `hellaswag-de` → `winogrande-de`
+  - German: `hellaswag-de` → `winogrande-de`, `mmlu-de` → `include-de`, `multiloko-de`
   - Portuguese: `mmlu-pt` → `alba-mcq-pt`, `cultura-viva-pt`
 
 ### Fixed

--- a/src/euroeval/dataset_configs/german.py
+++ b/src/euroeval/dataset_configs/german.py
@@ -60,14 +60,6 @@ MLSUM_DE_CONFIG = DatasetConfig(
     languages=[GERMAN],
 )
 
-MMLU_DE_CONFIG = DatasetConfig(
-    name="mmlu-de",
-    pretty_name="MMLU-de",
-    source="EuroEval/mmlu-de-mini",
-    task=KNOW,
-    languages=[GERMAN],
-)
-
 MULTI_IFEVAL_DE_CONFIG = DatasetConfig(
     name="multi-ifeval-de",
     pretty_name="MultiIFEval-de",
@@ -108,7 +100,33 @@ WINOGRANDE_DE_CONFIG = DatasetConfig(
     labels=["a", "b"],
 )
 
+INCLUDE_DE_CONFIG = DatasetConfig(
+    name="include-de",
+    pretty_name="INCLUDE-de",
+    source="EuroEval/include-de-mini",
+    task=KNOW,
+    languages=[GERMAN],
+)
+
+MULTILOKO_DE_CONFIG = DatasetConfig(
+    name="multiloko-de",
+    pretty_name="MultiLoKo-de",
+    source="EuroEval/multiloko-de-mini",
+    task=KNOW,
+    languages=[GERMAN],
+    val_split=None,
+)
+
 # Unofficial datasets ###
+
+MMLU_DE_CONFIG = DatasetConfig(
+    name="mmlu-de",
+    pretty_name="MMLU-de",
+    source="EuroEval/mmlu-de-mini",
+    task=KNOW,
+    languages=[GERMAN],
+    unofficial=True,
+)
 
 HELLASWAG_DE_CONFIG = DatasetConfig(
     name="hellaswag-de",
@@ -172,25 +190,6 @@ GOLDENSWAG_DE_CONFIG = DatasetConfig(
     source="EuroEval/goldenswag-de-mini",
     task=COMMON_SENSE,
     languages=[GERMAN],
-    unofficial=True,
-)
-
-INCLUDE_DE_CONFIG = DatasetConfig(
-    name="include-de",
-    pretty_name="INCLUDE-de",
-    source="EuroEval/include-de-mini",
-    task=KNOW,
-    languages=[GERMAN],
-    unofficial=True,
-)
-
-MULTILOKO_DE_CONFIG = DatasetConfig(
-    name="multiloko-de",
-    pretty_name="MultiLoKo-de",
-    source="EuroEval/multiloko-de-mini",
-    task=KNOW,
-    languages=[GERMAN],
-    val_split=None,
     unofficial=True,
 )
 

--- a/src/frontend/md/datasets/german.md
+++ b/src/frontend/md/datasets/german.md
@@ -540,7 +540,142 @@ euroeval --model <model-id> --dataset multi-wiki-qa-de
 
 ## Knowledge
 
-### MMLU-de
+### INCLUDE-de
+
+This dataset is part of [INCLUDE](https://doi.org/10.48550/arXiv.2411.19799), a
+comprehensive knowledge- and reasoning-centric benchmark that evaluates multilingual
+LLMs across 44 languages. It contains 4-option multiple-choice questions extracted from
+academic and professional exams, covering 57 topics including regional knowledge.
+
+The original dataset consists of a 'validation' split used as training data and a 'test'
+split. We use the 'validation' split as the training split, which has 25 samples. We
+sample 64 samples from the 'test' split for the validation split, and use the remaining
+512 samples for the test split. The sampling is done stratified by the subject column.
+
+Here are a few examples from the dataset:
+
+```json
+{
+  "text": "Wann dürfen Sie in einem Tunnel Ihr Fahrzeug wenden?\nAntwortmöglichkeiten:\na. Wenn Einsatzkräfte das Wenden ausdrücklich anordnen\nb. Wenn ich aus einer Gefahrensituation flüchten möchte\nc. Wenn ich unter Zeitdruck bin und sich vor mir ein Stau gebildet hat\nd. Nur wenn ich mit meinem Fahrzeug in einem Zug umkehren kann",
+  "label": "a",
+  "subject": "Driving License"
+}
+```
+
+```json
+{
+  "text": "Das Industrieland hat in einer Wirtschaftstätigkeit einen komparativen Vorteil, wenn\nAntwortmöglichkeiten:\na. in einer anderen Tätigkeit sein absoluter Vorteil größer ist.\nb. in dieser Tätigkeit sein absoluter Vorteil am größten ist.\nc. es keinen absoluten Vorteil hat.\nd. in dieser Tätigkeit sein absoluter Nachteil am geringsten ist.",
+  "label": "b",
+  "subject": "Economics"
+}
+```
+
+```json
+{
+  "text": "Ein Schiff fährt mit einer geradlinigen, gleichförmigen Bewegung auf dem offenen Meer. Zu gleicher Zeit fliegt auch ein Albatros mit einer in Bezug auf das Meer geradlinigen, gleichförmigen Bewegung in der Luft. Wie bewegt sich der Albatros in Bezug auf das Schiff?\nAntwortmöglichkeiten:\na. Die Bahn des Vogels ist geradlinig, aber seine Geschwindigkeit in Bezug auf das Schiff ist nicht konstant.\nb. Abhängig vom Winkel der zwei Geschwindigkeitsvektoren kann die Bahn des Vogels sowohl krummlinig, als auch geradlinig sein und auch seine Geschwindigkeit in Bezug auf das Schiff kann veränderlich sein.\nc. Der Vogel führt in Bezug auf das Schiff eine gleichförmige, geradlinige Bewegung aus.\nd. In bestimmten Fällen kann die Bahn des Vogels in Bezug auf das Schiff auch krummlinig sein, aber seine Geschwindigkeit hat einen konstanten Betrag.",
+  "label": "c",
+  "subject": "Physics"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  Die folgenden Fragen sind Multiple-Choice-Fragen (mit Antworten).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Frage: {text}
+  Antwort: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Frage: {text}
+
+  Beantworten Sie die obige Frage mit {labels_str}, und nichts anderes.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset include-de
+```
+
+### MultiLoKo-de
+
+This dataset was published in [this paper](https://arxiv.org/abs/2504.10356) and is part
+of MultiLoKo, a multilingual local knowledge benchmark covering 31 languages. The German
+questions are separately sourced and designed to target locally relevant topics for
+German-speaking populations.
+
+We use the 'dev' split (250 samples) from this dataset. The dataset contains open-ended
+questions with correct answers in the 'targets' column. We use the first target answer
+as the correct option and use GPT-4.1 to generate 3 plausible but incorrect alternatives
+per question. We create a 16 / 234 split for training and testing, respectively.
+
+Here are a few examples from the training split:
+
+```json
+{
+  "text": "In welchem Bereich sammelte Reiner Calmund erste berufliche und sportliche Erfahrungen, die später für seine Tätigkeit als Manager bei Bayer 04 Leverkusen relevant wurden?\nAntwortmöglichkeiten:\na. Trainer\nb. Spielerberater\nc. Physiotherapeut\nd. Sportjournalist",
+  "label": "a"
+}
+```
+
+```json
+{
+  "text": "Wie lange war Malu Dreyer Mitglied der SPD, als sie zum ersten Mal Landespräsidentin für den Wahlkreis Trier wurde?\nAntwortmöglichkeiten:\na. vierzehn Jahre\nb. elf Jahre\nc. sieben Jahre\nd. zwanzig Jahre",
+  "label": "b"
+}
+```
+
+```json
+{
+  "text": "Wie lautet der Name des Jungen, der in der vierten Staffel der Fernsehserie „Bettys Diagnose“ zu sehen ist und der der Hauptfigur in der Schule das Leben schwer macht?\nAntwortmöglichkeiten:\na. Tim Weigel\nb. Lukas Kramer\nc. Frank Stern\nd. Jonas Becker",
+  "label": "c"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  Die folgenden Fragen sind Multiple-Choice-Fragen (mit Antworten).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Frage: {text}
+  Antwort: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Frage: {text}
+
+  Beantworten Sie die obige Frage mit 'a', 'b', 'c' oder 'd', und nichts anderes.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset multiloko-de
+```
+
+### Unofficial: MMLU-de
 
 This dataset is a machine translated version of the English
 [MMLU dataset](https://openreview.net/forum?id=d7KBjmI3GmQ) and features questions
@@ -692,141 +827,6 @@ You can evaluate this dataset directly as follows:
 
 ```bash
 euroeval --model <model-id> --dataset arc-de
-```
-
-### Unofficial: INCLUDE-de
-
-This dataset is part of [INCLUDE](https://doi.org/10.48550/arXiv.2411.19799), a
-comprehensive knowledge- and reasoning-centric benchmark that evaluates multilingual
-LLMs across 44 languages. It contains 4-option multiple-choice questions extracted from
-academic and professional exams, covering 57 topics including regional knowledge.
-
-The original dataset consists of a 'validation' split used as training data and a 'test'
-split. We use the 'validation' split as the training split, which has 25 samples. We
-sample 64 samples from the 'test' split for the validation split, and use the remaining
-512 samples for the test split. The sampling is done stratified by the subject column.
-
-Here are a few examples from the dataset:
-
-```json
-{
-  "text": "Wann dürfen Sie in einem Tunnel Ihr Fahrzeug wenden?\nAntwortmöglichkeiten:\na. Wenn Einsatzkräfte das Wenden ausdrücklich anordnen\nb. Wenn ich aus einer Gefahrensituation flüchten möchte\nc. Wenn ich unter Zeitdruck bin und sich vor mir ein Stau gebildet hat\nd. Nur wenn ich mit meinem Fahrzeug in einem Zug umkehren kann",
-  "label": "a",
-  "subject": "Driving License"
-}
-```
-
-```json
-{
-  "text": "Das Industrieland hat in einer Wirtschaftstätigkeit einen komparativen Vorteil, wenn\nAntwortmöglichkeiten:\na. in einer anderen Tätigkeit sein absoluter Vorteil größer ist.\nb. in dieser Tätigkeit sein absoluter Vorteil am größten ist.\nc. es keinen absoluten Vorteil hat.\nd. in dieser Tätigkeit sein absoluter Nachteil am geringsten ist.",
-  "label": "b",
-  "subject": "Economics"
-}
-```
-
-```json
-{
-  "text": "Ein Schiff fährt mit einer geradlinigen, gleichförmigen Bewegung auf dem offenen Meer. Zu gleicher Zeit fliegt auch ein Albatros mit einer in Bezug auf das Meer geradlinigen, gleichförmigen Bewegung in der Luft. Wie bewegt sich der Albatros in Bezug auf das Schiff?\nAntwortmöglichkeiten:\na. Die Bahn des Vogels ist geradlinig, aber seine Geschwindigkeit in Bezug auf das Schiff ist nicht konstant.\nb. Abhängig vom Winkel der zwei Geschwindigkeitsvektoren kann die Bahn des Vogels sowohl krummlinig, als auch geradlinig sein und auch seine Geschwindigkeit in Bezug auf das Schiff kann veränderlich sein.\nc. Der Vogel führt in Bezug auf das Schiff eine gleichförmige, geradlinige Bewegung aus.\nd. In bestimmten Fällen kann die Bahn des Vogels in Bezug auf das Schiff auch krummlinig sein, aber seine Geschwindigkeit hat einen konstanten Betrag.",
-  "label": "c",
-  "subject": "Physics"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 5
-- Prefix prompt:
-
-  ```text
-  Die folgenden Fragen sind Multiple-Choice-Fragen (mit Antworten).
-  ```
-
-- Base prompt template:
-
-  ```text
-  Frage: {text}
-  Antwort: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Frage: {text}
-
-  Beantworten Sie die obige Frage mit {labels_str}, und nichts anderes.
-  ```
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset include-de
-```
-
-### Unofficial: MultiLoKo-de
-
-This dataset was published in [this paper](https://arxiv.org/abs/2504.10356) and is part
-of MultiLoKo, a multilingual local knowledge benchmark covering 31 languages. The German
-questions are separately sourced and designed to target locally relevant topics for
-German-speaking populations.
-
-We use the 'dev' split (250 samples) from this dataset. The dataset contains open-ended
-questions with correct answers in the 'targets' column. We use the first target answer
-as the correct option and use GPT-4.1 to generate 3 plausible but incorrect alternatives
-per question. We create a 16 / 234 split for training and testing, respectively.
-
-Here are a few examples from the training split:
-
-```json
-{
-  "text": "In welchem Bereich sammelte Reiner Calmund erste berufliche und sportliche Erfahrungen, die später für seine Tätigkeit als Manager bei Bayer 04 Leverkusen relevant wurden?\nAntwortmöglichkeiten:\na. Trainer\nb. Spielerberater\nc. Physiotherapeut\nd. Sportjournalist",
-  "label": "a"
-}
-```
-
-```json
-{
-  "text": "Wie lange war Malu Dreyer Mitglied der SPD, als sie zum ersten Mal Landespräsidentin für den Wahlkreis Trier wurde?\nAntwortmöglichkeiten:\na. vierzehn Jahre\nb. elf Jahre\nc. sieben Jahre\nd. zwanzig Jahre",
-  "label": "b"
-}
-```
-
-```json
-{
-  "text": "Wie lautet der Name des Jungen, der in der vierten Staffel der Fernsehserie „Bettys Diagnose“ zu sehen ist und der der Hauptfigur in der Schule das Leben schwer macht?\nAntwortmöglichkeiten:\na. Tim Weigel\nb. Lukas Kramer\nc. Frank Stern\nd. Jonas Becker",
-  "label": "c"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 5
-- Prefix prompt:
-
-  ```text
-  Die folgenden Fragen sind Multiple-Choice-Fragen (mit Antworten).
-  ```
-
-- Base prompt template:
-
-  ```text
-  Frage: {text}
-  Antwort: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Frage: {text}
-
-  Beantworten Sie die obige Frage mit 'a', 'b', 'c' oder 'd', und nichts anderes.
-  ```
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset multiloko-de
 ```
 
 ### Unofficial: EU-MMLU-de

--- a/src/leaderboards/bootstrap_cis.py
+++ b/src/leaderboards/bootstrap_cis.py
@@ -129,9 +129,12 @@ def bootstrap_rank_scores(
             categories=categories,
             rng=rng,
         )
-        for model_id, model_data in iteration_scores.items():
-            for category, cat_data in model_data.items():
-                for key, score in cat_data.items():
+        for model_id in sorted(iteration_scores.keys()):
+            model_data = iteration_scores[model_id]
+            for category in sorted(model_data.keys()):
+                cat_data = model_data[category]
+                for key in sorted(cat_data.keys()):
+                    score = cat_data[key]
                     bootstrap_scores[model_id][category][key].append(score)
 
     return _convert_bootstrap_scores_to_arrays(bootstrap_scores)
@@ -179,9 +182,9 @@ def _bootstrap_single_iteration(
         indices = rng.integers(0, n, size=n)
         sampled_datasets[task] = [ds_list[i] for i in indices]
 
-    sampled_set: set[str] = set()
-    for ds_list in sampled_datasets.values():
-        sampled_set.update(ds_list)
+    sampled_set = {
+        dataset for ds_list in sampled_datasets.values() for dataset in ds_list
+    }
 
     dataset_stats = _compute_dataset_stats(
         sampled_set=sampled_set,
@@ -191,6 +194,7 @@ def _bootstrap_single_iteration(
     )
 
     all_rank_scores = _compute_rank_scores(
+        sampled_datasets=sampled_datasets,
         dataset_stats=dataset_stats,
         dataset_models=dataset_models,
         model_datasets=model_datasets,
@@ -200,7 +204,7 @@ def _bootstrap_single_iteration(
     )
 
     aggregated: dict[str, dict[str, dict[str, float]]] = {}
-    for model_id in model_results:
+    for model_id in sorted(model_results.keys()):
         model_agg = _aggregate_bootstrap_sample(
             model_id=model_id,
             categories=categories,
@@ -219,16 +223,15 @@ def _bootstrap_single_iteration(
 def _aggregate_bootstrap_sample(
     model_id: str,
     categories: tuple[str, ...],
-    all_rank_scores: dict[str, dict[str, dict[str, float]]],
+    all_rank_scores: dict[str, dict[str, dict[str, list[float]]]],
     configs: dict[str, dict[str, list[str]]],
 ) -> dict[str, dict[str, float | None]]:
-    """Aggregate per-dataset scores for one model in one bootstrap sample.
+    """Aggregate sampled per-dataset scores for one model.
 
     Returns:
         category -> {lang: score, "overall": overall or None}
     """
     result: dict[str, dict[str, float | None]] = {}
-    # Sort for deterministic iteration order.
     for category in sorted(categories):
         model_rank_scores = all_rank_scores.get(model_id, {}).get(category, {})
         if not model_rank_scores:
@@ -241,15 +244,16 @@ def _aggregate_bootstrap_sample(
 
 
 def _aggregate_scores_to_categories(
-    dataset_scores: dict[str, float], configs: dict[str, dict[str, list[str]]]
+    dataset_scores: dict[str, list[float]], configs: dict[str, dict[str, list[str]]]
 ) -> tuple[dict[str, float], float | None]:
-    """Aggregate per-dataset scores up to language and overall mean rank scores.
+    """Aggregate sampled dataset scores to language and overall scores.
 
-    Hierarchy: dataset -> task -> language -> overall.
+    Hierarchy: sampled dataset occurrence -> task -> language -> overall.
+    Duplicate dataset samples are intentionally retained.
 
     Args:
         dataset_scores:
-            dataset -> score mapping for this model.
+            Dataset -> sampled rank scores for this model.
         configs:
             Per-language task -> dataset mappings.
 
@@ -260,29 +264,28 @@ def _aggregate_scores_to_categories(
     """
     lang_task_scores: dict[str, dict[str, list[float]]] = {}
 
-    for ds, score in dataset_scores.items():
-        task = None
-        found_lang = None
-        for lang_name, config in configs.items():
-            for task_name, task_ds in config.items():
-                if ds in task_ds:
-                    task = task_name
-                    found_lang = lang_name
-                    break
-            if task:
-                break
-        if task and task not in ORTHOGONAL_TASKS and found_lang:
-            lang_task_scores.setdefault(found_lang, {}).setdefault(task, []).append(
-                score
-            )
+    for lang_name in sorted(configs.keys()):
+        config = configs[lang_name]
+        for task_name in sorted(config.keys()):
+            if task_name in ORTHOGONAL_TASKS:
+                continue
+            for dataset in sorted(config[task_name]):
+                scores = dataset_scores.get(dataset, [])
+                if scores:
+                    lang_task_scores.setdefault(lang_name, {}).setdefault(
+                        task_name, []
+                    ).extend(scores)
 
     if not lang_task_scores:
         return {}, None
 
     language_scores: dict[str, float] = {}
     lang_means = []
-    for lang, task_scores in lang_task_scores.items():
-        task_means = [np.mean(scores) for scores in task_scores.values()]
+    for lang in sorted(lang_task_scores.keys()):
+        task_scores = lang_task_scores[lang]
+        task_means = [
+            np.mean(scores) for _, scores in sorted(task_scores.items()) if scores
+        ]
         if task_means:
             lang_mean = float(np.mean(task_means))
             language_scores[lang] = lang_mean
@@ -336,16 +339,19 @@ def _compute_dataset_stats(
 
 
 def _compute_rank_scores(
+    sampled_datasets: dict[str, list[str]],
     dataset_stats: dict[str, tuple[float, float]],
     dataset_models: dict[str, set[str]],
     model_datasets: dict[str, set[str]],
     model_results: dict[str, dict[str, list[tuple[list[float], float, float]]]],
     dataset_to_category: dict[str, set[str]],
     rng: np.random.Generator,
-) -> dict[str, dict[str, dict[str, float]]]:
-    """Compute rank scores for all models on all sampled datasets.
+) -> dict[str, dict[str, dict[str, list[float]]]]:
+    """Compute rank scores for sampled dataset occurrences.
 
     Args:
+        sampled_datasets:
+            Task -> sampled datasets, retaining bootstrap multiplicity.
         dataset_stats:
             Per-dataset statistics.
         dataset_models:
@@ -360,27 +366,31 @@ def _compute_rank_scores(
             Random number generator.
 
     Returns:
-        Nested dict: model_id -> category -> dataset -> score.
+        Nested dict: model_id -> category -> dataset -> sampled scores.
     """
-    all_rank_scores: dict[str, dict[str, dict[str, float]]] = {}
-    # Sort for deterministic RNG consumption.
-    for ds in sorted(dataset_stats.keys()):
-        best_mean, pooled_sd = dataset_stats[ds]
-        if pooled_sd <= 0:
-            continue
-        models_on_ds = dataset_models.get(ds, set())
-        for mid in sorted(models_on_ds):
-            if mid not in model_results or ds not in model_datasets[mid]:
+    all_rank_scores: dict[str, dict[str, dict[str, list[float]]]] = {}
+    for task in sorted(sampled_datasets.keys()):
+        for ds in sampled_datasets[task]:
+            if ds not in dataset_stats:
                 continue
-            raw, mean_sc, _ = model_results[mid][ds][0]
-            if not np.isfinite(mean_sc):
+            best_mean, pooled_sd = dataset_stats[ds]
+            if pooled_sd <= 0:
                 continue
-            resampled_raw = rng.choice(raw, size=len(raw), replace=True)
-            resampled_mean = float(np.mean(resampled_raw))
-            diff = (best_mean - resampled_mean) / pooled_sd
-            score = 1.0 + diff
-            for cat in dataset_to_category.get(ds, set()):
-                all_rank_scores.setdefault(mid, {}).setdefault(cat, {})[ds] = score
+            models_on_ds = dataset_models.get(ds, set())
+            for mid in sorted(models_on_ds):
+                if mid not in model_results or ds not in model_datasets[mid]:
+                    continue
+                raw, mean_sc, _ = model_results[mid][ds][0]
+                if not np.isfinite(mean_sc):
+                    continue
+                resampled_raw = rng.choice(raw, size=len(raw), replace=True)
+                resampled_mean = float(np.mean(resampled_raw))
+                diff = (best_mean - resampled_mean) / pooled_sd
+                score = 1.0 + diff
+                for cat in sorted(dataset_to_category.get(ds, set())):
+                    all_rank_scores.setdefault(mid, {}).setdefault(cat, {}).setdefault(
+                        ds, []
+                    ).append(score)
     return all_rank_scores
 
 

--- a/src/leaderboards/bootstrap_cis.py
+++ b/src/leaderboards/bootstrap_cis.py
@@ -40,11 +40,15 @@ def bootstrap_confidence_intervals(
     """
     result: dict[str, dict[str, dict[str, dict[str, float]]]] = {}
 
-    for model_id, cats_data in bootstrap_scores.items():
+    # Sort for deterministic iteration order.
+    for model_id in sorted(bootstrap_scores.keys()):
+        cats_data = bootstrap_scores[model_id]
         result[model_id] = {}
-        for cat, langs in cats_data.items():
+        for cat in sorted(cats_data.keys()):
+            langs = cats_data[cat]
             result[model_id][cat] = {}
-            for lang, samples in langs.items():
+            for lang in sorted(langs.keys()):
+                samples = langs[lang]
                 if len(samples) == 0:
                     continue
                 q_low = np.percentile(samples, 100 * alpha / 2)
@@ -94,13 +98,16 @@ def bootstrap_rank_scores(
 
     rng = np.random.default_rng(seed)
 
+    # Sort model IDs for deterministic iteration order (RNG consumption must be
+    # deterministic across runs with the same seed).
+    sorted_model_ids = sorted(model_results.keys())
     model_datasets: dict[str, set[str]] = {
-        mid: set(data.keys()) for mid, data in model_results.items()
+        mid: set(model_results[mid].keys()) for mid in sorted_model_ids
     }
 
     dataset_models: dict[str, set[str]] = defaultdict(set)
-    for mid, ds in model_datasets.items():
-        for d in ds:
+    for mid in sorted_model_ids:
+        for d in sorted(model_datasets[mid]):
             dataset_models[d].add(mid)
 
     task_datasets, dataset_to_category = _build_dataset_mappings(
@@ -163,9 +170,11 @@ def _bootstrap_single_iteration(
     Returns:
         Nested dict: model_id -> category -> language -> score.
     """
-    # Resample datasets with replacement (stratified by task)
+    # Resample datasets with replacement (stratified by task).
+    # Iterate in sorted order for deterministic RNG consumption.
     sampled_datasets: dict[str, list[str]] = {}
-    for task, ds_list in task_datasets.items():
+    for task in sorted(task_datasets.keys()):
+        ds_list = task_datasets[task]
         n = len(ds_list)
         indices = rng.integers(0, n, size=n)
         sampled_datasets[task] = [ds_list[i] for i in indices]
@@ -219,7 +228,8 @@ def _aggregate_bootstrap_sample(
         category -> {lang: score, "overall": overall or None}
     """
     result: dict[str, dict[str, float | None]] = {}
-    for category in categories:
+    # Sort for deterministic iteration order.
+    for category in sorted(categories):
         model_rank_scores = all_rank_scores.get(model_id, {}).get(category, {})
         if not model_rank_scores:
             continue
@@ -304,12 +314,13 @@ def _compute_dataset_stats(
         Dict of dataset -> (best_mean, pooled_sd).
     """
     dataset_stats: dict[str, tuple[float, float]] = {}
-    for ds in sampled_set:
+    # Sort for deterministic RNG consumption.
+    for ds in sorted(sampled_set):
         models_on_ds = dataset_models.get(ds, set())
         if not models_on_ds:
             continue
         scores: list[tuple[str, float, list[float]]] = []
-        for mid in models_on_ds:
+        for mid in sorted(models_on_ds):
             if mid in model_results and ds in model_datasets[mid]:
                 raw, mean_sc, _ = model_results[mid][ds][0]
                 if np.isfinite(mean_sc):
@@ -352,11 +363,13 @@ def _compute_rank_scores(
         Nested dict: model_id -> category -> dataset -> score.
     """
     all_rank_scores: dict[str, dict[str, dict[str, float]]] = {}
-    for ds, (best_mean, pooled_sd) in dataset_stats.items():
+    # Sort for deterministic RNG consumption.
+    for ds in sorted(dataset_stats.keys()):
+        best_mean, pooled_sd = dataset_stats[ds]
         if pooled_sd <= 0:
             continue
         models_on_ds = dataset_models.get(ds, set())
-        for mid in models_on_ds:
+        for mid in sorted(models_on_ds):
             if mid not in model_results or ds not in model_datasets[mid]:
                 continue
             raw, mean_sc, _ = model_results[mid][ds][0]
@@ -386,19 +399,24 @@ def _build_dataset_mappings(
         Tuple of (task_datasets dict, dataset_to_category dict).
     """
     dataset_to_task: dict[str, str] = {}
-    for _language, config in configs.items():
-        for task, task_datasets_list in config.items():
+    # Sort for deterministic iteration order.
+    for language in sorted(configs.keys()):
+        config = configs[language]
+        for task in sorted(config.keys()):
+            task_datasets_list = config[task]
             if task in ORTHOGONAL_TASKS:
                 continue
-            for ds in task_datasets_list:
+            for ds in sorted(task_datasets_list):
                 dataset_to_task[ds] = task
 
     task_datasets: dict[str, list[str]] = defaultdict(list)
-    for ds, task in dataset_to_task.items():
+    for ds in sorted(dataset_to_task.keys()):
+        task = dataset_to_task[ds]
         task_datasets[task].append(ds)
 
     dataset_to_category: dict[str, set[str]] = {}
-    for ds, task in dataset_to_task.items():
+    for ds in sorted(dataset_to_task.keys()):
+        task = dataset_to_task[ds]
         cats: set[str] = set()
         for category in categories:
             if category_includes_task(category=category, task=task):
@@ -422,10 +440,15 @@ def _convert_bootstrap_scores_to_arrays(
         Same structure but with np.ndarray values.
     """
     result: dict[str, dict[str, dict[str, np.ndarray]]] = {}
-    for mid, cats_data in bootstrap_scores.items():
+    # Sort for deterministic iteration order.
+    for mid in sorted(bootstrap_scores.keys()):
+        cats_data = bootstrap_scores[mid]
         result[mid] = {}
-        for cat, langs in cats_data.items():
+        for cat in sorted(cats_data.keys()):
+            langs = cats_data[cat]
             result[mid][cat] = {
-                lang: np.array(scores) for lang, scores in langs.items()
+                lang: np.array(scores)
+                for lang in sorted(langs.keys())
+                for scores in [langs[lang]]
             }
     return result

--- a/src/leaderboards/dataset_split_sizes.json
+++ b/src/leaderboards/dataset_split_sizes.json
@@ -529,6 +529,11 @@
     "train": 1024,
     "val": 256
   },
+  "EuroEval/include-de-mini": {
+    "test": 65,
+    "train": 15,
+    "val": 64
+  },
   "EuroEval/include-fr-mini": {
     "test": 318,
     "train": 22,
@@ -837,6 +842,10 @@
     "test": 2048,
     "train": 1024,
     "val": 256
+  },
+  "EuroEval/multiloko-de-mini": {
+    "test": 233,
+    "train": 16
   },
   "EuroEval/multiloko-fr-mini": {
     "test": 234,

--- a/src/leaderboards/leaderboard_generation.py
+++ b/src/leaderboards/leaderboard_generation.py
@@ -112,8 +112,8 @@ def generate_leaderboard(
         # model as "updated":
         #   * the ordinal "Rank" column (a position relative to the pool);
         #   * the "Rank score" column and the per-language rank columns
-        #     (bootstrap scores computed over the whole pool, so they shift for
-        #     everyone when the set of models changes);
+        #     (bootstrap scores are population-relative, so they shift when the
+        #     eligible model set changes);
         #   * the per-dataset "_version"/"_failures"/"_scored" companion columns.
         # The remaining columns are the per-dataset scores, which only change
         # when the model itself is re-evaluated — and additions/removals are

--- a/src/leaderboards/leaderboard_generation.py
+++ b/src/leaderboards/leaderboard_generation.py
@@ -14,11 +14,12 @@ import pandas as pd
 
 from euroeval.constants import ORTHOGONAL_TASKS
 
+from .bootstrap_cis import bootstrap_confidence_intervals, bootstrap_rank_scores
 from .constants import NUM_BOOTSTRAPS, OUTPUT_DIR
 from .link_generation import generate_task_link
 from .records import drop_val_duplicates, get_dataset, plain_model_id
 from .result_loading import load_raw_results
-from .score_computation import compute_ranks_bootstrap, compute_standard_ranks_bootstrap
+from .score_computation import compute_standard_ranks_from_bootstrap_scores
 from .score_extraction import extract_model_metadata, group_results_by_model
 from .task_metadata import category_includes_task, official_datasets_for_language
 
@@ -77,24 +78,17 @@ def generate_leaderboard(
     )
     model_results = drop_val_duplicates(model_results=model_results)
 
-    # Use bootstrap-based CIs for the displayed "Rank score ± margin" column.
-    # Bootstrap resamples datasets with replacement (stratified by task),
-    # recomputes the full hierarchy, and returns percentile CIs.
-    ranks = compute_ranks_bootstrap(
-        model_results=model_results,
-        configs=configs,
-        n_bootstraps=NUM_BOOTSTRAPS,
-        seed=42,
-    )
     metadata_dict = extract_model_metadata(results=results)
 
     # Only include dataset columns in monolingual leaderboards
     include_dataset_columns = len(configs) == 1
 
-    # Generate the leaderboard and store it to disk
+    # Generate the leaderboard and store it to disk.
+    # Ranks are computed per-category from the eligible model set, ensuring
+    # that displayed "Rank score" and ordinal "Rank" are derived from the
+    # same bootstrap distribution.
     df_pairs = _generate_dataframe(
         model_results=model_results,
-        ranks=ranks,
         metadata_dict=metadata_dict,
         categories=categories,
         leaderboard_configs=configs,
@@ -379,7 +373,6 @@ def _create_leaderboard_headers(
 
 def _generate_dataframe(
     model_results: dict[str, dict[str, list[tuple[list[float], float, float]]]],
-    ranks: dict[str, dict[str, dict[str, dict[str, float]]]],
     metadata_dict: dict[str, dict],
     categories: list[t.Literal["generative", "all_models"]],
     leaderboard_configs: dict[str, dict[str, list[str]]],
@@ -390,8 +383,6 @@ def _generate_dataframe(
     Args:
         model_results:
             The model results.
-        ranks:
-            The ranks of the models (from compute_ranks).
         metadata_dict:
             The metadata.
         categories:
@@ -415,14 +406,17 @@ def _generate_dataframe(
 
     dfs: list[tuple[pd.DataFrame, pd.DataFrame]] = []
     for category in categories:
-        (eligible_model_results, language_to_required_datasets, all_standard_ranks) = (
-            _compute_eligible_models_and_ranks(
-                model_results=model_results,
-                category=category,
-                category_to_datasets=category_to_datasets,
-                category_to_orthogonal_datasets=category_to_orthogonal_datasets,
-                leaderboard_configs=leaderboard_configs,
-            )
+        (
+            eligible_model_results,
+            language_to_required_datasets,
+            ranks,
+            all_standard_ranks,
+        ) = _compute_eligible_models_and_ranks(
+            model_results=model_results,
+            category=category,
+            category_to_datasets=category_to_datasets,
+            category_to_orthogonal_datasets=category_to_orthogonal_datasets,
+            leaderboard_configs=leaderboard_configs,
         )
 
         orthogonal_scores_by_plain = _collect_orthogonal_scores(
@@ -815,8 +809,12 @@ def _compute_eligible_models_and_ranks(
     category_to_datasets: dict[str, list[str]],
     category_to_orthogonal_datasets: dict[str, dict[str, str]],
     leaderboard_configs: dict[str, dict[str, list[str]]],
-) -> "tuple[dict[str, dict[str, list[tuple[list[float], float, float]]]], dict[str, list[str]], dict]":  # noqa: E501
+) -> "tuple[dict[str, dict[str, list[tuple[list[float], float, float]]]], dict[str, list[str]], dict, dict]":  # noqa: E501
     """Compute eligible models and bootstrap ranks for a category.
+
+    Computes both displayed rank scores (for the "Rank score" column) and
+    ordinal ranks from the SAME bootstrap distribution over the eligible model
+    set, ensuring consistency between the two.
 
     Args:
         model_results:
@@ -832,17 +830,20 @@ def _compute_eligible_models_and_ranks(
 
     Returns:
         Tuple of (eligible_model_results, language_to_required_datasets,
-        all_standard_ranks).
+        ranks, all_standard_ranks). Ranks are the displayed rank scores
+        (model_id -> category -> language -> {"score", "ci_lower", "ci_upper"}),
+        all_standard_ranks are the ordinal ranks (model_id -> category -> int).
     """
     required_datasets = [
         ds
-        for ds in category_to_datasets[category]
+        for ds in sorted(category_to_datasets[category])
         if ds not in category_to_orthogonal_datasets[category]
     ]
+    # Sort for deterministic iteration.
     eligible_model_results = {
-        mid: r
-        for mid, r in model_results.items()
-        if all(ds in r for ds in required_datasets)
+        mid: model_results[mid]
+        for mid in sorted(model_results.keys())
+        if all(ds in model_results[mid] for ds in required_datasets)
     }
 
     language_to_required_datasets = {
@@ -856,14 +857,30 @@ def _compute_eligible_models_and_ranks(
         for language, config in leaderboard_configs.items()
     }
 
-    all_standard_ranks = compute_standard_ranks_bootstrap(
+    # Compute bootstrap distributions once, then derive both displayed scores
+    # and ordinal ranks from the same distribution.
+    bootstrap_scores = bootstrap_rank_scores(
         model_results=eligible_model_results,
         configs=leaderboard_configs,
         n_bootstraps=NUM_BOOTSTRAPS,
         seed=42,
+        categories=(category,),
     )
 
-    return eligible_model_results, language_to_required_datasets, all_standard_ranks
+    # Displayed rank scores (median + percentile CI).
+    ranks = bootstrap_confidence_intervals(bootstrap_scores)
+
+    # Ordinal ranks from paired-bootstrap method.
+    all_standard_ranks = compute_standard_ranks_from_bootstrap_scores(
+        bootstrap_scores=bootstrap_scores, alpha=0.05
+    )
+
+    return (
+        eligible_model_results,
+        language_to_required_datasets,
+        ranks,
+        all_standard_ranks,
+    )
 
 
 def _create_simplified_and_rename(

--- a/src/leaderboards/openai_models.yaml
+++ b/src/leaderboards/openai_models.yaml
@@ -131,4 +131,3 @@
 - gpt-realtime-2.1-mini
 - gpt-transcribe
 - gpt-live-transcribe
-- ra-gpt-5.6-sol

--- a/src/leaderboards/score_computation.py
+++ b/src/leaderboards/score_computation.py
@@ -67,13 +67,15 @@ def compute_ranks(
     )
 
     # Step 2: Aggregate dataset -> task -> language -> overall.
+    # Sort for deterministic iteration order.
     model_task_ranks = defaultdict(lambda: defaultdict(lambda: defaultdict(dict)))
 
-    for model_id in model_dataset_ranks:
-        for category in categories:
+    for model_id in sorted(model_dataset_ranks.keys()):
+        for category in sorted(categories):
             if category not in model_dataset_ranks[model_id]:
                 continue
-            for language, config in configs.items():
+            for language in sorted(configs.keys()):
+                config = configs[language]
                 task_results = _aggregate_to_task_level(
                     model_id=model_id,
                     category=category,
@@ -87,10 +89,11 @@ def compute_ranks(
                         model_task_ranks[model_id][category][language][task] = task_data
 
     # Step 3: Aggregate task -> language -> overall.
+    # Sort for deterministic iteration order.
     final: dict[str, dict[str, dict[str, dict[str, float]]]] = {}
 
-    for model_id in model_dataset_ranks:
-        for category in categories:
+    for model_id in sorted(model_dataset_ranks.keys()):
+        for category in sorted(categories):
             if category not in model_dataset_ranks[model_id]:
                 continue
 
@@ -144,10 +147,12 @@ def _aggregate_to_language_level(
     lang_scores: dict[str, dict[str, float]] = {}
     overall_entries: list[dict[str, float]] = []
 
-    for language, config in configs.items():
+    # Sort for deterministic iteration order.
+    for language in sorted(configs.keys()):
+        config = configs[language]
         task_entries = [
             model_task_ranks[model_id][category][language].get(task)
-            for task in config
+            for task in sorted(config.keys())
             if task not in orthogonal_tasks
             and category_includes_task(category=category, task=task)
         ]
@@ -211,7 +216,9 @@ def _aggregate_to_task_level(
         Dict of task -> {score, ci_lower, ci_upper} or None.
     """
     task_results: dict[str, dict[str, float]] = {}
-    for task, task_datasets in config.items():
+    # Sort for deterministic iteration order.
+    for task in sorted(config.keys()):
+        task_datasets = config[task]
         if task in orthogonal_tasks:
             continue
         if not category_includes_task(category=category, task=task):
@@ -219,7 +226,7 @@ def _aggregate_to_task_level(
 
         entries = [
             model_dataset_ranks[model_id][category][ds]
-            for ds in task_datasets
+            for ds in sorted(task_datasets)
             if ds in model_dataset_ranks[model_id][category]
         ]
         if not entries:
@@ -266,18 +273,22 @@ def compute_dataset_ranks_bootstrap(
         lambda: defaultdict(dict)
     )
 
-    for _language, config in configs.items():
-        for category in LEADERBOARD_CATEGORIES:
+    # Sort for deterministic iteration order (RNG consumption must be
+    # deterministic across runs with the same seed).
+    for language in sorted(configs.keys()):
+        config = configs[language]
+        for category in sorted(LEADERBOARD_CATEGORIES):
             datasets = [
                 ds
-                for task, task_ds in config.items()
-                for ds in task_ds
+                for task in sorted(config.keys())
+                for ds in config[task]
                 if task not in ORTHOGONAL_TASKS
                 and category_includes_task(category, task)
             ]
             for dataset in datasets:
                 model_scores: dict[str, tuple[float, list[float]]] = {}
-                for model_id, results in model_results.items():
+                for model_id in sorted(model_results.keys()):
+                    results = model_results[model_id]
                     if dataset in results and results[dataset]:
                         raw, mean_sc, _ = results[dataset][0]
                         if np.isfinite(mean_sc):
@@ -427,41 +438,98 @@ def compute_standard_ranks_bootstrap(
         seed=seed,
     )
 
-    # Step 2: Compute CIs from bootstrap distributions and sort models.
+    # Step 2: Use paired-bootstrap method to derive ordinal ranks from the
+    # bootstrap score distributions.
+    return compute_standard_ranks_from_bootstrap_scores(
+        bootstrap_scores=bootstrap_scores, alpha=alpha
+    )
+
+
+def compute_standard_ranks_from_bootstrap_scores(
+    bootstrap_scores: dict[str, dict[str, dict[str, np.ndarray]]], alpha: float = 0.05
+) -> dict[str, dict[str, int]]:
+    """Compute ordinal ranks from pre-computed bootstrap score distributions.
+
+    Uses a paired-bootstrap approach: for each pair of models, computes the
+    distribution of differences (model_a - model_b) across bootstrap samples,
+    then determines whether model_a is significantly worse than model_b by
+    checking if the (1-alpha) percentile of the difference distribution is
+    strictly positive.
+
+    Models are grouped into rank groups: two models share the same rank if
+    neither is significantly worse than the other. Ranks are assigned in
+    order of median bootstrap score (lower = better).
+
+    This method is more statistically principled than the CI-overlap heuristic
+    because it directly uses the paired difference distribution.
+
+    Args:
+        bootstrap_scores: Pre-computed bootstrap distributions from
+            ``bootstrap_rank_scores``. Structure: model_id -> category ->
+            language -> np.ndarray of bootstrap scores.
+        alpha (optional): Significance level. Defaults to 0.05.
+
+    Returns:
+        model_id -> category -> int rank.
+    """
     ranks: dict[str, dict[str, int]] = {}
 
-    for category in LEADERBOARD_CATEGORIES:
-        scored: list[tuple[float, str, float, float]] = []
-        for model_id in model_results:
+    for category in sorted(
+        bootstrap_scores[list(bootstrap_scores.keys())[0]].keys()
+        if bootstrap_scores
+        else []
+    ):
+        # Collect models with overall scores for this category.
+        scored: list[tuple[float, str, np.ndarray]] = []
+        for model_id in sorted(bootstrap_scores.keys()):
             if (
-                model_id in bootstrap_scores
-                and category in bootstrap_scores[model_id]
+                category in bootstrap_scores[model_id]
                 and "overall" in bootstrap_scores[model_id][category]
             ):
                 samples = bootstrap_scores[model_id][category]["overall"]
-                mean_score = float(np.median(samples))
-                ci_lower = float(np.percentile(samples, alpha * 50))
-                ci_upper = float(np.percentile(samples, (1 - alpha) * 100))
-                scored.append((mean_score, model_id, ci_lower, ci_upper))
-
-        scored.sort(key=lambda x: x[0])
+                median_score = float(np.median(samples))
+                scored.append((median_score, model_id, samples))
 
         if not scored:
             continue
 
-        # Step 3: Walk down and assign ranks via CI overlap. Two models share a
-        # rank iff their bootstrap CIs overlap; a strictly higher lower bound
-        # starts a new rank group.
-        current_rank = 1
-        anchor_idx = 0
-        ranks.setdefault(scored[0][1], {})[category] = 1
+        scored.sort(key=lambda x: x[0])
 
-        for i in range(1, len(scored)):
-            candidate_ci_lower = scored[i][2]
-            anchor_ci_upper = scored[anchor_idx][3]
-            if candidate_ci_lower > anchor_ci_upper:
-                current_rank += 1
-                anchor_idx = i
-            ranks.setdefault(scored[i][1], {})[category] = current_rank
+        # Compute pairwise significance using paired differences.
+        # A model is "significantly worse" if the (1-alpha) percentile of
+        # (candidate - anchor) differences is strictly positive.
+        n_models = len(scored)
+        is_worse: list[list[bool]] = [[False] * n_models for _ in range(n_models)]
+
+        for i in range(n_models):
+            for j in range(i + 1, n_models):
+                # scored[i] has lower median than scored[j], so check if j is
+                # significantly worse than i.
+                diff = scored[j][2] - scored[i][2]
+                threshold = np.percentile(diff, (1 - alpha) * 100)
+                is_worse[j][i] = threshold > 0  # j significantly worse than i
+
+        # Assign ranks: start a new rank group only if the candidate is
+        # significantly worse than ALL models in the current rank group.
+        rank_groups: list[list[int]] = [[0]]  # First model starts group 0
+
+        for i in range(1, n_models):
+            # Check if model i is significantly worse than any model in the
+            # current rank group.
+            current_group = rank_groups[-1]
+            is_worse_than_all = all(is_worse[i][j] for j in current_group)
+
+            if is_worse_than_all:
+                rank_groups.append([i])
+            else:
+                rank_groups[-1].append(i)
+
+        # Flatten rank groups to model -> rank mapping.
+        current_rank = 1
+        for group in rank_groups:
+            for idx in group:
+                model_id = scored[idx][1]
+                ranks.setdefault(model_id, {})[category] = current_rank
+            current_rank += 1
 
     return ranks

--- a/src/leaderboards/score_computation.py
+++ b/src/leaderboards/score_computation.py
@@ -406,31 +406,28 @@ def compute_standard_ranks_bootstrap(
     seed: int | None = None,
     alpha: float = 0.05,
 ) -> dict[str, dict[str, int]]:
-    """Compute ordinal ranks (1, 2, 3...) with ties via bootstrap CIs.
+    """Compute ordinal ranks with ties from paired bootstrap differences.
 
-    Sorts by overall mean rank score ascending (lower = better). Walks down
-    the list; for each model, compares its CI against the current anchor's CI.
-    If the candidate's lower CI bound is strictly above the anchor's upper CI
-    bound (no overlap), it starts a new rank group. Otherwise it shares the
-    anchor's rank.
-
-    CIs are computed from the bootstrap distributions themselves (percentile
-    method), so the Rank column is consistent with the statistical uncertainty
-    captured by the bootstrap - rather than using a bootstrap hypothesis test
-    which operates on raw distributions and can disagree with the displayed CIs.
+    Sorts models by median rank score (lower = better). A candidate starts a
+    worse rank group only when the lower bound of the paired bootstrap CI for
+    ``candidate - anchor`` is strictly above zero for every model in the current
+    rank group.
 
     Args:
-        model_results: The model results.
-        configs: Per-language task -> dataset mappings.
-        n_bootstraps: Number of bootstrap replicates.
-        seed: Random seed for reproducibility.
-        alpha (optional): Significance level for the bootstrap CI. Defaults to
-            0.05.
+        model_results:
+            The model results.
+        configs:
+            Per-language task -> dataset mappings.
+        n_bootstraps:
+            Number of bootstrap replicates.
+        seed:
+            Random seed for reproducibility.
+        alpha (optional):
+            Significance level for the paired bootstrap CI. Defaults to 0.05.
 
     Returns:
         model_id -> category -> int rank.
     """
-    # Step 1: Compute bootstrap distributions.
     bootstrap_scores = bootstrap_rank_scores(
         model_results=model_results,
         configs=configs,
@@ -438,8 +435,6 @@ def compute_standard_ranks_bootstrap(
         seed=seed,
     )
 
-    # Step 2: Use paired-bootstrap method to derive ordinal ranks from the
-    # bootstrap score distributions.
     return compute_standard_ranks_from_bootstrap_scores(
         bootstrap_scores=bootstrap_scores, alpha=alpha
     )
@@ -474,12 +469,14 @@ def compute_standard_ranks_from_bootstrap_scores(
     """
     ranks: dict[str, dict[str, int]] = {}
 
-    for category in sorted(
-        bootstrap_scores[list(bootstrap_scores.keys())[0]].keys()
-        if bootstrap_scores
-        else []
-    ):
-        # Collect models with overall scores for this category.
+    categories = sorted(
+        {
+            category
+            for model_scores in bootstrap_scores.values()
+            for category in model_scores
+        }
+    )
+    for category in categories:
         scored: list[tuple[float, str, np.ndarray]] = []
         for model_id in sorted(bootstrap_scores.keys()):
             if (
@@ -495,27 +492,18 @@ def compute_standard_ranks_from_bootstrap_scores(
 
         scored.sort(key=lambda x: x[0])
 
-        # Compute pairwise significance using paired differences.
-        # A model is "significantly worse" if the (1-alpha) percentile of
-        # (candidate - anchor) differences is strictly positive.
         n_models = len(scored)
         is_worse: list[list[bool]] = [[False] * n_models for _ in range(n_models)]
 
         for i in range(n_models):
             for j in range(i + 1, n_models):
-                # scored[i] has lower median than scored[j], so check if j is
-                # significantly worse than i.
                 diff = scored[j][2] - scored[i][2]
-                threshold = np.percentile(diff, (1 - alpha) * 100)
-                is_worse[j][i] = threshold > 0  # j significantly worse than i
+                lower_bound = np.percentile(diff, 100 * alpha / 2)
+                is_worse[j][i] = lower_bound > 0
 
-        # Assign ranks: start a new rank group only if the candidate is
-        # significantly worse than ALL models in the current rank group.
-        rank_groups: list[list[int]] = [[0]]  # First model starts group 0
+        rank_groups: list[list[int]] = [[0]]
 
         for i in range(1, n_models):
-            # Check if model i is significantly worse than any model in the
-            # current rank group.
             current_group = rank_groups[-1]
             is_worse_than_all = all(is_worse[i][j] for j in current_group)
 

--- a/src/leaderboards/score_computation.py
+++ b/src/leaderboards/score_computation.py
@@ -281,7 +281,7 @@ def compute_dataset_ranks_bootstrap(
             datasets = [
                 ds
                 for task in sorted(config.keys())
-                for ds in config[task]
+                for ds in sorted(config[task])
                 if task not in ORTHOGONAL_TASKS
                 and category_includes_task(category, task)
             ]
@@ -505,9 +505,9 @@ def compute_standard_ranks_from_bootstrap_scores(
 
         for i in range(1, n_models):
             current_group = rank_groups[-1]
-            is_worse_than_all = all(is_worse[i][j] for j in current_group)
+            group_anchor = current_group[0]
 
-            if is_worse_than_all:
+            if is_worse[i][group_anchor]:
                 rank_groups.append([i])
             else:
                 rank_groups[-1].append(i)

--- a/tests/leaderboards/test_bootstrap_ranks.py
+++ b/tests/leaderboards/test_bootstrap_ranks.py
@@ -1,0 +1,313 @@
+"""Tests for bootstrap-based rank computation.
+
+Tests cover determinism, paired-rank behaviour, and eligible-set consistency.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from src.leaderboards.bootstrap_cis import (
+    bootstrap_confidence_intervals,
+    bootstrap_rank_scores,
+)
+from src.leaderboards.score_computation import (
+    compute_standard_ranks_bootstrap,
+    compute_standard_ranks_from_bootstrap_scores,
+)
+
+
+class TestBootstrapDeterminism:
+    """Tests for bootstrap determinism with seed."""
+
+    def test_bootstrap_scores_deterministic_with_seed(self) -> None:
+        """Bootstrapping with a seed produces identical results across runs."""
+        model_ids = ["model_a", "model_b", "model_c"]
+        datasets = [f"dataset_{i}" for i in range(8)]
+        model_results = _make_dummy_results(model_ids, datasets)
+        configs = _make_dummy_configs(["da"], datasets)
+
+        # Run twice with same seed
+        result1 = bootstrap_rank_scores(
+            model_results=model_results, configs=configs, n_bootstraps=100, seed=42
+        )
+        result2 = bootstrap_rank_scores(
+            model_results=model_results, configs=configs, n_bootstraps=100, seed=42
+        )
+
+        # Results should be identical
+        for model_id in model_ids:
+            for category in result1[model_id]:
+                for lang in result1[model_id][category]:
+                    np.testing.assert_array_equal(
+                        result1[model_id][category][lang],
+                        result2[model_id][category][lang],
+                    )
+
+    def test_bootstrap_scores_different_without_seed(self) -> None:
+        """Bootstrapping without a seed produces different results across runs."""
+        model_ids = ["model_a", "model_b"]
+        datasets = [f"dataset_{i}" for i in range(4)]
+        model_results = _make_dummy_results(model_ids, datasets)
+        configs = _make_dummy_configs(["da"], datasets)
+
+        result1 = bootstrap_rank_scores(
+            model_results=model_results, configs=configs, n_bootstraps=100, seed=None
+        )
+        result2 = bootstrap_rank_scores(
+            model_results=model_results, configs=configs, n_bootstraps=100, seed=None
+        )
+
+        # Results should be different (with very high probability)
+        model_id = model_ids[0]
+        category = list(result1[model_id].keys())[0]
+        lang = list(result1[model_id][category].keys())[0]
+        assert not np.array_equal(
+            result1[model_id][category][lang], result2[model_id][category][lang]
+        )
+
+    def test_semantic_inputs_same_order_produce_identical_arrays(self) -> None:
+        """Same semantic inputs with different dict insertion order give same results.
+
+        This tests that sorting model IDs, datasets, tasks, and categories before
+        iterating ensures determinism regardless of Python dict ordering.
+        """
+        model_ids = ["model_a", "model_b", "model_c"]
+        datasets = [f"dataset_{i}" for i in range(6)]
+        model_results = _make_dummy_results(model_ids, datasets)
+        configs = _make_dummy_configs(["da"], datasets)
+
+        # Create reordered versions (simulating different insertion order)
+        model_results_reordered = {
+            model_id: {
+                ds: model_results[model_id][ds]
+                for ds in reversed(list(model_results[model_id].keys()))
+            }
+            for model_id in reversed(model_ids)
+        }
+
+        configs_reordered = {
+            lang: {
+                task: list(reversed(configs[lang][task]))
+                for task in reversed(list(configs[lang].keys()))
+            }
+            for lang in reversed(list(configs.keys()))
+        }
+
+        result1 = bootstrap_rank_scores(
+            model_results=model_results, configs=configs, n_bootstraps=100, seed=42
+        )
+        result2 = bootstrap_rank_scores(
+            model_results=model_results_reordered,
+            configs=configs_reordered,
+            n_bootstraps=100,
+            seed=42,
+        )
+
+        # Results should be identical despite different iteration order
+        for model_id in model_ids:
+            for category in result1[model_id]:
+                for lang in result1[model_id][category]:
+                    np.testing.assert_array_equal(
+                        result1[model_id][category][lang],
+                        result2[model_id][category][lang],
+                    )
+
+
+def _make_dummy_configs(
+    languages: list[str], datasets: list[str]
+) -> dict[str, dict[str, list[str]]]:
+    """Create dummy configs mapping languages to tasks to datasets.
+
+    Uses valid task names that work with category_includes_task.
+
+    Returns:
+        Dict mapping language -> task -> list of dataset IDs.
+    """
+    configs = {}
+    for lang in languages:
+        # Use valid NLU task names
+        configs[lang] = {
+            "named-entity-recognition": datasets[: len(datasets) // 2],
+            "sentiment-classification": datasets[len(datasets) // 2 :],
+        }
+    return configs
+
+
+def _make_dummy_results(
+    model_ids: list[str],
+    dataset_ids: list[str],
+    base_score: float = 0.7,
+    noise: float = 0.01,
+) -> dict[str, dict[str, list[tuple[list[float], float, float]]]]:
+    """Create dummy model results for testing.
+
+    Each model has the same datasets with similar scores to create realistic
+    bootstrap distributions.
+
+    Returns:
+        Dict mapping model_id -> dataset -> [(raw_scores, mean, std_err)].
+    """
+    rng = np.random.default_rng(42)
+    results: dict[str, dict[str, list[tuple[list[float], float, float]]]] = {}
+
+    for model_id in model_ids:
+        results[model_id] = {}
+        for dataset_id in dataset_ids:
+            # Generate raw scores around base_score with some model-specific offset
+            model_offset = rng.uniform(-0.05, 0.05)
+            raw_scores = (
+                rng.uniform(0, 1, 100) * noise + base_score + model_offset
+            ).tolist()
+            mean_score = float(np.mean(raw_scores))
+            std_err = float(np.std(raw_scores) / np.sqrt(len(raw_scores)))
+            results[model_id][dataset_id] = [(raw_scores, mean_score, std_err)]
+
+    return results
+
+
+class TestEligibleSetConsistency:
+    """Tests for consistency between rank score and ordinal rank."""
+
+    def test_non_eligible_models_show_placeholder(self) -> None:
+        """Non-eligible models in full results get '-' for rank and rank score.
+
+        This tests the behavior in _build_model_row_data where non-eligible
+        models should show '-' for both columns.
+        """
+        # This is more of an integration test for leaderboard_generation
+        # but we verify the logic here
+        all_datasets = [f"dataset_{i}" for i in range(8)]
+
+        model_results = {
+            "eligible_model": {ds: [([0.7] * 100, 0.7, 0.01)] for ds in all_datasets},
+            "partial_model": {
+                ds: [([0.65] * 100, 0.65, 0.01)]
+                for ds in all_datasets[:6]  # Missing last 2
+            },
+        }
+
+        # Simulate eligibility check - must have ALL datasets
+        eligible_model_results = {
+            mid: mr
+            for mid, mr in model_results.items()
+            if all(ds in mr for ds in all_datasets)
+        }
+
+        # Only eligible_model should be in eligible results
+        assert "eligible_model" in eligible_model_results
+        assert "partial_model" not in eligible_model_results
+
+    def test_ranks_derived_from_same_bootstrap_distribution(self) -> None:
+        """Rank score and ordinal rank come from the same bootstrap distribution.
+
+        This is the key fix: previously, rank score was computed over all models
+        while ordinal rank was computed over eligible models only, causing
+        inconsistencies.
+        """
+        # Create model results where some models are "eligible" (have all datasets)
+        # and some are not
+        all_datasets = [f"dataset_{i}" for i in range(8)]
+
+        model_results: dict[str, dict[str, list[tuple[list[float], float, float]]]] = {
+            "eligible_model_a": {ds: [([0.7] * 100, 0.7, 0.01)] for ds in all_datasets},
+            "eligible_model_b": {
+                ds: [([0.65] * 100, 0.65, 0.01)] for ds in all_datasets
+            },
+            "partial_model": {
+                ds: [([0.60] * 100, 0.60, 0.01)]
+                for ds in all_datasets[:6]  # Missing last 2 datasets
+            },
+        }
+        configs = _make_dummy_configs(["da"], all_datasets)
+
+        # Eligibility check: model must have ALL datasets
+        required_datasets = all_datasets
+        eligible_model_results = {
+            mid: mr
+            for mid, mr in model_results.items()
+            if all(ds in mr for ds in required_datasets)
+        }
+
+        # Only the two eligible models should remain
+        assert "eligible_model_a" in eligible_model_results
+        assert "eligible_model_b" in eligible_model_results
+        assert "partial_model" not in eligible_model_results
+
+        bootstrap_scores = bootstrap_rank_scores(
+            model_results=eligible_model_results,
+            configs=configs,
+            n_bootstraps=200,
+            seed=42,
+            categories=("all_models",),
+        )
+
+        # Derive both rank score and ordinal rank from same distribution
+        rank_scores = bootstrap_confidence_intervals(bootstrap_scores)
+        ordinal_ranks = compute_standard_ranks_from_bootstrap_scores(
+            bootstrap_scores=bootstrap_scores, alpha=0.05
+        )
+
+        # Both should only contain eligible models
+        assert "eligible_model_a" in rank_scores
+        assert "eligible_model_b" in rank_scores
+        assert "eligible_model_a" in ordinal_ranks
+        assert "eligible_model_b" in ordinal_ranks
+        assert "partial_model" not in rank_scores  # Not in bootstrap
+        assert "partial_model" not in ordinal_ranks  # Not in bootstrap
+
+
+class TestPairedBootstrapRanks:
+    """Tests for paired-bootstrap ordinal rank computation."""
+
+    def test_better_models_get_lower_ranks(self) -> None:
+        """Models with higher scores should get lower (better) ranks."""
+        # Create results where model_a is clearly better than model_b
+        model_results: dict[str, dict[str, list[tuple[list[float], float, float]]]] = {
+            "model_a": {f"dataset_{i}": [([0.8] * 100, 0.8, 0.01)] for i in range(8)},
+            "model_b": {f"dataset_{i}": [([0.6] * 100, 0.6, 0.01)] for i in range(8)},
+        }
+        configs = _make_dummy_configs(["da"], list(model_results["model_a"].keys()))
+
+        ranks = compute_standard_ranks_bootstrap(
+            model_results=model_results, configs=configs, n_bootstraps=200, seed=42
+        )
+
+        # model_a should be ranked better (lower number) than model_b
+        assert ranks["model_a"]["all_models"] <= ranks["model_b"]["all_models"]
+
+    def test_paired_ranks_deterministic_with_seed(self) -> None:
+        """Paired-bootstrap ranks are deterministic when using a seed."""
+        model_ids = ["model_a", "model_b", "model_c"]
+        datasets = [f"dataset_{i}" for i in range(8)]
+        model_results = _make_dummy_results(model_ids, datasets)
+        configs = _make_dummy_configs(["da"], datasets)
+
+        ranks1 = compute_standard_ranks_bootstrap(
+            model_results=model_results, configs=configs, n_bootstraps=200, seed=42
+        )
+        ranks2 = compute_standard_ranks_bootstrap(
+            model_results=model_results, configs=configs, n_bootstraps=200, seed=42
+        )
+
+        assert ranks1 == ranks2
+
+    def test_paired_ranks_from_bootstrap_scores(self) -> None:
+        """Paired-bootstrap ranks can be derived from pre-computed bootstrap scores."""
+        model_ids = ["model_a", "model_b", "model_c"]
+        datasets = [f"dataset_{i}" for i in range(8)]
+        model_results = _make_dummy_results(model_ids, datasets)
+        configs = _make_dummy_configs(["da"], datasets)
+
+        bootstrap_scores = bootstrap_rank_scores(
+            model_results=model_results, configs=configs, n_bootstraps=200, seed=42
+        )
+
+        ranks = compute_standard_ranks_from_bootstrap_scores(
+            bootstrap_scores=bootstrap_scores, alpha=0.05
+        )
+
+        # All models should have ranks
+        for model_id in model_ids:
+            assert model_id in ranks
+            assert "all_models" in ranks[model_id]

--- a/tests/leaderboards/test_bootstrap_ranks.py
+++ b/tests/leaderboards/test_bootstrap_ranks.py
@@ -8,13 +8,31 @@ from __future__ import annotations
 import numpy as np
 
 from src.leaderboards.bootstrap_cis import (
+    _aggregate_scores_to_categories,
     bootstrap_confidence_intervals,
     bootstrap_rank_scores,
 )
 from src.leaderboards.score_computation import (
+    compute_dataset_ranks_bootstrap,
     compute_standard_ranks_bootstrap,
     compute_standard_ranks_from_bootstrap_scores,
 )
+
+
+class TestBootstrapAggregation:
+    """Tests for bootstrap aggregation semantics."""
+
+    def test_aggregate_scores_retains_duplicate_dataset_samples(self) -> None:
+        """Duplicate dataset samples contribute with their full multiplicity."""
+        configs = {"da": {"knowledge": ["dataset_a", "dataset_b"]}}
+        dataset_scores = {"dataset_a": [1.0, 3.0], "dataset_b": [5.0]}
+
+        language_scores, overall = _aggregate_scores_to_categories(
+            dataset_scores=dataset_scores, configs=configs
+        )
+
+        assert language_scores["da"] == 3.0
+        assert overall == 3.0
 
 
 class TestBootstrapDeterminism:
@@ -66,6 +84,31 @@ class TestBootstrapDeterminism:
             result1[model_id][category][lang], result2[model_id][category][lang]
         )
 
+    def test_dataset_rank_bootstrap_ignores_dataset_list_order(self) -> None:
+        """Dataset-level CIs are deterministic under config list reordering."""
+        model_ids = ["model_a", "model_b"]
+        datasets = [f"dataset_{i}" for i in range(4)]
+        model_results = _make_dummy_results(model_ids, datasets)
+        configs = _make_dummy_configs(["da"], datasets)
+        configs_reordered = {
+            "da": {
+                task: list(reversed(task_datasets))
+                for task, task_datasets in configs["da"].items()
+            }
+        }
+
+        result1 = compute_dataset_ranks_bootstrap(
+            model_results=model_results, configs=configs, n_bootstraps=100, seed=42
+        )
+        result2 = compute_dataset_ranks_bootstrap(
+            model_results=model_results,
+            configs=configs_reordered,
+            n_bootstraps=100,
+            seed=42,
+        )
+
+        assert result1 == result2
+
     def test_semantic_inputs_same_order_produce_identical_arrays(self) -> None:
         """Same semantic inputs with different dict insertion order give same results.
 
@@ -77,7 +120,6 @@ class TestBootstrapDeterminism:
         model_results = _make_dummy_results(model_ids, datasets)
         configs = _make_dummy_configs(["da"], datasets)
 
-        # Create reordered versions (simulating different insertion order)
         model_results_reordered = {
             model_id: {
                 ds: model_results[model_id][ds]
@@ -104,7 +146,6 @@ class TestBootstrapDeterminism:
             seed=42,
         )
 
-        # Results should be identical despite different iteration order
         for model_id in model_ids:
             for category in result1[model_id]:
                 for lang in result1[model_id][category]:
@@ -275,6 +316,26 @@ class TestPairedBootstrapRanks:
 
         # model_a should be ranked better (lower number) than model_b
         assert ranks["model_a"]["all_models"] <= ranks["model_b"]["all_models"]
+
+    def test_non_transitive_overlap_compares_to_group_anchor(self) -> None:
+        """An intermediate overlap does not pull worse models into rank 1."""
+        model_a = np.zeros(100)
+        model_b = np.full(100, 0.1)
+        model_b[:3] = -0.1
+        model_c = np.full(100, 0.2)
+        model_c[3:6] = 0.05
+        bootstrap_scores = {
+            "model_a": {"generative": {"overall": model_a}},
+            "model_b": {"generative": {"overall": model_b}},
+            "model_c": {"generative": {"overall": model_c}},
+        }
+
+        ranks = compute_standard_ranks_from_bootstrap_scores(
+            bootstrap_scores=bootstrap_scores, alpha=0.05
+        )
+
+        assert ranks["model_a"]["generative"] == ranks["model_b"]["generative"]
+        assert ranks["model_c"]["generative"] > ranks["model_a"]["generative"]
 
     def test_overlapping_paired_difference_ci_keeps_same_rank(self) -> None:
         """Models tie when paired differences are not reliably positive."""

--- a/tests/leaderboards/test_bootstrap_ranks.py
+++ b/tests/leaderboards/test_bootstrap_ranks.py
@@ -276,6 +276,19 @@ class TestPairedBootstrapRanks:
         # model_a should be ranked better (lower number) than model_b
         assert ranks["model_a"]["all_models"] <= ranks["model_b"]["all_models"]
 
+    def test_overlapping_paired_difference_ci_keeps_same_rank(self) -> None:
+        """Models tie when paired differences are not reliably positive."""
+        bootstrap_scores = {
+            "model_a": {"generative": {"overall": np.array([1.0, 1.0, 1.0, 1.0, 1.0])}},
+            "model_b": {"generative": {"overall": np.array([0.9, 1.1, 1.1, 1.1, 1.1])}},
+        }
+
+        ranks = compute_standard_ranks_from_bootstrap_scores(
+            bootstrap_scores=bootstrap_scores, alpha=0.05
+        )
+
+        assert ranks["model_a"]["generative"] == ranks["model_b"]["generative"]
+
     def test_paired_ranks_deterministic_with_seed(self) -> None:
         """Paired-bootstrap ranks are deterministic when using a seed."""
         model_ids = ["model_a", "model_b", "model_c"]
@@ -307,7 +320,6 @@ class TestPairedBootstrapRanks:
             bootstrap_scores=bootstrap_scores, alpha=0.05
         )
 
-        # All models should have ranks
         for model_id in model_ids:
             assert model_id in ranks
             assert "all_models" in ranks[model_id]


### PR DESCRIPTION
Swaps the official dataset `mmlu-de` for `include-de`, `multiloko-de`.

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `include-de`, `multiloko-de`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `mmlu-de` is demoted to unofficial and `include-de`, `multiloko-de` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.