### PR TITLE
fix: improve model loading errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,11 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fixed `_load_model_from_pretrained` final error message for `KeyError`/`RuntimeError`
+  after retry exhaustion. The raised `InvalidModel` now includes the model ID and
+  exception repr (e.g. `The model 'EuroBERT/EuroBERT-210m' could not be loaded. The
+  error was KeyError('default').`), making it consistent with the `OSError`/`ValueError`
+  handling branch.
 - Fixed `TypeError` in `setup_model_for_question_answering` when expanding token type
   embeddings from shape (1, ...) to (2, ...) for models like `fresh-xlm-roberta-base`
   that only have a single token type embedding. The bug was caused by passing `tensor=`

--- a/src/euroeval/benchmark_modules/hf.py
+++ b/src/euroeval/benchmark_modules/hf.py
@@ -908,7 +908,9 @@ def _load_model_from_pretrained(
                 )
                 model_kwargs["ignore_mismatched_sizes"] = True
                 continue
-            raise InvalidModel(str(e)) from e
+            raise InvalidModel(
+                f"The model {model_id!r} could not be loaded. The error was {e!r}."
+            ) from e
         except (TimeoutError, RequestError):
             log(
                 f"Couldn't load the model {model_id!r}. Retrying.",

--- a/tests/test_benchmark_modules/test_hf.py
+++ b/tests/test_benchmark_modules/test_hf.py
@@ -13,11 +13,13 @@ from transformers.models.xlm_roberta import (
 )
 
 from euroeval.benchmark_modules.hf import (
+    _load_model_from_pretrained,
     get_dtype,
     get_model_repo_info,
     setup_model_for_question_answering,
 )
 from euroeval.data_models import BenchmarkConfig, DatasetConfig, ModelConfig
+from euroeval.enums import TaskGroup
 from euroeval.exceptions import InvalidModel
 from euroeval.model_loading import load_model
 
@@ -73,6 +75,40 @@ def test_get_dtype(
         )
         == expected
     )
+
+
+def test_load_model_from_pretrained_keyerror_retry_and_message() -> None:
+    """Test KeyError retry and final message for _load_model_from_pretrained.
+
+    KeyError('default') is retried once with ignore_mismatched_sizes, and the final
+    InvalidModel includes the model ID, exception repr, and cause.
+
+    Regression test for the EuroBERT/EuroBERT-210m transformers 5 RoPE loading bug.
+    """
+    mock_model_cls = MagicMock()
+    # First call raises KeyError('default'), second call (with retry) also raises it.
+    side_effects = [KeyError("default"), KeyError("default")]
+    mock_model_cls.from_pretrained.side_effect = side_effects
+
+    with pytest.raises(InvalidModel) as exc_info:
+        _load_model_from_pretrained(
+            model_cls=mock_model_cls,
+            model_id="EuroBERT/EuroBERT-210m",
+            model_kwargs={},
+            task_group=TaskGroup.SEQUENCE_CLASSIFICATION,
+        )
+
+    # Verify the final error message contains model ID, exception repr, and cause.
+    message = str(exc_info.value)
+    assert "EuroBERT/EuroBERT-210m" in message
+    assert "KeyError('default')" in message
+
+    # Verify the exception chain is preserved.
+    assert exc_info.value.__cause__ is not None
+    assert isinstance(exc_info.value.__cause__, KeyError)
+
+    # Verify from_pretrained was called twice: initial attempt + one retry.
+    assert mock_model_cls.from_pretrained.call_count == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What
Improve EuroEval model-loading errors so failures no longer appear as a cryptic one-word message such as `default`.

## Changes
- Include the model ID and exception type/details in the final `InvalidModel` message.
- Preserve the original exception as the cause.
- Add regression coverage for the retry and error-message behaviour.

## Verification
- `uv run pytest tests/test_benchmark_modules/test_hf.py -q`
- `uv run ruff check src/euroeval/benchmark_modules/hf.py tests/test_benchmark_modules/test_hf.py`
- `uv run ruff format --check src/euroeval/benchmark_modules/hf.py tests/test_benchmark_modules/test_hf.py`