### PR TITLE
feat: Add unofficial BeWSC NLI dataset

### DIFF
--- a/.slopo/slopo.ignore.txt
+++ b/.slopo/slopo.ignore.txt
@@ -43,6 +43,10 @@ d008f8ed6c93  # scripts/dataset_creation/create_gsm8k.py
 4899b96e6cfd  # scripts/dataset_creation/create_piqa.py
 d81eb68f2948  # scripts/dataset_creation/create_copa.py
 a653617439bf  # scripts/dataset_creation/create_wic.py
+353386081479  # scripts/dataset_creation/create_berte_wd.py, scripts/dataset_creation/create_bewsc_nli.py
+44667581f41c  # scripts/dataset_creation/create_berte_wd.py, scripts/dataset_creation/create_bewsc_nli.py
+cf4c84011fe0  # scripts/dataset_creation/create_berte_wd.py, scripts/dataset_creation/create_bewsc_nli.py
+3a7aec563770  # scripts/dataset_creation/create_berte_wd.py, scripts/dataset_creation/create_bewsc_nli.py
 4c57aef481fb  # scripts/dataset_creation/create_boolq.py
 d37d12a12202  # scripts/dataset_creation/create_commitmentbank.py
 71fc771b060f  # scripts/dataset_creation/create_wnli.py
@@ -62,6 +66,7 @@ ac81abca3ab6  # scripts/dataset_creation/create_qnli.py
 01d1b47f0981  # euroeval/benchmark_modules/hf.py, euroeval/benchmark_modules/vllm.py
 06bf2c0c305a  # euroeval/benchmark_modules/vllm.py, euroeval/benchmark_modules/litellm.py
 0964ffc78620  # euroeval/benchmark_modules/vllm.py, euroeval/benchmark_modules/litellm.py
+29a4b5a07f71  # euroeval/benchmark_modules/dummy.py, euroeval/benchmark_modules/litellm.py, euroeval/benchmark_modules/vllm.py
 a52d4598fe08  # euroeval/task_group_utils/question_answering.py, euroeval/task_group_utils/sequence_classification.py
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Added the unofficial Belarusian linguistic acceptability dataset `belacola`, based on
   the BelaCoLA dataset from BelarusianGLUE.
 - Added the unofficial Belarusian BeRTE-WD binary natural language inference dataset.
+- Added the unofficial Belarusian BeWSC-NLI binary natural language inference dataset,
+  distinct from the official BeWSC common-sense reasoning benchmark.
 - Added the sample hallucination rate metric as the primary hallucination score, while
   retaining the token hallucination rate as a secondary score.
 

--- a/src/euroeval/dataset_configs/belarusian.py
+++ b/src/euroeval/dataset_configs/belarusian.py
@@ -75,6 +75,22 @@ BERTE_WD_CONFIG = DatasetConfig(
     unofficial=True,
 )
 
+BEWSC_NLI_CONFIG = DatasetConfig(
+    name="bewsc-nli",
+    pretty_name="BeWSC-NLI",
+    source="EuroEval/bewsc-nli",
+    task=NLI,
+    languages=[BELARUSIAN],
+    labels=["entailment", "non_entailment"],
+    prompt_label_mapping=dict(entailment="праўда", non_entailment="не вынікае"),
+    prompt_prefix="Ніжэй прыведзены пары сцвярджэнняў. Вызначце, ці вынікае "
+    "другое сцвярджэнне з першага. Адказ можа быць {labels_str}.",
+    prompt_template="{text}\nІмплікацыя: {label}",
+    instruction_prompt="{text}\n\nВызначце, ці вынікае другое сцвярджэнне з "
+    "першага. Адкажыце толькі {labels_str}, і нічога іншага.",
+    unofficial=True,
+)
+
 RAGTRUTH_BE_CONFIG = DatasetConfig(
     name="ragtruth-be",
     pretty_name="RAGTruth-be",

--- a/src/frontend/md/datasets/belarusian.md
+++ b/src/frontend/md/datasets/belarusian.md
@@ -384,6 +384,77 @@ You can evaluate this dataset directly as follows:
 euroeval --model <model-id> --dataset berte-wd
 ```
 
+### Unofficial: BeWSC-NLI
+
+[BeWSC-NLI](https://huggingface.co/datasets/maaxap/BelarusianGLUE) is the Belarusian
+binary natural language inference version of the BeWSC data from the BelarusianGLUE
+collection. It uses the source `bewsc_as_wnli` configuration: given a premise and a
+hypothesis, the task is to determine whether the hypothesis follows from the premise.
+This is distinct from the official `be-wsc` dataset, which is a WSC-style
+common-sense reasoning benchmark with multiple-choice coreference questions. The
+official WSC dataset is unchanged by this NLI conversion.
+
+The source contains 570 / 200 / 200 samples in its train, validation and test splits,
+respectively. EuroEval preserves all three source split boundaries and uses the same
+570 / 200 / 200 split; no split is truncated. Source label 1 means entailment and
+source label 0 means non-entailment. The binary task does not distinguish between
+neutral and contradiction cases.
+
+Here are three examples from the training split:
+
+```json
+{
+  "text": "Перадумова: Аліса шукала ў натоўпе сваю сяброўку Надзю. З-за таго, што яна заўсёды носіць чырвоны каптур, Аліса хутка заўважыла яе.\nГіпотэза: З-за таго, што Надзя заўсёды носіць чырвоны каптур, Аліса хутка заўважыла яе.",
+  "label": "entailment"
+}
+```
+
+```json
+{
+  "text": "Перадумова: Дзяніс растлумачыў сваю тэорыю Марку, але ён не пераканаў яго.\nГіпотэза: Дзяніс не пераканаў Марка.",
+  "label": "entailment"
+}
+```
+
+```json
+{
+  "text": "Перадумова: Мужчына ўзяў заплаканага хлопчыка за руку. Яго далонь была вялікай і цёплай.\nГіпотэза: Далонь заплаканага хлопчыка была вялікай і цёплай.",
+  "label": "non_entailment"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 12
+- Prefix prompt:
+
+  ```text
+  Ніжэй прыведзены пары сцвярджэнняў. Вызначце, ці вынікае другое сцвярджэнне з першага. Адказ можа быць 'праўда' або 'не вынікае'.
+  ```
+
+- Base prompt template:
+
+  ```text
+  {text}\nІмплікацыя: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  {text}\n\nВызначце, ці вынікае другое сцвярджэнне з першага. Адкажыце толькі 'праўда' або 'не вынікае', і нічога іншага.
+  ```
+
+- Label mapping:
+  - `entailment` ➡️ `праўда`
+  - `non_entailment` ➡️ `не вынікае`
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset bewsc-nli
+```
+
 ## Reading Comprehension
 
 ### MultiWikiQA-be

--- a/src/scripts/dataset_creation/create_bewsc_nli.py
+++ b/src/scripts/dataset_creation/create_bewsc_nli.py
@@ -1,0 +1,111 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets==3.5.0",
+#     "huggingface-hub==0.24.0",
+# ]
+# ///
+
+"""Create the BeWSC-NLI dataset and upload it to the Hugging Face Hub."""
+
+import logging
+
+from datasets import Dataset, DatasetDict, load_dataset
+
+logger = logging.getLogger(__name__)
+
+SOURCE_DATASET = "maaxap/BelarusianGLUE"
+SOURCE_CONFIG = "bewsc_as_wnli"
+TARGET_DATASET = "EuroEval/bewsc-nli"
+
+
+def main() -> None:
+    """Create the BeWSC-NLI dataset and upload it to the Hugging Face Hub."""
+    raw_dataset = load_dataset(path=SOURCE_DATASET, name=SOURCE_CONFIG)
+    dataset = process_dataset(raw_dataset=raw_dataset)
+
+    logger.info("Uploading %s", TARGET_DATASET)
+    dataset.push_to_hub(TARGET_DATASET, private=True)
+    logger.info("Uploaded %s", TARGET_DATASET)
+
+
+def process_dataset(raw_dataset: DatasetDict) -> DatasetDict:
+    """Format BeWSC-NLI while preserving the source split membership and order.
+
+    Args:
+        raw_dataset:
+            The source dataset with ``train``, ``validation`` and ``test`` splits.
+
+    Returns:
+        A EuroEval dataset with ``train``, ``val`` and ``test`` splits. Each row has a
+        Belarusian premise/hypothesis input in ``text`` and a string NLI label.
+    """
+    return DatasetDict(
+        {
+            "train": _process_split(dataset=raw_dataset["train"]),
+            "val": _process_split(dataset=raw_dataset["validation"]),
+            "test": _process_split(dataset=raw_dataset["test"]),
+        }
+    )
+
+
+def _process_split(dataset: Dataset) -> Dataset:
+    """Format one source split without changing its order or membership.
+
+    Args:
+        dataset:
+            A source split containing ``sentence1``, ``sentence2`` and ``label``.
+
+    Returns:
+        The formatted split with only ``text`` and ``label`` columns.
+    """
+    return Dataset.from_dict(
+        {
+            "text": [
+                _format_text(premise=row["sentence1"], hypothesis=row["sentence2"])
+                for row in dataset
+            ],
+            "label": [_map_label(label=row["label"]) for row in dataset],
+        }
+    )
+
+
+def _format_text(premise: str, hypothesis: str) -> str:
+    """Format a premise and hypothesis as a clear Belarusian input.
+
+    Args:
+        premise:
+            The source premise.
+        hypothesis:
+            The source hypothesis.
+
+    Returns:
+        A labelled premise/hypothesis pair.
+    """
+    return f"Перадумова: {premise}\nГіпотэза: {hypothesis}"
+
+
+def _map_label(label: int) -> str:
+    """Map a BeWSC-NLI label to EuroEval's binary NLI labels.
+
+    Args:
+        label:
+            The source label, where 1 denotes entailment and 0 denotes
+            non-entailment.
+
+    Returns:
+        The corresponding EuroEval label.
+
+    Raises:
+        ValueError:
+            If the source label is not 0 or 1.
+    """
+    if label == 1:
+        return "entailment"
+    if label == 0:
+        return "non_entailment"
+    raise ValueError(f"Unexpected BeWSC-NLI label: {label}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_scripts/test_create_bewsc_nli.py
+++ b/tests/test_scripts/test_create_bewsc_nli.py
@@ -1,0 +1,91 @@
+"""Tests for the BeWSC-NLI dataset creation script."""
+
+import pytest
+from datasets import Dataset, DatasetDict
+
+from src.euroeval.dataset_configs.belarusian import BEWSC_NLI_CONFIG
+from src.scripts.dataset_creation.create_bewsc_nli import (
+    _format_text,
+    _map_label,
+    process_dataset,
+)
+
+
+def test_config_uses_binary_nli_prompts() -> None:
+    """The dataset config exposes only entailment and non-entailment choices."""
+    assert BEWSC_NLI_CONFIG.name == "bewsc-nli"
+    assert BEWSC_NLI_CONFIG.source == "EuroEval/bewsc-nli"
+    assert BEWSC_NLI_CONFIG.labels == ["entailment", "non_entailment"]
+    assert set(BEWSC_NLI_CONFIG.prompt_label_mapping.values()) == {
+        "праўда",
+        "не вынікае",
+    }
+    assert "нейтраль" not in BEWSC_NLI_CONFIG.prompt_prefix
+    assert "супярэч" not in BEWSC_NLI_CONFIG.prompt_prefix
+
+
+def test_format_text() -> None:
+    """A source sentence pair is formatted as a Belarusian premise and hypothesis."""
+    assert _format_text(premise="Першая частка", hypothesis="Другая частка") == (
+        "Перадумова: Першая частка\nГіпотэза: Другая частка"
+    )
+
+
+@pytest.mark.parametrize(
+    ("source_label", "expected_label"), [(0, "non_entailment"), (1, "entailment")]
+)
+def test_map_label(source_label: int, expected_label: str) -> None:
+    """Source labels map to the two EuroEval NLI labels."""
+    assert _map_label(label=source_label) == expected_label
+
+
+def test_map_label_rejects_unknown_labels() -> None:
+    """Unexpected source labels fail rather than silently corrupting data."""
+    with pytest.raises(ValueError, match="Unexpected BeWSC-NLI label"):
+        _map_label(label=2)
+
+
+def test_process_dataset_preserves_splits_and_output_columns() -> None:
+    """Processing preserves source split order and emits only EuroEval columns."""
+    source = DatasetDict(
+        {
+            "train": _source_split(570),
+            "validation": _source_split(200),
+            "test": _source_split(200),
+        }
+    )
+
+    result = process_dataset(raw_dataset=source)
+
+    assert {split: len(dataset) for split, dataset in result.items()} == {
+        "train": 570,
+        "val": 200,
+        "test": 200,
+    }
+    assert result["train"].column_names == ["text", "label"]
+    assert result["val"].column_names == ["text", "label"]
+    assert result["test"].column_names == ["text", "label"]
+    assert result["train"][0]["text"].endswith("гіпотэза 0")
+    assert result["train"][-1]["text"].endswith("гіпотэза 569")
+    assert result["val"][-1]["text"].endswith("гіпотэза 199")
+    assert result["test"][-1]["text"].endswith("гіпотэза 199")
+
+
+def _source_split(size: int) -> Dataset:
+    """Create a source-shaped split with identifiable rows.
+
+    Args:
+        size:
+            Number of rows in the split.
+
+    Returns:
+        A source-shaped dataset split.
+    """
+    return Dataset.from_dict(
+        {
+            "index": [str(index) for index in range(size)],
+            "sentence1": [f"перадумова {index}" for index in range(size)],
+            "sentence2": [f"гіпотэза {index}" for index in range(size)],
+            "label": [index % 2 for index in range(size)],
+        }
+    )


### PR DESCRIPTION
## What
Adds the Belarusian BeWSC WNLI-format dataset as a distinct unofficial binary NLI benchmark. The existing official WSC-format `be-wsc` benchmark remains unchanged.

## Key features
- Converts `maaxap/BelarusianGLUE` `bewsc_as_wnli` into `EuroEval/bewsc-nli`.
- Preserves the complete source train/validation/test splits of 570/200/200; no `-mini` suffix is needed.
- Uses explicit `entailment` and `non_entailment` labels with Belarusian binary prompts.
- Adds dataset configuration, documentation, processing tests, changelog coverage, and reviewed Slopo ignores.

## Evaluation
```bash
euroeval --model <model-id> --dataset bewsc-nli
```

Related to deleted issue #2141