### PR TITLE
feat: swap official dataset scala-is -> ice-ec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,16 +84,12 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   parallel size. This fixes evaluation failures for models like SmolLM series (9/15
   heads) on multi-GPU setups, which previously raised errors like "Total number of
   attention heads (X) must be divisible by tensor parallel size (Y)".
-- Fixed `KeyError: 'rope_theta'` when loading models whose `config.json` still uses the
-  legacy top-level `rope_theta`/`rope_scaling` fields with a vLLM implementation that
-  expects the nested `rope_parameters` structure introduced in transformers 5.x (e.g.
-  OLMo-3 models such as `allenai/Olmo-3-1125-32B`). The model config now transcribes the
-  legacy fields into the nested structure, applied to an explicit allowlist of confirmed
-  model families.
-- Fixed handling of OLMo-3 models with the nested `rope_parameters` format from
-  transformers 5.x (containing `full_attention` and `sliding_attention` sub-dicts). The
-  override now flattens `full_attention` contents with top-level `rope_theta` for vLLM
-  compatibility, while preserving already-flat `rope_parameters` without modification.
+- Fixed vLLM RoPE config compatibility for OLMo-3 models across both legacy
+  top-level `rope_theta`/`rope_scaling` fields and the nested `rope_parameters`
+  format introduced in transformers 5.x. Legacy fields are transcribed into the
+  nested structure for an explicit allowlist of confirmed model families, and
+  nested `full_attention` contents are flattened with top-level `rope_theta`
+  for vLLM compatibility while already-flat `rope_parameters` are preserved.
 - Fixed startup verbosity to correctly respect the effective debug value (method
   argument if provided, otherwise initializer default), ensuring the `--verbose` hint
   is suppressed when debug mode is active via either path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Swapped official dataset for Icelandic:
+  `scala-is` → `ice-ec`.
+
 - Bumped minimum `transformers` version to 5.14.0 (required for XLMRoberta/Camembert
   `ForMultipleChoice` heads; see huggingface/transformers#47147).
 - Swapped official datasets for four languages (all performed by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,6 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Swapped official dataset for Icelandic:
-  `scala-is` → `ice-ec`.
-
 - Bumped minimum `transformers` version to 5.14.0 (required for XLMRoberta/Camembert
   `ForMultipleChoice` heads; see huggingface/transformers#47147).
 - Swapped official datasets for four languages (all performed by the
@@ -57,6 +54,7 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   - German: `hellaswag-de` → `winogrande-de`, `mmlu-de` → `include-de`, `multiloko-de`
   - Greek: `global-mmlu-el` → `greek-mmlu`
   - Hungarian: `mmlu-hu` → `include-hu`
+  - Icelandic: `scala-is` → `ice-ec`
   - Lithuanian: `include-lt`
   - Portuguese: `mmlu-pt` → `alba-mcq-pt`, `cultura-viva-pt`
 

--- a/src/euroeval/dataset_configs/icelandic.py
+++ b/src/euroeval/dataset_configs/icelandic.py
@@ -28,14 +28,6 @@ HOTTER_AND_COLDER_SENTIMENT_CONFIG = DatasetConfig(
     languages=[ICELANDIC],
 )
 
-SCALA_IS_CONFIG = DatasetConfig(
-    name="scala-is",
-    pretty_name="ScaLA-is",
-    source="EuroEval/scala-is",
-    task=LA,
-    languages=[ICELANDIC],
-)
-
 MIM_GOLD_NER_CONFIG = DatasetConfig(
     name="mim-gold-ner",
     pretty_name="MIM-GOLD-NER",
@@ -117,12 +109,20 @@ RAGTRUTH_IS_CONFIG = DatasetConfig(
 )
 
 
-# Unofficial datasets ###
-
 ICE_EC_CONFIG = DatasetConfig(
     name="ice-ec",
     pretty_name="ICE-EC",
     source="EuroEval/ice-ec",
+    task=LA,
+    languages=[ICELANDIC],
+)
+
+# Unofficial datasets ###
+
+SCALA_IS_CONFIG = DatasetConfig(
+    name="scala-is",
+    pretty_name="ScaLA-is",
+    source="EuroEval/scala-is",
     task=LA,
     languages=[ICELANDIC],
     unofficial=True,

--- a/src/frontend/md/datasets/icelandic.md
+++ b/src/frontend/md/datasets/icelandic.md
@@ -157,7 +157,77 @@ euroeval --model <model-id> --dataset mim-gold-ner
 
 ## Linguistic Acceptability
 
-### ScaLA-is
+### IceEC
+
+This dataset was published [here](https://github.com/antonkarl/iceErrorCorpus) and
+consists of texts in modern Icelandic from student essays, online news texts and
+Wikipedia articles, annotated for mistakes related to spelling, grammar, and other
+issues.
+
+The original full dataset consists of 58,200 / 5,270 samples for training and testing,
+respectively. We use a 1,024 / 256 / 2,048 split for training, validation and testing,
+where the training and testing splits are subsets of the original training and testing
+splits, and the validation split is a disjoint subset of the training split.
+
+Here are a few examples from the training split:
+
+```json
+{
+  "text": "Kannski erum við með meiri sölu í öðrum skrokkhlutum en síðum t.d., “ segir Steinþór.",
+  "label": "correct"
+}
+```
+
+```json
+{
+  "text": "Þó svo að hann sé leiðinlegur og ekkert tívolí gaman, þá er miðlar hann þekkingu til okkar og án hans mundi enginn menntun vera.",
+  "label": "incorrect"
+}
+```
+
+```json
+{
+  "text": "Síminn er hvers manns ábyrgð.",
+  "label": "incorrect"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 12
+- Prefix prompt:
+
+  ```text
+  Hér fyrir neðan eru setningar ásamt mati á því hvort þær eru málfræðilega réttar.
+  ```
+
+- Base prompt template:
+
+  ```text
+  Setning: {text}
+  Málfræðilega rétt: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Setning: {text}
+
+  Greindu hvort setningin er málfræðilega rétt. Svaraðu með 'já' ef setningin er rétt og 'nei' ef hún er það ekki.
+  ```
+
+- Label mapping:
+  - `correct` ➡️ `já`
+  - `incorrect` ➡️ `nei`
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset ice-ec
+```
+
+### Unofficial: ScaLA-is
 
 This dataset was published in [this paper](https://aclanthology.org/2023.nodalida-1.20/)
 and was automatically created from the
@@ -228,76 +298,6 @@ You can evaluate this dataset directly as follows:
 
 ```bash
 euroeval --model <model-id> --dataset scala-is
-```
-
-### Unofficial: IceEC
-
-This dataset was published [here](https://github.com/antonkarl/iceErrorCorpus) and
-consists of texts in modern Icelandic from student essays, online news texts and
-Wikipedia articles, annotated for mistakes related to spelling, grammar, and other
-issues.
-
-The original full dataset consists of 58,200 / 5,270 samples for training and testing,
-respectively. We use a 1,024 / 256 / 2,048 split for training, validation and testing,
-where the training and testing splits are subsets of the original training and testing
-splits, and the validation split is a disjoint subset of the training split.
-
-Here are a few examples from the training split:
-
-```json
-{
-  "text": "Kannski erum við með meiri sölu í öðrum skrokkhlutum en síðum t.d., “ segir Steinþór.",
-  "label": "correct"
-}
-```
-
-```json
-{
-  "text": "Þó svo að hann sé leiðinlegur og ekkert tívolí gaman, þá er miðlar hann þekkingu til okkar og án hans mundi enginn menntun vera.",
-  "label": "incorrect"
-}
-```
-
-```json
-{
-  "text": "Síminn er hvers manns ábyrgð.",
-  "label": "incorrect"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 12
-- Prefix prompt:
-
-  ```text
-  Hér fyrir neðan eru setningar ásamt mati á því hvort þær eru málfræðilega réttar.
-  ```
-
-- Base prompt template:
-
-  ```text
-  Setning: {text}
-  Málfræðilega rétt: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Setning: {text}
-
-  Greindu hvort setningin er málfræðilega rétt. Svaraðu með 'já' ef setningin er rétt og 'nei' ef hún er það ekki.
-  ```
-
-- Label mapping:
-  - `correct` ➡️ `já`
-  - `incorrect` ➡️ `nei`
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset ice-ec
 ```
 
 ### Unofficial: IceLinguistic

--- a/src/leaderboards/dataset_split_sizes.json
+++ b/src/leaderboards/dataset_split_sizes.json
@@ -480,6 +480,11 @@
     "train": 1024,
     "val": 256
   },
+  "EuroEval/ice-ec": {
+    "test": 2048,
+    "train": 1024,
+    "val": 256
+  },
   "EuroEval/icelandic-knowledge": {
     "test": 1024,
     "train": 842,


### PR DESCRIPTION
Swaps the official dataset `scala-is` for `ice-ec`.

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `ice-ec`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `scala-is` is demoted to unofficial and `ice-ec` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.