### PR TITLE
update hallucination task

### DIFF
--- a/src/euroeval/metrics/token_hallucination_classifier.py
+++ b/src/euroeval/metrics/token_hallucination_classifier.py
@@ -127,7 +127,7 @@ def _hallucination_model_id(language_code: str) -> str:
         The Hugging Face Hub repository ID of the hallucination detection model.
     """
     return (
-        "alexandrainst/mmBERT-small-multi-wiki-qa-synthetic-hallucinations-with-"
+        "EuroEval/mmBERT-small-multi-wiki-qa-synthetic-hallucinations-with-"
         f"ragtruth-{language_code}"
     )
 

--- a/tests/test_metrics/test_token_hallucination_classifier.py
+++ b/tests/test_metrics/test_token_hallucination_classifier.py
@@ -177,8 +177,7 @@ def test_detector_uses_correct_model_id(
         )
 
     expected_model_id = (
-        "alexandrainst/"
-        "mmBERT-small-multi-wiki-qa-synthetic-hallucinations-with-ragtruth-da"
+        "EuroEval/mmBERT-small-multi-wiki-qa-synthetic-hallucinations-with-ragtruth-da"
     )
     mock_cls.assert_called_once_with(
         method="transformer",


### PR DESCRIPTION
Updates the token hallucination metric to load the mirrored language-specific classifier models from the EuroEval Hugging Face organisation.

- Mirrored the 26 models from the Alexandra Institute RAGTruth hallucination classifier collection to `EuroEval/*` on Hugging Face.
- Updated the hallucination model ID construction to use `EuroEval/`.
- Updated the corresponding unit test expectation.

Validation:
- Verified all 26 EuroEval model repos match their source repos by file path, size, and blob/LFS hash.
- `uv run pytest tests/test_metrics/test_token_hallucination_classifier.py`
