### PR TITLE
feat: swap official dataset mmlu-hu -> include-hu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,6 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Swapped official dataset for Hungarian:
-`mmlu-hu` → `include-hu`.
-
 - Bumped minimum `transformers` version to 5.14.0 (required for XLMRoberta/Camembert
   `ForMultipleChoice` heads; see huggingface/transformers#47147).
 - Swapped official datasets for four languages (all performed by the
@@ -39,6 +36,7 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   - French: `mmlu-fr` → `include-fr`, `multiloko-fr`
   - German: `hellaswag-de` → `winogrande-de`, `mmlu-de` → `include-de`, `multiloko-de`
   - Greek: `global-mmlu-el` → `greek-mmlu`
+  - Hungarian: `mmlu-hu` → `include-hu`
   - Portuguese: `mmlu-pt` → `alba-mcq-pt`, `cultura-viva-pt`
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Swapped official dataset for Hungarian:
+`mmlu-hu` → `include-hu`.
+
 - Bumped minimum `transformers` version to 5.14.0 (required for XLMRoberta/Camembert
   `ForMultipleChoice` heads; see huggingface/transformers#47147).
 - Swapped official datasets for four languages (all performed by the

--- a/src/euroeval/dataset_configs/hungarian.py
+++ b/src/euroeval/dataset_configs/hungarian.py
@@ -56,14 +56,6 @@ HUNSUM_CONFIG = DatasetConfig(
     languages=[HUNGARIAN],
 )
 
-MMLU_HU_CONFIG = DatasetConfig(
-    name="mmlu-hu",
-    pretty_name="MMLU-hu",
-    source="EuroEval/mmlu-hu-mini",
-    task=KNOW,
-    languages=[HUNGARIAN],
-)
-
 WINOGRANDE_HU_CONFIG = DatasetConfig(
     name="winogrande-hu",
     pretty_name="Winogrande-hu",
@@ -93,12 +85,20 @@ RAGTRUTH_HU_CONFIG = DatasetConfig(
 )
 
 
-# Unofficial datasets ###
-
 INCLUDE_HU_CONFIG = DatasetConfig(
     name="include-hu",
     pretty_name="INCLUDE-hu",
     source="EuroEval/include-hu-mini",
+    task=KNOW,
+    languages=[HUNGARIAN],
+)
+
+# Unofficial datasets ###
+
+MMLU_HU_CONFIG = DatasetConfig(
+    name="mmlu-hu",
+    pretty_name="MMLU-hu",
+    source="EuroEval/mmlu-hu-mini",
     task=KNOW,
     languages=[HUNGARIAN],
     unofficial=True,

--- a/src/frontend/md/datasets/hungarian.md
+++ b/src/frontend/md/datasets/hungarian.md
@@ -474,7 +474,76 @@ euroeval --model <model-id> --dataset multi-wiki-qa-hu
 
 ## Knowledge
 
-### MMLU-hu
+### INCLUDE-hu
+
+This dataset is part of [INCLUDE](https://doi.org/10.48550/arXiv.2411.19799), a
+comprehensive knowledge- and reasoning-centric benchmark that evaluates multilingual
+LLMs across 44 languages. It contains 4-option multiple-choice questions extracted from
+academic and professional exams, covering 57 topics including regional knowledge.
+
+The original dataset consists of a 'validation' split used as training data and a 'test'
+split. We use the 'validation' split as the training split, which has 25 samples. We
+sample 64 samples from the 'test' split for the validation split, and use the remaining
+512 samples for the test split. The sampling is done stratified by the subject column.
+
+Here are a few examples from the dataset:
+
+```json
+{
+  "text": "Melyik hormon szabályozza a tejleadást?\nVálaszlehetőségek:\na. az oxitocin\nb. a progeszteron\nc. az ösztrogén\nd. az adrenalin",
+  "label": "a",
+  "subject": "Agriculture"
+}
+```
+
+```json
+{
+  "text": "Melyik hazánk legszelesebb tája?\nVálaszlehetőségek:\na. Tiszántúl\nb. Kisalföld\nc. Északi-középhegység\nd. Duna−Tisza köze",
+  "label": "b",
+  "subject": "Environmental studies and forestry"
+}
+```
+
+```json
+{
+  "text": "Melyik igaz az alábbi állítások közül?\nVálaszlehetőségek:\na. Az RNS hidrolízise aldohexózt is eredményez.\nb. Az amidok vizes oldatban erős bázisként viselkednek.\nc. Az adenin, citozin és a guanin a DNS- és RNS-molekulák hidrolízisének termékei.\nd. A fehérjék savas hidrolízisében foszforsav is keletkezik.",
+  "label": "c",
+  "subject": "Chemistry"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  Az alábbiakban több választási lehetőséget tartalmazó kérdések találhatók (válaszokkal együtt).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Kérdés: {text}
+  Válasz: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Kérdés: {text}
+
+  Válaszoljon a fenti kérdésre az elérhető lehetőségek közül {labels_str} használatával, és semmi mással.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset include-hu
+```
+
+### Unofficial: MMLU-hu
 
 This dataset is a machine translated version of the English
 [MMLU dataset](https://openreview.net/forum?id=d7KBjmI3GmQ) and features questions
@@ -545,75 +614,6 @@ You can evaluate this dataset directly as follows:
 
 ```bash
 euroeval --model <model-id> --dataset mmlu-hu
-```
-
-### Unofficial: INCLUDE-hu
-
-This dataset is part of [INCLUDE](https://doi.org/10.48550/arXiv.2411.19799), a
-comprehensive knowledge- and reasoning-centric benchmark that evaluates multilingual
-LLMs across 44 languages. It contains 4-option multiple-choice questions extracted from
-academic and professional exams, covering 57 topics including regional knowledge.
-
-The original dataset consists of a 'validation' split used as training data and a 'test'
-split. We use the 'validation' split as the training split, which has 25 samples. We
-sample 64 samples from the 'test' split for the validation split, and use the remaining
-512 samples for the test split. The sampling is done stratified by the subject column.
-
-Here are a few examples from the dataset:
-
-```json
-{
-  "text": "Melyik hormon szabályozza a tejleadást?\nVálaszlehetőségek:\na. az oxitocin\nb. a progeszteron\nc. az ösztrogén\nd. az adrenalin",
-  "label": "a",
-  "subject": "Agriculture"
-}
-```
-
-```json
-{
-  "text": "Melyik hazánk legszelesebb tája?\nVálaszlehetőségek:\na. Tiszántúl\nb. Kisalföld\nc. Északi-középhegység\nd. Duna−Tisza köze",
-  "label": "b",
-  "subject": "Environmental studies and forestry"
-}
-```
-
-```json
-{
-  "text": "Melyik igaz az alábbi állítások közül?\nVálaszlehetőségek:\na. Az RNS hidrolízise aldohexózt is eredményez.\nb. Az amidok vizes oldatban erős bázisként viselkednek.\nc. Az adenin, citozin és a guanin a DNS- és RNS-molekulák hidrolízisének termékei.\nd. A fehérjék savas hidrolízisében foszforsav is keletkezik.",
-  "label": "c",
-  "subject": "Chemistry"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 5
-- Prefix prompt:
-
-  ```text
-  Az alábbiakban több választási lehetőséget tartalmazó kérdések találhatók (válaszokkal együtt).
-  ```
-
-- Base prompt template:
-
-  ```text
-  Kérdés: {text}
-  Válasz: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Kérdés: {text}
-
-  Válaszoljon a fenti kérdésre az elérhető lehetőségek közül {labels_str} használatával, és semmi mással.
-  ```
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset include-hu
 ```
 
 ### Unofficial: EU-MMLU-hu

--- a/src/leaderboards/dataset_split_sizes.json
+++ b/src/leaderboards/dataset_split_sizes.json
@@ -549,6 +549,11 @@
     "train": 15,
     "val": 64
   },
+  "EuroEval/include-hu-mini": {
+    "test": 408,
+    "train": 13,
+    "val": 64
+  },
   "EuroEval/include-nl-mini": {
     "test": 469,
     "train": 24,


### PR DESCRIPTION
Swaps the official dataset `mmlu-hu` for `include-hu`.

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `include-hu`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `mmlu-hu` is demoted to unofficial and `include-hu` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.