### PR TITLE
feat: add official datasets danwic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,9 +59,6 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Added official datasets for Danish: `danwic`. The script 
-  `swap_leaderboard_dataset.py` now automatically updates CHANGELOG.md when performing dataset swaps.
-
 - Renamed the previous LLM-as-a-judge `open-ended-qa` task to `reference-free-qa`, and
   added a new reference-based `open-ended-qa` task using translation-style text-to-text
   metrics.
@@ -70,6 +67,7 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Swapped official datasets for four languages (all performed by the
   `swap_leaderboard_dataset.py` script, which now automatically updates this changelog):
   - Croatian: `mmlu-hr` → `include-hr`
+  - Danish: `danwic`
   - Dutch:
     - `scala-nl` → `dutch-cola`
     - `mmlu-nl` → `include-nl`, `multiloko-nl`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Added official datasets for Danish: `danwic`. The script 
+  `swap_leaderboard_dataset.py` now automatically updates CHANGELOG.md when performing dataset swaps.
+
 - Renamed the previous LLM-as-a-judge `open-ended-qa` task to `reference-free-qa`, and
   added a new reference-based `open-ended-qa` task using translation-style text-to-text
   metrics.

--- a/src/euroeval/dataset_configs/danish.py
+++ b/src/euroeval/dataset_configs/danish.py
@@ -122,6 +122,14 @@ ZEBRA_PUZZLE_EASY_DA_CONFIG = DatasetConfig(
     languages=[DANISH],
 )
 
+DANWIC_CONFIG = DatasetConfig(
+    name="danwic",
+    pretty_name="DanWiC",
+    source="EuroEval/danwic",
+    task=WIC,
+    languages=[DANISH],
+)
+
 # Unofficial datasets ###
 
 HELLASWAG_DA_CONFIG = DatasetConfig(
@@ -227,15 +235,6 @@ DANISH_LEXICAL_INFERENCE_CONFIG = DatasetConfig(
     task=NLI,
     languages=[DANISH],
     labels=["entailment", "contradiction"],
-    unofficial=True,
-)
-
-DANWIC_CONFIG = DatasetConfig(
-    name="danwic",
-    pretty_name="DanWiC",
-    source="EuroEval/danwic",
-    task=WIC,
-    languages=[DANISH],
     unofficial=True,
 )
 

--- a/src/frontend/generated/task-metrics.json
+++ b/src/frontend/generated/task-metrics.json
@@ -37,5 +37,9 @@
   "summarization": [
     "ChrF3++",
     "ChrF4++"
+  ],
+  "word-in-context": [
+    "Matthew's Correlation Coefficient",
+    "Macro-average F1-score"
   ]
 }

--- a/src/frontend/md/datasets/danish.md
+++ b/src/frontend/md/datasets/danish.md
@@ -627,7 +627,7 @@ euroeval --model <model-id> --dataset danish-lexical-inference
 
 ## Word in Context
 
-### Unofficial: DanWiC
+### DanWiC
 
 This dataset was published in
 [this paper](https://aclanthology.org/2024.lrec-main.1421/) and is based on the semantic

--- a/src/leaderboards/constants.py
+++ b/src/leaderboards/constants.py
@@ -185,6 +185,7 @@ LEADERBOARD_TASKS: list[str] = [
     "linguistic-acceptability",
     "reading-comprehension",
     "natural-language-inference",
+    "word-in-context",
     "summarization",
     "knowledge",
     "common-sense-reasoning",

--- a/src/leaderboards/dataset_split_sizes.json
+++ b/src/leaderboards/dataset_split_sizes.json
@@ -569,6 +569,11 @@
     "train": 13,
     "val": 64
   },
+  "EuroEval/include-it-mini": {
+    "test": 421,
+    "train": 27,
+    "val": 64
+  },
   "EuroEval/include-lt-mini": {
     "test": 430,
     "train": 25,
@@ -587,6 +592,11 @@
   "EuroEval/include-sr-mini": {
     "test": 478,
     "train": 15,
+    "val": 64
+  },
+  "EuroEval/include-uk-mini": {
+    "test": 442,
+    "train": 14,
     "val": 64
   },
   "EuroEval/kpwr-ner": {
@@ -915,6 +925,10 @@
     "test": 234,
     "train": 16
   },
+  "EuroEval/multiloko-it-mini": {
+    "test": 234,
+    "train": 16
+  },
   "EuroEval/multiloko-nl-mini": {
     "test": 233,
     "train": 16
@@ -1228,6 +1242,11 @@
     "train": 1024,
     "val": 256
   },
+  "EuroEval/skolprov": {
+    "test": 410,
+    "train": 32,
+    "val": 32
+  },
   "EuroEval/sqad-mini": {
     "test": 2048,
     "train": 1024,
@@ -1272,6 +1291,11 @@
     "test": 2048,
     "train": 1024,
     "val": 256
+  },
+  "EuroEval/swedish-facts": {
+    "test": 1097,
+    "train": 128,
+    "val": 64
   },
   "EuroEval/swedn-mini": {
     "test": 2048,

--- a/src/scripts/collect_evaluation_results.py
+++ b/src/scripts/collect_evaluation_results.py
@@ -668,11 +668,8 @@ def preview_in_dev_server() -> bool:
     # Start vercel dev as a subprocess
     try:
         dev_process = subprocess.Popen(
-            ["vercel", "dev", "--yes", "--non-interactive"],
+            ["vercel", "dev", "--yes", "--non-interactive", "--listen", "3000"],
             cwd=REPO_ROOT,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
         )
     except FileNotFoundError:
         logger.error("`vercel` CLI not found on PATH. Install with `npm i -g vercel`.")
@@ -685,10 +682,10 @@ def preview_in_dev_server() -> bool:
 
     print("\nWaiting for dev server to start...")
     while time.time() - start_time < timeout:
-        if dev_process.poll() is not None:
+        return_code = dev_process.poll()
+        if return_code is not None:
             # Process exited unexpectedly
-            output = dev_process.stdout.read()
-            logger.error(f"Dev server exited unexpectedly: {output}")
+            logger.error("Dev server exited unexpectedly with code %s.", return_code)
             return False
 
         # Give it a moment
@@ -715,10 +712,10 @@ def preview_in_dev_server() -> bool:
         return False
 
     logger.info("=" * 60)
-    logger.info("✓ Dev server is running at http://localhost:5174")
+    logger.info("✓ Dev server is running at http://localhost:3000")
     logger.info("=" * 60)
     print(
-        "\nPlease open http://localhost:5174 in your browser and check the "
+        "\nPlease open http://localhost:3000 in your browser and check the "
         "leaderboards.\n"
     )
 

--- a/src/scripts/swap_leaderboard_dataset.py
+++ b/src/scripts/swap_leaderboard_dataset.py
@@ -552,11 +552,7 @@ def _update_changelog(
             )
         )
         new_ds_str = ", ".join(f"`{ds}`" for ds in new_datasets)
-        entry = (
-            f"- Added official datasets for {lang_list}: {new_ds_str}. The script \n  "
-            "`swap_leaderboard_dataset.py` now automatically updates CHANGELOG.md "
-            "when performing dataset swaps."
-        )
+        entry = f"- Added official datasets for {lang_list}: {new_ds_str}."
 
     # Insert a blank line after "### Changed", then the entry
     lines.insert(changed_idx + 1, "")

--- a/tests/test_scripts/test_collect_evaluation_results.py
+++ b/tests/test_scripts/test_collect_evaluation_results.py
@@ -1,7 +1,9 @@
 """Tests for the collect_evaluation_results script, focusing on upload_results_to_hf."""
 
 import json
+import signal
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
@@ -32,6 +34,97 @@ class FakeHfApi:
     ) -> None:
         """No-op sync for testing."""
         pass
+
+
+def test_preview_in_dev_server_handles_early_exit_without_pipe(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An early server exit is reported without attempting to read stdout."""
+    process = FakeDevProcess(return_code=1)
+
+    monkeypatch.setattr(
+        collect_evaluation_results.subprocess, "Popen", lambda *args, **kwargs: process
+    )
+    caplog.set_level("INFO", logger="collect_evaluation_results")
+
+    assert collect_evaluation_results.preview_in_dev_server() is False
+
+    assert "Dev server exited unexpectedly with code 1." in caplog.text
+
+
+class FakeDevProcess:
+    """Fake Vercel process used to test preview lifecycle handling."""
+
+    stdout: None = None
+
+    def __init__(self, return_code: int | None = None) -> None:
+        """Initialise the fake process with an optional exit code."""
+        self.return_code = return_code
+        self.signals: list[signal.Signals] = []
+        self.wait_timeouts: list[float | None] = []
+
+    def kill(self) -> None:
+        """Fail if the test unexpectedly needs to kill the process.
+
+        Raises:
+            AssertionError: Always, because killing is unexpected in these tests.
+        """
+        raise AssertionError("The fake process should not need to be killed.")
+
+    def poll(self) -> int | None:
+        """Return the configured process exit code."""
+        return self.return_code
+
+    def send_signal(self, sig: signal.Signals) -> None:
+        """Record a signal sent to the process."""
+        self.signals.append(sig)
+
+    def wait(self, timeout: float | None = None) -> None:
+        """Record the timeout used while waiting for the process."""
+        self.wait_timeouts.append(timeout)
+
+
+def test_preview_in_dev_server_starts_and_stops_fixed_port(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Preview uses the fixed Vercel port and terminates the server afterwards."""
+    process = FakeDevProcess()
+    popen_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def fake_popen(*args: object, **kwargs: object) -> FakeDevProcess:
+        popen_calls.append((args, kwargs))
+        return process
+
+    socket_instance = Mock()
+    socket_instance.connect_ex.return_value = 0
+    socket_factory = Mock(return_value=socket_instance)
+    monkeypatch.setattr(collect_evaluation_results.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(collect_evaluation_results.socket, "socket", socket_factory)
+    monkeypatch.setattr(collect_evaluation_results.time, "time", lambda: 0.0)
+    monkeypatch.setattr(collect_evaluation_results.time, "sleep", lambda _: None)
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+    caplog.set_level("INFO", logger="collect_evaluation_results")
+
+    assert collect_evaluation_results.preview_in_dev_server() is True
+
+    assert popen_calls == [
+        (
+            (["vercel", "dev", "--yes", "--non-interactive", "--listen", "3000"],),
+            {"cwd": collect_evaluation_results.REPO_ROOT},
+        )
+    ]
+    socket_factory.assert_called_once_with(
+        collect_evaluation_results.socket.AF_INET,
+        collect_evaluation_results.socket.SOCK_STREAM,
+    )
+    socket_instance.connect_ex.assert_called_once_with(("127.0.0.1", 3000))
+    socket_instance.close.assert_called_once_with()
+    assert process.signals == [signal.SIGTERM]
+    assert process.wait_timeouts == [10]
+    assert "http://localhost:3000" in capsys.readouterr().out
+    assert "http://localhost:3000" in caplog.text
 
 
 def test_upload_results_to_hf_collision_leaves_results_dir_unmutated(


### PR DESCRIPTION
Adds `danwic` as official dataset(s).

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `danwic`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `danwic` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.