### PR TITLE
feat: add official datasets berte-wd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   the BelaCoLA dataset from BelarusianGLUE.
 - Added the unofficial Belarusian BeRTE-WD binary natural language inference dataset.
 
+### Changed
+
+- Promoted the unofficial dataset `berte-wd` to official.
+
 ### Fixed
 
 - Fixed `#no-thinking` LiteLLM evaluations when providers reject a zero thinking budget
@@ -73,8 +77,6 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   Scots.
 
 ### Changed
-
-- Added official datasets for Belarusian: `berte-wd`.
 
 - Renamed the previous LLM-as-a-judge `open-ended-qa` task to `reference-free-qa`, and
   added a new reference-based `open-ended-qa` task using translation-style text-to-text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Added official datasets for Belarusian: `berte-wd`.
+
 - Renamed the previous LLM-as-a-judge `open-ended-qa` task to `reference-free-qa`, and
   added a new reference-based `open-ended-qa` task using translation-style text-to-text
   metrics.

--- a/src/euroeval/dataset_configs/belarusian.py
+++ b/src/euroeval/dataset_configs/belarusian.py
@@ -66,8 +66,6 @@ MULTI_IFEVAL_BE_CONFIG = DatasetConfig(
     val_split=None,
 )
 
-# Unofficial datasets ###
-
 BERTE_WD_CONFIG = DatasetConfig(
     name="berte-wd",
     pretty_name="BeRTE-WD",
@@ -81,8 +79,9 @@ BERTE_WD_CONFIG = DatasetConfig(
     prompt_template="{text}\nІмплікацыя: {label}",
     instruction_prompt="{text}\n\nВызначце, ці вынікае другое сцвярджэнне з "
     "першага. Адкажыце толькі {labels_str}, і нічога іншага.",
-    unofficial=True,
 )
+
+# Unofficial datasets ###
 
 RAGTRUTH_BE_CONFIG = DatasetConfig(
     name="ragtruth-be",

--- a/src/frontend/md/datasets/belarusian.md
+++ b/src/frontend/md/datasets/belarusian.md
@@ -316,7 +316,7 @@ euroeval --model <model-id> --dataset belacola
 
 ## Natural Language Inference
 
-### Unofficial: BeRTE-WD
+### BeRTE-WD
 
 [BeRTE-WD](https://huggingface.co/datasets/maaxap/BelarusianGLUE) is the
 Belarusian textual entailment dataset from the BelarusianGLUE collection. Each sample

--- a/src/leaderboards/dataset_split_sizes.json
+++ b/src/leaderboards/dataset_split_sizes.json
@@ -59,6 +59,11 @@
     "train": 256,
     "val": 64
   },
+  "EuroEval/berte-wd-mini": {
+    "test": 360,
+    "train": 1024,
+    "val": 256
+  },
   "EuroEval/besls": {
     "test": 1616,
     "train": 256,


### PR DESCRIPTION
Adds `berte-wd` as official dataset(s).

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `berte-wd`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `berte-wd` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.