### PR TITLE
feat: add official datasets faroese-semantic-relations, faroese-metaphorical-explanations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Added official datasets for Faroese: `faroese-grammatical-correctness`. The script 
+  `swap_leaderboard_dataset.py` now automatically updates CHANGELOG.md when performing dataset swaps.
+
 - Renamed the previous LLM-as-a-judge `open-ended-qa` task to `reference-free-qa`, and
   added a new reference-based `open-ended-qa` task using translation-style text-to-text
   metrics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Added official datasets for Faroese: `faroese-semantic-relations`, `faroese-metaphorical-explanations`. The script 
+  `swap_leaderboard_dataset.py` now automatically updates CHANGELOG.md when performing dataset swaps.
+
 - Renamed the previous LLM-as-a-judge `open-ended-qa` task to `reference-free-qa`, and
   added a new reference-based `open-ended-qa` task using translation-style text-to-text
   metrics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,6 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Added official datasets for Faroese: `faroese-semantic-relations`, `faroese-metaphorical-explanations`. The script 
-  `swap_leaderboard_dataset.py` now automatically updates CHANGELOG.md when performing dataset swaps.
-
 - Renamed the previous LLM-as-a-judge `open-ended-qa` task to `reference-free-qa`, and
   added a new reference-based `open-ended-qa` task using translation-style text-to-text
   metrics.
@@ -70,6 +67,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   - Dutch:
     - `scala-nl` → `dutch-cola`
     - `mmlu-nl` → `include-nl`, `multiloko-nl`
+  - Faroese:
+    - `faroese-semantic-relations`
+    - `faroese-metaphorical-explanations`
   - Finnish:
     - `hellaswag-fi` → `winogrande-fi`
     - `include-fi`

--- a/src/euroeval/dataset_configs/faroese.py
+++ b/src/euroeval/dataset_configs/faroese.py
@@ -78,6 +78,14 @@ RAGTRUTH_FO_CONFIG = DatasetConfig(
 )
 
 
+FAROESE_GRAMMATICAL_CORRECTNESS_CONFIG = DatasetConfig(
+    name="faroese-grammatical-correctness",
+    pretty_name="Faroese Grammatical Correctness",
+    source="EuroEval/faroese-grammatical-correctness",
+    task=GEC,
+    languages=[FAROESE],
+)
+
 # Unofficial datasets ###
 
 FAROESE_SEMANTIC_RELATIONS_CONFIG = DatasetConfig(
@@ -95,15 +103,6 @@ FAROESE_METAPHORICAL_EXPLANATIONS_CONFIG = DatasetConfig(
     pretty_name="Faroese Metaphorical Explanations",
     source="EuroEval/faroese-metaphorical-explanations",
     task=KNOW,
-    languages=[FAROESE],
-    unofficial=True,
-)
-
-FAROESE_GRAMMATICAL_CORRECTNESS_CONFIG = DatasetConfig(
-    name="faroese-grammatical-correctness",
-    pretty_name="Faroese Grammatical Correctness",
-    source="EuroEval/faroese-grammatical-correctness",
-    task=GEC,
     languages=[FAROESE],
     unofficial=True,
 )

--- a/src/euroeval/dataset_configs/faroese.py
+++ b/src/euroeval/dataset_configs/faroese.py
@@ -78,8 +78,6 @@ RAGTRUTH_FO_CONFIG = DatasetConfig(
 )
 
 
-# Unofficial datasets ###
-
 FAROESE_SEMANTIC_RELATIONS_CONFIG = DatasetConfig(
     name="faroese-semantic-relations",
     pretty_name="Faroese Semantic Relations",
@@ -87,7 +85,6 @@ FAROESE_SEMANTIC_RELATIONS_CONFIG = DatasetConfig(
     task=KNOW,
     languages=[FAROESE],
     labels=["a", "b", "c", "d", "e", "f"],
-    unofficial=True,
 )
 
 FAROESE_METAPHORICAL_EXPLANATIONS_CONFIG = DatasetConfig(
@@ -96,8 +93,9 @@ FAROESE_METAPHORICAL_EXPLANATIONS_CONFIG = DatasetConfig(
     source="EuroEval/faroese-metaphorical-explanations",
     task=KNOW,
     languages=[FAROESE],
-    unofficial=True,
 )
+
+# Unofficial datasets ###
 
 FAROESE_GRAMMATICAL_CORRECTNESS_CONFIG = DatasetConfig(
     name="faroese-grammatical-correctness",

--- a/src/frontend/md/datasets/faroese.md
+++ b/src/frontend/md/datasets/faroese.md
@@ -691,7 +691,7 @@ euroeval --model <model-id> --dataset gerlangmod-fo
 
 ## Grammatical Error Correction
 
-### Unofficial: Faroese Grammatical Correctness
+### Faroese Grammatical Correctness
 
 This dataset was published in [this paper](https://doi.org/10.63317/4u4i99hc8co8)
 and consists of minimal pairs of an ungrammatical Faroese sentence and its

--- a/src/frontend/md/datasets/faroese.md
+++ b/src/frontend/md/datasets/faroese.md
@@ -466,7 +466,7 @@ euroeval --model <model-id> --dataset multi-wiki-qa-fo
 
 ## Knowledge
 
-### Unofficial: Faroese Semantic Relations
+### Faroese Semantic Relations
 
 This dataset was published in [this paper](https://doi.org/10.63317/4u4i99hc8co8)
 and tests knowledge of Faroese semantic relations. Each sample presents a Faroese
@@ -545,7 +545,7 @@ You can evaluate this dataset directly as follows:
 euroeval --model <model-id> --dataset faroese-semantic-relations
 ```
 
-### Unofficial: Faroese Metaphorical Explanations
+### Faroese Metaphorical Explanations
 
 This dataset was published in [this paper](https://doi.org/10.63317/4u4i99hc8co8)
 and tests comprehension of Faroese idioms. Each sample presents a Faroese

--- a/src/leaderboards/constants.py
+++ b/src/leaderboards/constants.py
@@ -186,6 +186,8 @@ LEADERBOARD_TASKS: list[str] = [
     "reading-comprehension",
     "natural-language-inference",
     "word-in-context",
+    "grammatical-error-correction",
+    "grammatical-error-detection",
     "open-ended-qa",
     "summarization",
     "knowledge",

--- a/src/leaderboards/dataset_split_sizes.json
+++ b/src/leaderboards/dataset_split_sizes.json
@@ -309,6 +309,22 @@
     "train": 1024,
     "val": 94
   },
+  "EuroEval/faroese-grammatical-correctness": {
+    "full_train": 4289,
+    "test": 2048,
+    "train": 1024,
+    "val": 256
+  },
+  "EuroEval/faroese-metaphorical-explanations": {
+    "test": 282,
+    "train": 140,
+    "val": 35
+  },
+  "EuroEval/faroese-semantic-relations": {
+    "test": 696,
+    "train": 348,
+    "val": 87
+  },
   "EuroEval/fone-mini": {
     "test": 2048,
     "train": 1024,

--- a/tests/test_scripts/test_swap_leaderboard_dataset.py
+++ b/tests/test_scripts/test_swap_leaderboard_dataset.py
@@ -650,6 +650,7 @@ class TestLoadCorpusAndBuildEvalJobs:
             "danish-citizen-tests",
             "winogrande-da",
             "danske-talemaader",
+            "danwic",
         }
         corpus = Corpus(
             datasets_by_language={"da": {"test-model": required_datasets}},
@@ -759,6 +760,7 @@ class TestLoadCorpusAndBuildEvalJobs:
             "danish-citizen-tests",
             "winogrande-da",
             "danske-talemaader",
+            "danwic",
         }
         corpus = Corpus(
             datasets_by_language={"da": {"test-model": required_datasets}},
@@ -875,6 +877,7 @@ class TestLoadCorpusAndBuildEvalJobs:
             "danish-citizen-tests",
             "winogrande-da",
             "danske-talemaader",
+            "danwic",
         }
         corpus = Corpus(
             datasets_by_language={"da": {"test-model": required_datasets}},
@@ -1317,6 +1320,7 @@ class TestLoadCorpusAndBuildEvalJobs:
             "danish-citizen-tests",
             "winogrande-da",
             "danske-talemaader",
+            "danwic",
         }
         split_agnostic_dataset = "dala"
 


### PR DESCRIPTION
Adds `faroese-semantic-relations`, `faroese-metaphorical-explanations` as official dataset(s).

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `faroese-semantic-relations`, `faroese-metaphorical-explanations`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `faroese-semantic-relations`, `faroese-metaphorical-explanations` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.