### PR TITLE
feat: swap official dataset hellaswag-fi -> winogrande-fi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Swapped official dataset for Finnish:
+  `hellaswag-fi` → `winogrande-fi`.
+
 - Bumped minimum `transformers` version to 5.14.0 (required for XLMRoberta/Camembert
   `ForMultipleChoice` heads; see huggingface/transformers#47147).
 - Swapped official datasets for four languages (all performed by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,15 +43,13 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Swapped official dataset for Finnish:
-  `hellaswag-fi` → `winogrande-fi`.
-
 - Bumped minimum `transformers` version to 5.14.0 (required for XLMRoberta/Camembert
   `ForMultipleChoice` heads; see huggingface/transformers#47147).
 - Swapped official datasets for four languages (all performed by the
   `swap_leaderboard_dataset.py` script, which now automatically updates this changelog):
   - Croatian: `mmlu-hr` → `include-hr`
   - Dutch: `scala-nl` → `dutch-cola`, `mmlu-nl` → `include-nl`, `multiloko-nl`
+  - Finnish: `hellaswag-fi` → `winogrande-fi`
   - French: `mmlu-fr` → `include-fr`, `multiloko-fr`
   - German: `hellaswag-de` → `winogrande-de`, `mmlu-de` → `include-de`, `multiloko-de`
   - Greek: `global-mmlu-el` → `greek-mmlu`

--- a/src/euroeval/dataset_configs/finnish.py
+++ b/src/euroeval/dataset_configs/finnish.py
@@ -51,14 +51,6 @@ XLSUM_FI_CONFIG = DatasetConfig(
     languages=[FINNISH],
 )
 
-HELLASWAG_FI_CONFIG = DatasetConfig(
-    name="hellaswag-fi",
-    pretty_name="HellaSwag-fi",
-    source="EuroEval/hellaswag-fi-mini",
-    task=COMMON_SENSE,
-    languages=[FINNISH],
-)
-
 SCALA_FI_CONFIG = DatasetConfig(
     name="scala-fi",
     pretty_name="ScaLA-fi",
@@ -99,7 +91,25 @@ RAGTRUTH_FI_CONFIG = DatasetConfig(
 )
 
 
+WINOGRANDE_FI_CONFIG = DatasetConfig(
+    name="winogrande-fi",
+    pretty_name="Winogrande-fi",
+    source="EuroEval/winogrande-fi",
+    task=COMMON_SENSE,
+    languages=[FINNISH],
+    labels=["a", "b"],
+)
+
 # Unofficial datasets ###
+
+HELLASWAG_FI_CONFIG = DatasetConfig(
+    name="hellaswag-fi",
+    pretty_name="HellaSwag-fi",
+    source="EuroEval/hellaswag-fi-mini",
+    task=COMMON_SENSE,
+    languages=[FINNISH],
+    unofficial=True,
+)
 
 BELEBELE_FI_CONFIG = DatasetConfig(
     name="belebele-fi",
@@ -125,16 +135,6 @@ GOLDENSWAG_FI_CONFIG = DatasetConfig(
     source="EuroEval/goldenswag-fi-mini",
     task=COMMON_SENSE,
     languages=[FINNISH],
-    unofficial=True,
-)
-
-WINOGRANDE_FI_CONFIG = DatasetConfig(
-    name="winogrande-fi",
-    pretty_name="Winogrande-fi",
-    source="EuroEval/winogrande-fi",
-    task=COMMON_SENSE,
-    languages=[FINNISH],
-    labels=["a", "b"],
     unofficial=True,
 )
 

--- a/src/frontend/md/datasets/finnish.md
+++ b/src/frontend/md/datasets/finnish.md
@@ -550,7 +550,7 @@ and is a translated and filtered version of the English
 [Winogrande dataset](https://doi.org/10.1145/3474381).
 
 The original full dataset consists of 47 / 1,210 samples for training and testing, and
-we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
+we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,082 split for
 training, validation and testing, respectively.
 
 Here are a few examples from the training split:

--- a/src/frontend/md/datasets/finnish.md
+++ b/src/frontend/md/datasets/finnish.md
@@ -543,7 +543,77 @@ euroeval --model <model-id> --dataset include-fi
 
 ## Common-sense Reasoning
 
-### HellaSwag-fi
+### Winogrande-fi
+
+This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2506.19468)
+and is a translated and filtered version of the English
+[Winogrande dataset](https://doi.org/10.1145/3474381).
+
+The original full dataset consists of 47 / 1,210 samples for training and testing, and
+we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
+training, validation and testing, respectively.
+
+Here are a few examples from the training split:
+
+```json
+{
+  "text": "Kun Dennis oli Puolassa, hän nautti matkasta enemmän kuin Jason, koska _ ymmärsi puolaa syvällisemmin. Mihin tyhjä _ viittaa?\nVastausvaihtoehdot:\na. Dennis\nb. Jason",
+  "label": "a"
+}
+```
+
+```json
+{
+  "text": "Michael halusi viedä Craigin vesille uudella veneellään. _ sanoi, että olisi hauskaa näyttää hänelle köysiä. Mihin tyhjä _ viittaa?\nVastausvaihtoehdot:\na. Michael\nb. Craig",
+  "label": "a"
+}
+```
+
+```json
+{
+  "text": "Voittaaksemme käyttäytymisharhan, meidän täytyy keskittyä enemmän tietoisten toimien muuttamiseen kuin tiedostamattomien toimien muuttamiseen, koska _ toimet ovat vapaaehtoisia. Mihin tyhjä _ viittaa?\nVastausvaihtoehdot:\na. tiedostamattomat\nb. tietoiset",
+  "label": "b"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  Seuraavat ovat monivalintakysymyksiä (vastauksineen).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Kysymys: {text}
+  Vastausvaihtoehdot:
+  a. {option_a}
+  b. {option_b}
+  Vastaus: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Kysymys: {text}
+  Vastausvaihtoehdot:
+  a. {option_a}
+  b. {option_b}
+
+  Vastaa yllä olevaan kysymykseen käyttämällä 'a' tai 'b', äläkä mitään muuta.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset winogrande-fi
+```
+
+### Unofficial: HellaSwag-fi
 
 This dataset is a machine translated version of the English
 [HellaSwag dataset](https://aclanthology.org/P19-1472/). The
@@ -692,76 +762,6 @@ You can evaluate this dataset directly as follows:
 
 ```bash
 euroeval --model <model-id> --dataset goldenswag-fi
-```
-
-### Unofficial: Winogrande-fi
-
-This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2506.19468)
-and is a translated and filtered version of the English
-[Winogrande dataset](https://doi.org/10.1145/3474381).
-
-The original full dataset consists of 47 / 1,210 samples for training and testing, and
-we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
-training, validation and testing, respectively.
-
-Here are a few examples from the training split:
-
-```json
-{
-  "text": "Kun Dennis oli Puolassa, hän nautti matkasta enemmän kuin Jason, koska _ ymmärsi puolaa syvällisemmin. Mihin tyhjä _ viittaa?\nVastausvaihtoehdot:\na. Dennis\nb. Jason",
-  "label": "a"
-}
-```
-
-```json
-{
-  "text": "Michael halusi viedä Craigin vesille uudella veneellään. _ sanoi, että olisi hauskaa näyttää hänelle köysiä. Mihin tyhjä _ viittaa?\nVastausvaihtoehdot:\na. Michael\nb. Craig",
-  "label": "a"
-}
-```
-
-```json
-{
-  "text": "Voittaaksemme käyttäytymisharhan, meidän täytyy keskittyä enemmän tietoisten toimien muuttamiseen kuin tiedostamattomien toimien muuttamiseen, koska _ toimet ovat vapaaehtoisia. Mihin tyhjä _ viittaa?\nVastausvaihtoehdot:\na. tiedostamattomat\nb. tietoiset",
-  "label": "b"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 5
-- Prefix prompt:
-
-  ```text
-  Seuraavat ovat monivalintakysymyksiä (vastauksineen).
-  ```
-
-- Base prompt template:
-
-  ```text
-  Kysymys: {text}
-  Vastausvaihtoehdot:
-  a. {option_a}
-  b. {option_b}
-  Vastaus: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Kysymys: {text}
-  Vastausvaihtoehdot:
-  a. {option_a}
-  b. {option_b}
-
-  Vastaa yllä olevaan kysymykseen käyttämällä 'a' tai 'b', äläkä mitään muuta.
-  ```
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset winogrande-fi
 ```
 
 ## Summarisation

--- a/src/leaderboards/dataset_split_sizes.json
+++ b/src/leaderboards/dataset_split_sizes.json
@@ -1344,6 +1344,11 @@
     "train": 1024,
     "val": 256
   },
+  "EuroEval/winogrande-fi": {
+    "test": 1085,
+    "train": 47,
+    "val": 128
+  },
   "EuroEval/winogrande-hr": {
     "test": 1085,
     "train": 47,

--- a/src/leaderboards/openai_models.yaml
+++ b/src/leaderboards/openai_models.yaml
@@ -76,7 +76,6 @@
 - gpt-audio-mini-2025-10-06
 - gpt-5-search-api
 - gpt-realtime-mini
-- gpt-realtime-mini-2025-10-06
 - sora-2
 - sora-2-pro
 - gpt-5-search-api-2025-10-14


### PR DESCRIPTION
Swaps the official dataset `hellaswag-fi` for `winogrande-fi`.

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `winogrande-fi`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `hellaswag-fi` is demoted to unofficial and `winogrande-fi` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.