### PR TITLE
feat: swap official dataset mmlu-es -> include-es, multiloko-es

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Swapped official dataset for Spanish:
+  `mmlu-es` → `include-es`, `multiloko-es`.
+
 - Renamed the previous LLM-as-a-judge `open-ended-qa` task to `reference-free-qa`, and
   added a new reference-based `open-ended-qa` task using translation-style text-to-text
   metrics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,6 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Swapped official dataset for Spanish:
-  `mmlu-es` → `include-es`, `multiloko-es`.
-
 - Renamed the previous LLM-as-a-judge `open-ended-qa` task to `reference-free-qa`, and
   added a new reference-based `open-ended-qa` task using translation-style text-to-text
   metrics.
@@ -86,7 +83,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
     - `mmlu-pt` → `alba-mcq-pt`, `cultura-viva-pt`
     - `goldenswag-pt` → `winogrande-pt`
   - Serbian: `mmlu-sr` → `include-sr`
-  - Spanish: `hellaswag-es` → `winogrande-es`
+  - Spanish:
+    - `hellaswag-es` → `winogrande-es`
+    - `mmlu-es` → `include-es`, `multiloko-es`
 
 ### Fixed
 

--- a/src/euroeval/dataset_configs/spanish.py
+++ b/src/euroeval/dataset_configs/spanish.py
@@ -58,14 +58,6 @@ MLSUM_ES_CONFIG = DatasetConfig(
     languages=[SPANISH],
 )
 
-MMLU_ES_CONFIG = DatasetConfig(
-    name="mmlu-es",
-    pretty_name="MMLU-es",
-    source="EuroEval/mmlu-es-mini",
-    task=KNOW,
-    languages=[SPANISH],
-)
-
 IFEVAL_ES_CONFIG = DatasetConfig(
     name="ifeval-es",
     pretty_name="IFEval-es",
@@ -107,7 +99,33 @@ WINOGRANDE_ES_CONFIG = DatasetConfig(
     labels=["a", "b"],
 )
 
+INCLUDE_ES_CONFIG = DatasetConfig(
+    name="include-es",
+    pretty_name="INCLUDE-es",
+    source="EuroEval/include-es-mini",
+    task=KNOW,
+    languages=[SPANISH],
+)
+
+MULTILOKO_ES_CONFIG = DatasetConfig(
+    name="multiloko-es",
+    pretty_name="MultiLoKo-es",
+    source="EuroEval/multiloko-es-mini",
+    task=KNOW,
+    languages=[SPANISH],
+    val_split=None,
+)
+
 # Unofficial datasets ###
+
+MMLU_ES_CONFIG = DatasetConfig(
+    name="mmlu-es",
+    pretty_name="MMLU-es",
+    source="EuroEval/mmlu-es-mini",
+    task=KNOW,
+    languages=[SPANISH],
+    unofficial=True,
+)
 
 HELLASWAG_ES_CONFIG = DatasetConfig(
     name="hellaswag-es",
@@ -171,25 +189,6 @@ GOLDENSWAG_ES_CONFIG = DatasetConfig(
     source="EuroEval/goldenswag-es-mini",
     task=COMMON_SENSE,
     languages=[SPANISH],
-    unofficial=True,
-)
-
-INCLUDE_ES_CONFIG = DatasetConfig(
-    name="include-es",
-    pretty_name="INCLUDE-es",
-    source="EuroEval/include-es-mini",
-    task=KNOW,
-    languages=[SPANISH],
-    unofficial=True,
-)
-
-MULTILOKO_ES_CONFIG = DatasetConfig(
-    name="multiloko-es",
-    pretty_name="MultiLoKo-es",
-    source="EuroEval/multiloko-es-mini",
-    task=KNOW,
-    languages=[SPANISH],
-    val_split=None,
     unofficial=True,
 )
 

--- a/src/frontend/md/datasets/spanish.md
+++ b/src/frontend/md/datasets/spanish.md
@@ -540,7 +540,142 @@ euroeval --model <model-id> --dataset multi-wiki-qa-es
 
 ## Knowledge
 
-### MMLU-es
+### INCLUDE-es
+
+This dataset is part of [INCLUDE](https://doi.org/10.48550/arXiv.2411.19799), a
+comprehensive knowledge- and reasoning-centric benchmark that evaluates multilingual
+LLMs across 44 languages. It contains 4-option multiple-choice questions extracted from
+academic and professional exams, covering 57 topics including regional knowledge.
+
+The original dataset consists of a 'validation' split used as training data and a 'test'
+split. We use the 'validation' split as the training split, which has 25 samples. We
+sample 64 samples from the 'test' split for the validation split, and use the remaining
+512 samples for the test split. The sampling is done stratified by the subject column.
+
+Here are a few examples from the dataset:
+
+```json
+{
+  "text": "Hormona que actúa sobre el metabolismo de agua, sodio, potasio y cloruro de sodio:\nOpciones:\na. Aldosterona\nb. Cortisol\nc. Corticosterona\nd. Cortisona",
+  "label": "a",
+  "subject": "Medicine"
+}
+```
+
+```json
+{
+  "text": "Nervio que inerva a los músculos esternocleidomastoideo y trapecio:\nOpciones:\na. Hipogloso\nb. Espinal\nc. Vago\nd. Acústico",
+  "label": "b",
+  "subject": "Medicine"
+}
+```
+
+```json
+{
+  "text": "Si el precio del bien sustituto disminuye, la curva de la demanda se\nOpciones:\na. expandirá\nb. incrementará\nc. desplazará hacia la izquierda\nd. mantendrá constante",
+  "label": "c",
+  "subject": "Economics"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  Las siguientes son preguntas de opción múltiple (con respuestas).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Pregunta: {text}
+  Respuesta: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Pregunta: {text}
+
+  Responda la pregunta anterior usando solo {labels_str}, y nada más.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset include-es
+```
+
+### MultiLoKo-es
+
+This dataset was published in [this paper](https://arxiv.org/abs/2504.10356) and is part
+of MultiLoKo, a multilingual local knowledge benchmark covering 31 languages. The
+Spanish questions are separately sourced and designed to target locally relevant topics
+for Spanish-speaking populations.
+
+We use the 'dev' split (250 samples) from this dataset. The dataset contains open-ended
+questions with correct answers in the 'targets' column. We use the first target answer
+as the correct option and use GPT-4.1 to generate 3 plausible but incorrect alternatives
+per question. We create a 16 / 234 split for training and testing, respectively.
+
+Here are a few examples from the training split:
+
+```json
+{
+  "text": "¿En qué país fue patentado el \"birome\" antecesor del actual bolígrafo?\nOpciones:\na. Argentina\nb. España\nc. Estados Unidos\nd. México",
+  "label": "a"
+}
+```
+
+```json
+{
+  "text": "¿En qué siglo viajó Isabel Zendal desde el puerto de La Coruña en La Real Expedición Filantrópica de la Vacuna, expedición que llevaría la vacuna de la viruela a América?\nOpciones:\na. Siglo XVIII\nb. Siglo XIX\nc. Siglo XVII\nd. Siglo XX",
+  "label": "b"
+}
+```
+
+```json
+{
+  "text": "¿Quién es la madre del primer hijo de Camilo Echeverri?\nOpciones:\na. Greeicy Rendón\nb. Tini Stoessel\nc. Evaluna Montaner\nd. Karol G",
+  "label": "c"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 5
+- Prefix prompt:
+
+  ```text
+  Las siguientes son preguntas de opción múltiple (con respuestas).
+  ```
+
+- Base prompt template:
+
+  ```text
+  Pregunta: {text}
+  Respuesta: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Pregunta: {text}
+
+  Responda la pregunta anterior usando solo 'a', 'b', 'c' o 'd', y nada más.
+  ```
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset multiloko-es
+```
+
+### Unofficial: MMLU-es
 
 This dataset is a machine translated version of the English
 [MMLU dataset](https://openreview.net/forum?id=d7KBjmI3GmQ) and features questions
@@ -616,141 +751,6 @@ You can evaluate this dataset directly as follows:
 
 ```bash
 euroeval --model <model-id> --dataset mmlu-es
-```
-
-### Unofficial: INCLUDE-es
-
-This dataset is part of [INCLUDE](https://doi.org/10.48550/arXiv.2411.19799), a
-comprehensive knowledge- and reasoning-centric benchmark that evaluates multilingual
-LLMs across 44 languages. It contains 4-option multiple-choice questions extracted from
-academic and professional exams, covering 57 topics including regional knowledge.
-
-The original dataset consists of a 'validation' split used as training data and a 'test'
-split. We use the 'validation' split as the training split, which has 25 samples. We
-sample 64 samples from the 'test' split for the validation split, and use the remaining
-512 samples for the test split. The sampling is done stratified by the subject column.
-
-Here are a few examples from the dataset:
-
-```json
-{
-  "text": "Hormona que actúa sobre el metabolismo de agua, sodio, potasio y cloruro de sodio:\nOpciones:\na. Aldosterona\nb. Cortisol\nc. Corticosterona\nd. Cortisona",
-  "label": "a",
-  "subject": "Medicine"
-}
-```
-
-```json
-{
-  "text": "Nervio que inerva a los músculos esternocleidomastoideo y trapecio:\nOpciones:\na. Hipogloso\nb. Espinal\nc. Vago\nd. Acústico",
-  "label": "b",
-  "subject": "Medicine"
-}
-```
-
-```json
-{
-  "text": "Si el precio del bien sustituto disminuye, la curva de la demanda se\nOpciones:\na. expandirá\nb. incrementará\nc. desplazará hacia la izquierda\nd. mantendrá constante",
-  "label": "c",
-  "subject": "Economics"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 5
-- Prefix prompt:
-
-  ```text
-  Las siguientes son preguntas de opción múltiple (con respuestas).
-  ```
-
-- Base prompt template:
-
-  ```text
-  Pregunta: {text}
-  Respuesta: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Pregunta: {text}
-
-  Responda la pregunta anterior usando solo {labels_str}, y nada más.
-  ```
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset include-es
-```
-
-### Unofficial: MultiLoKo-es
-
-This dataset was published in [this paper](https://arxiv.org/abs/2504.10356) and is part
-of MultiLoKo, a multilingual local knowledge benchmark covering 31 languages. The
-Spanish questions are separately sourced and designed to target locally relevant topics
-for Spanish-speaking populations.
-
-We use the 'dev' split (250 samples) from this dataset. The dataset contains open-ended
-questions with correct answers in the 'targets' column. We use the first target answer
-as the correct option and use GPT-4.1 to generate 3 plausible but incorrect alternatives
-per question. We create a 16 / 234 split for training and testing, respectively.
-
-Here are a few examples from the training split:
-
-```json
-{
-  "text": "¿En qué país fue patentado el \"birome\" antecesor del actual bolígrafo?\nOpciones:\na. Argentina\nb. España\nc. Estados Unidos\nd. México",
-  "label": "a"
-}
-```
-
-```json
-{
-  "text": "¿En qué siglo viajó Isabel Zendal desde el puerto de La Coruña en La Real Expedición Filantrópica de la Vacuna, expedición que llevaría la vacuna de la viruela a América?\nOpciones:\na. Siglo XVIII\nb. Siglo XIX\nc. Siglo XVII\nd. Siglo XX",
-  "label": "b"
-}
-```
-
-```json
-{
-  "text": "¿Quién es la madre del primer hijo de Camilo Echeverri?\nOpciones:\na. Greeicy Rendón\nb. Tini Stoessel\nc. Evaluna Montaner\nd. Karol G",
-  "label": "c"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 5
-- Prefix prompt:
-
-  ```text
-  Las siguientes son preguntas de opción múltiple (con respuestas).
-  ```
-
-- Base prompt template:
-
-  ```text
-  Pregunta: {text}
-  Respuesta: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Pregunta: {text}
-
-  Responda la pregunta anterior usando solo 'a', 'b', 'c' o 'd', y nada más.
-  ```
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset multiloko-es
 ```
 
 ### Unofficial: MultiNRC-es

--- a/src/leaderboards/dataset_split_sizes.json
+++ b/src/leaderboards/dataset_split_sizes.json
@@ -544,6 +544,11 @@
     "train": 15,
     "val": 64
   },
+  "EuroEval/include-es-mini": {
+    "test": 474,
+    "train": 20,
+    "val": 64
+  },
   "EuroEval/include-fi-mini": {
     "test": 467,
     "train": 24,
@@ -875,6 +880,10 @@
   },
   "EuroEval/multiloko-de-mini": {
     "test": 233,
+    "train": 16
+  },
+  "EuroEval/multiloko-es-mini": {
+    "test": 234,
     "train": 16
   },
   "EuroEval/multiloko-fr-mini": {


### PR DESCRIPTION
Swaps the official dataset `mmlu-es` for `include-es`, `multiloko-es`.

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `include-es`, `multiloko-es`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `mmlu-es` is demoted to unofficial and `include-es`, `multiloko-es` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.