### PR TITLE
feat: Add unofficial BeRTE-WD dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Added the unofficial Belarusian linguistic acceptability dataset `belacola`, based on
   the BelaCoLA dataset from BelarusianGLUE.
+- Added the unofficial Belarusian BeRTE-WD binary natural language inference dataset.
 - Added the sample hallucination rate metric as the primary hallucination score, while
   retaining the token hallucination rate as a secondary score.
 

--- a/src/euroeval/dataset_configs/belarusian.py
+++ b/src/euroeval/dataset_configs/belarusian.py
@@ -2,7 +2,7 @@
 
 from ..data_models import DatasetConfig
 from ..languages import BELARUSIAN
-from ..tasks import COMMON_SENSE, HALLU, INSTRUCTION_FOLLOWING, LA, NER, RC, SENT
+from ..tasks import COMMON_SENSE, HALLU, INSTRUCTION_FOLLOWING, LA, NER, NLI, RC, SENT
 
 # Official datasets ###
 
@@ -58,6 +58,22 @@ MULTI_IFEVAL_BE_CONFIG = DatasetConfig(
 
 
 # Unofficial datasets ###
+
+BERTE_WD_CONFIG = DatasetConfig(
+    name="berte-wd",
+    pretty_name="BeRTE-WD",
+    source="EuroEval/berte-wd-mini",
+    task=NLI,
+    languages=[BELARUSIAN],
+    labels=["entailment", "contradiction"],
+    prompt_label_mapping=dict(entailment="праўда", contradiction="хлусня"),
+    prompt_prefix="Ніжэй прыведзены пары сцвярджэнняў. Вызначце, ці вынікае "
+    "другое сцвярджэнне з першага. Адказ можа быць {labels_str}.",
+    prompt_template="{text}\nІмплікацыя: {label}",
+    instruction_prompt="{text}\n\nВызначце, ці вынікае другое сцвярджэнне з "
+    "першага. Адкажыце толькі {labels_str}, і нічога іншага.",
+    unofficial=True,
+)
 
 RAGTRUTH_BE_CONFIG = DatasetConfig(
     name="ragtruth-be",

--- a/src/euroeval/dataset_configs/belarusian.py
+++ b/src/euroeval/dataset_configs/belarusian.py
@@ -65,8 +65,8 @@ BERTE_WD_CONFIG = DatasetConfig(
     source="EuroEval/berte-wd-mini",
     task=NLI,
     languages=[BELARUSIAN],
-    labels=["entailment", "contradiction"],
-    prompt_label_mapping=dict(entailment="праўда", contradiction="хлусня"),
+    labels=["entailment", "non_entailment"],
+    prompt_label_mapping=dict(entailment="праўда", non_entailment="не вынікае"),
     prompt_prefix="Ніжэй прыведзены пары сцвярджэнняў. Вызначце, ці вынікае "
     "другое сцвярджэнне з першага. Адказ можа быць {labels_str}.",
     prompt_template="{text}\nІмплікацыя: {label}",

--- a/src/frontend/md/datasets/belarusian.md
+++ b/src/frontend/md/datasets/belarusian.md
@@ -314,6 +314,76 @@ You can evaluate this dataset directly as follows:
 euroeval --model <model-id> --dataset belacola
 ```
 
+## Natural Language Inference
+
+### Unofficial: BeRTE-WD
+
+[BeRTE-WD](https://huggingface.co/datasets/maaxap/BelarusianGLUE) is the
+Belarusian textual entailment dataset from the BelarusianGLUE collection. Each sample
+contains a premise and a hypothesis, and the task is to determine whether the hypothesis
+follows from the premise. The source labels are binary: 1 means entailment and 0 means
+non-entailment. EuroEval represents the latter as `non_entailment`; this dataset does
+not distinguish between contradiction and neutral cases.
+
+The source has 1,080 / 360 / 360 samples in its train, validation and test splits. We
+preserve those split boundaries and take the first 1,024 training samples, first 256
+validation samples and all 360 test samples, resulting in a 1,024 / 256 / 360 split.
+
+Here are three representative examples from the training split:
+
+```json
+{
+  "text": "Перадумова: Прынцэса Эавін мела 1 дзіця.\nГіпотэза: Прынцэса Эавін не мела іншых дзяцей, акрамя двух.",
+  "label": "non_entailment"
+}
+```
+
+```json
+{
+  "text": "Перадумова: Стэпавы арол мае размах крылаў 203 см.\nГіпотэза: Стэпавы арол мае размах крылаў блізу двух метраў.",
+  "label": "entailment"
+}
+```
+
+```json
+{
+  "text": "Перадумова: Яўхім Фёдаравіч Карскі валодаў рускай мовай.\nГіпотэза: Яўхім Фёдаравіч Карскі мог разумець тэксты на рускай мове.",
+  "label": "entailment"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 12
+- Prefix prompt:
+
+  ```text
+  Ніжэй прыведзены пары сцвярджэнняў. Вызначце, ці вынікае другое сцвярджэнне з першага. Адказ можа быць 'праўда' або 'не вынікае'.
+  ```
+
+- Base prompt template:
+
+  ```text
+  {text}\nІмплікацыя: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  {text}\n\nВызначце, ці вынікае другое сцвярджэнне з першага. Адкажыце толькі 'праўда' або 'не вынікае', і нічога іншага.
+  ```
+
+- Label mapping:
+  - `entailment` ➡️ `праўда`
+  - `non_entailment` ➡️ `не вынікае`
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset berte-wd
+```
+
 ## Reading Comprehension
 
 ### MultiWikiQA-be

--- a/src/scripts/dataset_creation/create_berte_wd.py
+++ b/src/scripts/dataset_creation/create_berte_wd.py
@@ -1,0 +1,102 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets==3.5.0",
+#     "huggingface-hub==0.24.0",
+# ]
+# ///
+
+"""Create the BeRTE-WD dataset and upload it to the Hugging Face Hub."""
+
+import logging
+
+from datasets import Dataset, DatasetDict, load_dataset
+
+logger = logging.getLogger(__name__)
+
+SOURCE_DATASET = "maaxap/BelarusianGLUE"
+SOURCE_CONFIG = "bertewd"
+TARGET_DATASET = "EuroEval/berte-wd-mini"
+MAX_TRAIN = 1024
+MAX_VAL = 256
+MAX_TEST = 360
+
+
+def main() -> None:
+    """Create the BeRTE-WD dataset and upload it to the Hugging Face Hub."""
+    raw_dataset = load_dataset(SOURCE_DATASET, SOURCE_CONFIG)
+    dataset = process_dataset(raw_dataset=raw_dataset)
+
+    logger.info("Uploading %s", TARGET_DATASET)
+    dataset.push_to_hub(TARGET_DATASET, private=True)
+    logger.info("Uploaded %s", TARGET_DATASET)
+
+
+def process_dataset(raw_dataset: DatasetDict) -> DatasetDict:
+    """Format BeRTE-WD and cap each original split independently.
+
+    Args:
+        raw_dataset:
+            The source dataset with ``train``, ``validation`` and ``test`` splits.
+
+    Returns:
+        A EuroEval dataset with ``train``, ``val`` and ``test`` splits. Each row has a
+        Belarusian premise/hypothesis input in ``text`` and a string NLI label.
+
+    """
+    return DatasetDict(
+        {
+            "train": _process_split(dataset=raw_dataset["train"], max_size=MAX_TRAIN),
+            "val": _process_split(dataset=raw_dataset["validation"], max_size=MAX_VAL),
+            "test": _process_split(dataset=raw_dataset["test"], max_size=MAX_TEST),
+        }
+    )
+
+
+def _process_split(dataset: Dataset, max_size: int) -> Dataset:
+    """Format and cap one source split without changing its order or membership.
+
+    Returns:
+        The formatted and capped split.
+    """
+    dataset = dataset.select(range(min(len(dataset), max_size)))
+    return Dataset.from_dict(
+        {
+            "text": [
+                _format_text(premise=row["text"], hypothesis=row["hypothesis"])
+                for row in dataset
+            ],
+            "label": [_map_label(label=row["label"]) for row in dataset],
+        }
+    )
+
+
+def _format_text(premise: str, hypothesis: str) -> str:
+    """Format a premise and hypothesis as a clear Belarusian input.
+
+    Returns:
+        A labelled premise/hypothesis pair.
+    """
+    return f"Перадумова: {premise}\nГіпотэза: {hypothesis}"
+
+
+def _map_label(label: int) -> str:
+    """Map a BeRTE-WD label to EuroEval's binary NLI labels.
+
+    Returns:
+        The corresponding EuroEval label.
+
+    Raises:
+        ValueError:
+            If the source label is not 0 or 1.
+    """
+    if label == 1:
+        return "entailment"
+    if label == 0:
+        return "contradiction"
+    raise ValueError(f"Unexpected BeRTE-WD label: {label}")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/src/scripts/dataset_creation/create_berte_wd.py
+++ b/src/scripts/dataset_creation/create_berte_wd.py
@@ -93,7 +93,7 @@ def _map_label(label: int) -> str:
     if label == 1:
         return "entailment"
     if label == 0:
-        return "contradiction"
+        return "non_entailment"
     raise ValueError(f"Unexpected BeRTE-WD label: {label}")
 
 

--- a/tests/test_scripts/test_create_berte_wd.py
+++ b/tests/test_scripts/test_create_berte_wd.py
@@ -1,0 +1,76 @@
+"""Tests for the BeRTE-WD dataset creation script."""
+
+import pytest
+from datasets import Dataset, DatasetDict
+
+from src.scripts.dataset_creation.create_berte_wd import _map_label, process_dataset
+
+
+@pytest.mark.parametrize(
+    ("source_label", "expected_label"), [(0, "contradiction"), (1, "entailment")]
+)
+def test_map_label(source_label: int, expected_label: str) -> None:
+    """Source labels map to the two EuroEval NLI labels."""
+    assert _map_label(label=source_label) == expected_label
+
+
+def test_map_label_rejects_unknown_labels() -> None:
+    """Unexpected source labels fail rather than silently corrupting data."""
+    with pytest.raises(ValueError, match="Unexpected BeRTE-WD label"):
+        _map_label(label=2)
+
+
+def test_process_dataset_caps_splits_independently() -> None:
+    """Processing preserves split membership while applying each cap separately."""
+    source = DatasetDict(
+        {
+            "train": _source_split(1080),
+            "validation": _source_split(360),
+            "test": _source_split(360),
+        }
+    )
+
+    result = process_dataset(raw_dataset=source)
+
+    assert {split: len(dataset) for split, dataset in result.items()} == {
+        "train": 1024,
+        "val": 256,
+        "test": 360,
+    }
+    assert result["train"]["text"][-1].startswith("Перадумова: перадумова 1023")
+    assert result["val"]["text"][-1].startswith("Перадумова: перадумова 255")
+    assert result["test"]["text"][-1].startswith("Перадумова: перадумова 359")
+
+
+def _source_split(size: int) -> Dataset:
+    """Create a source-shaped split with identifiable rows.
+
+    Returns:
+        A source-shaped dataset split.
+    """
+    return Dataset.from_dict(
+        {
+            "text": [f"перадумова {index}" for index in range(size)],
+            "hypothesis": [f"гіпотэза {index}" for index in range(size)],
+            "label": [index % 2 for index in range(size)],
+        }
+    )
+
+
+def test_process_dataset_formats_pairs_and_maps_labels() -> None:
+    """Each output row combines both statements and uses binary NLI labels."""
+    source = DatasetDict(
+        {
+            "train": _source_split(2),
+            "validation": _source_split(1),
+            "test": _source_split(1),
+        }
+    )
+
+    result = process_dataset(raw_dataset=source)
+
+    assert result["train"][0] == {
+        "text": "Перадумова: перадумова 0\nГіпотэза: гіпотэза 0",
+        "label": "contradiction",
+    }
+    assert result["train"][1]["label"] == "entailment"

--- a/tests/test_scripts/test_create_berte_wd.py
+++ b/tests/test_scripts/test_create_berte_wd.py
@@ -7,7 +7,7 @@ from src.scripts.dataset_creation.create_berte_wd import _map_label, process_dat
 
 
 @pytest.mark.parametrize(
-    ("source_label", "expected_label"), [(0, "contradiction"), (1, "entailment")]
+    ("source_label", "expected_label"), [(0, "non_entailment"), (1, "entailment")]
 )
 def test_map_label(source_label: int, expected_label: str) -> None:
     """Source labels map to the two EuroEval NLI labels."""
@@ -71,6 +71,6 @@ def test_process_dataset_formats_pairs_and_maps_labels() -> None:
 
     assert result["train"][0] == {
         "text": "Перадумова: перадумова 0\nГіпотэза: гіпотэза 0",
-        "label": "contradiction",
+        "label": "non_entailment",
     }
     assert result["train"][1]["label"] == "entailment"


### PR DESCRIPTION
## What
Adds the Belarusian BeRTE-WD binary textual entailment dataset as an unofficial EuroEval benchmark.

## Key features
- Converts `maaxap/BelarusianGLUE` `bertewd` into `EuroEval/berte-wd-mini`.
- Preserves source split semantics and caps train/validation/test independently at 1024/256/360.
- Uses explicit `entailment` and `non_entailment` labels because the source negative class combines neutral and contradictory hypotheses.
- Adds dataset configuration, Belarusian binary prompts, documentation, processing tests, and an Unreleased changelog entry.

## Evaluation
```bash
euroeval --model <model-id> --dataset berte-wd
```

Fixes #2139