### PR TITLE
feat: Add unofficial BelaCoLA dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Added the unofficial Belarusian linguistic acceptability dataset `belacola`, based on
+  the BelaCoLA dataset from BelarusianGLUE.
 - Added the sample hallucination rate metric as the primary hallucination score, while
   retaining the token hallucination rate as a secondary score.
 

--- a/src/euroeval/dataset_configs/belarusian.py
+++ b/src/euroeval/dataset_configs/belarusian.py
@@ -68,3 +68,12 @@ RAGTRUTH_BE_CONFIG = DatasetConfig(
     train_split=None,
     unofficial=True,
 )
+
+BELACOLA_CONFIG = DatasetConfig(
+    name="belacola",
+    pretty_name="BelaCoLA",
+    source="EuroEval/belacola-mini",
+    task=LA,
+    languages=[BELARUSIAN],
+    unofficial=True,
+)

--- a/src/frontend/md/datasets/belarusian.md
+++ b/src/frontend/md/datasets/belarusian.md
@@ -240,6 +240,80 @@ You can evaluate this dataset directly as follows:
 euroeval --model <model-id> --dataset scala-be
 ```
 
+### Unofficial: BelaCoLA
+
+BelaCoLA is a Belarusian linguistic acceptability corpus from the
+[BelarusianGLUE benchmark](https://huggingface.co/datasets/maaxap/BelarusianGLUE),
+introduced in [Aparovich et al. (2025)](https://aclanthology.org/2025.acl-long.25/).
+It is similar to CoLA and RuCoLA: Belarusian sentences are labelled as acceptable or
+unacceptable by three fluent Belarusian-speaking linguists. The in-domain data comes
+from translated RuCoLA sentences, Belarusian normative sources, and Common Voice.
+
+The source `belacola_in_domain` configuration contains 1,992 / 300 / 300 samples for
+training, validation and testing, respectively. We preserve these source split
+boundaries and select the first 1,024 / 256 / 300 samples from them for EuroEval. The
+source data is already shuffled, and selecting rows in order makes this conversion
+deterministic. The resulting labels are `correct` for source label `1` (acceptable) and
+`incorrect` for source label `0` (unacceptable).
+
+Here are a few examples from the training split:
+
+```json
+{
+  "text": "М.С. Міхалкоў нядаўна яшчэ раз выказаў сваё жаданне быць пахаваны тут.",
+  "label": "incorrect"
+}
+```
+
+```json
+{
+  "text": "Загад адступаць быў аддадзены салдатам камандзірам.",
+  "label": "correct"
+}
+```
+
+```json
+{
+  "text": "Бальніцу прынёс абозу загад камбата заняць чарговы дзень.",
+  "label": "incorrect"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 12
+- Prefix prompt:
+
+  ```text
+  Ніжэй прыведзены сказы і ці з'яўляюцца яны граматычна правільнымі.
+  ```
+
+- Base prompt template:
+
+  ```text
+  Сказ: {text}
+  Граматычна правільны: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Сказ: {text}
+
+  Вызначце, ці сказ граматычна правільны ці не. Адкажыце толькі {labels_str}, і нічога іншага.
+  ```
+
+- Label mapping:
+  - `correct` ➡️ `так`
+  - `incorrect` ➡️ `не`
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset belacola
+```
+
 ## Reading Comprehension
 
 ### MultiWikiQA-be

--- a/src/scripts/dataset_creation/create_belacola.py
+++ b/src/scripts/dataset_creation/create_belacola.py
@@ -1,0 +1,77 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets==4.0.0",
+#     "huggingface-hub==0.34.4",
+# ]
+# ///
+
+"""Create the BelaCoLA dataset and upload it to the Hugging Face Hub."""
+
+from datasets import Dataset, DatasetDict, load_dataset
+from huggingface_hub import HfApi
+
+SOURCE_REPOSITORY = "maaxap/BelarusianGLUE"
+SOURCE_CONFIG = "belacola_in_domain"
+TARGET_REPOSITORY = "EuroEval/belacola-mini"
+
+SPLIT_LIMITS = {"train": 1024, "validation": 256, "test": 300}
+LABEL_MAPPING = {0: "incorrect", 1: "correct"}
+
+
+def main() -> None:
+    """Create the BelaCoLA dataset and upload it to the Hugging Face Hub."""
+    source_dataset = load_dataset(
+        path=SOURCE_REPOSITORY, name=SOURCE_CONFIG, token=True
+    )
+    assert isinstance(source_dataset, DatasetDict)
+
+    dataset = process_dataset(source_dataset=source_dataset)
+
+    HfApi().delete_repo(repo_id=TARGET_REPOSITORY, repo_type="dataset", missing_ok=True)
+    dataset.push_to_hub(repo_id=TARGET_REPOSITORY, private=True)
+
+
+def process_dataset(source_dataset: DatasetDict) -> DatasetDict:
+    """Convert and cap the source BelaCoLA splits.
+
+    The source dataset is already shuffled and has separate in-domain train,
+    validation and test splits. Selecting the first rows in each split keeps the
+    conversion deterministic while preserving those split boundaries.
+
+    Args:
+        source_dataset:
+            The in-domain BelaCoLA dataset loaded from the Hugging Face Hub.
+
+    Returns:
+        A dataset with EuroEval's ``text`` and ``label`` columns and train, val
+        and test splits.
+    """
+    return DatasetDict(
+        {
+            output_split: _process_split(
+                dataset=source_dataset[source_split], limit=SPLIT_LIMITS[source_split]
+            )
+            for output_split, source_split in {
+                "train": "train",
+                "val": "validation",
+                "test": "test",
+            }.items()
+        }
+    )
+
+
+def _process_split(dataset: Dataset, limit: int) -> Dataset:
+    """Select, rename and label one BelaCoLA split.
+
+    Returns:
+        The processed split with ``text`` and ``label`` columns.
+    """
+    dataset = dataset.select(range(min(dataset.num_rows, limit)))
+    dataset = dataset.select_columns(["sentence", "label"])
+    dataset = dataset.rename_column("sentence", "text")
+    return dataset.map(lambda sample: {"label": LABEL_MAPPING[sample["label"]]})
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_scripts/test_create_belacola.py
+++ b/tests/test_scripts/test_create_belacola.py
@@ -1,0 +1,43 @@
+"""Tests for the BelaCoLA dataset creation script."""
+
+from datasets import Dataset, DatasetDict
+
+from src.scripts.dataset_creation.create_belacola import process_dataset
+
+
+def test_process_dataset_preserves_splits_and_caps_independently() -> None:
+    """Each source split is capped independently and mapped to EuroEval columns."""
+    source_dataset = DatasetDict(
+        {
+            "train": _make_split(size=1026, prefix="train"),
+            "validation": _make_split(size=258, prefix="validation"),
+            "test": _make_split(size=301, prefix="test"),
+        }
+    )
+
+    result = process_dataset(source_dataset=source_dataset)
+
+    assert list(result) == ["train", "val", "test"]
+    assert [result[split].num_rows for split in result] == [1024, 256, 300]
+    assert result["train"].column_names == ["text", "label"]
+    assert result["train"]["text"][-1] == "train 1023"
+    assert result["val"]["text"][0] == "validation 0"
+    assert result["test"]["text"][-1] == "test 299"
+    assert result["train"]["label"][:2] == ["incorrect", "correct"]
+
+
+def _make_split(size: int, prefix: str) -> Dataset:
+    """Create a small source-shaped split for testing.
+
+    Returns:
+        A dataset with the same columns as the BelaCoLA source data.
+    """
+    return Dataset.from_dict(
+        {
+            "idx": list(range(size)),
+            "label": [index % 2 for index in range(size)],
+            "sentence": [f"{prefix} {index}" for index in range(size)],
+            "source": ["rucola"] * size,
+            "detailed_source": ["test"] * size,
+        }
+    )


### PR DESCRIPTION
## What
Adds the Belarusian BelaCoLA linguistic acceptability dataset as an unofficial EuroEval benchmark.

## Key features
- Converts `maaxap/BelarusianGLUE` `belacola_in_domain` into `EuroEval/belacola-mini`.
- Preserves source split semantics and caps train/validation/test independently at 1024/256/300.
- Adds dataset configuration, documentation, processing tests, and an Unreleased changelog entry.

## Evaluation
```bash
euroeval --model <model-id> --dataset belacola
```

Fixes #2138