### PR TITLE
Evaluate puzzles in lower case

### DIFF
--- a/src/euroeval/metrics/logic_puzzles.py
+++ b/src/euroeval/metrics/logic_puzzles.py
@@ -365,8 +365,8 @@ class CellWiseAccuracyMetric(LogicPuzzleMetric):
             prediction.values(), label.values()
         ):
             # strip whitespace (coerce to str to handle non-string attributes)
-            attributes_pred = {str(attr).strip() for attr in attributes_pred}
-            attributes_label = {str(attr).strip() for attr in attributes_label}
+            attributes_pred = {str(attr).strip().lower() for attr in attributes_pred}
+            attributes_label = {str(attr).strip().lower() for attr in attributes_label}
 
             # Count the number of correct attributes
             n_correct_attributes += len(attributes_pred.intersection(attributes_label))

--- a/src/euroeval/metrics/logic_puzzles.py
+++ b/src/euroeval/metrics/logic_puzzles.py
@@ -366,7 +366,9 @@ class CellWiseAccuracyMetric(LogicPuzzleMetric):
         ):
             # strip whitespace (coerce to str to handle non-string attributes)
             attributes_pred = {str(attr).strip().casefold() for attr in attributes_pred}
-            attributes_label = {str(attr).strip().casefold() for attr in attributes_label}
+            attributes_label = {
+                str(attr).strip().casefold() for attr in attributes_label
+            }
 
             # Count the number of correct attributes
             n_correct_attributes += len(attributes_pred.intersection(attributes_label))
@@ -423,7 +425,9 @@ class PuzzleLevelAccuracyMetric(LogicPuzzleMetric):
         ):
             # strip whitespace (coerce to str to handle non-string attributes)
             attributes_pred = {str(attr).strip().casefold() for attr in attributes_pred}
-            attributes_label = {str(attr).strip().casefold() for attr in attributes_label}
+            attributes_label = {
+                str(attr).strip().casefold() for attr in attributes_label
+            }
             if attributes_pred != attributes_label:
                 return 0
 

--- a/src/euroeval/metrics/logic_puzzles.py
+++ b/src/euroeval/metrics/logic_puzzles.py
@@ -365,8 +365,8 @@ class CellWiseAccuracyMetric(LogicPuzzleMetric):
             prediction.values(), label.values()
         ):
             # strip whitespace (coerce to str to handle non-string attributes)
-            attributes_pred = {str(attr).strip().lower() for attr in attributes_pred}
-            attributes_label = {str(attr).strip().lower() for attr in attributes_label}
+            attributes_pred = {str(attr).strip().casefold() for attr in attributes_pred}
+            attributes_label = {str(attr).strip().casefold() for attr in attributes_label}
 
             # Count the number of correct attributes
             n_correct_attributes += len(attributes_pred.intersection(attributes_label))
@@ -422,8 +422,8 @@ class PuzzleLevelAccuracyMetric(LogicPuzzleMetric):
             prediction.values(), label.values()
         ):
             # strip whitespace (coerce to str to handle non-string attributes)
-            attributes_pred = {str(attr).strip() for attr in attributes_pred}
-            attributes_label = {str(attr).strip() for attr in attributes_label}
+            attributes_pred = {str(attr).strip().casefold() for attr in attributes_pred}
+            attributes_label = {str(attr).strip().casefold() for attr in attributes_label}
             if attributes_pred != attributes_label:
                 return 0
 


### PR DESCRIPTION
The attribute case should not matter in the solution. It means we do accept slightly wrong answers in e.g. German.