### PR TITLE
feat: swap official dataset goldenswag-pt -> winogrande-pt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,6 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Swapped official dataset for European Portuguese, Portuguese:
-  `goldenswag-pt` → `winogrande-pt`.
-
 - Renamed the previous LLM-as-a-judge `open-ended-qa` task to `reference-free-qa`, and
   added a new reference-based `open-ended-qa` task using translation-style text-to-text
   metrics.
@@ -67,16 +64,22 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Swapped official datasets for four languages (all performed by the
   `swap_leaderboard_dataset.py` script, which now automatically updates this changelog):
   - Croatian: `mmlu-hr` → `include-hr`
-  - Dutch: `scala-nl` → `dutch-cola`, `mmlu-nl` → `include-nl`, `multiloko-nl`
+  - Dutch:
+    - `scala-nl` → `dutch-cola`
+    - `mmlu-nl` → `include-nl`, `multiloko-nl`
   - Finnish: `hellaswag-fi` → `winogrande-fi`
   - French: `mmlu-fr` → `include-fr`, `multiloko-fr`
-  - German: `hellaswag-de` → `winogrande-de`, `mmlu-de` → `include-de`, `multiloko-de`
+  - German:
+    - `hellaswag-de` → `winogrande-de`
+    - `mmlu-de` → `include-de`, `multiloko-de`
   - Greek: `global-mmlu-el` → `greek-mmlu`
   - Hungarian: `mmlu-hu` → `include-hu`
   - Icelandic: `scala-is` → `ice-ec`
   - Italian: `hellaswag-it` → `winogrande-it`
   - Lithuanian: `include-lt`
-  - Portuguese: `mmlu-pt` → `alba-mcq-pt`, `cultura-viva-pt`
+  - Portuguese:
+    - `mmlu-pt` → `alba-mcq-pt`, `cultura-viva-pt`
+    - `goldenswag-pt` → `winogrande-pt`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Swapped official dataset for European Portuguese, Portuguese:
+  `goldenswag-pt` → `winogrande-pt`.
+
 - Renamed the previous LLM-as-a-judge `open-ended-qa` task to `reference-free-qa`, and
   added a new reference-based `open-ended-qa` task using translation-style text-to-text
   metrics.

--- a/src/euroeval/dataset_configs/portuguese.py
+++ b/src/euroeval/dataset_configs/portuguese.py
@@ -59,14 +59,6 @@ PUBLICO_CONFIG = DatasetConfig(
     languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
 )
 
-GOLDENSWAG_PT_CONFIG = DatasetConfig(
-    name="goldenswag-pt",
-    pretty_name="GoldenSwag-pt",
-    source="EuroEval/goldenswag-pt-mini",
-    task=COMMON_SENSE,
-    languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
-)
-
 MULTI_IFEVAL_PT_CONFIG = DatasetConfig(
     name="multi-ifeval-pt",
     pretty_name="MultiIFEval-pt",
@@ -108,7 +100,25 @@ CULTURA_VIVA_PT_CONFIG = DatasetConfig(
     languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
 )
 
+WINOGRANDE_PT_CONFIG = DatasetConfig(
+    name="winogrande-pt",
+    pretty_name="Winogrande-pt",
+    source="EuroEval/winogrande-pt",
+    task=COMMON_SENSE,
+    languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
+    labels=["a", "b"],
+)
+
 # Unofficial datasets ###
+
+GOLDENSWAG_PT_CONFIG = DatasetConfig(
+    name="goldenswag-pt",
+    pretty_name="GoldenSwag-pt",
+    source="EuroEval/goldenswag-pt-mini",
+    task=COMMON_SENSE,
+    languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
+    unofficial=True,
+)
 
 MMLU_PT_CONFIG = DatasetConfig(
     name="mmlu-pt",
@@ -136,16 +146,6 @@ BOOLQ_PT_CONFIG = DatasetConfig(
     source="EuroEval/boolq-pt",
     task=MCRC,
     languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
-    unofficial=True,
-)
-
-WINOGRANDE_PT_CONFIG = DatasetConfig(
-    name="winogrande-pt",
-    pretty_name="Winogrande-pt",
-    source="EuroEval/winogrande-pt",
-    task=COMMON_SENSE,
-    languages=[PORTUGUESE, EUROPEAN_PORTUGUESE],
-    labels=["a", "b"],
     unofficial=True,
 )
 

--- a/src/frontend/md/datasets/portuguese.md
+++ b/src/frontend/md/datasets/portuguese.md
@@ -1091,7 +1091,77 @@ euroeval --model <model-id> --dataset eu-mmlu-pt
 
 ## Common-sense Reasoning
 
-### GoldenSwag-pt
+### Winogrande-pt
+
+This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2506.19468)
+and is a translated and filtered version of the English
+[Winogrande dataset](https://doi.org/10.1145/3474381).
+
+The original full dataset consists of 47 / 1,210 samples for training and testing, and
+we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
+training, validation and testing, respectively.
+
+Here are a few examples from the training split:
+
+```json
+{
+  "text": "Megan tem muito mais dinheiro do que Jessica porque _ acabou de comprar o bilhete de loteria vencedor. A que se refere o espaço em branco _?\nOpções:\na. Megan\nb. Jessica",
+  "label": "a"
+}
+```
+
+```json
+{
+  "text": "Elena pegaria o inventário na parte de trás da loja para Megan vender cada vez porque _ era uma empresária. A que se refere o espaço em branco _?\nOpções:\na. Elena\nb. Megan",
+  "label": "a"
+}
+```
+
+```json
+{
+  "text": "Joseph tinha que ter unhas bem cuidadas para o trabalho, mas não Kevin, porque _ trabalhava em uma fazenda. A que se refere o espaço em branco _?\nOpções:\na. Joseph\nb. Kevin",
+  "label": "b"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  As seguintes são perguntas de escolha múltipla (com respostas).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Pergunta: {text}
+  Opções:
+  a. {option_a}
+  b. {option_b}
+  Resposta: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Pergunta: {text}
+  Opções:
+  a. {option_a}
+  b. {option_b}
+
+  Responde à pergunta acima usando só 'a' ou 'b', e nada mais.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset winogrande-pt
+```
+
+### Unofficial: GoldenSwag-pt
 
 This dataset is a filtered and machine translated version of the English
 [HellaSwag dataset](https://aclanthology.org/P19-1472/), featuring both video
@@ -1167,76 +1237,6 @@ You can evaluate this dataset directly as follows:
 
 ```bash
 euroeval --model <model-id> --dataset goldenswag-pt
-```
-
-### Unofficial: Winogrande-pt
-
-This dataset was published in [this paper](https://doi.org/10.48550/arXiv.2506.19468)
-and is a translated and filtered version of the English
-[Winogrande dataset](https://doi.org/10.1145/3474381).
-
-The original full dataset consists of 47 / 1,210 samples for training and testing, and
-we use 128 of the test samples for validation, resulting in a 47 / 128 / 1,085 split for
-training, validation and testing, respectively.
-
-Here are a few examples from the training split:
-
-```json
-{
-  "text": "Megan tem muito mais dinheiro do que Jessica porque _ acabou de comprar o bilhete de loteria vencedor. A que se refere o espaço em branco _?\nOpções:\na. Megan\nb. Jessica",
-  "label": "a"
-}
-```
-
-```json
-{
-  "text": "Elena pegaria o inventário na parte de trás da loja para Megan vender cada vez porque _ era uma empresária. A que se refere o espaço em branco _?\nOpções:\na. Elena\nb. Megan",
-  "label": "a"
-}
-```
-
-```json
-{
-  "text": "Joseph tinha que ter unhas bem cuidadas para o trabalho, mas não Kevin, porque _ trabalhava em uma fazenda. A que se refere o espaço em branco _?\nOpções:\na. Joseph\nb. Kevin",
-  "label": "b"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 5
-- Prefix prompt:
-
-  ```text
-  As seguintes são perguntas de escolha múltipla (com respostas).
-  ```
-
-- Base prompt template:
-
-  ```text
-  Pergunta: {text}
-  Opções:
-  a. {option_a}
-  b. {option_b}
-  Resposta: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Pergunta: {text}
-  Opções:
-  a. {option_a}
-  b. {option_b}
-
-  Responde à pergunta acima usando só 'a' ou 'b', e nada mais.
-  ```
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset winogrande-pt
 ```
 
 ## Summarisation

--- a/src/leaderboards/dataset_split_sizes.json
+++ b/src/leaderboards/dataset_split_sizes.json
@@ -1384,6 +1384,11 @@
     "train": 47,
     "val": 128
   },
+  "EuroEval/winogrande-pt": {
+    "test": 1085,
+    "train": 47,
+    "val": 128
+  },
   "EuroEval/winogrande-ro": {
     "test": 1085,
     "train": 47,


### PR DESCRIPTION
Swaps the official dataset `goldenswag-pt` for `winogrande-pt`.

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `winogrande-pt`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `goldenswag-pt` is demoted to unofficial and `winogrande-pt` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.