### PR TITLE
feat: swap official dataset scala-be -> belacola

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Swapped official dataset for Belarusian:
+  `scala-be` → `belacola`.
+
 - Upgraded the vLLM dependency to version 0.27.1 or newer.
 - Promoted the unofficial dataset `berte-wd` to official.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,7 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Swapped official dataset for Belarusian:
-  `scala-be` → `belacola`.
-
+- Swapped official dataset for Belarusian: `scala-be` → `belacola`.
 - Upgraded the vLLM dependency to version 0.27.1 or newer.
 - Promoted the unofficial dataset `berte-wd` to official.
 

--- a/src/euroeval/dataset_configs/belarusian.py
+++ b/src/euroeval/dataset_configs/belarusian.py
@@ -24,14 +24,6 @@ BESLS_CONFIG = DatasetConfig(
     languages=[BELARUSIAN],
 )
 
-SCALA_BE_CONFIG = DatasetConfig(
-    name="scala-be",
-    pretty_name="ScaLA-be",
-    source="EuroEval/scala-be",
-    task=LA,
-    languages=[BELARUSIAN],
-)
-
 WIKIANN_BE_CONFIG = DatasetConfig(
     name="wikiann-be",
     pretty_name="WikiANN-be",
@@ -89,7 +81,24 @@ BEWIC_CONFIG = DatasetConfig(
     languages=[BELARUSIAN],
 )
 
+BELACOLA_CONFIG = DatasetConfig(
+    name="belacola",
+    pretty_name="BelaCoLA",
+    source="EuroEval/belacola-mini",
+    task=LA,
+    languages=[BELARUSIAN],
+)
+
 # Unofficial datasets ###
+
+SCALA_BE_CONFIG = DatasetConfig(
+    name="scala-be",
+    pretty_name="ScaLA-be",
+    source="EuroEval/scala-be",
+    task=LA,
+    languages=[BELARUSIAN],
+    unofficial=True,
+)
 
 RAGTRUTH_BE_CONFIG = DatasetConfig(
     name="ragtruth-be",
@@ -98,13 +107,4 @@ RAGTRUTH_BE_CONFIG = DatasetConfig(
     task=HALLU,
     languages=[BELARUSIAN],
     train_split=None,
-)
-
-BELACOLA_CONFIG = DatasetConfig(
-    name="belacola",
-    pretty_name="BelaCoLA",
-    source="EuroEval/belacola-mini",
-    task=LA,
-    languages=[BELARUSIAN],
-    unofficial=True,
 )

--- a/src/frontend/md/datasets/belarusian.md
+++ b/src/frontend/md/datasets/belarusian.md
@@ -167,80 +167,7 @@ euroeval --model <model-id> --dataset wikiann-be
 
 ## Linguistic Acceptability
 
-### ScaLA-be
-
-This dataset was published in [this paper](https://aclanthology.org/2023.nodalida-1.20/)
-and was automatically created from the
-[Belarusian Universal Dependencies treebank](https://github.com/UniversalDependencies/UD_Belarusian-HSE)
-by assuming that the documents in the treebank are correct, and corrupting the samples
-to create grammatically incorrect samples. The corruptions were done by either removing
-a word from a sentence, or by swapping two neighbouring words in a sentence. To ensure
-that this does indeed break the grammaticality of the sentence, a set of rules were used
-on the part-of-speech tags of the words in the sentence.
-
-The original full dataset consists of 1,024 / 256 / 2,048 samples for training,
-validation and testing, respectively (so 3,328 samples used in total). These splits are
-used as-is in the framework.
-
-Here are a few examples from the training split:
-
-```json
-{
-  "text": "Скончыла Беларускую акадэмію мастацтваў (курс Міхаіла Жданоўскага) і курс дакументальнага кіно Doc Pro у Школе Вайды (Варшава).",
-  "label": "correct"
-}
-```
-
-```json
-{
-  "text": "Дзяржаўныя СМІ не расказалі пра тыя рэкамэндацыі WHO, якіх Беларусь не выконвае",
-  "label": "correct"
-}
-```
-
-```json
-{
-  "text": "Але праз 19 гадоў Статут новы ВКЛ скасаваў большасьць палажэньняў Люблінскай уніі.",
-  "label": "incorrect"
-}
-```
-
-When evaluating generative models, we use the following setup (see the
-[methodology](/methodology) for more information on how these are used):
-
-- Number of few-shot examples: 12
-- Prefix prompt:
-
-  ```text
-  Ніжэй прыведзены сказы і ці з'яўляюцца яны граматычна правільнымі.
-  ```
-
-- Base prompt template:
-
-  ```text
-  Сказ: {text}
-  Граматычна правільны: {label}
-  ```
-
-- Instruction-tuned prompt template:
-
-  ```text
-  Сказ: {text}
-
-  Вызначце, ці сказ граматычна правільны ці не. Адкажыце толькі {labels_str}, і нічога іншага.
-  ```
-
-- Label mapping:
-  - `correct` ➡️ `так`
-  - `incorrect` ➡️ `не`
-
-You can evaluate this dataset directly as follows:
-
-```bash
-euroeval --model <model-id> --dataset scala-be
-```
-
-### Unofficial: BelaCoLA
+### BelaCoLA
 
 BelaCoLA is a Belarusian linguistic acceptability corpus from the
 [BelarusianGLUE benchmark](https://huggingface.co/datasets/maaxap/BelarusianGLUE),
@@ -312,6 +239,79 @@ You can evaluate this dataset directly as follows:
 
 ```bash
 euroeval --model <model-id> --dataset belacola
+```
+
+### Unofficial: ScaLA-be
+
+This dataset was published in [this paper](https://aclanthology.org/2023.nodalida-1.20/)
+and was automatically created from the
+[Belarusian Universal Dependencies treebank](https://github.com/UniversalDependencies/UD_Belarusian-HSE)
+by assuming that the documents in the treebank are correct, and corrupting the samples
+to create grammatically incorrect samples. The corruptions were done by either removing
+a word from a sentence, or by swapping two neighbouring words in a sentence. To ensure
+that this does indeed break the grammaticality of the sentence, a set of rules were used
+on the part-of-speech tags of the words in the sentence.
+
+The original full dataset consists of 1,024 / 256 / 2,048 samples for training,
+validation and testing, respectively (so 3,328 samples used in total). These splits are
+used as-is in the framework.
+
+Here are a few examples from the training split:
+
+```json
+{
+  "text": "Скончыла Беларускую акадэмію мастацтваў (курс Міхаіла Жданоўскага) і курс дакументальнага кіно Doc Pro у Школе Вайды (Варшава).",
+  "label": "correct"
+}
+```
+
+```json
+{
+  "text": "Дзяржаўныя СМІ не расказалі пра тыя рэкамэндацыі WHO, якіх Беларусь не выконвае",
+  "label": "correct"
+}
+```
+
+```json
+{
+  "text": "Але праз 19 гадоў Статут новы ВКЛ скасаваў большасьць палажэньняў Люблінскай уніі.",
+  "label": "incorrect"
+}
+```
+
+When evaluating generative models, we use the following setup (see the
+[methodology](/methodology) for more information on how these are used):
+
+- Number of few-shot examples: 12
+- Prefix prompt:
+
+  ```text
+  Ніжэй прыведзены сказы і ці з'яўляюцца яны граматычна правільнымі.
+  ```
+
+- Base prompt template:
+
+  ```text
+  Сказ: {text}
+  Граматычна правільны: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Сказ: {text}
+
+  Вызначце, ці сказ граматычна правільны ці не. Адкажыце толькі {labels_str}, і нічога іншага.
+  ```
+
+- Label mapping:
+  - `correct` ➡️ `так`
+  - `incorrect` ➡️ `не`
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset scala-be
 ```
 
 ## Natural Language Inference


### PR DESCRIPTION
Swaps the official dataset `scala-be` for `belacola`.

## What

- Every model with a rank score on the affected leaderboard(s) was evaluated on `belacola`, mirroring how each appears on the leaderboard (validation/test split and zero-/few-shot).
- `scala-be` is demoted to unofficial and `belacola` promoted to official in the dataset configs and the dataset documentation, keeping each file's official-first grouping.

The leaderboards will pick up the change on the next regeneration.