### PR TITLE
feat: swap official dataset global-mmlu-el -> greek-mmlu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Swapped official dataset for Greek:
+`global-mmlu-el` → `greek-mmlu`.
+
 - Bumped minimum `transformers` version to 5.14.0 (required for XLMRoberta/Camembert
   `ForMultipleChoice` heads; see huggingface/transformers#47147).
 - Swapped official datasets for four languages (all performed by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,6 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Swapped official dataset for Greek:
-`global-mmlu-el` → `greek-mmlu`.
-
 - Bumped minimum `transformers` version to 5.14.0 (required for XLMRoberta/Camembert
   `ForMultipleChoice` heads; see huggingface/transformers#47147).
 - Swapped official datasets for four languages (all performed by the
@@ -38,6 +35,7 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   - Dutch: `scala-nl` → `dutch-cola`, `mmlu-nl` → `include-nl`, `multiloko-nl`
   - French: `mmlu-fr` → `include-fr`, `multiloko-fr`
   - German: `hellaswag-de` → `winogrande-de`
+  - Greek: `global-mmlu-el` → `greek-mmlu`
   - Portuguese: `mmlu-pt` → `alba-mcq-pt`, `cultura-viva-pt`
 
 ### Fixed

--- a/src/euroeval/dataset_configs/greek.py
+++ b/src/euroeval/dataset_configs/greek.py
@@ -57,14 +57,6 @@ GREEK_WIKIPEDIA_CONFIG = DatasetConfig(
     languages=[GREEK],
 )
 
-GLOBAL_MMLU_EL_CONFIG = DatasetConfig(
-    name="global-mmlu-el",
-    pretty_name="GlobalMMLU-el",
-    source="EuroEval/global-mmlu-el-mini",
-    task=KNOW,
-    languages=[GREEK],
-)
-
 WINOGRANDE_EL_CONFIG = DatasetConfig(
     name="winogrande-el",
     pretty_name="Winogrande-el",
@@ -93,7 +85,24 @@ RAGTRUTH_EL_CONFIG = DatasetConfig(
 )
 
 
+GREEK_MMLU_CONFIG = DatasetConfig(
+    name="greek-mmlu",
+    pretty_name="GreekMMLU",
+    source="EuroEval/greek-mmlu-mini",
+    task=KNOW,
+    languages=[GREEK],
+)
+
 # Unofficial datasets ###
+
+GLOBAL_MMLU_EL_CONFIG = DatasetConfig(
+    name="global-mmlu-el",
+    pretty_name="GlobalMMLU-el",
+    source="EuroEval/global-mmlu-el-mini",
+    task=KNOW,
+    languages=[GREEK],
+    unofficial=True,
+)
 
 MULTI_IFEVAL_EL_CONFIG = DatasetConfig(
     name="multi-ifeval-el",
@@ -110,15 +119,6 @@ INCLUDE_EL_CONFIG = DatasetConfig(
     name="include-el",
     pretty_name="INCLUDE-el",
     source="EuroEval/include-el-mini",
-    task=KNOW,
-    languages=[GREEK],
-    unofficial=True,
-)
-
-GREEK_MMLU_CONFIG = DatasetConfig(
-    name="greek-mmlu",
-    pretty_name="GreekMMLU",
-    source="EuroEval/greek-mmlu-mini",
     task=KNOW,
     languages=[GREEK],
     unofficial=True,

--- a/src/frontend/md/datasets/greek.md
+++ b/src/frontend/md/datasets/greek.md
@@ -510,7 +510,77 @@ euroeval --model <model-id> --dataset multi-wiki-qa-el
 
 ## Knowledge
 
-### Global-MMLU-el
+### GreekMMLU
+
+GreekMMLU was published in [this paper](https://doi.org/10.48550/arXiv.2602.05150) and
+is a native Greek benchmark for massive multitask language understanding, comprising
+multiple-choice questions across 45 subject areas sourced from academic, professional,
+and governmental exams in Greece. Unlike machine-translated benchmarks, all questions
+are originally authored or sourced in Greek.
+
+The publicly released dataset includes a 'dev' split and a 'test' split. We use the
+'dev' split as the training split, which has 215 samples after filtering. We sample 256
+/ 2,048 samples from the 'test' split for our validation and test splits, stratified by
+subject.
+
+Here are a few examples from the training split:
+
+```json
+{
+  "text": "Ποια είναι η βαθύτερη λίμνη της Γης;\nΕπιλογές:\na. Βαϊκάλη\nb. Κασπία\nc. Βικτώρια\nd. Νεκρά Θάλασσα",
+  "label": "a",
+  "subject": "Geography"
+}
+```
+
+```json
+{
+  "text": "Στο CorelDraw για να κάνουμε zoom in στην απεικόνιση της οθόνης χρησιμοποιούμε τη συντόμευση \"Ctrl + +\".\nΕπιλογές:\na. Σωστό\nb. Λάθος",
+  "label": "b",
+  "subject": "Art"
+}
+```
+
+```json
+{
+  "text": "Ποιο είναι το αντίθετο του επιθέτου «ομαλός»;\nΕπιλογές:\na. λεία\nb. ομαλός\nc. ανώμαλος\nd. δυνατός",
+  "label": "c",
+  "subject": "Modern Greek Language"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  Ακολουθούν ερωτήσεις πολλαπλών επιλογών (με απαντήσεις).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Ερώτηση: {text}
+  Απάντηση: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Ερώτηση: {text}
+
+  Απαντήστε στην παραπάνω ερώτηση χρησιμοποιώντας 'a', 'b', 'c' ή 'd', και τίποτα άλλο.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset greek-mmlu
+```
+
+### Unofficial: Global-MMLU-el
 
 Global-MMLU is a machine translated version of the English
 [MMLU dataset](https://openreview.net/forum?id=d7KBjmI3GmQ) and features questions
@@ -644,76 +714,6 @@ You can evaluate this dataset directly as follows:
 
 ```bash
 euroeval --model <model-id> --dataset include-el
-```
-
-### Unofficial: GreekMMLU
-
-GreekMMLU was published in [this paper](https://doi.org/10.48550/arXiv.2602.05150) and
-is a native Greek benchmark for massive multitask language understanding, comprising
-multiple-choice questions across 45 subject areas sourced from academic, professional,
-and governmental exams in Greece. Unlike machine-translated benchmarks, all questions
-are originally authored or sourced in Greek.
-
-The publicly released dataset includes a 'dev' split and a 'test' split. We use the
-'dev' split as the training split, which has 215 samples after filtering. We sample 256
-/ 2,048 samples from the 'test' split for our validation and test splits, stratified by
-subject.
-
-Here are a few examples from the training split:
-
-```json
-{
-  "text": "Ποια είναι η βαθύτερη λίμνη της Γης;\nΕπιλογές:\na. Βαϊκάλη\nb. Κασπία\nc. Βικτώρια\nd. Νεκρά Θάλασσα",
-  "label": "a",
-  "subject": "Geography"
-}
-```
-
-```json
-{
-  "text": "Στο CorelDraw για να κάνουμε zoom in στην απεικόνιση της οθόνης χρησιμοποιούμε τη συντόμευση \"Ctrl + +\".\nΕπιλογές:\na. Σωστό\nb. Λάθος",
-  "label": "b",
-  "subject": "Art"
-}
-```
-
-```json
-{
-  "text": "Ποιο είναι το αντίθετο του επιθέτου «ομαλός»;\nΕπιλογές:\na. λεία\nb. ομαλός\nc. ανώμαλος\nd. δυνατός",
-  "label": "c",
-  "subject": "Modern Greek Language"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 5
-- Prefix prompt:
-
-  ```text
-  Ακολουθούν ερωτήσεις πολλαπλών επιλογών (με απαντήσεις).
-  ```
-
-- Base prompt template:
-
-  ```text
-  Ερώτηση: {text}
-  Απάντηση: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Ερώτηση: {text}
-
-  Απαντήστε στην παραπάνω ερώτηση χρησιμοποιώντας 'a', 'b', 'c' ή 'd', και τίποτα άλλο.
-  ```
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset greek-mmlu
 ```
 
 ### Unofficial: EU-MMLU-el

--- a/src/leaderboards/dataset_split_sizes.json
+++ b/src/leaderboards/dataset_split_sizes.json
@@ -380,6 +380,11 @@
     "train": 1024,
     "val": 256
   },
+  "EuroEval/greek-mmlu-mini": {
+    "test": 2048,
+    "train": 215,
+    "val": 256
+  },
   "EuroEval/greek-sa-mini": {
     "test": 2048,
     "train": 1024,


### PR DESCRIPTION
Swaps the official dataset `global-mmlu-el` for `greek-mmlu`.

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `greek-mmlu`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `global-mmlu-el` is demoted to unofficial and `greek-mmlu` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.