### PR TITLE
Add natural-language-inference to leaderboard tasks

### DIFF
--- a/src/frontend/generated/task-metrics.json
+++ b/src/frontend/generated/task-metrics.json
@@ -18,6 +18,10 @@
     "Micro-average F1-score without MISC tags",
     "Micro-average F1-score"
   ],
+  "natural-language-inference": [
+    "Matthew's Correlation Coefficient",
+    "Macro-average F1-score"
+  ],
   "reading-comprehension": [
     "F1-score",
     "Exact Match"

--- a/src/leaderboards/constants.py
+++ b/src/leaderboards/constants.py
@@ -184,6 +184,7 @@ LEADERBOARD_TASKS: list[str] = [
     "named-entity-recognition",
     "linguistic-acceptability",
     "reading-comprehension",
+    "natural-language-inference",
     "summarization",
     "knowledge",
     "common-sense-reasoning",


### PR DESCRIPTION
## What

Adds `natural-language-inference` (NLI) to the set of tasks displayed on every
EuroEval leaderboard.

## Why

NLI is a core NLU capability missing from the leaderboards. More official NLI datasets
are on the way, so wiring the task in now means they'll flow through automatically as
they land.

## How

The leaderboard pipeline derives everything from `euroeval.tasks`, so this is a
two-line change:
- Add `natural-language-inference` to `LEADERBOARD_TASKS` in
  `src/leaderboards/constants.py`.
- Regenerate `src/frontend/generated/task-metrics.json` so the frontend knows
  NLI's metrics (MCC + Macro F1).

NLI is a sequence-classification (NLU) task, so it scores in both the `generative`
and `all_models` leaderboard categories and contributes to the rank score. Currently only
`ltzglue-rte` (Luxembourgish) is official, so that leaderboard will show the
first NLI scores.
