### PR TITLE
Feat: Add opt-in flag for HF bucket upload

### DIFF
--- a/src/leaderboards/result_processing.py
+++ b/src/leaderboards/result_processing.py
@@ -125,7 +125,7 @@ def process_results(
 def _upload_per_model_files(
     processed_records: list[dict[str, t.Any]], upload_to_bucket: bool = False
 ) -> None:
-    """Write one JSON file per logical result and sync to the HF bucket.
+    """Write one JSON file per logical result and optionally sync to the HF bucket.
 
     Each record is written to
     ``results/<sanitise(model_id)>/<dataset>__<split>__<shot>.json``.

--- a/src/leaderboards/result_processing.py
+++ b/src/leaderboards/result_processing.py
@@ -43,6 +43,7 @@ def process_results(
     banned_model_patterns: list[re.Pattern],
     api_model_patterns: list[re.Pattern],
     trained_from_scratch_patterns: list[re.Pattern],
+    upload_to_bucket: bool = False,
 ) -> None:
     """Process EuroEval records from a JSONL file.
 
@@ -60,6 +61,9 @@ def process_results(
             A list of regex patterns for API inference models.
         trained_from_scratch_patterns:
             A list of regex patterns for trained-from-scratch models.
+        upload_to_bucket (optional):
+            Whether to sync the processed per-model files to the Hugging Face
+            results bucket. Defaults to False.
     """
     # Load raw results first so per-model files in RESULTS_DIR are synced.
     records = load_raw_results()
@@ -111,12 +115,16 @@ def process_results(
         for record in tqdm(processed_records, desc="Adding missing entries")
     ]
 
-    _upload_per_model_files(processed_records=processed_records)
+    _upload_per_model_files(
+        processed_records=processed_records, upload_to_bucket=upload_to_bucket
+    )
     load_raw_results.cache_clear()
     logger.info("Cleared load_raw_results cache.")
 
 
-def _upload_per_model_files(processed_records: list[dict[str, t.Any]]) -> None:
+def _upload_per_model_files(
+    processed_records: list[dict[str, t.Any]], upload_to_bucket: bool = False
+) -> None:
     """Write one JSON file per logical result and sync to the HF bucket.
 
     Each record is written to
@@ -128,13 +136,17 @@ def _upload_per_model_files(processed_records: list[dict[str, t.Any]]) -> None:
     Args:
         processed_records:
             The processed records to upload.
+        upload_to_bucket (optional):
+            Whether to sync the written files to the Hugging Face results
+            bucket. If False, files are only written locally to RESULTS_DIR,
+            and no HF_TOKEN is required. Defaults to False.
 
     Raises:
         RuntimeError:
-            If HF_TOKEN is not set or bucket sync fails.
+            If HF_TOKEN is not set or bucket sync fails, when uploading.
     """
-    hf_token = resolve_hf_token()
-    if not hf_token:
+    hf_token = resolve_hf_token() if upload_to_bucket else None
+    if upload_to_bucket and not hf_token:
         raise RuntimeError(
             "HF_TOKEN not set. Cannot upload results to Hugging Face bucket. "
             "Run 'hf auth login' or set the HF_TOKEN environment variable."
@@ -187,12 +199,20 @@ def _upload_per_model_files(processed_records: list[dict[str, t.Any]]) -> None:
         if result is not None:
             written_files.append(result)
 
-    api = HfApi()
-    # Upload only the written files to the bucket
-    api.batch_bucket_files(
-        bucket_id=HF_RESULTS_BUCKET, add=written_files, token=hf_token
-    )
-    logger.info(f"Uploaded {len(written_files):,} result files to {hf_results_bucket}.")
+    if upload_to_bucket:
+        api = HfApi()
+        # Upload only the written files to the bucket
+        api.batch_bucket_files(
+            bucket_id=HF_RESULTS_BUCKET, add=written_files, token=hf_token
+        )
+        logger.info(
+            f"Uploaded {len(written_files):,} result files to {hf_results_bucket}."
+        )
+    else:
+        logger.info(
+            f"Skipped uploading {len(written_files):,} result file(s) to "
+            f"{hf_results_bucket} (upload_to_bucket=False)."
+        )
 
     if dropped_count > 0:
         logger.info(f"Dropped {dropped_count:,} records with unresolvable identities.")

--- a/src/scripts/generate_leaderboards.py
+++ b/src/scripts/generate_leaderboards.py
@@ -89,11 +89,22 @@ load_dotenv()
         "leaderboard generation when results haven't changed."
     ),
 )
+@click.option(
+    "--upload/--no-upload",
+    default=False,
+    show_default=True,
+    help=(
+        "Whether to sync processed results to the Hugging Face results bucket. "
+        "Leave disabled to process results and regenerate leaderboards locally "
+        "without touching the shared bucket."
+    ),
+)
 def main(
     categories: tuple[t.Literal["generative", "all_models"], ...],
     force: bool,
     skip_core_models_check: bool,
     skip_results_processing: bool,
+    upload: bool,
 ) -> None:
     """Generate all leaderboards.
 
@@ -109,6 +120,9 @@ def main(
         skip_results_processing (optional):
             If True, skip processing evaluation results from JSONL. Assumes the
             results directory already contains processed results.
+        upload (optional):
+            Whether to sync processed results to the Hugging Face results
+            bucket. Defaults to False.
     """
     # If the results directory isn't populated, restore the newest backup.
     restore_from_backup_if_missing()
@@ -121,6 +135,7 @@ def main(
             banned_model_patterns=BANNED_MODEL_PATTERNS,
             api_model_patterns=API_MODEL_PATTERNS,
             trained_from_scratch_patterns=TRAINED_FROM_SCRATCH_PATTERNS,
+            upload_to_bucket=upload,
         )
 
     # Offer to refresh the core-model list if it hasn't been touched in

--- a/src/scripts/generate_leaderboards.py
+++ b/src/scripts/generate_leaderboards.py
@@ -94,9 +94,9 @@ load_dotenv()
     default=False,
     show_default=True,
     help=(
-        "Whether to sync processed results to the Hugging Face results bucket. "
+        "Whether to upload processed results to the Hugging Face results bucket. "
         "Leave disabled to process results and regenerate leaderboards locally "
-        "without touching the shared bucket."
+        "without uploading to the shared bucket."
     ),
 )
 def main(

--- a/tests/leaderboards/test_result_processing.py
+++ b/tests/leaderboards/test_result_processing.py
@@ -59,7 +59,7 @@ class TestUploadPerModelFilesPerRecordTree:
             ):
                 with caplog.at_level("WARNING"):
                     result_processing._upload_per_model_files(
-                        processed_records=[invalid_record]
+                        processed_records=[invalid_record], upload_to_bucket=True
                     )
 
         # No files should be written
@@ -108,7 +108,9 @@ class TestUploadPerModelFilesPerRecordTree:
                 "leaderboards.result_processing.resolve_hf_token",
                 return_value="test_token",
             ):
-                result_processing._upload_per_model_files(processed_records=[record])
+                result_processing._upload_per_model_files(
+                    processed_records=[record], upload_to_bucket=True
+                )
 
         model_dir = tmp_path / "org_model"
         result_file = model_dir / "mmlu__test__zeroshot.json"
@@ -190,7 +192,8 @@ class TestUploadPerModelFilesPerRecordTree:
                 return_value="test_token",
             ):
                 result_processing._upload_per_model_files(
-                    processed_records=[older_record, newer_record]
+                    processed_records=[older_record, newer_record],
+                    upload_to_bucket=True,
                 )
 
         # Only one file should exist
@@ -265,7 +268,7 @@ class TestUploadPerModelFilesPerRecordTree:
             ):
                 with pytest.raises(ValueError, match="Identity collision detected"):
                     result_processing._upload_per_model_files(
-                        processed_records=[record_a, record_b]
+                        processed_records=[record_a, record_b], upload_to_bucket=True
                     )
 
         # No files should be written on collision
@@ -303,7 +306,9 @@ class TestUploadPerModelFilesPerRecordTree:
                 "leaderboards.result_processing.resolve_hf_token",
                 return_value="test_token",
             ):
-                result_processing._upload_per_model_files(processed_records=[record])
+                result_processing._upload_per_model_files(
+                    processed_records=[record], upload_to_bucket=True
+                )
 
         # Check directory structure
         model_dir = tmp_path / "org_Qwen3-0.6B"
@@ -347,7 +352,9 @@ def test_cache_freshness_load_before_cache_construction(
     monkeypatch.setattr(result_processing, "load_raw_results", fake_load_raw_results)
     monkeypatch.setattr(Cache, "from_results_dir", fake_cache_from_results_dir)
     monkeypatch.setattr(
-        result_processing, "_upload_per_model_files", lambda processed_records: None
+        result_processing,
+        "_upload_per_model_files",
+        lambda processed_records, upload_to_bucket=False: None,
     )
 
     result_processing.process_results(
@@ -393,7 +400,9 @@ def test_process_results_clears_cache_after_upload(
     monkeypatch.setattr(result_processing, "load_raw_results", fake_load_raw_results)
     monkeypatch.setattr(Cache, "from_results_dir", fake_cache_from_results_dir)
     monkeypatch.setattr(
-        result_processing, "_upload_per_model_files", lambda processed_records: None
+        result_processing,
+        "_upload_per_model_files",
+        lambda processed_records, upload_to_bucket=False: None,
     )
 
     result_processing.process_results(
@@ -474,7 +483,9 @@ def test_upload_per_model_files_passes_hf_token(
         with patch(
             "leaderboards.result_processing.resolve_hf_token", return_value="test_token"
         ):
-            result_processing._upload_per_model_files(processed_records=[record])
+            result_processing._upload_per_model_files(
+                processed_records=[record], upload_to_bucket=True
+            )
 
     mock_api.batch_bucket_files.assert_called_once()
     call_kwargs = mock_api.batch_bucket_files.call_args.kwargs
@@ -498,7 +509,9 @@ def test_upload_per_model_files_raises_on_sync_failure(
             "leaderboards.result_processing.resolve_hf_token", return_value="test_token"
         ):
             with pytest.raises(HfHubHTTPError, match="Bucket sync failed"):
-                result_processing._upload_per_model_files(processed_records=[])
+                result_processing._upload_per_model_files(
+                    processed_records=[], upload_to_bucket=True
+                )
 
 
 def test_upload_per_model_files_raises_without_hf_token(
@@ -514,7 +527,9 @@ def test_upload_per_model_files_raises_without_hf_token(
     # Patch resolve_hf_token to return None (simulating missing HF_TOKEN)
     with patch("leaderboards.result_processing.resolve_hf_token", return_value=None):
         with pytest.raises(RuntimeError, match="HF_TOKEN not set"):
-            result_processing._upload_per_model_files(processed_records=[])
+            result_processing._upload_per_model_files(
+                processed_records=[], upload_to_bucket=True
+            )
 
 
 def test_upload_results_to_bucket_passes_hf_token(


### PR DESCRIPTION
This PR adds an `--upload/--no-upload` flag to `generate_leaderboards.py`, defaulting to `--no-upload`, so results can be processed and leaderboards regenerated locally without uploading results to the Hugging Face results bucket (or needing `HF_TOKEN`) unless explicitly requested.