### PR TITLE
feat: add model release date metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Added model release dates to benchmark result metadata for Hugging Face Hub and API
+  models.
 - Added the unofficial Belarusian Word-in-Context dataset `bewic`, based on the BeWiC
   dataset from BelarusianGLUE.
 - Added the unofficial Belarusian linguistic acceptability dataset `belacola`, based on

--- a/src/euroeval/benchmark_modules/base.py
+++ b/src/euroeval/benchmark_modules/base.py
@@ -461,6 +461,7 @@ def _build_model_config_helper(
             cache_dir=benchmark_config.cache_dir, model_id=model_id
         ),
         adapter_base_model_id=adapter_base_model_id,
+        release_date=model_info.release_date,
         generation_config=generation_config,
     )
 

--- a/src/euroeval/benchmark_modules/hf.py
+++ b/src/euroeval/benchmark_modules/hf.py
@@ -1439,7 +1439,9 @@ def get_model_repo_info(
 
     # Try to get model info from local directory first
     model_info: HfApiModelInfo | None = None
-    if Path(model_id).is_dir():
+    release_date: str | None = None
+    is_local_model = Path(model_id).is_dir()
+    if is_local_model:
         model_info = _get_local_model_info(model_id=model_id)
         if model_info is None:
             return None
@@ -1453,6 +1455,9 @@ def get_model_repo_info(
         )
         if model_info is None:
             return None
+        release_date = _get_model_release_date(
+            hf_api=hf_api, model_id=model_id, revision=revision, token=token
+        )
 
     # Handle adapter models - get base model tags
     tags = model_info.tags or list()
@@ -1493,7 +1498,10 @@ def get_model_repo_info(
         return None
 
     return HFModelInfo(
-        pipeline_tag=pipeline_tag, tags=tags, adapter_base_model_id=base_model_id
+        pipeline_tag=pipeline_tag,
+        tags=tags,
+        adapter_base_model_id=base_model_id,
+        release_date=release_date,
     )
 
 
@@ -1657,6 +1665,36 @@ def _get_local_model_info(model_id: str) -> HfApiModelInfo | None:
             level=logging.WARNING,
         )
         return None
+
+
+def _get_model_release_date(
+    hf_api: HfApi, model_id: str, revision: str, token: str | None
+) -> str | None:
+    """Return the date when model weights first appeared in a Hub repository."""
+
+    def contains_weights(files: c.Iterable[str]) -> bool:
+        return any(
+            path.endswith(".safetensors")
+            or re.search(r"(?:^|/)(?:adapter|pytorch)_model.*\.bin$", path) is not None
+            for path in files
+        )
+
+    try:
+        commits = hf_api.list_repo_commits(
+            repo_id=model_id, revision=revision, token=token
+        )
+        for commit in reversed(commits):
+            files = hf_api.list_repo_files(
+                repo_id=model_id, revision=commit.commit_id, token=token
+            )
+            if contains_weights(files):
+                return commit.created_at.date().isoformat()
+    except (HfHubHTTPError, HFValidationError, OSError, RequestException) as e:
+        log(
+            f"Could not determine the release date for {model_id!r}: {e}",
+            level=logging.DEBUG,
+        )
+    return None
 
 
 def _get_tags_for_adapter_model(

--- a/src/euroeval/benchmark_modules/hf.py
+++ b/src/euroeval/benchmark_modules/hf.py
@@ -1455,7 +1455,7 @@ def get_model_repo_info(
         )
         if model_info is None:
             return None
-        release_date = _get_model_release_date(
+        release_date = get_model_release_date(
             hf_api=hf_api, model_id=model_id, revision=revision, token=token
         )
 
@@ -1667,36 +1667,6 @@ def _get_local_model_info(model_id: str) -> HfApiModelInfo | None:
         return None
 
 
-def _get_model_release_date(
-    hf_api: HfApi, model_id: str, revision: str, token: str | None
-) -> str | None:
-    """Return the date when model weights first appeared in a Hub repository."""
-
-    def contains_weights(files: c.Iterable[str]) -> bool:
-        return any(
-            path.endswith(".safetensors")
-            or re.search(r"(?:^|/)(?:adapter|pytorch)_model.*\.bin$", path) is not None
-            for path in files
-        )
-
-    try:
-        commits = hf_api.list_repo_commits(
-            repo_id=model_id, revision=revision, token=token
-        )
-        for commit in reversed(commits):
-            files = hf_api.list_repo_files(
-                repo_id=model_id, revision=commit.commit_id, token=token
-            )
-            if contains_weights(files):
-                return commit.created_at.date().isoformat()
-    except (HfHubHTTPError, HFValidationError, OSError, RequestException) as e:
-        log(
-            f"Could not determine the release date for {model_id!r}: {e}",
-            level=logging.DEBUG,
-        )
-    return None
-
-
 def _get_tags_for_adapter_model(
     model_id: str,
     revision: str,
@@ -1791,3 +1761,48 @@ def _infer_pipeline_tag(
     ):
         return "text-generation"
     return "fill-mask"
+
+
+def get_model_release_date(
+    hf_api: HfApi, model_id: str, revision: str, token: str | None
+) -> str | None:
+    """Return the date when model weights first appeared in a Hub repository.
+
+    Args:
+        hf_api:
+            The Hugging Face Hub API client.
+        model_id:
+            The Hugging Face model repository ID.
+        revision:
+            The repository revision whose history should be inspected.
+        token:
+            The Hugging Face authentication token, if any.
+
+    Returns:
+        The ISO-formatted date of the earliest commit containing recognised model
+        weights, or None if it cannot be determined.
+    """
+
+    def contains_weights(files: c.Iterable[str]) -> bool:
+        return any(
+            path.endswith(".safetensors")
+            or re.search(r"(?:^|/)(?:adapter|pytorch)_model.*\.bin$", path) is not None
+            for path in files
+        )
+
+    try:
+        commits = hf_api.list_repo_commits(
+            repo_id=model_id, revision=revision, token=token
+        )
+        for commit in reversed(commits):
+            files = hf_api.list_repo_files(
+                repo_id=model_id, revision=commit.commit_id, token=token
+            )
+            if contains_weights(files):
+                return commit.created_at.date().isoformat()
+    except (HfHubHTTPError, HFValidationError, OSError, RequestException) as e:
+        log(
+            f"Could not determine the release date for {model_id!r}: {e}",
+            level=logging.DEBUG,
+        )
+    return None

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -168,7 +168,7 @@ NUM_PARAMS_MAPPING = {
 
 
 # Release dates for API aliases which do not carry a dated version in their ID.
-# Dated model IDs are handled generically by `_get_api_model_release_date` below.
+# Dated model IDs are handled generically by `get_api_model_release_date` below.
 # Sources are the providers' model launch posts and model changelogs:
 # https://platform.openai.com/docs/models, https://docs.anthropic.com/en/docs/about-claude/models,
 # https://ai.google.dev/gemini-api/docs/models, and https://docs.x.ai/docs/models.
@@ -207,18 +207,31 @@ MODEL_RELEASE_DATE_MAPPING = {
     r"(openai/)?gpt-5\.3-codex": "2026-02-05",
     r"(openai/)?gpt-5\.3-chat-latest": "2026-03-03",
     r"(openai/)?gpt-5\.4": "2026-03-05",
+    r"(openai/)?gpt-5\.4-pro": "2026-03-05",
     r"(openai/)?gpt-5\.4-(?:mini|nano)": "2026-03-17",
     r"(openai/)?gpt-5\.5": "2026-04-23",
-    r"(openai/)?gpt-5\.6-(?:sol|terra|luna)": "2026-07-09",
+    r"(openai/)?gpt-5\.5-pro": "2026-04-23",
+    r"(openai/)?gpt-5\.6(?:-(?:sol|terra|luna))?": "2026-07-09",
     # Anthropic
     r"(anthropic/)?claude-3-opus": "2024-03-04",
     r"(anthropic/)?claude-3-sonnet": "2024-03-04",
     r"(anthropic/)?claude-3-haiku": "2024-03-13",
     r"(anthropic/)?claude-3-5-sonnet": "2024-06-20",
     r"(anthropic/)?claude-3-5-haiku": "2024-11-04",
+    r"(anthropic/)?claude-3-7-sonnet": "2025-02-24",
+    r"(anthropic/)?claude-(?:opus|sonnet)-4": "2025-05-22",
+    r"(anthropic/)?claude-opus-4-1": "2025-08-05",
+    r"(anthropic/)?claude-sonnet-4-5": "2025-09-29",
     r"(anthropic/)?claude-haiku-4-5": "2025-10-15",
+    r"(anthropic/)?claude-opus-4-5": "2025-11-24",
+    r"(anthropic/)?claude-opus-4-6": "2026-02-05",
     r"(anthropic/)?claude-sonnet-4-6": "2026-02-17",
+    r"(anthropic/)?claude-opus-4-7": "2026-04-16",
+    r"(anthropic/)?claude-mythos-preview": "2026-04-07",
     r"(anthropic/)?claude-opus-4-8": "2026-05-28",
+    r"(anthropic/)?claude-(?:fable|mythos)-5": "2026-06-09",
+    r"(anthropic/)?claude-sonnet-5": "2026-06-30",
+    r"(anthropic/)?claude-opus-5": "2026-07-24",
     # Google
     r"(gemini/)?gemini-1\.5-pro.*": "2024-02-15",
     r"(gemini/)?gemini-1\.5-flash.*": "2024-05-14",
@@ -228,6 +241,11 @@ MODEL_RELEASE_DATE_MAPPING = {
     r"(gemini/)?gemini-3-pro.*": "2025-11-18",
     r"(gemini/)?gemini-3-flash.*": "2025-12-17",
     r"(gemini/)?gemini-3\.1-pro.*": "2026-02-19",
+    r"(gemini/)?gemini-3\.1-flash-lite.*": "2026-03-03",
+    r"(gemini/)?gemini-3\.5-flash$": "2026-05-19",
+    r"(gemini/)?gemini-3\.5-flash-lite$": "2026-07-21",
+    r"(gemini/)?gemini-3\.6-flash$": "2026-07-21",
+    r"(gemini/)?gemini-3\.7-flash$": "2026-08-13",
     # xAI
     r"(xai/)?grok-1": "2023-11-04",
     r"(xai/)?grok-1\.5": "2024-03-28",
@@ -237,33 +255,10 @@ MODEL_RELEASE_DATE_MAPPING = {
     r"(xai/)?grok-4": "2025-07-09",
     r"(xai/)?grok-4-fast.*": "2025-09-19",
     r"(xai/)?grok-4\.1.*": "2025-11-17",
+    r"(xai/)?grok-4\.20.*": "2026-03-10",
+    r"(xai/)?grok-4\.5.*": "2026-07-08",
+    r"(xai/)?grok-4\.6.*": "2026-08-12",
 }
-
-
-def _get_api_model_release_date(model_id: str) -> str | None:
-    """Get an API model release date from its version or manual metadata.
-
-    Args:
-        model_id:
-            The LiteLLM model identifier.
-
-    Returns:
-        The ISO-formatted release date, or None if no date is known.
-    """
-    # Explicit annotations are authoritative, including corrections to a date
-    # embedded in an upstream model identifier.
-    for pattern, release_date in MODEL_RELEASE_DATE_MAPPING.items():
-        if re.fullmatch(pattern=pattern, string=model_id) is not None:
-            return release_date
-
-    date_match = re.search(r"(?<!\d)(\d{4})-?(\d{2})-?(\d{2})(?!\d)", model_id)
-    if date_match is not None:
-        try:
-            return datetime.date(*map(int, date_match.groups())).isoformat()
-        except ValueError:
-            pass
-    return None
-
 
 REASONING_MODELS = [
     r"(openai/)?gpt-5.4-.*",
@@ -1633,7 +1628,7 @@ class LiteLLMModel(BenchmarkModule):
                 cache_dir=benchmark_config.cache_dir, model_id=model_id
             ),
             adapter_base_model_id=None,
-            release_date=_get_api_model_release_date(model_id_components.model_id),
+            release_date=get_api_model_release_date(model_id_components.model_id),
         )
 
     @cached_property
@@ -2072,6 +2067,31 @@ def clean_model_id(model_id: str, benchmark_config: BenchmarkConfig) -> str:
         new_model_id = "openai/openai/" + re.sub(r"(openai/)*", "", new_model_id)
 
     return new_model_id
+
+
+def get_api_model_release_date(model_id: str) -> str | None:
+    """Get an API model release date from its version or manual metadata.
+
+    Args:
+        model_id:
+            The LiteLLM model identifier.
+
+    Returns:
+        The ISO-formatted release date, or None if no date is known.
+    """
+    # Explicit annotations are authoritative, including corrections to a date
+    # embedded in an upstream model identifier.
+    for pattern, release_date in MODEL_RELEASE_DATE_MAPPING.items():
+        if re.fullmatch(pattern=pattern, string=model_id) is not None:
+            return release_date
+
+    date_match = re.search(r"(?<!\d)(\d{4})-?(\d{2})-?(\d{2})(?!\d)", model_id)
+    if date_match is not None:
+        try:
+            return datetime.date(*map(int, date_match.groups())).isoformat()
+        except ValueError:
+            pass
+    return None
 
 
 def set_up_benchmark_config_for_model(

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import collections.abc as c
+import datetime
 import json
 import logging
 import os
@@ -164,6 +165,104 @@ NUM_PARAMS_MAPPING = {
     # ALX models
     r"(alx/)?qwen3\.5-397b.*": 403_000_000_000,
 }
+
+
+# Release dates for API aliases which do not carry a dated version in their ID.
+# Dated model IDs are handled generically by `_get_api_model_release_date` below.
+# Sources are the providers' model launch posts and model changelogs:
+# https://platform.openai.com/docs/models, https://docs.anthropic.com/en/docs/about-claude/models,
+# https://ai.google.dev/gemini-api/docs/models, and https://docs.x.ai/docs/models.
+MODEL_RELEASE_DATE_MAPPING = {
+    # OpenAI
+    r"(openai/)?gpt-3\.5-turbo": "2023-03-01",
+    r"(openai/)?gpt-3\.5-turbo-instruct": "2023-09-18",
+    r"(openai/)?gpt-3\.5-turbo-0301": "2023-03-01",
+    r"(openai/)?gpt-3\.5-turbo-0613": "2023-06-13",
+    r"(openai/)?gpt-3\.5-turbo-1106": "2023-11-06",
+    r"(openai/)?gpt-3\.5-turbo-0125": "2024-01-25",
+    r"(openai/)?gpt-3\.5-turbo-instruct-0914": "2023-09-14",
+    r"(openai/)?gpt-4": "2023-03-14",
+    r"(openai/)?gpt-4(?:-32k)?-0314": "2023-03-14",
+    r"(openai/)?gpt-4(?:-32k)?-0613": "2023-06-13",
+    r"(openai/)?gpt-4-turbo": "2024-04-09",
+    r"(openai/)?gpt-4o": "2024-05-13",
+    r"(openai/)?gpt-4o-mini": "2024-07-18",
+    r"(openai/)?o1-(?:mini|preview)": "2024-09-12",
+    r"(openai/)?o1": "2024-12-17",
+    r"(openai/)?o1-pro": "2025-04-14",
+    r"(openai/)?o3-mini": "2025-01-31",
+    r"(openai/)?gpt-4\.1": "2025-04-14",
+    r"(openai/)?gpt-4\.1-mini": "2025-04-14",
+    r"(openai/)?gpt-4\.1-nano": "2025-04-14",
+    r"(openai/)?o3": "2025-04-16",
+    r"(openai/)?o4-mini": "2025-04-16",
+    r"(openai/)?gpt-5": "2025-08-07",
+    r"(openai/)?gpt-5-(?:chat-latest|pro)": "2025-08-07",
+    r"(openai/)?gpt-5-mini": "2025-08-07",
+    r"(openai/)?gpt-5-nano": "2025-08-07",
+    r"(openai/)?gpt-5\.1": "2025-11-13",
+    r"(openai/)?gpt-5\.1-chat-latest": "2025-11-13",
+    r"(openai/)?gpt-5\.2": "2025-12-11",
+    r"(openai/)?gpt-5\.2-(?:chat-latest|pro)": "2025-12-11",
+    r"(openai/)?gpt-5\.3-codex": "2026-02-05",
+    r"(openai/)?gpt-5\.3-chat-latest": "2026-03-03",
+    r"(openai/)?gpt-5\.4": "2026-03-05",
+    r"(openai/)?gpt-5\.4-(?:mini|nano)": "2026-03-17",
+    r"(openai/)?gpt-5\.5": "2026-04-23",
+    r"(openai/)?gpt-5\.6-(?:sol|terra|luna)": "2026-07-09",
+    # Anthropic
+    r"(anthropic/)?claude-3-opus": "2024-03-04",
+    r"(anthropic/)?claude-3-sonnet": "2024-03-04",
+    r"(anthropic/)?claude-3-haiku": "2024-03-13",
+    r"(anthropic/)?claude-3-5-sonnet": "2024-06-20",
+    r"(anthropic/)?claude-3-5-haiku": "2024-11-04",
+    r"(anthropic/)?claude-haiku-4-5": "2025-10-15",
+    r"(anthropic/)?claude-sonnet-4-6": "2026-02-17",
+    r"(anthropic/)?claude-opus-4-8": "2026-05-28",
+    # Google
+    r"(gemini/)?gemini-1\.5-pro.*": "2024-02-15",
+    r"(gemini/)?gemini-1\.5-flash.*": "2024-05-14",
+    r"(gemini/)?gemini-2\.0-flash.*": "2024-12-11",
+    r"(gemini/)?gemini-2\.5-pro.*": "2025-03-25",
+    r"(gemini/)?gemini-2\.5-flash.*": "2025-04-17",
+    r"(gemini/)?gemini-3-pro.*": "2025-11-18",
+    r"(gemini/)?gemini-3-flash.*": "2025-12-17",
+    r"(gemini/)?gemini-3\.1-pro.*": "2026-02-19",
+    # xAI
+    r"(xai/)?grok-1": "2023-11-04",
+    r"(xai/)?grok-1\.5": "2024-03-28",
+    r"(xai/)?grok-2": "2024-08-13",
+    r"(xai/)?grok-3(?:-beta)?": "2025-02-19",
+    r"(xai/)?grok-3-mini.*": "2025-04-09",
+    r"(xai/)?grok-4": "2025-07-09",
+    r"(xai/)?grok-4-fast.*": "2025-09-19",
+    r"(xai/)?grok-4\.1.*": "2025-11-17",
+}
+
+
+def _get_api_model_release_date(model_id: str) -> str | None:
+    """Get an API model release date from its version or manual metadata.
+
+    Args:
+        model_id:
+            The LiteLLM model identifier.
+
+    Returns:
+        The ISO-formatted release date, or None if no date is known.
+    """
+    # Explicit annotations are authoritative, including corrections to a date
+    # embedded in an upstream model identifier.
+    for pattern, release_date in MODEL_RELEASE_DATE_MAPPING.items():
+        if re.fullmatch(pattern=pattern, string=model_id) is not None:
+            return release_date
+
+    date_match = re.search(r"(?<!\d)(\d{4})-?(\d{2})-?(\d{2})(?!\d)", model_id)
+    if date_match is not None:
+        try:
+            return datetime.date(*map(int, date_match.groups())).isoformat()
+        except ValueError:
+            pass
+    return None
 
 
 REASONING_MODELS = [
@@ -1534,6 +1633,7 @@ class LiteLLMModel(BenchmarkModule):
                 cache_dir=benchmark_config.cache_dir, model_id=model_id
             ),
             adapter_base_model_id=None,
+            release_date=_get_api_model_release_date(model_id_components.model_id),
         )
 
     @cached_property

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -754,6 +754,7 @@ class Benchmarker:
                         else not benchmark_config.evaluate_test_split
                     ),
                     use_bits_per_character=benchmark_config.use_bits_per_character,
+                    release_date=model_config.release_date,
                     vllm_version=(
                         get_package_version("vllm")
                         if model_config.inference_backend == InferenceBackend.VLLM

--- a/src/euroeval/data_models.py
+++ b/src/euroeval/data_models.py
@@ -1,6 +1,7 @@
 """Data models used in EuroEval."""
 
 import collections.abc as c
+import datetime
 import importlib.metadata
 import json
 import logging
@@ -125,6 +126,7 @@ class BenchmarkResult(pydantic.BaseModel):
     commercially_licensed: bool | None = None
     open: bool | None = None
     trained_from_scratch: bool | None = None
+    release_date: str | None = None
 
     def append_to_results(self, results_path: Path) -> None:
         """Append the benchmark result to the results file.
@@ -273,6 +275,29 @@ class BenchmarkResult(pydantic.BaseModel):
         """
         return benchmark_result_from_eee_dict(config=config)
 
+    @pydantic.field_validator("release_date", mode="before")
+    @classmethod
+    def normalise_release_date(cls, value: object) -> str | None:
+        """Normalise release dates and discard malformed historical metadata.
+
+        Args:
+            value:
+                The release date value being validated.
+
+        Returns:
+            An ISO-formatted date, or None when the value is absent or malformed.
+        """
+        if isinstance(value, datetime.datetime):
+            return value.date().isoformat()
+        if isinstance(value, datetime.date):
+            return value.isoformat()
+        if not isinstance(value, str):
+            return None
+        try:
+            return datetime.date.fromisoformat(value).isoformat()
+        except ValueError:
+            return None
+
 
 class HashableDict(dict[t.Any, t.Any]):
     """A hashable dictionary."""
@@ -335,11 +360,15 @@ class HFModelInfo:
         adapter_base_model_id:
             The model ID of the base model if the model is an adapter model. Can be None
             if the model is not an adapter model.
+        release_date (optional):
+            The date when model weights were first publicly available, formatted as
+            ISO 8601. Defaults to None when it cannot be determined.
     """
 
     pipeline_tag: str
     tags: c.Sequence[str]
     adapter_base_model_id: str | None
+    release_date: str | None = None
 
 
 @dataclass
@@ -370,6 +399,8 @@ class ModelConfig:
         adapter_base_model_id:
             The model ID of the base model if the model is an adapter model. Can be None
             if the model is not an adapter model.
+        release_date (optional):
+            The model's public release date, formatted as ISO 8601. Defaults to None.
         generation_config (optional):
             The generation configuration for generative models, if specified in the
             model repository. Defaults to no generation configuration.
@@ -386,6 +417,7 @@ class ModelConfig:
     fresh: bool
     model_cache_dir: str
     adapter_base_model_id: str | None
+    release_date: str | None = None
     generation_config: GenerationConfig | None = None
 
     def __hash__(self) -> int:

--- a/src/euroeval/eee_utils.py
+++ b/src/euroeval/eee_utils.py
@@ -87,6 +87,9 @@ def benchmark_result_from_eee_dict(config: dict) -> "BenchmarkResult":
     trained_from_scratch = parse_optional_bool(
         model_additional.get("trained_from_scratch", config.get("trained_from_scratch"))
     )
+    release_date = parse_optional_str(
+        model_additional.get("release_date", config.get("release_date"))
+    )
 
     return BenchmarkResult(
         dataset=dataset,
@@ -128,6 +131,7 @@ def benchmark_result_from_eee_dict(config: dict) -> "BenchmarkResult":
         commercially_licensed=commercially_licensed,
         open=open,
         trained_from_scratch=trained_from_scratch,
+        release_date=release_date,
     )
 
 
@@ -290,6 +294,8 @@ def benchmark_result_to_eee_dict(result: "BenchmarkResult") -> dict:
         model_additional_details["open"] = result.open
     if result.trained_from_scratch is not None:
         model_additional_details["trained_from_scratch"] = result.trained_from_scratch
+    if result.release_date is not None:
+        model_additional_details["release_date"] = result.release_date
 
     model_info: dict = {
         "name": result.model,

--- a/src/leaderboards/cache.py
+++ b/src/leaderboards/cache.py
@@ -36,6 +36,8 @@ class Cache:
             A mapping from model IDs to whether they were trained from scratch.
         model_url:
             A mapping from model IDs to their model URL.
+        release_date:
+            A mapping from model IDs to their ISO-formatted release date.
     """
 
     generative_type: dict[str, str | None] = field(default_factory=dict)
@@ -44,6 +46,7 @@ class Cache:
     open: dict[str, bool] = field(default_factory=dict)
     trained_from_scratch: dict[str, bool] = field(default_factory=dict)
     model_url: dict[str, str | None] = field(default_factory=dict)
+    release_date: dict[str, str | None] = field(default_factory=dict)
 
     @classmethod
     def from_results_dir(cls, results_dir: Path) -> "Cache":
@@ -116,6 +119,8 @@ class Cache:
                 ]
             if "model_url" in additional and additional["model_url"] is not None:
                 cache.model_url[model_id] = additional["model_url"]
+            if "release_date" in additional:
+                cache.release_date[model_id] = additional["release_date"]
 
         return cache
 

--- a/src/leaderboards/model_metadata.py
+++ b/src/leaderboards/model_metadata.py
@@ -13,6 +13,7 @@ import shutil
 import typing as t
 import warnings
 from copy import deepcopy
+from datetime import date
 
 import httpx
 from huggingface_hub import HfApi
@@ -24,6 +25,8 @@ from huggingface_hub.errors import (
 from huggingface_hub.hf_api import RepositoryNotFoundError
 from requests.exceptions import RequestException
 
+from euroeval.benchmark_modules.hf import _get_model_release_date
+from euroeval.benchmark_modules.litellm import _get_api_model_release_date
 from euroeval.string_utils import split_model_id
 
 from .cache import Cache
@@ -491,6 +494,50 @@ def is_trained_from_scratch(
             cache.trained_from_scratch[model_id] = False
             return False
         logger.error("Invalid input. Please try again.")
+
+
+def backfill_release_dates(records: list[dict], cache: Cache) -> list[dict]:
+    """Add release dates to historical records, looking up each model once.
+
+    Existing valid dates are authoritative. API dates use the curated provider
+    metadata, while Hugging Face dates are the first commit containing model
+    weights. Lookup failures remain ``None`` and are cached for the whole run.
+
+    Returns:
+        The records with normalised or inferred release dates.
+    """
+    hf_api: HfApi | None = None
+    for record in records:
+        additional = record.setdefault("model_info", {}).setdefault(
+            "additional_details", {}
+        )
+        existing = additional.get("release_date")
+        if isinstance(existing, str):
+            try:
+                normalised = date.fromisoformat(existing).isoformat()
+            except ValueError:
+                pass
+            else:
+                additional["release_date"] = normalised
+                continue
+
+        model_id = split_model_id(
+            model_id=plain_model_id(get_model_name(record=record))
+        ).model_id
+        if model_id not in cache.release_date:
+            model_url = additional.get("model_url") or cache.model_url.get(model_id)
+            if isinstance(model_url, str) and (
+                "huggingface.co/" in model_url or "hf.co/" in model_url
+            ):
+                if hf_api is None:
+                    hf_api = HfApi()
+                cache.release_date[model_id] = _get_model_release_date(
+                    hf_api=hf_api, model_id=model_id, revision="main", token=None
+                )
+            else:
+                cache.release_date[model_id] = _get_api_model_release_date(model_id)
+        additional["release_date"] = cache.release_date[model_id]
+    return records
 
 
 def fix_metadata(record: dict[str, t.Any]) -> dict[str, t.Any]:

--- a/src/leaderboards/model_metadata.py
+++ b/src/leaderboards/model_metadata.py
@@ -11,6 +11,7 @@ import logging
 import re
 import shutil
 import typing as t
+import urllib.parse
 import warnings
 from copy import deepcopy
 from datetime import date
@@ -25,8 +26,8 @@ from huggingface_hub.errors import (
 from huggingface_hub.hf_api import RepositoryNotFoundError
 from requests.exceptions import RequestException
 
-from euroeval.benchmark_modules.hf import _get_model_release_date
-from euroeval.benchmark_modules.litellm import _get_api_model_release_date
+from euroeval.benchmark_modules.hf import get_model_release_date
+from euroeval.benchmark_modules.litellm import get_api_model_release_date
 from euroeval.string_utils import split_model_id
 
 from .cache import Cache
@@ -92,6 +93,7 @@ def add_missing_entries(
         model_additional["model_url"] = _generate_model_url_with_cache(
             model_id=plain_model_id(get_model_name(record=record)), cache=cache
         )
+    model_additional["release_date"] = _get_release_date(record=record, cache=cache)
 
     return record
 
@@ -251,6 +253,53 @@ def _parse_generative_type_input(
     if input_lower in {"3", "reasoning"}:
         return "reasoning"
     return None
+
+
+def _get_release_date(record: dict, cache: Cache) -> str | None:
+    """Get a model release date, using cached metadata when available.
+
+    Args:
+        record:
+            An EEE result record.
+        cache:
+            The model metadata cache.
+
+    Returns:
+        The ISO-formatted release date, or None if no date can be determined.
+    """
+    additional = record["model_info"]["additional_details"]
+    existing = additional.get("release_date")
+    if isinstance(existing, str):
+        try:
+            return date.fromisoformat(existing).isoformat()
+        except ValueError:
+            pass
+
+    model_id = split_model_id(
+        model_id=plain_model_id(get_model_name(record=record))
+    ).model_id
+    if model_id in cache.release_date:
+        cached = cache.release_date[model_id]
+        if cached is None:
+            return None
+        try:
+            return date.fromisoformat(cached).isoformat()
+        except ValueError:
+            del cache.release_date[model_id]
+
+    model_url = additional.get("model_url") or cache.model_url.get(model_id)
+    hf_hosts = {"hf.co", "huggingface.co", "www.hf.co", "www.huggingface.co"}
+    if (
+        isinstance(model_url, str)
+        and urllib.parse.urlparse(model_url).netloc in hf_hosts
+    ):
+        release_date = get_model_release_date(
+            hf_api=HfApi(), model_id=model_id, revision="main", token=None
+        )
+    else:
+        release_date = get_api_model_release_date(model_id)
+    cache.release_date[model_id] = release_date
+    return release_date
 
 
 def is_commercially_licensed(record: dict, cache: Cache) -> bool:
@@ -494,50 +543,6 @@ def is_trained_from_scratch(
             cache.trained_from_scratch[model_id] = False
             return False
         logger.error("Invalid input. Please try again.")
-
-
-def backfill_release_dates(records: list[dict], cache: Cache) -> list[dict]:
-    """Add release dates to historical records, looking up each model once.
-
-    Existing valid dates are authoritative. API dates use the curated provider
-    metadata, while Hugging Face dates are the first commit containing model
-    weights. Lookup failures remain ``None`` and are cached for the whole run.
-
-    Returns:
-        The records with normalised or inferred release dates.
-    """
-    hf_api: HfApi | None = None
-    for record in records:
-        additional = record.setdefault("model_info", {}).setdefault(
-            "additional_details", {}
-        )
-        existing = additional.get("release_date")
-        if isinstance(existing, str):
-            try:
-                normalised = date.fromisoformat(existing).isoformat()
-            except ValueError:
-                pass
-            else:
-                additional["release_date"] = normalised
-                continue
-
-        model_id = split_model_id(
-            model_id=plain_model_id(get_model_name(record=record))
-        ).model_id
-        if model_id not in cache.release_date:
-            model_url = additional.get("model_url") or cache.model_url.get(model_id)
-            if isinstance(model_url, str) and (
-                "huggingface.co/" in model_url or "hf.co/" in model_url
-            ):
-                if hf_api is None:
-                    hf_api = HfApi()
-                cache.release_date[model_id] = _get_model_release_date(
-                    hf_api=hf_api, model_id=model_id, revision="main", token=None
-                )
-            else:
-                cache.release_date[model_id] = _get_api_model_release_date(model_id)
-        additional["release_date"] = cache.release_date[model_id]
-    return records
 
 
 def fix_metadata(record: dict[str, t.Any]) -> dict[str, t.Any]:

--- a/src/leaderboards/record_fields.py
+++ b/src/leaderboards/record_fields.py
@@ -16,8 +16,9 @@ def deduplicate_records(records: list[dict[str, t.Any]]) -> list[dict[str, t.Any
     on the same leaderboard row, so only one should survive. Among records with
     an equal (newest) version, the one with richer metadata wins (more non-default
     fields for commercially_licensed, open, merge, trained_from_scratch,
-    generative_type, model_url). If still tied, the first one in input order is
-    kept to preserve explicit boolean values against conflicting later duplicates.
+    generative_type, model_url, and release_date). If still tied, the first one in
+    input order is kept to preserve explicit boolean values against conflicting later
+    duplicates.
     Output is ordered by hash for stable, diff-friendly downstream files.
 
     Args:
@@ -58,7 +59,7 @@ def _metadata_richness_score(record: dict) -> int:
     Returns:
         An integer score: +1 for each non-default metadata field found among
         ``commercially_licensed``, ``open``, ``merge``, ``trained_from_scratch``,
-        ``generative_type``, and ``model_url``.
+        ``generative_type``, ``model_url``, and ``release_date``.
     """
     additional = record.get("model_info", {}).get("additional_details", {})
     score = 0
@@ -85,6 +86,10 @@ def _metadata_richness_score(record: dict) -> int:
 
     # model_url: non-null
     if additional.get("model_url") is not None:
+        score += 1
+
+    # release_date: non-null
+    if additional.get("release_date") is not None:
         score += 1
 
     return score

--- a/src/leaderboards/result_processing.py
+++ b/src/leaderboards/result_processing.py
@@ -21,7 +21,12 @@ from tqdm.auto import tqdm
 from .cache import Cache
 from .constants import HF_RESULTS_BUCKET, RESULTS_DIR
 from .evaluation_common import resolve_hf_token
-from .model_metadata import add_missing_entries, fix_metadata, record_is_valid
+from .model_metadata import (
+    add_missing_entries,
+    backfill_release_dates,
+    fix_metadata,
+    record_is_valid,
+)
 from .record_fields import deduplicate_records
 from .records import get_model_name
 from .result_identity import (
@@ -114,6 +119,7 @@ def process_results(
         )
         for record in tqdm(processed_records, desc="Adding missing entries")
     ]
+    processed_records = backfill_release_dates(records=processed_records, cache=cache)
 
     _upload_per_model_files(
         processed_records=processed_records, upload_to_bucket=upload_to_bucket

--- a/src/leaderboards/result_processing.py
+++ b/src/leaderboards/result_processing.py
@@ -21,12 +21,7 @@ from tqdm.auto import tqdm
 from .cache import Cache
 from .constants import HF_RESULTS_BUCKET, RESULTS_DIR
 from .evaluation_common import resolve_hf_token
-from .model_metadata import (
-    add_missing_entries,
-    backfill_release_dates,
-    fix_metadata,
-    record_is_valid,
-)
+from .model_metadata import add_missing_entries, fix_metadata, record_is_valid
 from .record_fields import deduplicate_records
 from .records import get_model_name
 from .result_identity import (
@@ -119,8 +114,6 @@ def process_results(
         )
         for record in tqdm(processed_records, desc="Adding missing entries")
     ]
-    processed_records = backfill_release_dates(records=processed_records, cache=cache)
-
     _upload_per_model_files(
         processed_records=processed_records, upload_to_bucket=upload_to_bucket
     )

--- a/tests/leaderboards/test_cache.py
+++ b/tests/leaderboards/test_cache.py
@@ -89,6 +89,18 @@ class TestCacheFromResultsDir:
         assert cache.trained_from_scratch.get("test/model") is False
         assert cache.model_url.get("test/model") == "https://example.com/model"
 
+    def test_preserves_release_date(self, tmp_path: Path) -> None:
+        """Release dates are reused instead of repeatedly querying providers."""
+        model_dir = tmp_path / "test_model"
+        model_dir.mkdir()
+        record = _make_eee_record(model_id="test/model", model_name="test/model")
+        record["model_info"]["additional_details"]["release_date"] = "2024-02-03"
+        (model_dir / "ds__test__zeroshot.json").write_text(json.dumps(record))
+
+        cache = Cache.from_results_dir(results_dir=tmp_path)
+
+        assert cache.release_date["test/model"] == "2024-02-03"
+
     def test_raises_on_nonexistent_directory(self) -> None:
         """Should raise FileNotFoundError for nonexistent directory."""
         with pytest.raises(FileNotFoundError, match="Results directory"):

--- a/tests/leaderboards/test_model_metadata.py
+++ b/tests/leaderboards/test_model_metadata.py
@@ -23,7 +23,6 @@ from leaderboards.cache import Cache, _is_hf_url_for_model
 from leaderboards.constants import TRAINED_FROM_SCRATCH_PATTERNS
 from leaderboards.model_metadata import (
     add_missing_entries,
-    backfill_release_dates,
     is_commercially_licensed,
     is_merge,
     is_open,
@@ -55,6 +54,7 @@ class TestCachePriority:
                     "merge": False,
                     "commercially_licensed": False,
                     "trained_from_scratch": False,
+                    "release_date": "2025-04-29",
                 },
             },
             "generative": True,
@@ -91,6 +91,7 @@ class TestCachePriority:
                     "merge": False,
                     "commercially_licensed": False,
                     "trained_from_scratch": False,
+                    "release_date": "2025-04-29",
                 },
             },
             "generative": True,
@@ -919,8 +920,54 @@ class TestValSuffixMetadataLookup:
         )
 
 
-@patch("leaderboards.model_metadata._get_model_release_date")
-def test_backfill_release_dates_preserves_existing_date(
+@patch("leaderboards.model_metadata.get_model_release_date")
+def test_add_missing_entries_caches_missing_release_date(
+    mock_release_date: MagicMock,
+) -> None:
+    """A failed lookup is cached and not repeated for the same model."""
+    mock_release_date.return_value = None
+    records = [
+        {
+            "model_info": {
+                "name": "org/model",
+                "additional_details": {"model_url": "https://hf.co/org/model"},
+            }
+        }
+        for _ in range(2)
+    ]
+    cache = Cache()
+
+    for record in records:
+        _add_missing_entries_with_complete_metadata(record=record, cache=cache)
+
+    mock_release_date.assert_called_once()
+    assert "org/model" in cache.release_date
+    assert cache.release_date["org/model"] is None
+
+
+def _add_missing_entries_with_complete_metadata(record: dict, cache: Cache) -> dict:
+    """Populate unrelated metadata so release-date tests never prompt.
+
+    Returns:
+        The record after adding any missing metadata.
+    """
+    additional = record["model_info"]["additional_details"]
+    additional.update(
+        generative_type="base",
+        merge=False,
+        commercially_licensed=True,
+        open=True,
+        trained_from_scratch=False,
+    )
+    return add_missing_entries(
+        record=record,
+        trained_from_scratch_patterns=TRAINED_FROM_SCRATCH_PATTERNS,
+        cache=cache,
+    )
+
+
+@patch("leaderboards.model_metadata.get_model_release_date")
+def test_add_missing_entries_preserves_existing_release_date(
     mock_release_date: MagicMock,
 ) -> None:
     """A valid historical release date is never replaced by a lookup."""
@@ -934,13 +981,38 @@ def test_backfill_release_dates_preserves_existing_date(
         }
     }
 
-    backfill_release_dates(records=[record], cache=Cache())
+    _add_missing_entries_with_complete_metadata(record=record, cache=Cache())
 
     mock_release_date.assert_not_called()
 
 
-def test_backfill_release_dates_reuses_api_date_for_all_records() -> None:
+@patch("leaderboards.model_metadata.get_model_release_date")
+def test_add_missing_entries_repairs_malformed_release_date(
+    mock_release_date: MagicMock,
+) -> None:
+    """Malformed historical dates are replaced with provider metadata."""
+    mock_release_date.return_value = "2024-02-03"
+    record = {
+        "model_info": {
+            "name": "org/model",
+            "additional_details": {
+                "model_url": "https://hf.co/org/model",
+                "release_date": "not-a-date",
+            },
+        }
+    }
+
+    _add_missing_entries_with_complete_metadata(record=record, cache=Cache())
+
+    assert record["model_info"]["additional_details"]["release_date"] == "2024-02-03"
+
+
+@patch("leaderboards.model_metadata.get_api_model_release_date")
+def test_add_missing_entries_reuses_api_release_date_for_all_records(
+    mock_release_date: MagicMock,
+) -> None:
     """Historical API records are enriched without duplicate lookups."""
+    mock_release_date.return_value = "2023-06-13"
     records = [
         {
             "model_info": {
@@ -951,16 +1023,21 @@ def test_backfill_release_dates_reuses_api_date_for_all_records() -> None:
         for _ in range(2)
     ]
 
-    enriched = backfill_release_dates(records=records, cache=Cache())
+    cache = Cache()
+    enriched = [
+        _add_missing_entries_with_complete_metadata(record=record, cache=cache)
+        for record in records
+    ]
 
     assert all(
         record["model_info"]["additional_details"]["release_date"] == "2023-06-13"
         for record in enriched
     )
+    mock_release_date.assert_called_once_with("openai/gpt-4-0613")
 
 
-@patch("leaderboards.model_metadata._get_model_release_date")
-def test_backfill_release_dates_uses_first_hf_weights_commit(
+@patch("leaderboards.model_metadata.get_model_release_date")
+def test_add_missing_entries_uses_first_hf_weights_commit(
     mock_release_date: MagicMock,
 ) -> None:
     """Historical Hugging Face records use the shared weights-history lookup."""
@@ -972,7 +1049,10 @@ def test_backfill_release_dates_uses_first_hf_weights_commit(
         }
     }
 
-    backfill_release_dates(records=[record], cache=Cache())
+    cache = Cache()
+    cache.release_date["org/model"] = "also-not-a-date"
+
+    _add_missing_entries_with_complete_metadata(record=record, cache=cache)
 
     assert record["model_info"]["additional_details"]["release_date"] == "2024-02-03"
     mock_release_date.assert_called_once()

--- a/tests/leaderboards/test_model_metadata.py
+++ b/tests/leaderboards/test_model_metadata.py
@@ -23,6 +23,7 @@ from leaderboards.cache import Cache, _is_hf_url_for_model
 from leaderboards.constants import TRAINED_FROM_SCRATCH_PATTERNS
 from leaderboards.model_metadata import (
     add_missing_entries,
+    backfill_release_dates,
     is_commercially_licensed,
     is_merge,
     is_open,
@@ -916,3 +917,62 @@ class TestValSuffixMetadataLookup:
         mock_api.model_info.assert_called_once_with(
             repo_id="microsoft/Phi-3-mini-4k-instruct"
         )
+
+
+@patch("leaderboards.model_metadata._get_model_release_date")
+def test_backfill_release_dates_preserves_existing_date(
+    mock_release_date: MagicMock,
+) -> None:
+    """A valid historical release date is never replaced by a lookup."""
+    record = {
+        "model_info": {
+            "name": "org/model",
+            "additional_details": {
+                "model_url": "https://hf.co/org/model",
+                "release_date": "2024-02-03",
+            },
+        }
+    }
+
+    backfill_release_dates(records=[record], cache=Cache())
+
+    mock_release_date.assert_not_called()
+
+
+def test_backfill_release_dates_reuses_api_date_for_all_records() -> None:
+    """Historical API records are enriched without duplicate lookups."""
+    records = [
+        {
+            "model_info": {
+                "name": "openai/gpt-4-0613",
+                "additional_details": {"model_url": "https://openai.com/gpt-4"},
+            }
+        }
+        for _ in range(2)
+    ]
+
+    enriched = backfill_release_dates(records=records, cache=Cache())
+
+    assert all(
+        record["model_info"]["additional_details"]["release_date"] == "2023-06-13"
+        for record in enriched
+    )
+
+
+@patch("leaderboards.model_metadata._get_model_release_date")
+def test_backfill_release_dates_uses_first_hf_weights_commit(
+    mock_release_date: MagicMock,
+) -> None:
+    """Historical Hugging Face records use the shared weights-history lookup."""
+    mock_release_date.return_value = "2024-02-03"
+    record = {
+        "model_info": {
+            "name": "org/model",
+            "additional_details": {"model_url": "https://hf.co/org/model"},
+        }
+    }
+
+    backfill_release_dates(records=[record], cache=Cache())
+
+    assert record["model_info"]["additional_details"]["release_date"] == "2024-02-03"
+    mock_release_date.assert_called_once()

--- a/tests/leaderboards/test_record_fields.py
+++ b/tests/leaderboards/test_record_fields.py
@@ -131,6 +131,20 @@ def test_deduplicate_keeps_newest_version() -> None:
     assert deduped[0]["eval_library"]["version"] == "17.6.0"
 
 
+def test_deduplicate_prefers_record_with_release_date() -> None:
+    """Release metadata survives deduplication against an otherwise equal record."""
+    without_date = _record(version="18.0.0")
+    with_date = _record(version="18.0.0")
+    with_date["model_info"]["additional_details"]["release_date"] = "2024-02-03"
+
+    deduped = deduplicate_records(records=[without_date, with_date])
+
+    assert len(deduped) == 1
+    assert (
+        deduped[0]["model_info"]["additional_details"]["release_date"] == "2024-02-03"
+    )
+
+
 def test_deduplicate_prefers_richer_metadata_same_version() -> None:
     """Among same-version duplicates, the one with richer metadata wins.
 
@@ -198,6 +212,14 @@ def test_metadata_richness_score_commercial() -> None:
     record_false = _record()
     record_false["model_info"]["additional_details"]["commercially_licensed"] = False
     assert _metadata_richness_score(record=record_false) == 1
+
+
+def test_metadata_richness_score_counts_release_date() -> None:
+    """A known release date contributes to metadata richness."""
+    record = _record()
+    initial_score = _metadata_richness_score(record)
+    record["model_info"]["additional_details"]["release_date"] = "2024-02-03"
+    assert _metadata_richness_score(record) == initial_score + 1
 
 
 def test_metadata_richness_score_empty() -> None:

--- a/tests/test_benchmark_modules/test_hf.py
+++ b/tests/test_benchmark_modules/test_hf.py
@@ -1,6 +1,7 @@
 """Unit tests for the `hf` module."""
 
 import dataclasses
+import datetime
 import hashlib
 from unittest.mock import MagicMock, patch
 
@@ -13,6 +14,7 @@ from transformers.models.xlm_roberta import (
 )
 
 from euroeval.benchmark_modules.hf import (
+    _get_model_release_date,
     _load_model_from_pretrained,
     get_dtype,
     get_model_repo_info,
@@ -77,6 +79,73 @@ def test_get_dtype(
     )
 
 
+def test_get_model_release_date_handles_hub_errors() -> None:
+    """Release-date lookup remains optional when Hub history is unavailable."""
+    api = MagicMock()
+    api.list_repo_commits.side_effect = OSError("offline")
+
+    assert _get_model_release_date(api, "org/model", "main", None) is None
+
+
+def test_get_model_release_date_returns_none_without_weights() -> None:
+    """A repository without recognized model weights has no inferred release date."""
+    api = MagicMock()
+    commit = MagicMock(
+        commit_id="readme",
+        created_at=datetime.datetime(2024, 2, 3, tzinfo=datetime.timezone.utc),
+    )
+    api.list_repo_commits.return_value = [commit]
+    api.list_repo_files.return_value = ["README.md", "optimizer.bin"]
+
+    assert _get_model_release_date(api, "org/model", "main", None) is None
+
+
+@pytest.mark.parametrize(
+    "weight_file",
+    [
+        "pytorch_model.bin",
+        "nested/pytorch_model-00001-of-00002.bin",
+        "adapter_model.bin",
+    ],
+)
+def test_get_model_release_date_supports_pytorch_weights(weight_file: str) -> None:
+    """PyTorch and adapter weight naming conventions count as model weights."""
+    api = MagicMock()
+    commit = MagicMock(
+        commit_id="weights",
+        created_at=datetime.datetime(2024, 2, 3, tzinfo=datetime.timezone.utc),
+    )
+    api.list_repo_commits.return_value = [commit]
+    api.list_repo_files.return_value = [weight_file]
+
+    assert _get_model_release_date(api, "org/model", "main", None) == "2024-02-03"
+
+
+def test_get_model_release_date_uses_first_weights_commit() -> None:
+    """Repository scaffolding before the weights upload is not a release."""
+    api = MagicMock()
+    old = MagicMock(
+        commit_id="scaffold",
+        created_at=datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc),
+    )
+    released = MagicMock(
+        commit_id="weights",
+        created_at=datetime.datetime(2024, 2, 3, tzinfo=datetime.timezone.utc),
+    )
+    newer = MagicMock(
+        commit_id="readme",
+        created_at=datetime.datetime(2024, 3, 1, tzinfo=datetime.timezone.utc),
+    )
+    api.list_repo_commits.return_value = [newer, released, old]
+    api.list_repo_files.side_effect = [
+        ["README.md"],
+        ["model-00001-of-00002.safetensors"],
+    ]
+
+    assert _get_model_release_date(api, "org/model", "main", None) == "2024-02-03"
+    assert api.list_repo_files.call_count == 2
+
+
 def test_load_model_from_pretrained_keyerror_retry_and_message() -> None:
     """Test KeyError retry and final message for _load_model_from_pretrained.
 
@@ -135,11 +204,18 @@ def test_safetensors_check(
     """Test the safetensors availability check functionality."""
     with (
         patch.object(HfApi, "list_repo_files") as mock_list_files,
+        patch.object(HfApi, "list_repo_commits") as mock_list_commits,
         patch.object(HfApi, "model_info") as mock_model_info,
     ):
         mock_list_files.return_value = repo_files
+        mock_list_commits.return_value = [
+            MagicMock(
+                commit_id="weights",
+                created_at=datetime.datetime(2024, 2, 3, tzinfo=datetime.timezone.utc),
+            )
+        ]
         mock_model_info.return_value = MagicMock(
-            id="test-model", tags=["test"], pipeline_tag="fill-mask"
+            id="test-model", tags=["test"], pipeline_tag="fill-mask", siblings=[]
         )
         hash_model_id = hashlib.md5(
             ",".join(repo_files).encode("utf-8")
@@ -155,6 +231,8 @@ def test_safetensors_check(
             run_with_cli=benchmark_config.run_with_cli,
         )
         assert (result is not None) == model_exists
+        if result is not None and repo_files:
+            assert result.release_date == "2024-02-03"
 
 
 def test_setup_model_for_qa_expands_single_row_token_type_embeddings() -> None:

--- a/tests/test_benchmark_modules/test_hf.py
+++ b/tests/test_benchmark_modules/test_hf.py
@@ -14,9 +14,9 @@ from transformers.models.xlm_roberta import (
 )
 
 from euroeval.benchmark_modules.hf import (
-    _get_model_release_date,
     _load_model_from_pretrained,
     get_dtype,
+    get_model_release_date,
     get_model_repo_info,
     setup_model_for_question_answering,
 )
@@ -84,7 +84,7 @@ def test_get_model_release_date_handles_hub_errors() -> None:
     api = MagicMock()
     api.list_repo_commits.side_effect = OSError("offline")
 
-    assert _get_model_release_date(api, "org/model", "main", None) is None
+    assert get_model_release_date(api, "org/model", "main", None) is None
 
 
 def test_get_model_release_date_returns_none_without_weights() -> None:
@@ -97,7 +97,7 @@ def test_get_model_release_date_returns_none_without_weights() -> None:
     api.list_repo_commits.return_value = [commit]
     api.list_repo_files.return_value = ["README.md", "optimizer.bin"]
 
-    assert _get_model_release_date(api, "org/model", "main", None) is None
+    assert get_model_release_date(api, "org/model", "main", None) is None
 
 
 @pytest.mark.parametrize(
@@ -118,7 +118,7 @@ def test_get_model_release_date_supports_pytorch_weights(weight_file: str) -> No
     api.list_repo_commits.return_value = [commit]
     api.list_repo_files.return_value = [weight_file]
 
-    assert _get_model_release_date(api, "org/model", "main", None) == "2024-02-03"
+    assert get_model_release_date(api, "org/model", "main", None) == "2024-02-03"
 
 
 def test_get_model_release_date_uses_first_weights_commit() -> None:
@@ -142,7 +142,7 @@ def test_get_model_release_date_uses_first_weights_commit() -> None:
         ["model-00001-of-00002.safetensors"],
     ]
 
-    assert _get_model_release_date(api, "org/model", "main", None) == "2024-02-03"
+    assert get_model_release_date(api, "org/model", "main", None) == "2024-02-03"
     assert api.list_repo_files.call_count == 2
 
 

--- a/tests/test_benchmark_modules/test_litellm.py
+++ b/tests/test_benchmark_modules/test_litellm.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from litellm.types.utils import Choices
 
-from euroeval.benchmark_modules.litellm import LiteLLMModel, _get_api_model_release_date
+from euroeval.benchmark_modules.litellm import LiteLLMModel, get_api_model_release_date
 from euroeval.data_models import BenchmarkConfig, DatasetConfig, ModelConfig
 from euroeval.exceptions import InvalidModel
 from euroeval.model_loading import load_model
@@ -120,18 +120,33 @@ class TestCreateModelOutput:
         ("openai/o1-pro", "2025-04-14"),
         ("openai/gpt-5-chat-latest", "2025-08-07"),
         ("openai/gpt-5.2-pro", "2025-12-11"),
+        ("openai/gpt-5.4-pro", "2026-03-05"),
+        ("openai/gpt-5.5-pro", "2026-04-23"),
         ("anthropic/claude-3-5-sonnet-20241022", "2024-10-22"),
         ("anthropic/claude-sonnet-4-6", "2026-02-17"),
+        ("anthropic/claude-opus-4-7", "2026-04-16"),
+        ("anthropic/claude-mythos-preview", "2026-04-07"),
+        ("anthropic/claude-fable-5", "2026-06-09"),
+        ("anthropic/claude-sonnet-5", "2026-06-30"),
+        ("anthropic/claude-opus-5", "2026-07-24"),
         ("gemini/gemini-3.1-pro-preview", "2026-02-19"),
+        ("gemini/gemini-3.1-flash-lite", "2026-03-03"),
+        ("gemini/gemini-3.5-flash", "2026-05-19"),
+        ("gemini/gemini-3.6-flash", "2026-07-21"),
+        ("gemini/gemini-3.7-flash", "2026-08-13"),
         ("xai/grok-4-fast-reasoning", "2025-09-19"),
+        ("xai/grok-4.20", "2026-03-10"),
+        ("xai/grok-4.5", "2026-07-08"),
+        ("xai/grok-4.6", "2026-08-12"),
         ("openai/gpt-5.6-luna", "2026-07-09"),
+        ("openai/gpt-5.6", "2026-07-09"),
         ("provider/undated-model", None),
         ("provider/model-2024-99-99", None),
     ],
 )
 def test_get_api_model_release_date(model_id: str, expected: str | None) -> None:
     """API aliases and dated model IDs resolve to their release dates."""
-    assert _get_api_model_release_date(model_id) == expected
+    assert get_api_model_release_date(model_id) == expected
 
 
 def test_litellm_model_config_includes_release_date(
@@ -151,4 +166,4 @@ def test_manual_api_release_date_overrides_embedded_date() -> None:
         {r"provider/model-2024-01-01": "2024-02-03"},
         clear=True,
     ):
-        assert _get_api_model_release_date("provider/model-2024-01-01") == "2024-02-03"
+        assert get_api_model_release_date("provider/model-2024-01-01") == "2024-02-03"

--- a/tests/test_benchmark_modules/test_litellm.py
+++ b/tests/test_benchmark_modules/test_litellm.py
@@ -1,12 +1,12 @@
 """Unit tests for the `litellm` module."""
 
 import dataclasses
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from litellm.types.utils import Choices
 
-from euroeval.benchmark_modules.litellm import LiteLLMModel
+from euroeval.benchmark_modules.litellm import LiteLLMModel, _get_api_model_release_date
 from euroeval.data_models import BenchmarkConfig, DatasetConfig, ModelConfig
 from euroeval.exceptions import InvalidModel
 from euroeval.model_loading import load_model
@@ -108,3 +108,47 @@ class TestCreateModelOutput:
         assert output.scores[0] is not None
         assert len(output.scores[0]) == 1
         assert output.scores[1] == []
+
+
+@pytest.mark.parametrize(
+    ("model_id", "expected"),
+    [
+        ("openai/gpt-4o", "2024-05-13"),
+        ("openai/gpt-4o-2024-08-06", "2024-08-06"),
+        ("openai/gpt-4-0613", "2023-06-13"),
+        ("openai/gpt-3.5-turbo-0125", "2024-01-25"),
+        ("openai/o1-pro", "2025-04-14"),
+        ("openai/gpt-5-chat-latest", "2025-08-07"),
+        ("openai/gpt-5.2-pro", "2025-12-11"),
+        ("anthropic/claude-3-5-sonnet-20241022", "2024-10-22"),
+        ("anthropic/claude-sonnet-4-6", "2026-02-17"),
+        ("gemini/gemini-3.1-pro-preview", "2026-02-19"),
+        ("xai/grok-4-fast-reasoning", "2025-09-19"),
+        ("openai/gpt-5.6-luna", "2026-07-09"),
+        ("provider/undated-model", None),
+        ("provider/model-2024-99-99", None),
+    ],
+)
+def test_get_api_model_release_date(model_id: str, expected: str | None) -> None:
+    """API aliases and dated model IDs resolve to their release dates."""
+    assert _get_api_model_release_date(model_id) == expected
+
+
+def test_litellm_model_config_includes_release_date(
+    benchmark_config: BenchmarkConfig,
+) -> None:
+    """API release metadata is propagated into the model configuration."""
+    config = LiteLLMModel.get_model_config(
+        model_id="openai/gpt-4o-2024-08-06", benchmark_config=benchmark_config
+    )
+    assert config.release_date == "2024-08-06"
+
+
+def test_manual_api_release_date_overrides_embedded_date() -> None:
+    """Curated annotations take precedence over dates parsed from model IDs."""
+    with patch.dict(
+        "euroeval.benchmark_modules.litellm.MODEL_RELEASE_DATE_MAPPING",
+        {r"provider/model-2024-01-01": "2024-02-03"},
+        clear=True,
+    ):
+        assert _get_api_model_release_date("provider/model-2024-01-01") == "2024-02-03"

--- a/tests/test_benchmarker.py
+++ b/tests/test_benchmarker.py
@@ -10,6 +10,7 @@ from dataclasses import replace
 from pathlib import Path
 from shutil import rmtree
 from typing import Never
+from unittest.mock import MagicMock
 
 import pytest
 import torch
@@ -352,6 +353,43 @@ def test_benchmark_openai(
     )
     assert isinstance(benchmark_result, list)
     assert all(isinstance(result, BenchmarkResult) for result in benchmark_result)
+
+
+def test_benchmark_result_includes_model_release_date(
+    monkeypatch: pytest.MonkeyPatch,
+    model_config: ModelConfig,
+    dataset_config: DatasetConfig,
+    benchmark_config: BenchmarkConfig,
+) -> None:
+    """A completed evaluation copies model release metadata into its result."""
+    dated_config = replace(model_config, release_date="2024-02-03")
+    model = MagicMock()
+    model.num_params = 100
+    model.model_max_length = 512
+    model.vocab_size = 32_000
+    model.generative_type = None
+    model.prepare_datasets.return_value = MagicMock()
+
+    monkeypatch.setattr("euroeval.benchmarker.enforce_reproducibility", MagicMock())
+    monkeypatch.setattr("euroeval.benchmarker.initial_logging", MagicMock())
+    monkeypatch.setattr("euroeval.benchmarker.load_data", MagicMock())
+    monkeypatch.setattr(
+        "euroeval.benchmarker.load_model", MagicMock(return_value=model)
+    )
+    monkeypatch.setattr("euroeval.benchmarker.finetune", MagicMock())
+    monkeypatch.setattr("euroeval.benchmarker.log_scores", MagicMock(return_value={}))
+
+    result = Benchmarker(progress_bar=False, save_results=False)._benchmark_single(
+        model=model,
+        model_config=dated_config,
+        dataset_config=dataset_config,
+        benchmark_config=benchmark_config,
+        num_finished_benchmarks=0,
+        num_total_benchmarks=1,
+    )
+
+    assert isinstance(result, BenchmarkResult)
+    assert result.release_date == "2024-02-03"
 
 
 def test_benchmark_results_is_a_list(benchmarker: Benchmarker) -> None:

--- a/tests/test_data_models.py
+++ b/tests/test_data_models.py
@@ -250,6 +250,21 @@ class TestBenchmarkResult:
         """Test that `BenchmarkResult.from_dict` works as expected."""
         assert BenchmarkResult.from_dict(config) == expected
 
+    @pytest.mark.parametrize(
+        ("release_date", "expected"),
+        [("2024-02-03", "2024-02-03"), ("not-a-date", None), (None, None)],
+    )
+    def test_release_date_normalisation(
+        self,
+        benchmark_result: BenchmarkResult,
+        release_date: str | None,
+        expected: str | None,
+    ) -> None:
+        """Missing and malformed release dates remain backwards compatible."""
+        result = benchmark_result.model_copy(update={"release_date": release_date})
+        result = BenchmarkResult.model_validate(result.model_dump())
+        assert result.release_date == expected
+
 
 class TestMetric:
     """Tests for the `Metric` class."""

--- a/tests/test_eee_utils.py
+++ b/tests/test_eee_utils.py
@@ -123,6 +123,7 @@ class TestEeeUtils:
             merge=False,
             languages=["da"],
             task="sentiment-classification",
+            release_date="2024-02-03",
             results={
                 "total": {
                     "test_mcc": 42.5,
@@ -141,6 +142,9 @@ class TestEeeUtils:
         original.append_to_results(results_path=results_path)
         content = results_path.read_text().strip()
         eee_dict = json.loads(content)
+        assert (
+            eee_dict["model_info"]["additional_details"]["release_date"] == "2024-02-03"
+        )
 
         # Verify confidence intervals are stored correctly for each metric
         eval_results = {
@@ -164,6 +168,7 @@ class TestEeeUtils:
 
         # Verify round-trip restores results
         restored = BenchmarkResult.from_dict(eee_dict)
+        assert restored.release_date == "2024-02-03"
         assert restored.results["total"]["test_mcc"] == 42.5  # ty: ignore[index]  # ty:ignore[ignore-comment-unknown-rule, invalid-argument-type]
         assert (
             abs(


### PR DESCRIPTION
## Summary

Implements the metadata portion of #900, providing the release-date data needed for the planned performance-over-time leaderboard visualization.

- add an optional, backwards-compatible `release_date` field to benchmark results and model configuration
- determine Hugging Face model release dates from the earliest repository commit containing Safetensors or PyTorch model weights
- maintain curated release dates for API model aliases and parse dates from versioned API model IDs
- serialize release dates in EEE output and restore them when reading historical results
- backfill missing release dates while processing existing leaderboard records, with per-model caching
- preserve valid historical dates and gracefully handle missing, malformed, or unavailable metadata
- include release dates in leaderboard metadata-richness deduplication
- add regression coverage for Hugging Face history, API aliases and dated IDs, serialization, benchmarking propagation, caching, and historical backfilling

## Verification

- `169 passed, 199 skipped` in the focused affected test suite (the skips are dependency-marked benchmark tests whose prerequisite modules were not included in the focused invocation)
- all pre-commit hooks pass, including Ruff, formatting, ty, vulture, function ordering, and Markdown lint
- `git diff --check` passes

I am eager to contribute more and would be happy to follow up with the visualization portion or address any review feedback.