### PR TITLE
feat: swap official dataset hellaswag-it -> winogrande-it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Swapped official dataset for Italian:
+  `hellaswag-it` → `winogrande-it`.
+
 - Bumped minimum `transformers` version to 5.14.0 (required for XLMRoberta/Camembert
   `ForMultipleChoice` heads; see huggingface/transformers#47147).
 - Swapped official datasets for four languages (all performed by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,6 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Swapped official dataset for Italian:
-  `hellaswag-it` → `winogrande-it`.
-
 - Bumped minimum `transformers` version to 5.14.0 (required for XLMRoberta/Camembert
   `ForMultipleChoice` heads; see huggingface/transformers#47147).
 - Swapped official datasets for four languages (all performed by the
@@ -67,6 +64,7 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   - Greek: `global-mmlu-el` → `greek-mmlu`
   - Hungarian: `mmlu-hu` → `include-hu`
   - Icelandic: `scala-is` → `ice-ec`
+  - Italian: `hellaswag-it` → `winogrande-it`
   - Lithuanian: `include-lt`
   - Portuguese: `mmlu-pt` → `alba-mcq-pt`, `cultura-viva-pt`
 

--- a/src/euroeval/dataset_configs/italian.py
+++ b/src/euroeval/dataset_configs/italian.py
@@ -67,14 +67,6 @@ MMLU_IT_CONFIG = DatasetConfig(
     languages=[ITALIAN],
 )
 
-HELLASWAG_IT_CONFIG = DatasetConfig(
-    name="hellaswag-it",
-    pretty_name="HellaSwag-it",
-    source="EuroEval/hellaswag-it-mini",
-    task=COMMON_SENSE,
-    languages=[ITALIAN],
-)
-
 MULTI_IFEVAL_IT_CONFIG = DatasetConfig(
     name="multi-ifeval-it",
     pretty_name="MultiIFEval-it",
@@ -107,7 +99,25 @@ RAGTRUTH_IT_CONFIG = DatasetConfig(
 )
 
 
+WINOGRANDE_IT_CONFIG = DatasetConfig(
+    name="winogrande-it",
+    pretty_name="Winogrande-it",
+    source="EuroEval/winogrande-it",
+    task=COMMON_SENSE,
+    languages=[ITALIAN],
+    labels=["a", "b"],
+)
+
 # Unofficial datasets ###
+
+HELLASWAG_IT_CONFIG = DatasetConfig(
+    name="hellaswag-it",
+    pretty_name="HellaSwag-it",
+    source="EuroEval/hellaswag-it-mini",
+    task=COMMON_SENSE,
+    languages=[ITALIAN],
+    unofficial=True,
+)
 
 IFEVAL_IT_CONFIG = DatasetConfig(
     name="ifeval-it",
@@ -153,16 +163,6 @@ GOLDENSWAG_IT_CONFIG = DatasetConfig(
     source="EuroEval/goldenswag-it-mini",
     task=COMMON_SENSE,
     languages=[ITALIAN],
-    unofficial=True,
-)
-
-WINOGRANDE_IT_CONFIG = DatasetConfig(
-    name="winogrande-it",
-    pretty_name="Winogrande-it",
-    source="EuroEval/winogrande-it",
-    task=COMMON_SENSE,
-    languages=[ITALIAN],
-    labels=["a", "b"],
     unofficial=True,
 )
 

--- a/src/frontend/md/datasets/italian.md
+++ b/src/frontend/md/datasets/italian.md
@@ -847,7 +847,77 @@ euroeval --model <model-id> --dataset eu-mmlu-it
 
 ## Common-sense Reasoning
 
-### HellaSwag-it
+### Winogrande-it
+
+This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2506.19468)
+and is a translated and filtered version of the English
+[Winogrande dataset](https://doi.org/10.1145/3474381).
+
+The original full dataset consists of 47 / 1,210 samples for training and testing, and
+we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
+training, validation and testing, respectively.
+
+Here are a few examples from the training split:
+
+```json
+{
+  "text": "Il sushi marciva sul bancone a meno che non venisse messo nel frigorifero, poiché il _ lo esponeva alla contaminazione. A cosa si riferisce il vuoto _?\nScelte:\na. bancone\nb. frigorifero",
+  "label": "a"
+}
+```
+
+```json
+{
+  "text": "Rebecca ha preso Amy per fare il carpooling al lavoro ogni giorno, quindi _ ha chiesto dei soldi per la benzina. A cosa si riferisce il vuoto _?\nScelte:\na. Rebecca\nb. Amy",
+  "label": "a"
+}
+```
+
+```json
+{
+  "text": "Laura aveva sempre più motivazione nella vita e nel raggiungere obiettivi rispetto a Katrina, poiché _ era pigra. A cosa si riferisce il vuoto _?\nScelte:\na. Laura\nb. Katrina",
+  "label": "b"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  Le seguenti sono domande a scelta multipla (con relative risposte).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Domanda: {text}
+  Scelte:
+  a. {option_a}
+  b. {option_b}
+  Risposta: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Domanda: {text}
+  Scelte:
+  a. {option_a}
+  b. {option_b}
+
+  Rispondete alla domanda precedente con 'a' o 'b' e nient'altro.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset winogrande-it
+```
+
+### Unofficial: HellaSwag-it
 
 This dataset is a machine translated version of the English
 [HellaSwag dataset](https://aclanthology.org/P19-1472/). The original dataset was based
@@ -998,76 +1068,6 @@ You can evaluate this dataset directly as follows:
 
 ```bash
 euroeval --model <model-id> --dataset goldenswag-it
-```
-
-### Unofficial: Winogrande-it
-
-This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2506.19468)
-and is a translated and filtered version of the English
-[Winogrande dataset](https://doi.org/10.1145/3474381).
-
-The original full dataset consists of 47 / 1,210 samples for training and testing, and
-we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
-training, validation and testing, respectively.
-
-Here are a few examples from the training split:
-
-```json
-{
-  "text": "Il sushi marciva sul bancone a meno che non venisse messo nel frigorifero, poiché il _ lo esponeva alla contaminazione. A cosa si riferisce il vuoto _?\nScelte:\na. bancone\nb. frigorifero",
-  "label": "a"
-}
-```
-
-```json
-{
-  "text": "Rebecca ha preso Amy per fare il carpooling al lavoro ogni giorno, quindi _ ha chiesto dei soldi per la benzina. A cosa si riferisce il vuoto _?\nScelte:\na. Rebecca\nb. Amy",
-  "label": "a"
-}
-```
-
-```json
-{
-  "text": "Laura aveva sempre più motivazione nella vita e nel raggiungere obiettivi rispetto a Katrina, poiché _ era pigra. A cosa si riferisce il vuoto _?\nScelte:\na. Laura\nb. Katrina",
-  "label": "b"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 5
-- Prefix prompt:
-
-  ```text
-  Le seguenti sono domande a scelta multipla (con relative risposte).
-  ```
-
-- Base prompt template:
-
-  ```text
-  Domanda: {text}
-  Scelte:
-  a. {option_a}
-  b. {option_b}
-  Risposta: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Domanda: {text}
-  Scelte:
-  a. {option_a}
-  b. {option_b}
-
-  Rispondete alla domanda precedente con 'a' o 'b' e nient'altro.
-  ```
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset winogrande-it
 ```
 
 ## Summarisation

--- a/src/leaderboards/dataset_split_sizes.json
+++ b/src/leaderboards/dataset_split_sizes.json
@@ -1364,6 +1364,11 @@
     "train": 64,
     "val": 128
   },
+  "EuroEval/winogrande-it": {
+    "test": 1085,
+    "train": 47,
+    "val": 128
+  },
   "EuroEval/winogrande-lt": {
     "test": 1085,
     "train": 47,


### PR DESCRIPTION
Swaps the official dataset `hellaswag-it` for `winogrande-it`.

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `winogrande-it`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `hellaswag-it` is demoted to unofficial and `winogrande-it` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.