### PR TITLE
fix: validate release dates during deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fixed leaderboard deduplication treating malformed model release dates as valid
+  metadata.
 - Fixed an infinite loop in token-classification few-shot example selection when the
   training split runs out of entity-bearing examples before `num_few_shots` is reached,
   including when the labels contain case variants of the same entity (e.g. `b-per` and

--- a/src/euroeval/data_models.py
+++ b/src/euroeval/data_models.py
@@ -275,19 +275,9 @@ class BenchmarkResult(pydantic.BaseModel):
         """
         return benchmark_result_from_eee_dict(config=config)
 
-    @pydantic.field_validator("release_date", mode="before")
-    @classmethod
-    def normalise_release_date(cls, value: object) -> str | None:
-        """Normalise release dates and discard malformed historical metadata.
-
-        Args:
-            value:
-                The release date value being validated.
-
-        Returns:
-            An ISO-formatted date, or None when the value is absent or malformed.
-        """
-        return normalise_release_date(value)
+    _normalise_release_date = pydantic.field_validator("release_date", mode="before")(
+        normalise_release_date
+    )
 
 
 class HashableDict(dict[t.Any, t.Any]):

--- a/src/euroeval/data_models.py
+++ b/src/euroeval/data_models.py
@@ -1,7 +1,6 @@
 """Data models used in EuroEval."""
 
 import collections.abc as c
-import datetime
 import importlib.metadata
 import json
 import logging
@@ -21,6 +20,7 @@ from .constants import (
     CHOICES_MAPPING,
     MAX_NUMBER_OF_LOGGING_LANGUAGES,
 )
+from .date_utils import normalise_release_date
 from .eee_utils import benchmark_result_from_eee_dict, benchmark_result_to_eee_dict
 from .enums import Device, GenerativeType, ModelType, TaskGroup
 from .exceptions import InvalidBenchmark
@@ -287,16 +287,7 @@ class BenchmarkResult(pydantic.BaseModel):
         Returns:
             An ISO-formatted date, or None when the value is absent or malformed.
         """
-        if isinstance(value, datetime.datetime):
-            return value.date().isoformat()
-        if isinstance(value, datetime.date):
-            return value.isoformat()
-        if not isinstance(value, str):
-            return None
-        try:
-            return datetime.date.fromisoformat(value).isoformat()
-        except ValueError:
-            return None
+        return normalise_release_date(value)
 
 
 class HashableDict(dict[t.Any, t.Any]):

--- a/src/euroeval/date_utils.py
+++ b/src/euroeval/date_utils.py
@@ -1,0 +1,26 @@
+"""Utilities for normalising date metadata."""
+
+import datetime
+
+
+def normalise_release_date(value: object) -> str | None:
+    """Normalise a model release date.
+
+    Args:
+        value:
+            The release date value to normalise.
+
+    Returns:
+        An ISO-formatted date, or None when the value is absent or malformed.
+    """
+    if isinstance(value, datetime.datetime):
+        return value.date().isoformat()
+    if isinstance(value, datetime.date):
+        return value.isoformat()
+    if not isinstance(value, str):
+        return None
+    try:
+        normalised = datetime.date.fromisoformat(value).isoformat()
+    except ValueError:
+        return None
+    return normalised if value == normalised else None

--- a/src/leaderboards/model_metadata.py
+++ b/src/leaderboards/model_metadata.py
@@ -14,7 +14,6 @@ import typing as t
 import urllib.parse
 import warnings
 from copy import deepcopy
-from datetime import date
 
 import httpx
 from huggingface_hub import HfApi
@@ -28,6 +27,7 @@ from requests.exceptions import RequestException
 
 from euroeval.benchmark_modules.hf import get_model_release_date
 from euroeval.benchmark_modules.litellm import get_api_model_release_date
+from euroeval.date_utils import normalise_release_date
 from euroeval.string_utils import split_model_id
 
 from .cache import Cache
@@ -268,12 +268,9 @@ def _get_release_date(record: dict, cache: Cache) -> str | None:
         The ISO-formatted release date, or None if no date can be determined.
     """
     additional = record["model_info"]["additional_details"]
-    existing = additional.get("release_date")
-    if isinstance(existing, str):
-        try:
-            return date.fromisoformat(existing).isoformat()
-        except ValueError:
-            pass
+    existing = normalise_release_date(additional.get("release_date"))
+    if existing is not None:
+        return existing
 
     model_id = split_model_id(
         model_id=plain_model_id(get_model_name(record=record))
@@ -282,10 +279,11 @@ def _get_release_date(record: dict, cache: Cache) -> str | None:
         cached = cache.release_date[model_id]
         if cached is None:
             return None
-        try:
-            return date.fromisoformat(cached).isoformat()
-        except ValueError:
+        normalised_cached = normalise_release_date(cached)
+        if normalised_cached is None:
             del cache.release_date[model_id]
+        else:
+            return normalised_cached
 
     model_url = additional.get("model_url") or cache.model_url.get(model_id)
     hf_hosts = {"hf.co", "huggingface.co", "www.hf.co", "www.huggingface.co"}

--- a/src/leaderboards/record_fields.py
+++ b/src/leaderboards/record_fields.py
@@ -6,6 +6,8 @@ import json
 import re
 import typing as t
 
+from euroeval.date_utils import normalise_release_date
+
 from .records import get_bool_field, get_record_hash, is_few_shot_record
 
 
@@ -88,8 +90,8 @@ def _metadata_richness_score(record: dict) -> int:
     if additional.get("model_url") is not None:
         score += 1
 
-    # release_date: non-null
-    if additional.get("release_date") is not None:
+    # release_date: valid ISO date
+    if normalise_release_date(additional.get("release_date")) is not None:
         score += 1
 
     return score

--- a/tests/leaderboards/test_record_fields.py
+++ b/tests/leaderboards/test_record_fields.py
@@ -2,6 +2,8 @@
 
 import typing as t
 
+import pytest
+
 from leaderboards.record_fields import _metadata_richness_score, deduplicate_records
 
 
@@ -180,6 +182,21 @@ def test_deduplicate_prefers_richer_metadata_same_version() -> None:
     assert additional.get("trained_from_scratch") is True
 
 
+def test_deduplicate_prefers_valid_release_date_over_malformed_value() -> None:
+    """Malformed release metadata does not win over a valid release date."""
+    malformed = _record(version="18.0.0")
+    malformed["model_info"]["additional_details"]["release_date"] = "not-a-date"
+    valid = _record(version="18.0.0")
+    valid["model_info"]["additional_details"]["release_date"] = "2024-02-03"
+
+    deduped = deduplicate_records(records=[malformed, valid])
+
+    assert len(deduped) == 1
+    assert (
+        deduped[0]["model_info"]["additional_details"]["release_date"] == "2024-02-03"
+    )
+
+
 def test_deduplicate_preserves_distinct_datasets() -> None:
     """Records for genuinely distinct rows are all preserved."""
     records = [
@@ -249,6 +266,20 @@ def test_metadata_richness_score_generative_type() -> None:
     record = _record()
     record["model_info"]["additional_details"]["generative_type"] = "instruction_tuned"
     assert _metadata_richness_score(record=record) == 1
+
+
+@pytest.mark.parametrize(
+    "release_date", [None, "", "not-a-date", "2025-02-30", "20240203"]
+)
+def test_metadata_richness_score_ignores_invalid_release_date(
+    release_date: str | None,
+) -> None:
+    """Missing and malformed release dates do not contribute to richness."""
+    record = _record()
+    initial_score = _metadata_richness_score(record)
+    record["model_info"]["additional_details"]["release_date"] = release_date
+
+    assert _metadata_richness_score(record) == initial_score
 
 
 def test_metadata_richness_score_merge() -> None:

--- a/tests/test_date_utils.py
+++ b/tests/test_date_utils.py
@@ -1,0 +1,27 @@
+"""Tests for date utilities."""
+
+import datetime
+
+import pytest
+
+from euroeval.date_utils import normalise_release_date
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("2024-02-03", "2024-02-03"),
+        (datetime.date(2024, 2, 3), "2024-02-03"),
+        (datetime.datetime(2024, 2, 3, 12, 30), "2024-02-03"),
+        (None, None),
+        ("", None),
+        ("not-a-date", None),
+        ("2025-02-30", None),
+        ("20240203", None),
+        ("2024-W05-6", None),
+        (20240203, None),
+    ],
+)
+def test_normalise_release_date(value: object, expected: str | None) -> None:
+    """Release dates are normalised consistently across all consumers."""
+    assert normalise_release_date(value) == expected


### PR DESCRIPTION
## Summary

Follow-up to #2154 and the Copilot review comment in [this discussion](https://github.com/EuroEval/EuroEval/pull/2154#discussion_r3861127348).

- count `release_date` as rich metadata only when it is a real calendar date in the canonical `YYYY-MM-DD` format
- share one release-date normalizer across model validation, metadata enrichment, cache handling, and deduplication
- ensure a valid release date wins over a malformed value when otherwise identical records are deduplicated
- cover missing, empty, malformed, impossible, compact, week-date, date-object, and datetime-object inputs

## Verification

- `96 passed` in the focused date, data-model, record-field, and metadata-enrichment test suite
- `make check` passes, including Ruff, formatting, ty, vulture, funcsort, and Markdown lint
- `git diff --check` passes
