### PR TITLE
feat: add official datasets faroese-grammatical-correctness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Added official datasets for Faroese: `faroese-grammatical-correctness`. The script 
+  `swap_leaderboard_dataset.py` now automatically updates CHANGELOG.md when performing dataset swaps.
+
 - Renamed the previous LLM-as-a-judge `open-ended-qa` task to `reference-free-qa`, and
   added a new reference-based `open-ended-qa` task using translation-style text-to-text
   metrics.

--- a/src/euroeval/dataset_configs/faroese.py
+++ b/src/euroeval/dataset_configs/faroese.py
@@ -78,6 +78,14 @@ RAGTRUTH_FO_CONFIG = DatasetConfig(
 )
 
 
+FAROESE_GRAMMATICAL_CORRECTNESS_CONFIG = DatasetConfig(
+    name="faroese-grammatical-correctness",
+    pretty_name="Faroese Grammatical Correctness",
+    source="EuroEval/faroese-grammatical-correctness",
+    task=GEC,
+    languages=[FAROESE],
+)
+
 # Unofficial datasets ###
 
 FAROESE_SEMANTIC_RELATIONS_CONFIG = DatasetConfig(
@@ -95,15 +103,6 @@ FAROESE_METAPHORICAL_EXPLANATIONS_CONFIG = DatasetConfig(
     pretty_name="Faroese Metaphorical Explanations",
     source="EuroEval/faroese-metaphorical-explanations",
     task=KNOW,
-    languages=[FAROESE],
-    unofficial=True,
-)
-
-FAROESE_GRAMMATICAL_CORRECTNESS_CONFIG = DatasetConfig(
-    name="faroese-grammatical-correctness",
-    pretty_name="Faroese Grammatical Correctness",
-    source="EuroEval/faroese-grammatical-correctness",
-    task=GEC,
     languages=[FAROESE],
     unofficial=True,
 )

--- a/src/frontend/md/datasets/faroese.md
+++ b/src/frontend/md/datasets/faroese.md
@@ -691,7 +691,7 @@ euroeval --model <model-id> --dataset gerlangmod-fo
 
 ## Grammatical Error Correction
 
-### Unofficial: Faroese Grammatical Correctness
+### Faroese Grammatical Correctness
 
 This dataset was published in [this paper](https://doi.org/10.63317/4u4i99hc8co8)
 and consists of minimal pairs of an ungrammatical Faroese sentence and its


### PR DESCRIPTION
Adds `faroese-grammatical-correctness` as official dataset(s).

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `faroese-grammatical-correctness`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `faroese-grammatical-correctness` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.