### PR TITLE
feat: Add unofficial BeWiC dataset

### DIFF
--- a/.slopo/slopo.ignore.txt
+++ b/.slopo/slopo.ignore.txt
@@ -43,6 +43,9 @@ d008f8ed6c93  # scripts/dataset_creation/create_gsm8k.py
 4899b96e6cfd  # scripts/dataset_creation/create_piqa.py
 d81eb68f2948  # scripts/dataset_creation/create_copa.py
 a653617439bf  # scripts/dataset_creation/create_wic.py
+b21ad08cd2de  # scripts/dataset_creation/create_belacola.py, scripts/dataset_creation/create_bewic.py
+2cb2bc995f08  # scripts/dataset_creation/create_belacola.py, scripts/dataset_creation/create_bewic.py
+2289bf101c6b  # scripts/dataset_creation/create_belacola.py, scripts/dataset_creation/create_bewic.py
 4c57aef481fb  # scripts/dataset_creation/create_boolq.py
 d37d12a12202  # scripts/dataset_creation/create_commitmentbank.py
 71fc771b060f  # scripts/dataset_creation/create_wnli.py
@@ -62,6 +65,7 @@ ac81abca3ab6  # scripts/dataset_creation/create_qnli.py
 01d1b47f0981  # euroeval/benchmark_modules/hf.py, euroeval/benchmark_modules/vllm.py
 06bf2c0c305a  # euroeval/benchmark_modules/vllm.py, euroeval/benchmark_modules/litellm.py
 0964ffc78620  # euroeval/benchmark_modules/vllm.py, euroeval/benchmark_modules/litellm.py
+29a4b5a07f71  # euroeval/benchmark_modules/dummy.py, euroeval/benchmark_modules/litellm.py, euroeval/benchmark_modules/vllm.py
 a52d4598fe08  # euroeval/task_group_utils/question_answering.py, euroeval/task_group_utils/sequence_classification.py
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Added the unofficial Belarusian Word-in-Context dataset `bewic`, based on the BeWiC
+  dataset from BelarusianGLUE.
 - Added the unofficial Belarusian linguistic acceptability dataset `belacola`, based on
   the BelaCoLA dataset from BelarusianGLUE.
 - Added the unofficial Belarusian BeRTE-WD binary natural language inference dataset.

--- a/src/euroeval/dataset_configs/belarusian.py
+++ b/src/euroeval/dataset_configs/belarusian.py
@@ -2,7 +2,17 @@
 
 from ..data_models import DatasetConfig
 from ..languages import BELARUSIAN
-from ..tasks import COMMON_SENSE, HALLU, INSTRUCTION_FOLLOWING, LA, NER, NLI, RC, SENT, WIC
+from ..tasks import (
+    COMMON_SENSE,
+    HALLU,
+    INSTRUCTION_FOLLOWING,
+    LA,
+    NER,
+    NLI,
+    RC,
+    SENT,
+    WIC,
+)
 
 # Official datasets ###
 

--- a/src/euroeval/dataset_configs/belarusian.py
+++ b/src/euroeval/dataset_configs/belarusian.py
@@ -2,7 +2,7 @@
 
 from ..data_models import DatasetConfig
 from ..languages import BELARUSIAN
-from ..tasks import COMMON_SENSE, HALLU, INSTRUCTION_FOLLOWING, LA, NER, NLI, RC, SENT
+from ..tasks import COMMON_SENSE, HALLU, INSTRUCTION_FOLLOWING, LA, NER, NLI, RC, SENT, WIC
 
 # Official datasets ###
 
@@ -90,6 +90,15 @@ BELACOLA_CONFIG = DatasetConfig(
     pretty_name="BelaCoLA",
     source="EuroEval/belacola-mini",
     task=LA,
+    languages=[BELARUSIAN],
+    unofficial=True,
+)
+
+BEWIC_CONFIG = DatasetConfig(
+    name="bewic",
+    pretty_name="BeWiC",
+    source="EuroEval/bewic-mini",
+    task=WIC,
     languages=[BELARUSIAN],
     unofficial=True,
 )

--- a/src/frontend/md/datasets/belarusian.md
+++ b/src/frontend/md/datasets/belarusian.md
@@ -464,6 +464,81 @@ You can evaluate this dataset directly as follows:
 euroeval --model <model-id> --dataset multi-wiki-qa-be
 ```
 
+## Word in Context
+
+### Unofficial: BeWiC
+
+BeWiC is the Belarusian Word-in-Context dataset from the
+[BelarusianGLUE benchmark](https://huggingface.co/datasets/maaxap/BelarusianGLUE),
+introduced in [Aparovich et al. (2025)](https://aclanthology.org/2025.acl-long.25/). It
+measures the ability to distinguish word meanings or senses in context: given one target
+word in two Belarusian sentences, the task is to determine whether it has the same sense
+in both contexts.
+
+The original `bewic` configuration consists of 5,626 / 400 / 400 samples in its train,
+validation and test splits. We preserve these source split boundaries and select the first
+1,024 / 256 / 400 samples for EuroEval. The source data is already shuffled, and selecting
+rows in order makes this conversion deterministic. Source label `1` means `same_sense`,
+while source label `0` means `different_sense`.
+
+Here are a few examples from the training split:
+
+```json
+{
+  "text": "Слова: чуць\nКантэкст 1: Стаіць Іван пад дубам, аж чуе — пішчаць на дубе ў гняздзе птушаняты.\nКантэкст 2: Толькі спрактыкаваны чалавек мог намацаць пад рудой тванню цвёрдую палоску насцілу: чуць збочыў — і плюхнешся ў тарфяную калатушу.",
+  "label": "different_sense"
+}
+```
+
+```json
+{
+  "text": "Слова: прыз\nКантэкст 1: Дог, якога вы бачылі, мае два міжнародныя прызы.\nКантэкст 2: Здавалася, перад Сяргеем быў адзін з тых атлетаў, якія прывыклі браць прызы па падыманню цяжараў на спартыўных спаборніцтвах.",
+  "label": "same_sense"
+}
+```
+
+```json
+{
+  "text": "Слова: стан\nКантэкст 1: Снапы ў Любы былі цяжкія, але зграбныя, з тонкім станам і роўнымі гузырамі.\nКантэкст 2: Сцяпан пачаў у галаве складаць гэтае пісьмо, падбіраць такія словы і выразы, якія б дакладна адлюстравалі яго душэўны стан, яго радасць.",
+  "label": "different_sense"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 12
+- Prefix prompt:
+
+  ```text
+  Ніжэй прыведзены прыклады слоў, якія выкарыстоўваюцца ў двух кантэкстах, і ці маюць яны аднолькавае значэнне.
+  ```
+
+- Base prompt template:
+
+  ```text
+  {text}
+  Аднолькавае значэнне: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  {text}
+
+  Ці мае слова аднолькавае значэнне ў абодвух кантэкстах? Адкажыце толькі {labels_str}, і нічога іншага.
+  ```
+
+- Label mapping:
+  - `same_sense` ➡️ `так`
+  - `different_sense` ➡️ `не`
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset bewic
+```
+
 ## Common-sense Reasoning
 
 ### BE-WSC

--- a/src/scripts/dataset_creation/create_bewic.py
+++ b/src/scripts/dataset_creation/create_bewic.py
@@ -1,0 +1,99 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets==4.0.0",
+#     "huggingface-hub==0.34.4",
+# ]
+# ///
+
+"""Create the BeWiC dataset and upload it to the Hugging Face Hub.
+
+BeWiC is the Belarusian Word-in-Context task from the BelarusianGLUE benchmark. Given
+one word in two sentences, the task is to determine whether it has the same sense in
+both contexts.
+"""
+
+from datasets import Dataset, DatasetDict, load_dataset
+from huggingface_hub import HfApi
+
+SOURCE_REPOSITORY = "maaxap/BelarusianGLUE"
+SOURCE_CONFIG = "bewic"
+TARGET_REPOSITORY = "EuroEval/bewic-mini"
+
+SPLIT_LIMITS = {"train": 1024, "validation": 256, "test": 400}
+LABEL_MAPPING = {0: "different_sense", 1: "same_sense"}
+
+
+def main() -> None:
+    """Create the BeWiC dataset and upload it to the Hugging Face Hub."""
+    source_dataset = load_dataset(
+        path=SOURCE_REPOSITORY, name=SOURCE_CONFIG, token=True
+    )
+    assert isinstance(source_dataset, DatasetDict)
+
+    dataset = process_dataset(source_dataset=source_dataset)
+
+    HfApi().delete_repo(repo_id=TARGET_REPOSITORY, repo_type="dataset", missing_ok=True)
+    dataset.push_to_hub(repo_id=TARGET_REPOSITORY, private=True)
+
+
+def process_dataset(source_dataset: DatasetDict) -> DatasetDict:
+    """Convert and cap the source BeWiC splits.
+
+    The source dataset has separate train, validation and test splits. Selecting rows
+    independently in each split preserves those boundaries and makes the conversion
+    deterministic.
+
+    Args:
+        source_dataset:
+            The BeWiC dataset loaded from the Hugging Face Hub.
+
+    Returns:
+        A dataset with EuroEval's ``text`` and ``label`` columns and train, val and test
+        splits.
+    """
+    return DatasetDict(
+        {
+            output_split: _process_split(
+                dataset=source_dataset[source_split], limit=SPLIT_LIMITS[source_split]
+            )
+            for output_split, source_split in {
+                "train": "train",
+                "val": "validation",
+                "test": "test",
+            }.items()
+        }
+    )
+
+
+def _process_split(dataset: Dataset, limit: int) -> Dataset:
+    """Select and format one BeWiC split.
+
+    Args:
+        dataset:
+            A source BeWiC split.
+        limit:
+            The maximum number of rows to retain.
+
+    Returns:
+        The processed split with ``text`` and ``label`` columns.
+    """
+    dataset = dataset.select(range(min(dataset.num_rows, limit)))
+    dataset = dataset.select_columns(["word", "sentence1", "sentence2", "label"])
+
+    def format_sample(sample: dict[str, str | int]) -> dict[str, str]:
+        return {
+            "text": (
+                f"Слова: {str(sample['word']).strip()}\n"
+                f"Кантэкст 1: {str(sample['sentence1']).strip()}\n"
+                f"Кантэкст 2: {str(sample['sentence2']).strip()}"
+            ),
+            "label": LABEL_MAPPING[int(sample["label"])],
+        }
+
+    dataset = dataset.map(format_sample, remove_columns=dataset.column_names)
+    return dataset.select_columns(["text", "label"])
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_scripts/test_create_bewic.py
+++ b/tests/test_scripts/test_create_bewic.py
@@ -1,0 +1,99 @@
+"""Tests for the BeWiC dataset creation script."""
+
+from datasets import Dataset, DatasetDict
+
+from src.scripts.dataset_creation.create_bewic import process_dataset
+
+
+def test_process_dataset_constructs_text_with_both_contexts() -> None:
+    """The processed text identifies the target word and includes both contexts."""
+    source_dataset = DatasetDict(
+        {
+            "train": Dataset.from_dict(
+                {
+                    "word": ["слова"],
+                    "sentence1": ["Першы кантэкст."],
+                    "sentence2": ["Другі кантэкст."],
+                    "label": [1],
+                }
+            ),
+            "validation": Dataset.from_dict(
+                {
+                    "word": ["слова"],
+                    "sentence1": ["Першы кантэкст."],
+                    "sentence2": ["Другі кантэкст."],
+                    "label": [1],
+                }
+            ),
+            "test": Dataset.from_dict(
+                {
+                    "word": ["слова"],
+                    "sentence1": ["Першы кантэкст."],
+                    "sentence2": ["Другі кантэкст."],
+                    "label": [1],
+                }
+            ),
+        }
+    )
+
+    result = process_dataset(source_dataset=source_dataset)
+
+    assert result["train"]["text"][0] == (
+        "Слова: слова\nКантэкст 1: Першы кантэкст.\nКантэкст 2: Другі кантэкст."
+    )
+
+
+def test_process_dataset_maps_source_labels() -> None:
+    """Source labels 0 and 1 become different- and same-sense labels."""
+    source_dataset = DatasetDict(
+        {
+            "train": _make_split(size=2, prefix="train"),
+            "validation": _make_split(size=2, prefix="validation"),
+            "test": _make_split(size=2, prefix="test"),
+        }
+    )
+
+    result = process_dataset(source_dataset=source_dataset)
+
+    assert result["train"]["label"] == ["different_sense", "same_sense"]
+
+
+def _make_split(size: int, prefix: str) -> Dataset:
+    """Create a small source-shaped split for testing.
+
+    Returns:
+        A dataset with the same columns as the BeWiC source data.
+    """
+    return Dataset.from_dict(
+        {
+            "word": [f"word {index}" for index in range(size)],
+            "sentence1": [f"{prefix} context one {index}" for index in range(size)],
+            "sentence2": [f"{prefix} context two {index}" for index in range(size)],
+            "start1": [0] * size,
+            "end1": [1] * size,
+            "start2": [0] * size,
+            "end2": [1] * size,
+            "label": [index % 2 for index in range(size)],
+            "idx": list(range(size)),
+        }
+    )
+
+
+def test_process_dataset_preserves_splits_and_caps_independently() -> None:
+    """Each source split is capped independently and mapped to EuroEval columns."""
+    source_dataset = DatasetDict(
+        {
+            "train": _make_split(size=1026, prefix="train"),
+            "validation": _make_split(size=258, prefix="validation"),
+            "test": _make_split(size=401, prefix="test"),
+        }
+    )
+
+    result = process_dataset(source_dataset=source_dataset)
+
+    assert list(result) == ["train", "val", "test"]
+    assert [result[split].num_rows for split in result] == [1024, 256, 400]
+    assert result["train"].column_names == ["text", "label"]
+    assert result["train"]["text"][-1].startswith("Слова: word 1023")
+    assert result["val"]["text"][0].startswith("Слова: word 0")
+    assert result["test"]["text"][-1].startswith("Слова: word 399")


### PR DESCRIPTION
## What
Adds the Belarusian BeWiC Word-in-Context dataset as an unofficial EuroEval benchmark.

## Key features
- Converts `maaxap/BelarusianGLUE` `bewic` into `EuroEval/bewic-mini`.
- Preserves source split semantics and caps train/validation/test independently at 1024/256/400.
- Formats each example with its target word and both contexts, mapping labels to `same_sense` and `different_sense`.
- Uses the existing Belarusian WiC prompts and adds documentation, processing tests, and an Unreleased changelog entry.

## Evaluation
```bash
euroeval --model <model-id> --dataset bewic
```

Fixes #2140