### PR TITLE
feat: add official datasets bewic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,6 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Added official datasets for Belarusian: `bewic`.
-
 - Upgraded the vLLM dependency to version 0.27.1 or newer.
 - Promoted the unofficial dataset `berte-wd` to official.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Added official datasets for Belarusian: `bewic`.
+
 - Upgraded the vLLM dependency to version 0.27.1 or newer.
 - Promoted the unofficial dataset `berte-wd` to official.
 

--- a/src/euroeval/dataset_configs/belarusian.py
+++ b/src/euroeval/dataset_configs/belarusian.py
@@ -81,6 +81,14 @@ BERTE_WD_CONFIG = DatasetConfig(
     "першага. Адкажыце толькі {labels_str}, і нічога іншага.",
 )
 
+BEWIC_CONFIG = DatasetConfig(
+    name="bewic",
+    pretty_name="BeWiC",
+    source="EuroEval/bewic-mini",
+    task=WIC,
+    languages=[BELARUSIAN],
+)
+
 # Unofficial datasets ###
 
 RAGTRUTH_BE_CONFIG = DatasetConfig(
@@ -97,15 +105,6 @@ BELACOLA_CONFIG = DatasetConfig(
     pretty_name="BelaCoLA",
     source="EuroEval/belacola-mini",
     task=LA,
-    languages=[BELARUSIAN],
-    unofficial=True,
-)
-
-BEWIC_CONFIG = DatasetConfig(
-    name="bewic",
-    pretty_name="BeWiC",
-    source="EuroEval/bewic-mini",
-    task=WIC,
     languages=[BELARUSIAN],
     unofficial=True,
 )

--- a/src/frontend/md/datasets/belarusian.md
+++ b/src/frontend/md/datasets/belarusian.md
@@ -466,7 +466,7 @@ euroeval --model <model-id> --dataset multi-wiki-qa-be
 
 ## Word in Context
 
-### Unofficial: BeWiC
+### BeWiC
 
 BeWiC is the Belarusian Word-in-Context dataset from the
 [BelarusianGLUE benchmark](https://huggingface.co/datasets/maaxap/BelarusianGLUE),

--- a/src/leaderboards/dataset_split_sizes.json
+++ b/src/leaderboards/dataset_split_sizes.json
@@ -69,6 +69,11 @@
     "train": 256,
     "val": 128
   },
+  "EuroEval/bewic-mini": {
+    "test": 400,
+    "train": 1024,
+    "val": 256
+  },
   "EuroEval/bfcl-v2": {
     "test": 2001,
     "train": 250,


### PR DESCRIPTION
Adds `bewic` as official dataset(s).

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `bewic`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `bewic` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.