### PR TITLE
feat: add official datasets culturaqa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,9 +59,6 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Added official datasets for Greek: `culturaqa`. The script 
-  `swap_leaderboard_dataset.py` now automatically updates CHANGELOG.md when performing dataset swaps.
-
 - Renamed the previous LLM-as-a-judge `open-ended-qa` task to `reference-free-qa`, and
   added a new reference-based `open-ended-qa` task using translation-style text-to-text
   metrics.
@@ -81,7 +78,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   - German:
     - `hellaswag-de` → `winogrande-de`
     - `mmlu-de` → `include-de`, `multiloko-de`
-  - Greek: `global-mmlu-el` → `greek-mmlu`
+  - Greek:
+    - `global-mmlu-el` → `greek-mmlu`
+    - `culturaqa`
   - Hungarian: `mmlu-hu` → `include-hu`
   - Icelandic: `scala-is` → `ice-ec`
   - Italian:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Added official datasets for Greek: `culturaqa`. The script 
+  `swap_leaderboard_dataset.py` now automatically updates CHANGELOG.md when performing dataset swaps.
+
 - Renamed the previous LLM-as-a-judge `open-ended-qa` task to `reference-free-qa`, and
   added a new reference-based `open-ended-qa` task using translation-style text-to-text
   metrics.

--- a/src/euroeval/dataset_configs/greek.py
+++ b/src/euroeval/dataset_configs/greek.py
@@ -94,6 +94,19 @@ GREEK_MMLU_CONFIG = DatasetConfig(
     languages=[GREEK],
 )
 
+CULTURAQA_CONFIG = DatasetConfig(
+    name="culturaqa",
+    pretty_name="CulturaQA",
+    source="EuroEval/culturaqa-mini",
+    task=OPEN_ENDED_QA,
+    languages=[GREEK],
+    prompt_prefix="Ακολουθούν ερωτήσεις με τις αντίστοιχες απαντήσεις.",
+    prompt_template="Ερώτηση: {text}\nΑπάντηση: {target_text}",
+    instruction_prompt=(
+        "Απαντήστε στην παρακάτω ερώτηση με ακρίβεια και συντομία.\n\nΕρώτηση: {text}"
+    ),
+)
+
 # Unofficial datasets ###
 
 GLOBAL_MMLU_EL_CONFIG = DatasetConfig(
@@ -132,18 +145,4 @@ EU_MMLU_EL_CONFIG = DatasetConfig(
     task=KNOW,
     languages=[GREEK],
     unofficial=True,
-)
-
-CULTURAQA_CONFIG = DatasetConfig(
-    name="culturaqa",
-    pretty_name="CulturaQA",
-    source="EuroEval/culturaqa-mini",
-    task=OPEN_ENDED_QA,
-    languages=[GREEK],
-    unofficial=True,
-    prompt_prefix="Ακολουθούν ερωτήσεις με τις αντίστοιχες απαντήσεις.",
-    prompt_template="Ερώτηση: {text}\nΑπάντηση: {target_text}",
-    instruction_prompt=(
-        "Απαντήστε στην παρακάτω ερώτηση με ακρίβεια και συντομία.\n\nΕρώτηση: {text}"
-    ),
 )

--- a/src/frontend/generated/task-metrics.json
+++ b/src/frontend/generated/task-metrics.json
@@ -22,6 +22,10 @@
     "Matthew's Correlation Coefficient",
     "Macro-average F1-score"
   ],
+  "open-ended-qa": [
+    "ChrF3++",
+    "ChrF4++"
+  ],
   "reading-comprehension": [
     "F1-score",
     "Exact Match"

--- a/src/frontend/md/datasets/greek.md
+++ b/src/frontend/md/datasets/greek.md
@@ -586,7 +586,7 @@ You can evaluate this dataset directly as follows:
 euroeval --model <model-id> --dataset greek-mmlu
 ```
 
-### Unofficial: CulturaQA
+### CulturaQA
 
 CulturaQA is a Greek open-ended question answering dataset that captures knowledge from
 Greek culture. It spans many domains: Greek art, history, mythology, politics, economy,

--- a/src/leaderboards/constants.py
+++ b/src/leaderboards/constants.py
@@ -186,6 +186,7 @@ LEADERBOARD_TASKS: list[str] = [
     "reading-comprehension",
     "natural-language-inference",
     "word-in-context",
+    "open-ended-qa",
     "summarization",
     "knowledge",
     "common-sense-reasoning",

--- a/src/leaderboards/dataset_split_sizes.json
+++ b/src/leaderboards/dataset_split_sizes.json
@@ -129,6 +129,11 @@
     "train": 1024,
     "val": 256
   },
+  "EuroEval/culturaqa-mini": {
+    "test": 500,
+    "train": 1024,
+    "val": 200
+  },
   "EuroEval/czech-news-mini": {
     "test": 2048,
     "train": 1024,

--- a/src/scripts/collect_evaluation_results.py
+++ b/src/scripts/collect_evaluation_results.py
@@ -695,15 +695,13 @@ def preview_in_dev_server() -> bool:
         # Give it a moment
         time.sleep(2)
 
-        # Try to connect to localhost:5173 (default Vite dev port)
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        # Resolve localhost so this works with IPv4- or IPv6-only dev servers.
         try:
-            result = sock.connect_ex(("127.0.0.1", 5173))
+            sock = socket.create_connection(("localhost", 5173), timeout=1)
             sock.close()
-            if result == 0:
-                ready = True
-                break
-        except Exception:
+            ready = True
+            break
+        except OSError:
             pass
 
     if not ready:

--- a/src/scripts/collect_evaluation_results.py
+++ b/src/scripts/collect_evaluation_results.py
@@ -668,8 +668,12 @@ def preview_in_dev_server() -> bool:
     # Start vercel dev as a subprocess
     try:
         dev_process = subprocess.Popen(
-            ["vercel", "dev", "--yes", "--non-interactive", "--listen", "3000"],
+            ["vercel", "dev", "--yes", "--non-interactive"],
             cwd=REPO_ROOT,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
         )
     except FileNotFoundError:
         logger.error("`vercel` CLI not found on PATH. Install with `npm i -g vercel`.")
@@ -682,19 +686,19 @@ def preview_in_dev_server() -> bool:
 
     print("\nWaiting for dev server to start...")
     while time.time() - start_time < timeout:
-        return_code = dev_process.poll()
-        if return_code is not None:
+        if dev_process.poll() is not None:
             # Process exited unexpectedly
-            logger.error("Dev server exited unexpectedly with code %s.", return_code)
+            output = dev_process.stdout.read() if dev_process.stdout else ""
+            logger.error("Dev server exited unexpectedly: %s", output)
             return False
 
         # Give it a moment
         time.sleep(2)
 
-        # Try to connect to localhost:3000 (default Vercel dev port)
+        # Try to connect to localhost:5173 (default Vite dev port)
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
-            result = sock.connect_ex(("127.0.0.1", 3000))
+            result = sock.connect_ex(("127.0.0.1", 5173))
             sock.close()
             if result == 0:
                 ready = True
@@ -712,10 +716,10 @@ def preview_in_dev_server() -> bool:
         return False
 
     logger.info("=" * 60)
-    logger.info("✓ Dev server is running at http://localhost:3000")
+    logger.info("✓ Dev server is running at http://localhost:5173")
     logger.info("=" * 60)
     print(
-        "\nPlease open http://localhost:3000 in your browser and check the "
+        "\nPlease open http://localhost:5173 in your browser and check the "
         "leaderboards.\n"
     )
 

--- a/tests/test_scripts/test_collect_evaluation_results.py
+++ b/tests/test_scripts/test_collect_evaluation_results.py
@@ -98,10 +98,11 @@ def test_preview_in_dev_server_starts_and_stops_fixed_port(
         return process
 
     socket_instance = Mock()
-    socket_instance.connect_ex.return_value = 0
     socket_factory = Mock(return_value=socket_instance)
     monkeypatch.setattr(collect_evaluation_results.subprocess, "Popen", fake_popen)
-    monkeypatch.setattr(collect_evaluation_results.socket, "socket", socket_factory)
+    monkeypatch.setattr(
+        collect_evaluation_results.socket, "create_connection", socket_factory
+    )
     monkeypatch.setattr(collect_evaluation_results.time, "time", lambda: 0.0)
     monkeypatch.setattr(collect_evaluation_results.time, "sleep", lambda _: None)
     monkeypatch.setattr("builtins.input", lambda _: "y")
@@ -121,11 +122,7 @@ def test_preview_in_dev_server_starts_and_stops_fixed_port(
             },
         )
     ]
-    socket_factory.assert_called_once_with(
-        collect_evaluation_results.socket.AF_INET,
-        collect_evaluation_results.socket.SOCK_STREAM,
-    )
-    socket_instance.connect_ex.assert_called_once_with(("127.0.0.1", 5173))
+    socket_factory.assert_called_once_with(("localhost", 5173), timeout=1)
     socket_instance.close.assert_called_once_with()
     assert process.signals == [signal.SIGTERM]
     assert process.wait_timeouts == [10]

--- a/tests/test_scripts/test_collect_evaluation_results.py
+++ b/tests/test_scripts/test_collect_evaluation_results.py
@@ -36,10 +36,10 @@ class FakeHfApi:
         pass
 
 
-def test_preview_in_dev_server_handles_early_exit_without_pipe(
+def test_preview_in_dev_server_handles_early_exit(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """An early server exit is reported without attempting to read stdout."""
+    """An early server exit is reported without failing on missing output."""
     process = FakeDevProcess(return_code=1)
 
     monkeypatch.setattr(
@@ -49,7 +49,7 @@ def test_preview_in_dev_server_handles_early_exit_without_pipe(
 
     assert collect_evaluation_results.preview_in_dev_server() is False
 
-    assert "Dev server exited unexpectedly with code 1." in caplog.text
+    assert "Dev server exited unexpectedly:" in caplog.text
 
 
 class FakeDevProcess:
@@ -89,7 +89,7 @@ def test_preview_in_dev_server_starts_and_stops_fixed_port(
     caplog: pytest.LogCaptureFixture,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Preview uses the fixed Vercel port and terminates the server afterwards."""
+    """Preview uses the fixed Vite port and terminates the server afterwards."""
     process = FakeDevProcess()
     popen_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
 
@@ -111,20 +111,26 @@ def test_preview_in_dev_server_starts_and_stops_fixed_port(
 
     assert popen_calls == [
         (
-            (["vercel", "dev", "--yes", "--non-interactive", "--listen", "3000"],),
-            {"cwd": collect_evaluation_results.REPO_ROOT},
+            (["vercel", "dev", "--yes", "--non-interactive"],),
+            {
+                "cwd": collect_evaluation_results.REPO_ROOT,
+                "stdin": collect_evaluation_results.subprocess.DEVNULL,
+                "stdout": collect_evaluation_results.subprocess.PIPE,
+                "stderr": collect_evaluation_results.subprocess.STDOUT,
+                "text": True,
+            },
         )
     ]
     socket_factory.assert_called_once_with(
         collect_evaluation_results.socket.AF_INET,
         collect_evaluation_results.socket.SOCK_STREAM,
     )
-    socket_instance.connect_ex.assert_called_once_with(("127.0.0.1", 3000))
+    socket_instance.connect_ex.assert_called_once_with(("127.0.0.1", 5173))
     socket_instance.close.assert_called_once_with()
     assert process.signals == [signal.SIGTERM]
     assert process.wait_timeouts == [10]
-    assert "http://localhost:3000" in capsys.readouterr().out
-    assert "http://localhost:3000" in caplog.text
+    assert "http://localhost:5173" in capsys.readouterr().out
+    assert "http://localhost:5173" in caplog.text
 
 
 def test_upload_results_to_hf_collision_leaves_results_dir_unmutated(


### PR DESCRIPTION
Adds `culturaqa` as official dataset(s).

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `culturaqa`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `culturaqa` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.