### PR TITLE
fix: respect debug for startup verbosity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   transformers 5.x (containing `full_attention` and `sliding_attention` sub-dicts). The
   override now flattens `full_attention` contents with top-level `rope_theta` for vLLM
   compatibility, while preserving already-flat `rope_parameters` without modification.
+- Fixed startup verbosity to correctly respect the effective debug value (method
+  argument if provided, otherwise initializer default), ensuring the `--verbose` hint
+  is suppressed when debug mode is active via either path.
 
 ## [v17.7.0] - 2026-07-22
 

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -419,7 +419,10 @@ class Benchmarker:
             if verbose is not None
             else self.benchmark_config_default_params.verbose
         )
-        if os.getenv("FULL_LOG", "0") == "1" or debug:
+        effective_debug = (
+            debug if debug is not None else self.benchmark_config_default_params.debug
+        )
+        if os.getenv("FULL_LOG", "0") == "1" or effective_debug:
             is_verbose = True
 
         log_once(

--- a/tests/test_benchmarker.py
+++ b/tests/test_benchmarker.py
@@ -58,6 +58,130 @@ class TestClearCacheFn:
         rmtree(path="does-not-exist", ignore_errors=True)
 
 
+class TestDebugStartupVerbosity:
+    """Tests for the --debug startup verbosity bug fix."""
+
+    def test_call_debug_true_suppresses_hint(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that call debug=True suppresses the --verbose hint."""
+        logged_messages: list[str] = []
+        monkeypatch.delenv("FULL_LOG", raising=False)
+
+        def mock_log_once(message: str, level: int, prefix: str = "") -> None:
+            logged_messages.append(message)
+
+        monkeypatch.setattr("euroeval.benchmarker.log_once", mock_log_once)
+        monkeypatch.setattr("euroeval.benchmarker.log", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            "euroeval.benchmarker.adjust_logging_level", lambda *args, **kwargs: None
+        )
+
+        benchmarker = Benchmarker(
+            progress_bar=False,
+            save_results=False,
+            num_iterations=1,
+            debug=False,
+            run_with_cli=True,
+        )
+
+        # Mock the methods that would do real work
+        monkeypatch.setattr(
+            benchmarker, "_fetch_model_configs", lambda *args, **kwargs: []
+        )
+        monkeypatch.setattr(
+            benchmarker, "_create_model_dataset_mapping", lambda *args, **kwargs: {}
+        )
+
+        benchmarker.benchmark(model="test_model", debug=True)
+
+        # Should use the short message (no --verbose hint) when debug=True
+        assert any("Started EuroEval run." in msg for msg in logged_messages)
+        assert not any(
+            "Run with `--verbose` for more information" in msg
+            for msg in logged_messages
+        )
+
+    def test_init_debug_true_suppresses_hint(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that init debug=True suppresses the --verbose hint."""
+        logged_messages: list[str] = []
+        monkeypatch.delenv("FULL_LOG", raising=False)
+
+        def mock_log_once(message: str, level: int, prefix: str = "") -> None:
+            logged_messages.append(message)
+
+        monkeypatch.setattr("euroeval.benchmarker.log_once", mock_log_once)
+        monkeypatch.setattr("euroeval.benchmarker.log", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            "euroeval.benchmarker.adjust_logging_level", lambda *args, **kwargs: None
+        )
+
+        benchmarker = Benchmarker(
+            progress_bar=False,
+            save_results=False,
+            num_iterations=1,
+            debug=True,
+            run_with_cli=True,
+        )
+
+        # Mock the methods that would do real work
+        monkeypatch.setattr(
+            benchmarker, "_fetch_model_configs", lambda *args, **kwargs: []
+        )
+        monkeypatch.setattr(
+            benchmarker, "_create_model_dataset_mapping", lambda *args, **kwargs: {}
+        )
+
+        benchmarker.benchmark(model="test_model")
+
+        # Should use the short message (no --verbose hint) when debug=True
+        assert any("Started EuroEval run." in msg for msg in logged_messages)
+        assert not any(
+            "Run with `--verbose` for more information" in msg
+            for msg in logged_messages
+        )
+
+    def test_non_debug_shows_hint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that the normal non-debug case still shows the --verbose hint."""
+        logged_messages: list[str] = []
+        monkeypatch.delenv("FULL_LOG", raising=False)
+
+        def mock_log_once(message: str, level: int, prefix: str = "") -> None:
+            logged_messages.append(message)
+
+        monkeypatch.setattr("euroeval.benchmarker.log_once", mock_log_once)
+        monkeypatch.setattr("euroeval.benchmarker.log", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            "euroeval.benchmarker.adjust_logging_level", lambda *args, **kwargs: None
+        )
+
+        benchmarker = Benchmarker(
+            progress_bar=False,
+            save_results=False,
+            num_iterations=1,
+            debug=False,
+            run_with_cli=True,
+        )
+
+        # Mock the methods that would do real work
+        monkeypatch.setattr(
+            benchmarker, "_fetch_model_configs", lambda *args, **kwargs: []
+        )
+        monkeypatch.setattr(
+            benchmarker, "_create_model_dataset_mapping", lambda *args, **kwargs: {}
+        )
+
+        benchmarker.benchmark(model="test_model")
+
+        # Should show the --verbose hint when debug=False
+        assert any(
+            "Run with `--verbose` for more information" in msg
+            for msg in logged_messages
+        )
+
+
 @pytest.fixture(scope="module")
 def benchmarker() -> Generator[Benchmarker, None, None]:
     """A `Benchmarker` instance.


### PR DESCRIPTION
## What

Fixes the startup message shown when running EuroEval with debug mode enabled. Since `--debug` already implies verbose output, debug runs now show the concise startup message instead of telling users to run with `--verbose`.

## Key changes

- Resolves the effective debug value before choosing the startup message.
- Preserves the normal non-debug startup hint.
- Adds focused regression coverage for initialiser-level and call-level debug settings.

## Validation

- `uv run pytest tests/test_benchmarker.py::TestDebugStartupVerbosity -v`
- `make check test`
