### PR TITLE
feat: swap official dataset mmlu-sr -> include-sr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,6 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Swapped official dataset for Serbian:
-  `mmlu-sr` → `include-sr`.
-
 - Renamed the previous LLM-as-a-judge `open-ended-qa` task to `reference-free-qa`, and
   added a new reference-based `open-ended-qa` task using translation-style text-to-text
   metrics.
@@ -85,6 +82,7 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   - Portuguese:
     - `mmlu-pt` → `alba-mcq-pt`, `cultura-viva-pt`
     - `goldenswag-pt` → `winogrande-pt`
+  - Serbian: `mmlu-sr` → `include-sr`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Swapped official dataset for Serbian:
+  `mmlu-sr` → `include-sr`.
+
 - Renamed the previous LLM-as-a-judge `open-ended-qa` task to `reference-free-qa`, and
   added a new reference-based `open-ended-qa` task using translation-style text-to-text
   metrics.

--- a/src/euroeval/dataset_configs/serbian.py
+++ b/src/euroeval/dataset_configs/serbian.py
@@ -56,14 +56,6 @@ LR_SUM_SR_CONFIG = DatasetConfig(
     languages=[SERBIAN],
 )
 
-MMLU_SR_CONFIG = DatasetConfig(
-    name="mmlu-sr",
-    pretty_name="MMLU-sr",
-    source="EuroEval/mmlu-sr-mini",
-    task=KNOW,
-    languages=[SERBIAN],
-)
-
 WINOGRANDE_SR_CONFIG = DatasetConfig(
     name="winogrande-sr",
     pretty_name="Winogrande-sr",
@@ -93,12 +85,20 @@ RAGTRUTH_SR_CONFIG = DatasetConfig(
 )
 
 
-# Unofficial datasets ###
-
 INCLUDE_SR_CONFIG = DatasetConfig(
     name="include-sr",
     pretty_name="INCLUDE-sr",
     source="EuroEval/include-sr-mini",
+    task=KNOW,
+    languages=[SERBIAN],
+)
+
+# Unofficial datasets ###
+
+MMLU_SR_CONFIG = DatasetConfig(
+    name="mmlu-sr",
+    pretty_name="MMLU-sr",
+    source="EuroEval/mmlu-sr-mini",
     task=KNOW,
     languages=[SERBIAN],
     unofficial=True,

--- a/src/frontend/md/datasets/serbian.md
+++ b/src/frontend/md/datasets/serbian.md
@@ -393,7 +393,76 @@ euroeval --model <model-id> --dataset multi-wiki-qa-sr
 
 ## Knowledge
 
-### MMLU-sr
+### INCLUDE-sr
+
+This dataset is part of [INCLUDE](https://doi.org/10.48550/arXiv.2411.19799), a
+comprehensive knowledge- and reasoning-centric benchmark that evaluates multilingual
+LLMs across 44 languages. It contains 4-option multiple-choice questions extracted from
+academic and professional exams, covering 57 topics including regional knowledge.
+
+The original dataset consists of a 'validation' split used as training data and a 'test'
+split. We use the 'validation' split as the training split, which has 25 samples. We
+sample 64 samples from the 'test' split for the validation split, and use the remaining
+512 samples for the test split. The sampling is done stratified by the subject column.
+
+Here are a few examples from the dataset:
+
+```json
+{
+  "text": "Које се од наведених понашања уобичајено појављује на крају сензомоторичке фазе?\nOpcije:\na. Дете брише мрље од чоколаде с лица када у огледалу види трагове чоколаде.\nb. Дете се користи кухачом као мачем којим напада замишљене непријатеље.\nc. Дете зна да количина сока остаје иста без обзира на облик чаше.\nd. Дете игра улогу маме па лутку води у шетњу и пева јој.",
+  "label": "a",
+  "subject": "Psychology"
+}
+```
+
+```json
+{
+  "text": "Која од наведених супстанци није елементарна супстанца?\nOpcije:\na. арсен\nb. амалгам\nc. астат\nd. америциј",
+  "label": "b",
+  "subject": "Chemistry"
+}
+```
+
+```json
+{
+  "text": "Како се назива облик агресије којим се користи ученик који виче на свога пријатеља након што га је наставник неправедно оценио?\nOpcije:\na. физичка агресија\nb. директна агресија\nc. помакнута агресија\nd. пасивна агресија",
+  "label": "c",
+  "subject": "Psychology"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  Slede pitanja višestrukog izbora (sa odgovorima).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Pitanje: {text}
+  Odgovor: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Pitanje: {text}
+
+  Odgovorite na navedeno pitanje koristeći {labels_str}, i ništa drugo.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset include-sr
+```
+
+### Unofficial: MMLU-sr
 
 This dataset was published [in this paper](https://doi.org/10.48550/arXiv.2009.03300)
 and features questions within 57 different topics, such as elementary mathematics, US
@@ -462,75 +531,6 @@ You can evaluate this dataset directly as follows:
 
 ```bash
 euroeval --model <model-id> --dataset mmlu-sr
-```
-
-### Unofficial: INCLUDE-sr
-
-This dataset is part of [INCLUDE](https://doi.org/10.48550/arXiv.2411.19799), a
-comprehensive knowledge- and reasoning-centric benchmark that evaluates multilingual
-LLMs across 44 languages. It contains 4-option multiple-choice questions extracted from
-academic and professional exams, covering 57 topics including regional knowledge.
-
-The original dataset consists of a 'validation' split used as training data and a 'test'
-split. We use the 'validation' split as the training split, which has 25 samples. We
-sample 64 samples from the 'test' split for the validation split, and use the remaining
-512 samples for the test split. The sampling is done stratified by the subject column.
-
-Here are a few examples from the dataset:
-
-```json
-{
-  "text": "Које се од наведених понашања уобичајено појављује на крају сензомоторичке фазе?\nOpcije:\na. Дете брише мрље од чоколаде с лица када у огледалу види трагове чоколаде.\nb. Дете се користи кухачом као мачем којим напада замишљене непријатеље.\nc. Дете зна да количина сока остаје иста без обзира на облик чаше.\nd. Дете игра улогу маме па лутку води у шетњу и пева јој.",
-  "label": "a",
-  "subject": "Psychology"
-}
-```
-
-```json
-{
-  "text": "Која од наведених супстанци није елементарна супстанца?\nOpcije:\na. арсен\nb. амалгам\nc. астат\nd. америциј",
-  "label": "b",
-  "subject": "Chemistry"
-}
-```
-
-```json
-{
-  "text": "Како се назива облик агресије којим се користи ученик који виче на свога пријатеља након што га је наставник неправедно оценио?\nOpcije:\na. физичка агресија\nb. директна агресија\nc. помакнута агресија\nd. пасивна агресија",
-  "label": "c",
-  "subject": "Psychology"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 5
-- Prefix prompt:
-
-  ```text
-  Slede pitanja višestrukog izbora (sa odgovorima).
-  ```
-
-- Base prompt template:
-
-  ```text
-  Pitanje: {text}
-  Odgovor: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Pitanje: {text}
-
-  Odgovorite na navedeno pitanje koristeći {labels_str}, i ništa drugo.
-  ```
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset include-sr
 ```
 
 ## Common-sense Reasoning

--- a/src/leaderboards/dataset_split_sizes.json
+++ b/src/leaderboards/dataset_split_sizes.json
@@ -579,6 +579,11 @@
     "train": 24,
     "val": 64
   },
+  "EuroEval/include-sr-mini": {
+    "test": 478,
+    "train": 15,
+    "val": 64
+  },
   "EuroEval/kpwr-ner": {
     "test": 2048,
     "train": 1024,


### PR DESCRIPTION
Swaps the official dataset `mmlu-sr` for `include-sr`.

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `include-sr`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `mmlu-sr` is demoted to unofficial and `include-sr` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.