### PR TITLE
feat: add unofficial Slovak SKLEP datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   dataset from BelarusianGLUE.
 - Added the unofficial Belarusian linguistic acceptability dataset `belacola`, based on
   the BelaCoLA dataset from BelarusianGLUE.
+- Added five unofficial Slovak datasets derived from SKLEP: SKLEP NLI, SKLEP RTE,
+  SK-QuAD, WikiGoldSK and Reviews3.
 - Added the unofficial Belarusian BeRTE-WD binary natural language inference dataset.
 
 ### Changed

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2022-2026 Dan Saattrup Smart
+Copyright (c) 2021-2026 Dan Saattrup Smart
+Copyright (c) 2022-2026 Alexandra Instituttet A/S
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/euroeval/dataset_configs/slovak.py
+++ b/src/euroeval/dataset_configs/slovak.py
@@ -92,7 +92,6 @@ SKLEP_NLI_CONFIG = DatasetConfig(
     source="EuroEval/sklep-nli-mini",
     task=NLI,
     languages=[SLOVAK],
-    labels=["entailment", "neutral", "contradiction"],
     unofficial=True,
 )
 
@@ -106,9 +105,9 @@ SK_QUAD_CONFIG = DatasetConfig(
 )
 
 WIKIGOLDSK_CONFIG = DatasetConfig(
-    name="wikigoldsk",
+    name="wikigold-sk",
     pretty_name="WikiGoldSK",
-    source="EuroEval/wikigoldsk-mini",
+    source="EuroEval/wikigold-sk-mini",
     task=NER,
     languages=[SLOVAK],
     unofficial=True,

--- a/src/euroeval/dataset_configs/slovak.py
+++ b/src/euroeval/dataset_configs/slovak.py
@@ -2,7 +2,17 @@
 
 from ..data_models import DatasetConfig
 from ..languages import SLOVAK
-from ..tasks import COMMON_SENSE, HALLU, INSTRUCTION_FOLLOWING, KNOW, LA, NER, RC, SENT
+from ..tasks import (
+    COMMON_SENSE,
+    HALLU,
+    INSTRUCTION_FOLLOWING,
+    KNOW,
+    LA,
+    NER,
+    NLI,
+    RC,
+    SENT,
+)
 
 # Official datasets ###
 
@@ -75,6 +85,63 @@ RAGTRUTH_SK_CONFIG = DatasetConfig(
 
 
 # Unofficial datasets ###
+
+SKLEP_NLI_CONFIG = DatasetConfig(
+    name="sklep-nli",
+    pretty_name="SKLEP NLI",
+    source="EuroEval/sklep-nli-mini",
+    task=NLI,
+    languages=[SLOVAK],
+    labels=["entailment", "neutral", "contradiction"],
+    unofficial=True,
+)
+
+SK_QUAD_CONFIG = DatasetConfig(
+    name="sk-quad",
+    pretty_name="SK-QuAD",
+    source="EuroEval/sk-quad-mini",
+    task=RC,
+    languages=[SLOVAK],
+    unofficial=True,
+)
+
+WIKIGOLDSK_CONFIG = DatasetConfig(
+    name="wikigoldsk",
+    pretty_name="WikiGoldSK",
+    source="EuroEval/wikigoldsk-mini",
+    task=NER,
+    languages=[SLOVAK],
+    unofficial=True,
+)
+
+SKLEP_RTE_CONFIG = DatasetConfig(
+    name="sklep-rte",
+    pretty_name="SKLEP RTE",
+    source="EuroEval/sklep-rte-mini",
+    task=NLI,
+    languages=[SLOVAK],
+    labels=["entailment", "not entailment"],
+    prompt_label_mapping={"entailment": "pravda", "not entailment": "nepravda"},
+    prompt_prefix=(
+        "Nasledujú páry tvrdení a ich logická súvislosť, ktorá môže byť {labels_str}."
+    ),
+    prompt_template="{text}\nImplikácia: {label}",
+    instruction_prompt=(
+        "{text}\n\nUrčite, či druhé tvrdenie vyplýva z prvého. Odpovedzte so "
+        "{labels_str}, a nič iné."
+    ),
+    unofficial=True,
+)
+
+REVIEWS3_CONFIG = DatasetConfig(
+    name="reviews3",
+    pretty_name="Reviews3",
+    source="EuroEval/reviews3-mini",
+    task=SENT,
+    languages=[SLOVAK],
+    labels=["negative", "positive"],
+    unofficial=True,
+)
 
 EU_MMLU_SK_CONFIG = DatasetConfig(
     name="eu-mmlu-sk",

--- a/src/frontend/md/datasets/slovak.md
+++ b/src/frontend/md/datasets/slovak.md
@@ -153,7 +153,7 @@ euroeval --model <model-id> --dataset reviews3
 ### Unofficial: SKLEP NLI
 
 [SKLEP](https://doi.org/10.18653/v1/2025.findings-acl.1371) is a Slovak language-understanding
-benchmark described in [this paper](https://doi.org/10.18653/v1/2025.findings-acl.1371).
+benchmark.
 This dataset is its three-way NLI task. The training pairs were automatically
 translated from English without manual correction, while the validation and test
 pairs were post-edited by native Slovak speakers.
@@ -167,21 +167,21 @@ Here are three examples from the final training split:
 
 ```json
 {
-  "text": "Premise: Určite neboli účinnejšie ako nemagnetické stabilizátory zápästia , ktoré som si zobral v drogérii .\nHypothesis: Obidva a nemagnetické stabilizátory zápästia boli na hovno!",
+  "text": "Prvé tvrdenie: Určite neboli účinnejšie ako nemagnetické stabilizátory zápästia , ktoré som si zobral v drogérii .\nDruhé tvrdenie: Obidva a nemagnetické stabilizátory zápästia boli na hovno!",
   "label": "contradiction"
 }
 ```
 
 ```json
 {
-  "text": "Premise: Základným predpokladom tejto línie je, že zistenia viery a rozumu nie sú v rozpore – iba ich metódy sú.\nHypothesis: Základným predpokladom tejto línie je, že zistenia viery a rozumu nie sú v rozpore",
+  "text": "Prvé tvrdenie: Základným predpokladom tejto línie je, že zistenia viery a rozumu nie sú v rozpore – iba ich metódy sú.\nDruhé tvrdenie: Základným predpokladom tejto línie je, že zistenia viery a rozumu nie sú v rozpore",
   "label": "entailment"
 }
 ```
 
 ```json
 {
-  "text": "Premise: by mal byť schopný metabolizovať jednu uncu alkoholu za hodinu\nHypothesis: Alkohol sa dá metabolizovať .",
+  "text": "Prvé tvrdenie: by mal byť schopný metabolizovať jednu uncu alkoholu za hodinu\nDruhé tvrdenie: Alkohol sa dá metabolizovať .",
   "label": "entailment"
 }
 ```
@@ -240,21 +240,21 @@ Here are three examples from the final training split:
 
 ```json
 {
-  "text": "Premise: V Bushovej administratíve a globálnych energetických kruhoch narastá sentiment, aby po akejkoľvek vojne poverili ťažbu ropy v ich krajine irackých profesionálov, a to aj napriek tlaku niektorých predstaviteľov, aby Spojené štáty prevzali kontrolu nad lukratívnymi ropnými poliami.\nHypothesis: Spojené štáty pohrozili „najvážnejšími dôsledkami“, ak Irak použije chemické alebo biologické zbrane proti USA, zničí kuvajtské ropné polia alebo sa podieľa na terorizme.",
+  "text": "Prvé tvrdenie: V Bushovej administratíve a globálnych energetických kruhoch narastá sentiment, aby po akejkoľvek vojne poverili ťažbu ropy v ich krajine irackých profesionálov, a to aj napriek tlaku niektorých predstaviteľov, aby Spojené štáty prevzali kontrolu nad lukratívnymi ropnými poliami.\nDruhé tvrdenie: Spojené štáty pohrozili „najvážnejšími dôsledkami“, ak Irak použije chemické alebo biologické zbrane proti USA, zničí kuvajtské ropné polia alebo sa podieľa na terorizme.",
   "label": "not entailment"
 }
 ```
 
 ```json
 {
-  "text": "Premise: Remastrovaná verzia Raňajky u Tiffanyho od Paramountu s Audrey Hepburn v hlavnej úlohe je naplánovaná na 2. novembra za 40 dolárov.\nHypothesis: Audrey Hepburn hrala vo filme \"Raňajky u Tiffanyho\".",
+  "text": "Prvé tvrdenie: Remastrovaná verzia Raňajky u Tiffanyho od Paramountu s Audrey Hepburn v hlavnej úlohe je naplánovaná na 2. novembra za 40 dolárov.\nDruhé tvrdenie: Audrey Hepburn hrala vo filme \"Raňajky u Tiffanyho\".",
   "label": "entailment"
 }
 ```
 
 ```json
 {
-  "text": "Premise: V subsaharskej Afrike je približne jeden z 30 ľudí infikovaný vírusom HIV.\nHypothesis: 30% ľudí infikovaných HIV žije v Afrike.",
+  "text": "Prvé tvrdenie: V subsaharskej Afrike je približne jeden z 30 ľudí infikovaný vírusom HIV.\nDruhé tvrdenie: 30% ľudí infikovaných HIV žije v Afrike.",
   "label": "not entailment"
 }
 ```

--- a/src/frontend/md/datasets/slovak.md
+++ b/src/frontend/md/datasets/slovak.md
@@ -77,7 +77,7 @@ euroeval --model <model-id> --dataset csfd-sentiment-sk
 
 ### Unofficial: Reviews3
 
-[Reviews3](https://github.com/slovak-nlp/sklep) is the binary sentiment-analysis
+[Reviews3](https://doi.org/10.18653/v1/2025.findings-acl.1371) is the binary sentiment-analysis
 component of SKLEP. It contains manually labelled Slovak customer-service reviews;
 neutral source examples are not part of this binary task.
 
@@ -139,9 +139,8 @@ When evaluating generative models, we use the following setup:
 
 SKLEP declares mixed upstream licences for its components (`other`, CC BY-SA 4.0,
 CC BY-SA 3.0 and MIT) and does not provide a single unified licence. Consult the
-[SKLEP paper](https://aclanthology.org/2025.findings-acl.1371/) and [source
-repository](https://github.com/slovak-nlp/sklep) for attribution and component-specific
-terms.
+[SKLEP paper](https://doi.org/10.18653/v1/2025.findings-acl.1371) for attribution and
+component-specific terms.
 
 You can evaluate this dataset directly as follows:
 
@@ -153,8 +152,8 @@ euroeval --model <model-id> --dataset reviews3
 
 ### Unofficial: SKLEP NLI
 
-[SKLEP](https://github.com/slovak-nlp/sklep) is a Slovak language-understanding
-benchmark described in [this paper](https://aclanthology.org/2025.findings-acl.1371/).
+[SKLEP](https://doi.org/10.18653/v1/2025.findings-acl.1371) is a Slovak language-understanding
+benchmark described in [this paper](https://doi.org/10.18653/v1/2025.findings-acl.1371).
 This dataset is its three-way NLI task. The training pairs were automatically
 translated from English without manual correction, while the validation and test
 pairs were post-edited by native Slovak speakers.
@@ -224,11 +223,12 @@ euroeval --model <model-id> --dataset sklep-nli
 
 ### Unofficial: SKLEP RTE
 
-This is SKLEP's binary Recognising Textual Entailment task. Its training pairs were
-automatically translated without manual correction, while the validation and test
-pairs were post-edited by native Slovak speakers. The test split was also manually
-relabelled. The two source labels are entailment and not entailment; the latter
-combines cases that are not entailed rather than distinguishing neutral from
+This is SKLEP's binary Recognising Textual Entailment task, described in
+[the SKLEP paper](https://doi.org/10.18653/v1/2025.findings-acl.1371). Its training
+pairs were automatically translated without manual correction, while the validation
+and test pairs were post-edited by native Slovak speakers. The test split was also
+manually relabelled. The two source labels are entailment and not entailment; the
+latter combines cases that are not entailed rather than distinguishing neutral from
 contradiction.
 
 The source contains 2,490 / 277 / 1,660 train, validation and test samples. We
@@ -288,8 +288,8 @@ When evaluating generative models, we use the following setup:
   - `not entailment` ➡️ `nepravda`
 
 As with the other SKLEP tasks, the upstream release has mixed component licences and
-no unified licence. See the [SKLEP paper](https://aclanthology.org/2025.findings-acl.1371/)
-and [source repository](https://github.com/slovak-nlp/sklep) for attribution.
+no unified licence. See the [SKLEP paper](https://doi.org/10.18653/v1/2025.findings-acl.1371)
+for attribution.
 
 You can evaluate this dataset directly as follows:
 
@@ -445,7 +445,7 @@ euroeval --model <model-id> --dataset uner-sk
 
 ### Unofficial: WikiGoldSK
 
-[WikiGoldSK](https://github.com/slovak-nlp/sklep) is the WikiGoldSK named
+[WikiGoldSK](https://doi.org/10.18653/v1/2025.findings-acl.1371) is the WikiGoldSK named
 entity-recognition component of SKLEP. It is manually annotated Slovak Wikipedia
 text using the CoNLL-2003 entity types LOC, ORG, PER and MISC, with BIO tags.
 
@@ -512,14 +512,13 @@ When evaluating generative models, we use the following setup:
   - `B/I-MISC` ➡️ `rôzne`
 
 SKLEP declares mixed upstream licences for its components rather than a unified
-licence. See the [SKLEP paper](https://aclanthology.org/2025.findings-acl.1371/) and
-[source repository](https://github.com/slovak-nlp/sklep) for attribution and the
-applicable component terms.
+licence. See the [SKLEP paper](https://doi.org/10.18653/v1/2025.findings-acl.1371) for
+attribution and the applicable component terms.
 
 You can evaluate this dataset directly as follows:
 
 ```bash
-euroeval --model <model-id> --dataset wikigoldsk
+euroeval --model <model-id> --dataset wikigold-sk
 ```
 
 ## Linguistic Acceptability
@@ -676,7 +675,7 @@ euroeval --model <model-id> --dataset multi-wiki-qa-sk
 
 ### Unofficial: SK-QuAD
 
-[SK-QuAD](https://github.com/slovak-nlp/sklep) is the extractive question-answering
+[SK-QuAD](https://doi.org/10.18653/v1/2025.findings-acl.1371) is the extractive question-answering
 component of SKLEP. It consists of Slovak Wikipedia contexts and questions created
 and validated by human annotators. This EuroEval version is answerable-only: rows with
 empty answers or answer offsets that do not exactly match their context were removed
@@ -747,9 +746,8 @@ Models receive the context and question and answer in at most three words. No
 answer-label mapping is used.
 
 The SKLEP release declares mixed upstream licences rather than one unified licence.
-See the [SKLEP paper](https://aclanthology.org/2025.findings-acl.1371/) and [source
-repository](https://github.com/slovak-nlp/sklep) for citation and component-specific
-licensing information.
+See the [SKLEP paper](https://doi.org/10.18653/v1/2025.findings-acl.1371) for citation
+and component-specific licensing information.
 
 You can evaluate this dataset directly as follows:
 

--- a/src/frontend/md/datasets/slovak.md
+++ b/src/frontend/md/datasets/slovak.md
@@ -75,6 +75,225 @@ You can evaluate this dataset directly as follows:
 euroeval --model <model-id> --dataset csfd-sentiment-sk
 ```
 
+### Unofficial: Reviews3
+
+[Reviews3](https://github.com/slovak-nlp/sklep) is the binary sentiment-analysis
+component of SKLEP. It contains manually labelled Slovak customer-service reviews;
+neutral source examples are not part of this binary task.
+
+The source contains 3,560 / 522 / 1,042 train, validation and test samples. We sampled
+the train and validation splits independently with seed 4242 and retained the complete
+test split, resulting in 1,024 / 256 / 1,042 samples. Source split boundaries are
+preserved. The labels are negative and positive.
+
+Here are three examples from the final training split:
+
+```json
+{
+  "text": "Za promtnost, a ochotu poradit",
+  "label": "positive"
+}
+```
+
+```json
+{
+  "text": "Milá jasná odborná odpoved.",
+  "label": "positive"
+}
+```
+
+```json
+{
+  "text": "Sklamana som z toho, ze som svoju poziadavku riesila dost dlho cez zakaznicku linku. Telefonat bol dost dlhy.",
+  "label": "negative"
+}
+```
+
+When evaluating generative models, we use the following setup:
+
+- Number of few-shot examples: 12
+- Prefix prompt:
+
+  ```text
+  Nižšie sú dokumenty a ich sentiment, ktorý môže byť 'negatívne' alebo 'pozitívne'.
+  ```
+
+- Base prompt template:
+
+  ```text
+  Dokument: {text}
+  Sentiment: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Dokument: {text}
+
+  Klasifikujte pocit v dokumente. Odpovedzte so 'negatívne' alebo 'pozitívne', a nič iné.
+  ```
+
+- Label mapping:
+  - `negative` ➡️ `negatívne`
+  - `positive` ➡️ `pozitívne`
+
+SKLEP declares mixed upstream licences for its components (`other`, CC BY-SA 4.0,
+CC BY-SA 3.0 and MIT) and does not provide a single unified licence. Consult the
+[SKLEP paper](https://aclanthology.org/2025.findings-acl.1371/) and [source
+repository](https://github.com/slovak-nlp/sklep) for attribution and component-specific
+terms.
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset reviews3
+```
+
+## Natural Language Inference
+
+### Unofficial: SKLEP NLI
+
+[SKLEP](https://github.com/slovak-nlp/sklep) is a Slovak language-understanding
+benchmark described in [this paper](https://aclanthology.org/2025.findings-acl.1371/).
+This dataset is its three-way NLI task. The premise and hypothesis pairs were
+translated from English and post-edited by native Slovak speakers.
+
+The source contains 392,702 / 2,490 / 5,004 train, validation and test samples. We
+sampled each source split independently with seed 4242, resulting in 1,024 / 256 /
+2,048 samples. No samples cross split boundaries. The labels are entailment, neutral
+and contradiction.
+
+Here are three examples from the final training split:
+
+```json
+{
+  "text": "Premise: Určite neboli účinnejšie ako nemagnetické stabilizátory zápästia , ktoré som si zobral v drogérii .\nHypothesis: Obidva a nemagnetické stabilizátory zápästia boli na hovno!",
+  "label": "contradiction"
+}
+```
+
+```json
+{
+  "text": "Premise: Základným predpokladom tejto línie je, že zistenia viery a rozumu nie sú v rozpore – iba ich metódy sú.\nHypothesis: Základným predpokladom tejto línie je, že zistenia viery a rozumu nie sú v rozpore",
+  "label": "entailment"
+}
+```
+
+```json
+{
+  "text": "Premise: by mal byť schopný metabolizovať jednu uncu alkoholu za hodinu\nHypothesis: Alkohol sa dá metabolizovať .",
+  "label": "entailment"
+}
+```
+
+When evaluating generative models, we use the following setup:
+
+- Number of few-shot examples: 12
+- Prefix prompt:
+
+  ```text
+  Nasledujú páry tvrdení a ich logická súvislosť, ktorá môže byť 'pravda', 'neutrálny' alebo 'nepravda'.
+  ```
+
+- Base prompt template:
+
+  ```text
+  {text}\nImplikácia: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  {text}\n\nUrčite, či druhé tvrdenie vyplýva z prvého, je s ním v rozpore alebo nemá logickú väzbu. Odpovedzte so 'pravda', 'neutrálny' alebo 'nepravda', a nič iné.
+  ```
+
+- Label mapping:
+  - `entailment` ➡️ `pravda`
+  - `neutral` ➡️ `neutrálny`
+  - `contradiction` ➡️ `nepravda`
+
+The upstream SKLEP release declares multiple upstream licences rather than one
+licence for the benchmark; consult the component sources before redistribution.
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset sklep-nli
+```
+
+### Unofficial: SKLEP RTE
+
+This is SKLEP's binary Recognising Textual Entailment task. It contains translated
+and native-speaker post-edited Slovak premise and hypothesis pairs. The two source
+labels are entailment and not entailment; the latter combines cases that are not
+entailed rather than distinguishing neutral from contradiction.
+
+The source contains 2,490 / 277 / 1,660 train, validation and test samples. We
+sampled train and validation independently with seed 4242 and retained the complete
+test split, resulting in 1,024 / 256 / 1,660 samples. All samples remain in their
+original source split.
+
+Here are three examples from the final training split:
+
+```json
+{
+  "text": "Premise: V Bushovej administratíve a globálnych energetických kruhoch narastá sentiment, aby po akejkoľvek vojne poverili ťažbu ropy v ich krajine irackých profesionálov, a to aj napriek tlaku niektorých predstaviteľov, aby Spojené štáty prevzali kontrolu nad lukratívnymi ropnými poliami.\nHypothesis: Spojené štáty pohrozili „najvážnejšími dôsledkami“, ak Irak použije chemické alebo biologické zbrane proti USA, zničí kuvajtské ropné polia alebo sa podieľa na terorizme.",
+  "label": "not entailment"
+}
+```
+
+```json
+{
+  "text": "Premise: Remastrovaná verzia Raňajky u Tiffanyho od Paramountu s Audrey Hepburn v hlavnej úlohe je naplánovaná na 2. novembra za 40 dolárov.\nHypothesis: Audrey Hepburn hrala vo filme \"Raňajky u Tiffanyho\".",
+  "label": "entailment"
+}
+```
+
+```json
+{
+  "text": "Premise: V subsaharskej Afrike je približne jeden z 30 ľudí infikovaný vírusom HIV.\nHypothesis: 30% ľudí infikovaných HIV žije v Afrike.",
+  "label": "not entailment"
+}
+```
+
+When evaluating generative models, we use the following setup:
+
+- Number of few-shot examples: 12
+- Prefix prompt:
+
+  ```text
+  Nasledujú páry tvrdení a ich logická súvislosť, ktorá môže byť 'pravda' alebo 'nepravda'.
+  ```
+
+- Base prompt template:
+
+  ```text
+  {text}
+  Implikácia: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  {text}
+
+  Určite, či druhé tvrdenie vyplýva z prvého. Odpovedzte so 'pravda' alebo 'nepravda', a nič iné.
+  ```
+
+- Label mapping:
+  - `entailment` ➡️ `pravda`
+  - `not entailment` ➡️ `nepravda`
+
+As with the other SKLEP tasks, the upstream release has mixed component licences and
+no unified licence. See the [SKLEP paper](https://aclanthology.org/2025.findings-acl.1371/)
+and [source repository](https://github.com/slovak-nlp/sklep) for attribution.
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset sklep-rte
+```
+
 ## Named Entity Recognition
 
 ### UNER-sk
@@ -219,6 +438,85 @@ You can evaluate this dataset directly as follows:
 
 ```bash
 euroeval --model <model-id> --dataset uner-sk
+```
+
+### Unofficial: WikiGoldSK
+
+[WikiGoldSK](https://github.com/slovak-nlp/sklep) is the WikiGoldSK named
+entity-recognition component of SKLEP. It is manually annotated Slovak Wikipedia
+text using the CoNLL-2003 entity types LOC, ORG, PER and MISC, with BIO tags.
+
+The source contains 4,687 / 669 / 1,340 train, validation and test samples. We
+sampled train and validation independently with seed 4242 and retained the complete
+test split, resulting in 1,024 / 256 / 1,340 samples. The source split boundaries
+are preserved. The final schema contains `text`, `tokens` and `labels` columns, with
+`O` plus B/I tags for LOC, ORG, PER and MISC.
+
+Here are three examples from the final training split:
+
+```json
+{
+  "text": "V roku 2020 bude vozidlo prechádzať okolo Marsu približne 6,9 milióna kilometrov , mimo vplyvu jeho gravitačnej sféry .",
+  "tokens": ["V", "roku", "2020", "bude", "vozidlo", "prechádzať", "okolo", "Marsu", "približne", "6,9", "milióna", "kilometrov", ",", "mimo", "vplyvu", "jeho", "gravitačnej", "sféry", "."],
+  "labels": ["O", "O", "O", "O", "O", "O", "O", "B-LOC", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O"]
+}
+```
+
+```json
+{
+  "text": "Na Slovensku a v Česku rastie celkom hojne na celom území od nížin až do podhoria .",
+  "tokens": ["Na", "Slovensku", "a", "v", "Česku", "rastie", "celkom", "hojne", "na", "celom", "území", "od", "nížin", "až", "do", "podhoria", "."],
+  "labels": ["O", "B-LOC", "O", "O", "B-LOC", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O"]
+}
+```
+
+```json
+{
+  "text": "Morálka žoldnierov , ktorí tvorili jadro armády a po chvatnom ústupe z Rakúska , keď mnohí nedostali vyplatený žold , bola na nízkej úrovni .",
+  "tokens": ["Morálka", "žoldnierov", ",", "ktorí", "tvorili", "jadro", "armády", "a", "po", "chvatnom", "ústupe", "z", "Rakúska", ",", "keď", "mnohí", "nedostali", "vyplatený", "žold", ",", "bola", "na", "nízkej", "úrovni", "."],
+  "labels": ["O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "B-LOC", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O"]
+}
+```
+
+When evaluating generative models, we use the following setup:
+
+- Number of few-shot examples: 8
+- Prefix prompt:
+
+  ```text
+  Nasledujúce sú vety a JSON-objekty s pomenovanými entitami, ktoré sa nachádzajú v danej vete.
+  ```
+
+- Base prompt template:
+
+  ```text
+  Veta: {text}
+  Pomenované entity: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Veta: {text}
+
+  Identifikujte pomenované entity vo vete. Výstup by mal byť vo forme JSON-objektu s kľúčmi {labels_str}. Hodnoty by mali byť zoznamy pomenovaných entít danej kategórie, presne tak, ako sa vyskytujú vo vete.
+  ```
+
+- Label mapping:
+  - `B/I-PER` ➡️ `osoba`
+  - `B/I-LOC` ➡️ `miesto`
+  - `B/I-ORG` ➡️ `organizácia`
+  - `B/I-MISC` ➡️ `rôzne`
+
+SKLEP declares mixed upstream licences for its components rather than a unified
+licence. See the [SKLEP paper](https://aclanthology.org/2025.findings-acl.1371/) and
+[source repository](https://github.com/slovak-nlp/sklep) for attribution and the
+applicable component terms.
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset wikigoldsk
 ```
 
 ## Linguistic Acceptability
@@ -371,6 +669,89 @@ You can evaluate this dataset directly as follows:
 
 ```bash
 euroeval --model <model-id> --dataset multi-wiki-qa-sk
+```
+
+### Unofficial: SK-QuAD
+
+[SK-QuAD](https://github.com/slovak-nlp/sklep) is the extractive question-answering
+component of SKLEP. It consists of Slovak Wikipedia contexts and questions created
+and validated by human annotators. This EuroEval version is answerable-only: rows with
+empty answers or answer offsets that do not exactly match their context were removed
+before sampling.
+
+The source contains 71,999 / 9,583 / 9,583 train, validation and test samples. After
+answer filtering, we sampled each source split independently with seed 4242, resulting
+in 1,024 / 256 / 2,048 samples. Source split boundaries are preserved. Each row has
+`context`, `question` and `answers`; answer offsets are validated against the context.
+
+Here are three examples from the final training split:
+
+```json
+{
+  "id": "1024234",
+  "context": "Pred prvou svetovou vojnou dal majiteľ veľkostatku v Ladzanoch Alfréd Westfried vybudovať úzkokoľajnú železničku na prepravu dreva z Ladzian do Hontianskych Tesárov (cca 8 kilometrov). Počas prvej svetovej vojny bola táto trať rozšírená severným smerom do obce Klastava. Po prvej svetovej vojne bola trať predĺžená cez lokalitu Dobrá voda až pod Sitno, na lokalitu Záholík. Celkovo dosiahla trať dĺžku až 36 kilometrov. V roku 1948 bola trať zoštátnená, ale už v roku 1952 bola jej prevádzka ukončená.",
+  "question": "Kadiaľ bola predĺžená trať v Ladzanoch po prvej svetovej vojne ?",
+  "answers": {"text": ["cez lokalitu Dobrá voda až pod Sitno, na lokalitu Záholík"], "answer_start": [315]}
+}
+```
+
+```json
+{
+  "id": "1089558",
+  "context": "Veľký rozmach obec zaznamenala predovšetkým po druhej svetovej vojne. Do dediny bola zavedená elektrina, vybudovali sa cesty, vystaval sa kultúrny dom, budova predajne potravín a pohostinstva, obyvatelia si budovali svoje nové rodinné domy. V druhej polovice 20. storočia sa rapídne zlepšil život na našich dedinách, a nebolo to inak ani v tej našej.\nObec je v súčasnosti splynofikovaná a  má vlastný verejný vodovod, ktorý bol odovzdaný do používania v roku 1994. Zdrojom vody sú tri pramene \"Pod Gavreckou\", ktoré sú zachytené a voda je privádzaná do zásobného vodojemu, z ktorého potom samospádom prichádza do domácnosti.\nJe tu  rozostavaná stavba \"Kanalizácia a ČOV Šandal\". V obci sú zrealizované zberné kanalizačné stoky, chýba však ešte čistiareň odpadových vôd z nedostatku finančných prostriedkov.\nObec zrekonštruovala všetky svoje miestne komunikácie. Pre zvýšenie kvality života v obci bol svojpomocne vybudovaný dom smútku, ktorý bol umiestnený pri miestnom cintoríne.",
+  "question": "Od ktorého roku ma obec Šandal vlastný verejný vodovod ?",
+  "answers": {"text": ["1994"], "answer_start": [459]}
+}
+```
+
+```json
+{
+  "id": "1086301",
+  "context": "18. decembra 2005 utrpel Šaron ľahkú mozgovú porážku a bol hospitalizovaný v nemocnici. Po dvoch dňoch bol prepustený, ale 4. januára 2006 utrpel novú, tentoraz ťažkú mozgovú porážku. Previezli ho do nemocnice, kde sa podrobil dvom zložitým operáciám. Jeho stav bol taký vážny, že lekári označili za nepravdepodobné, že by Šaron v budúcnosti mohol vykonávať svoju funkciu. Od 14. apríla 2006 ho vo funkcii izraelského preméra oficiálne nahradil Ehud Olmert, ktorý ho ako podpredseda vlády zastupoval už od januára. 28. mája 2006 ho previezli do liečebne dlhodobo chorých. Šanca, že by sa Šaron dostal z hlbokej kómy a vegetatívneho stavu, v ktorom sa nachádzal, sa podľa lekárov každým dňom znižovala. 11. januára 2014 zomrel po ôsmich rokoch v kóme.",
+  "question": "Čo utrpel Šaron v roku 2005 ?",
+  "answers": {"text": ["ľahkú mozgovú porážku"], "answer_start": [31]}
+}
+```
+
+When evaluating generative models, we use the following setup:
+
+- Number of few-shot examples: 4
+- Prefix prompt:
+
+  ```text
+  Nasledujú texty s pridruženými otázkami a odpoveďami.
+  ```
+
+- Base prompt template:
+
+  ```text
+  Text: {text}
+  Otázka: {question}
+  Odpoveď na maximálne 3 slová: {label}
+  ```
+
+- Instruction-tuned prompt template:
+
+  ```text
+  Text: {text}
+
+  Odpovedzte na nasledujúcu otázku týkajúcu sa textu uvedeného vyššie maximálne 3 slovami.
+
+  Otázka: {question}
+  ```
+
+Models receive the context and question and answer in at most three words. No
+answer-label mapping is used.
+
+The SKLEP release declares mixed upstream licences rather than one unified licence.
+See the [SKLEP paper](https://aclanthology.org/2025.findings-acl.1371/) and [source
+repository](https://github.com/slovak-nlp/sklep) for citation and component-specific
+licensing information.
+
+You can evaluate this dataset directly as follows:
+
+```bash
+euroeval --model <model-id> --dataset sk-quad
 ```
 
 ## Knowledge

--- a/src/frontend/md/datasets/slovak.md
+++ b/src/frontend/md/datasets/slovak.md
@@ -155,8 +155,9 @@ euroeval --model <model-id> --dataset reviews3
 
 [SKLEP](https://github.com/slovak-nlp/sklep) is a Slovak language-understanding
 benchmark described in [this paper](https://aclanthology.org/2025.findings-acl.1371/).
-This dataset is its three-way NLI task. The premise and hypothesis pairs were
-translated from English and post-edited by native Slovak speakers.
+This dataset is its three-way NLI task. The training pairs were automatically
+translated from English without manual correction, while the validation and test
+pairs were post-edited by native Slovak speakers.
 
 The source contains 392,702 / 2,490 / 5,004 train, validation and test samples. We
 sampled each source split independently with seed 4242, resulting in 1,024 / 256 /
@@ -223,10 +224,12 @@ euroeval --model <model-id> --dataset sklep-nli
 
 ### Unofficial: SKLEP RTE
 
-This is SKLEP's binary Recognising Textual Entailment task. It contains translated
-and native-speaker post-edited Slovak premise and hypothesis pairs. The two source
-labels are entailment and not entailment; the latter combines cases that are not
-entailed rather than distinguishing neutral from contradiction.
+This is SKLEP's binary Recognising Textual Entailment task. Its training pairs were
+automatically translated without manual correction, while the validation and test
+pairs were post-edited by native Slovak speakers. The test split was also manually
+relabelled. The two source labels are entailment and not entailment; the latter
+combines cases that are not entailed rather than distinguishing neutral from
+contradiction.
 
 The source contains 2,490 / 277 / 1,660 train, validation and test samples. We
 sampled train and validation independently with seed 4242 and retained the complete
@@ -474,7 +477,7 @@ Here are three examples from the final training split:
 {
   "text": "Morálka žoldnierov , ktorí tvorili jadro armády a po chvatnom ústupe z Rakúska , keď mnohí nedostali vyplatený žold , bola na nízkej úrovni .",
   "tokens": ["Morálka", "žoldnierov", ",", "ktorí", "tvorili", "jadro", "armády", "a", "po", "chvatnom", "ústupe", "z", "Rakúska", ",", "keď", "mnohí", "nedostali", "vyplatený", "žold", ",", "bola", "na", "nízkej", "úrovni", "."],
-  "labels": ["O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "B-LOC", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O"]
+  "labels": ["O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "B-LOC", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O"]
 }
 ```
 

--- a/src/leaderboards/dataset_split_sizes.json
+++ b/src/leaderboards/dataset_split_sizes.json
@@ -1146,6 +1146,11 @@
     "train": 1024,
     "val": 256
   },
+  "EuroEval/reviews3-mini": {
+    "test": 1042,
+    "train": 1024,
+    "val": 256
+  },
   "EuroEval/ro-sent-mini": {
     "test": 2048,
     "train": 1024,
@@ -1370,6 +1375,21 @@
     "train": 1024,
     "val": 256
   },
+  "EuroEval/sk-quad-mini": {
+    "test": 2048,
+    "train": 1024,
+    "val": 256
+  },
+  "EuroEval/sklep-nli-mini": {
+    "test": 2048,
+    "train": 1024,
+    "val": 256
+  },
+  "EuroEval/sklep-rte-mini": {
+    "test": 1660,
+    "train": 1024,
+    "val": 256
+  },
   "EuroEval/skolprov": {
     "test": 410,
     "train": 32,
@@ -1507,6 +1527,11 @@
   },
   "EuroEval/wikiann-sq-mini": {
     "test": 1000,
+    "train": 1024,
+    "val": 256
+  },
+  "EuroEval/wikigoldsk-mini": {
+    "test": 1340,
     "train": 1024,
     "val": 256
   },

--- a/src/leaderboards/dataset_split_sizes.json
+++ b/src/leaderboards/dataset_split_sizes.json
@@ -1530,7 +1530,7 @@
     "train": 1024,
     "val": 256
   },
-  "EuroEval/wikigoldsk-mini": {
+  "EuroEval/wikigold-sk-mini": {
     "test": 1340,
     "train": 1024,
     "val": 256

--- a/src/scripts/dataset_creation/create_reviews3.py
+++ b/src/scripts/dataset_creation/create_reviews3.py
@@ -1,0 +1,59 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets>=3.5.0",
+#     "huggingface-hub>=0.24.0",
+# ]
+# ///
+
+"""Create the SKLEP Reviews3 Slovak sentiment mini dataset."""
+
+from datasets import Dataset, DatasetDict, load_dataset
+
+try:
+    from sklep_utils import make_dataset_dict, upload_private
+except ModuleNotFoundError:
+    from src.scripts.dataset_creation.sklep_utils import (
+        make_dataset_dict,
+        upload_private,
+    )
+
+SOURCE_DATASET = "slovak-nlp/sklep"
+TARGET_DATASET = "EuroEval/reviews3-mini"
+LABELS = ("negative", "positive")
+
+
+def main() -> None:
+    """Download, process, and privately upload SKLEP Reviews3."""
+    source = load_dataset(path=SOURCE_DATASET, name="sentiment-analysis")
+    assert isinstance(source, DatasetDict)
+    dataset = process_dataset(raw_dataset=source)
+    upload_private(dataset=dataset, repository_id=TARGET_DATASET)
+
+
+def process_dataset(raw_dataset: DatasetDict) -> DatasetDict:
+    """Convert Reviews3 to EuroEval's text-classification schema.
+
+    Returns:
+        The processed dataset with independently capped splits.
+    """
+    return make_dataset_dict(
+        train=_process_split(raw_dataset["train"]),
+        validation=_process_split(raw_dataset["validation"]),
+        test=_process_split(raw_dataset["test"]),
+    )
+
+
+def _process_split(source: Dataset) -> Dataset:
+    """Convert one Reviews3 source split.
+
+    Returns:
+        The processed split.
+    """
+    return Dataset.from_list(
+        [{"text": row["text"], "label": LABELS[int(row["label"])]} for row in source]
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/dataset_creation/create_reviews3.py
+++ b/src/scripts/dataset_creation/create_reviews3.py
@@ -11,9 +11,9 @@
 from datasets import Dataset, DatasetDict, load_dataset
 
 try:
-    from sklep_utils import make_dataset_dict, upload_private
+    from dataset_utils import make_dataset_dict, upload_private
 except ModuleNotFoundError:
-    from src.scripts.dataset_creation.sklep_utils import (
+    from src.scripts.dataset_creation.dataset_utils import (
         make_dataset_dict,
         upload_private,
     )

--- a/src/scripts/dataset_creation/create_sk_quad.py
+++ b/src/scripts/dataset_creation/create_sk_quad.py
@@ -1,0 +1,92 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets>=3.5.0",
+#     "huggingface-hub>=0.24.0",
+# ]
+# ///
+
+"""Create the answerable-only SK-QuAD Slovak QA mini dataset."""
+
+from datasets import Dataset, DatasetDict, load_dataset
+
+try:
+    from sklep_utils import make_dataset_dict, upload_private
+except ModuleNotFoundError:
+    from src.scripts.dataset_creation.sklep_utils import (
+        make_dataset_dict,
+        upload_private,
+    )
+
+SOURCE_DATASET = "slovak-nlp/sklep"
+TARGET_DATASET = "EuroEval/sk-quad-mini"
+
+
+def main() -> None:
+    """Download, process, and privately upload answerable SK-QuAD."""
+    source = load_dataset(path=SOURCE_DATASET, name="question-answering")
+    assert isinstance(source, DatasetDict)
+    dataset = process_dataset(raw_dataset=source)
+    upload_private(dataset=dataset, repository_id=TARGET_DATASET)
+
+
+def process_dataset(raw_dataset: DatasetDict) -> DatasetDict:
+    """Filter invalid answers and convert SK-QuAD to EuroEval's QA schema.
+
+    Returns:
+        The processed dataset with independently capped splits.
+    """
+    return make_dataset_dict(
+        train=_process_split(raw_dataset["train"]),
+        validation=_process_split(raw_dataset["validation"]),
+        test=_process_split(raw_dataset["test"]),
+    )
+
+
+def _process_split(source: Dataset) -> Dataset:
+    """Filter and convert one SK-QuAD source split.
+
+    Returns:
+        The processed split.
+    """
+    rows = []
+    for index, row in enumerate(source):
+        answers = row["answers"]
+        if not _answers_are_valid(
+            context=row["context"],
+            answer_texts=answers["text"],
+            answer_starts=answers["answer_start"],
+        ):
+            continue
+        rows.append(
+            {
+                "id": row.get("id", str(index)),
+                "context": row["context"],
+                "question": row["question"],
+                "answers": {
+                    "text": list(answers["text"]),
+                    "answer_start": list(answers["answer_start"]),
+                },
+            }
+        )
+    return Dataset.from_list(rows)
+
+
+def _answers_are_valid(
+    context: str, answer_texts: list[str], answer_starts: list[int]
+) -> bool:
+    """Return whether every answer is non-empty and has a correct offset."""
+    if not answer_texts or len(answer_texts) != len(answer_starts):
+        return False
+    return all(
+        isinstance(text, str)
+        and bool(text)
+        and isinstance(start, int)
+        and 0 <= start <= len(context) - len(text)
+        and context[start : start + len(text)] == text
+        for text, start in zip(answer_texts, answer_starts, strict=True)
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/dataset_creation/create_sk_quad.py
+++ b/src/scripts/dataset_creation/create_sk_quad.py
@@ -11,9 +11,9 @@
 from datasets import Dataset, DatasetDict, load_dataset
 
 try:
-    from sklep_utils import make_dataset_dict, upload_private
+    from dataset_utils import make_dataset_dict, upload_private
 except ModuleNotFoundError:
-    from src.scripts.dataset_creation.sklep_utils import (
+    from src.scripts.dataset_creation.dataset_utils import (
         make_dataset_dict,
         upload_private,
     )

--- a/src/scripts/dataset_creation/create_sklep_nli.py
+++ b/src/scripts/dataset_creation/create_sklep_nli.py
@@ -1,0 +1,64 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets>=3.5.0",
+#     "huggingface-hub>=0.24.0",
+# ]
+# ///
+
+"""Create the SKLEP three-way Slovak NLI mini dataset."""
+
+from datasets import Dataset, DatasetDict, load_dataset
+
+try:
+    from sklep_utils import make_dataset_dict, upload_private
+except ModuleNotFoundError:
+    from src.scripts.dataset_creation.sklep_utils import (
+        make_dataset_dict,
+        upload_private,
+    )
+
+SOURCE_DATASET = "slovak-nlp/sklep"
+TARGET_DATASET = "EuroEval/sklep-nli-mini"
+LABELS = ("entailment", "neutral", "contradiction")
+
+
+def main() -> None:
+    """Download, process, and privately upload the SKLEP NLI dataset."""
+    source = load_dataset(path=SOURCE_DATASET, name="nli")
+    assert isinstance(source, DatasetDict)
+    dataset = process_dataset(raw_dataset=source)
+    upload_private(dataset=dataset, repository_id=TARGET_DATASET)
+
+
+def process_dataset(raw_dataset: DatasetDict) -> DatasetDict:
+    """Convert SKLEP NLI pairs to EuroEval's text and label schema.
+
+    Returns:
+        The processed dataset with independently capped splits.
+    """
+    return make_dataset_dict(
+        train=_process_split(raw_dataset["train"]),
+        validation=_process_split(raw_dataset["validation"]),
+        test=_process_split(raw_dataset["test"]),
+    )
+
+
+def _process_split(source: Dataset) -> Dataset:
+    """Convert one NLI source split.
+
+    Returns:
+        The processed split.
+    """
+    rows = [
+        {
+            "text": f"Premise: {row['premise']}\nHypothesis: {row['hypothesis']}",
+            "label": LABELS[int(row["label"])],
+        }
+        for row in source
+    ]
+    return Dataset.from_list(rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/dataset_creation/create_sklep_nli.py
+++ b/src/scripts/dataset_creation/create_sklep_nli.py
@@ -6,14 +6,14 @@
 # ]
 # ///
 
-"""Create the SKLEP three-way Slovak NLI mini dataset."""
+"""Create the SKLEP three-way Slovakian NLI mini dataset."""
 
 from datasets import Dataset, DatasetDict, load_dataset
 
 try:
-    from sklep_utils import MAX_TEST, MAX_TRAIN, MAX_VAL, cap_split, upload_private
+    from dataset_utils import MAX_TEST, MAX_TRAIN, MAX_VAL, cap_split, upload_private
 except ModuleNotFoundError:
-    from src.scripts.dataset_creation.sklep_utils import (
+    from src.scripts.dataset_creation.dataset_utils import (
         MAX_TEST,
         MAX_TRAIN,
         MAX_VAL,

--- a/src/scripts/dataset_creation/create_sklep_nli.py
+++ b/src/scripts/dataset_creation/create_sklep_nli.py
@@ -11,10 +11,13 @@
 from datasets import Dataset, DatasetDict, load_dataset
 
 try:
-    from sklep_utils import make_dataset_dict, upload_private
+    from sklep_utils import MAX_TEST, MAX_TRAIN, MAX_VAL, cap_split, upload_private
 except ModuleNotFoundError:
     from src.scripts.dataset_creation.sklep_utils import (
-        make_dataset_dict,
+        MAX_TEST,
+        MAX_TRAIN,
+        MAX_VAL,
+        cap_split,
         upload_private,
     )
 
@@ -37,10 +40,18 @@ def process_dataset(raw_dataset: DatasetDict) -> DatasetDict:
     Returns:
         The processed dataset with independently capped splits.
     """
-    return make_dataset_dict(
-        train=_process_split(raw_dataset["train"]),
-        validation=_process_split(raw_dataset["validation"]),
-        test=_process_split(raw_dataset["test"]),
+    return DatasetDict(
+        {
+            "train": _process_split(
+                cap_split(dataset=raw_dataset["train"], maximum=MAX_TRAIN)
+            ),
+            "val": _process_split(
+                cap_split(dataset=raw_dataset["validation"], maximum=MAX_VAL)
+            ),
+            "test": _process_split(
+                cap_split(dataset=raw_dataset["test"], maximum=MAX_TEST)
+            ),
+        }
     )
 
 

--- a/src/scripts/dataset_creation/create_sklep_nli.py
+++ b/src/scripts/dataset_creation/create_sklep_nli.py
@@ -6,7 +6,7 @@
 # ]
 # ///
 
-"""Create the SKLEP three-way Slovakian NLI mini dataset."""
+"""Create the SKLEP three-way Slovak NLI mini dataset."""
 
 from datasets import Dataset, DatasetDict, load_dataset
 
@@ -63,7 +63,9 @@ def _process_split(source: Dataset) -> Dataset:
     """
     rows = [
         {
-            "text": f"Premise: {row['premise']}\nHypothesis: {row['hypothesis']}",
+            "text": (
+                f"Prvé tvrdenie: {row['premise']}\nDruhé tvrdenie: {row['hypothesis']}"
+            ),
             "label": LABELS[int(row["label"])],
         }
         for row in source

--- a/src/scripts/dataset_creation/create_sklep_rte.py
+++ b/src/scripts/dataset_creation/create_sklep_rte.py
@@ -6,14 +6,14 @@
 # ]
 # ///
 
-"""Create the SKLEP binary Slovak RTE mini dataset."""
+"""Create the SKLEP binary Slovakian RTE mini dataset."""
 
 from datasets import Dataset, DatasetDict, load_dataset
 
 try:
-    from sklep_utils import make_dataset_dict, upload_private
+    from dataset_utils import make_dataset_dict, upload_private
 except ModuleNotFoundError:
-    from src.scripts.dataset_creation.sklep_utils import (
+    from src.scripts.dataset_creation.dataset_utils import (
         make_dataset_dict,
         upload_private,
     )

--- a/src/scripts/dataset_creation/create_sklep_rte.py
+++ b/src/scripts/dataset_creation/create_sklep_rte.py
@@ -6,7 +6,7 @@
 # ]
 # ///
 
-"""Create the SKLEP binary Slovakian RTE mini dataset."""
+"""Create the SKLEP binary Slovak RTE mini dataset."""
 
 from datasets import Dataset, DatasetDict, load_dataset
 
@@ -52,7 +52,7 @@ def _process_split(source: Dataset) -> Dataset:
     """
     rows = [
         {
-            "text": f"Premise: {row['text1']}\nHypothesis: {row['text2']}",
+            "text": f"Prvé tvrdenie: {row['text1']}\nDruhé tvrdenie: {row['text2']}",
             "label": LABELS[int(row["label"])],
         }
         for row in source

--- a/src/scripts/dataset_creation/create_sklep_rte.py
+++ b/src/scripts/dataset_creation/create_sklep_rte.py
@@ -1,0 +1,64 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets>=3.5.0",
+#     "huggingface-hub>=0.24.0",
+# ]
+# ///
+
+"""Create the SKLEP binary Slovak RTE mini dataset."""
+
+from datasets import Dataset, DatasetDict, load_dataset
+
+try:
+    from sklep_utils import make_dataset_dict, upload_private
+except ModuleNotFoundError:
+    from src.scripts.dataset_creation.sklep_utils import (
+        make_dataset_dict,
+        upload_private,
+    )
+
+SOURCE_DATASET = "slovak-nlp/sklep"
+TARGET_DATASET = "EuroEval/sklep-rte-mini"
+LABELS = ("entailment", "not entailment")
+
+
+def main() -> None:
+    """Download, process, and privately upload the SKLEP RTE dataset."""
+    source = load_dataset(path=SOURCE_DATASET, name="rte")
+    assert isinstance(source, DatasetDict)
+    dataset = process_dataset(raw_dataset=source)
+    upload_private(dataset=dataset, repository_id=TARGET_DATASET)
+
+
+def process_dataset(raw_dataset: DatasetDict) -> DatasetDict:
+    """Convert SKLEP RTE pairs to EuroEval's binary NLI schema.
+
+    Returns:
+        The processed dataset with independently capped splits.
+    """
+    return make_dataset_dict(
+        train=_process_split(raw_dataset["train"]),
+        validation=_process_split(raw_dataset["validation"]),
+        test=_process_split(raw_dataset["test"]),
+    )
+
+
+def _process_split(source: Dataset) -> Dataset:
+    """Convert one RTE source split.
+
+    Returns:
+        The processed split.
+    """
+    rows = [
+        {
+            "text": f"Premise: {row['text1']}\nHypothesis: {row['text2']}",
+            "label": LABELS[int(row["label"])],
+        }
+        for row in source
+    ]
+    return Dataset.from_list(rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/dataset_creation/create_wikigoldsk.py
+++ b/src/scripts/dataset_creation/create_wikigoldsk.py
@@ -11,15 +11,15 @@
 from datasets import Dataset, DatasetDict, load_dataset
 
 try:
-    from sklep_utils import make_dataset_dict, upload_private
+    from dataset_utils import make_dataset_dict, upload_private
 except ModuleNotFoundError:
-    from src.scripts.dataset_creation.sklep_utils import (
+    from src.scripts.dataset_creation.dataset_utils import (
         make_dataset_dict,
         upload_private,
     )
 
 SOURCE_DATASET = "slovak-nlp/sklep"
-TARGET_DATASET = "EuroEval/wikigoldsk-mini"
+TARGET_DATASET = "EuroEval/wikigold-sk-mini"
 NER_LABELS = (
     "O",
     "B-LOC",

--- a/src/scripts/dataset_creation/create_wikigoldsk.py
+++ b/src/scripts/dataset_creation/create_wikigoldsk.py
@@ -1,0 +1,98 @@
+# /// script
+# requires-python = ">=3.10,<4.0"
+# dependencies = [
+#     "datasets>=3.5.0",
+#     "huggingface-hub>=0.24.0",
+# ]
+# ///
+
+"""Create the SKLEP WikiGoldSK Slovak NER mini dataset."""
+
+from datasets import Dataset, DatasetDict, load_dataset
+
+try:
+    from sklep_utils import make_dataset_dict, upload_private
+except ModuleNotFoundError:
+    from src.scripts.dataset_creation.sklep_utils import (
+        make_dataset_dict,
+        upload_private,
+    )
+
+SOURCE_DATASET = "slovak-nlp/sklep"
+TARGET_DATASET = "EuroEval/wikigoldsk-mini"
+NER_LABELS = (
+    "O",
+    "B-LOC",
+    "I-LOC",
+    "B-ORG",
+    "I-ORG",
+    "B-PER",
+    "I-PER",
+    "B-MISC",
+    "I-MISC",
+)
+
+
+def main() -> None:
+    """Download, process, and privately upload WikiGoldSK."""
+    source = load_dataset(path=SOURCE_DATASET, name="ner-wikigoldsk")
+    assert isinstance(source, DatasetDict)
+    dataset = process_dataset(raw_dataset=source)
+    upload_private(dataset=dataset, repository_id=TARGET_DATASET)
+
+
+def process_dataset(raw_dataset: DatasetDict) -> DatasetDict:
+    """Convert WikiGoldSK to EuroEval's token-classification schema.
+
+    Returns:
+        The processed dataset with independently capped splits.
+    """
+    return make_dataset_dict(
+        train=_process_split(raw_dataset["train"]),
+        validation=_process_split(raw_dataset["validation"]),
+        test=_process_split(raw_dataset["test"]),
+    )
+
+
+def _process_split(source: Dataset) -> Dataset:
+    """Convert one WikiGoldSK source split and validate tag alignment.
+
+    Returns:
+        The processed split.
+
+    Raises:
+        ValueError:
+            If source tokens and labels are not aligned.
+    """
+    rows = []
+    for row in source:
+        tokens = list(row["tokens"])
+        source_labels = row.get("ner_tags_text")
+        if source_labels is None:
+            source_labels = row["ner_tags"]
+        labels = [_normalise_label(label=label) for label in source_labels]
+        if len(tokens) != len(labels):
+            raise ValueError("WikiGoldSK tokens and labels must have equal lengths")
+        rows.append({"text": row["sentence"], "tokens": tokens, "labels": labels})
+    return Dataset.from_list(rows)
+
+
+def _normalise_label(label: int | str) -> str:
+    """Return a canonical WikiGoldSK label.
+
+    Raises:
+        ValueError:
+            If the source label is not part of the WikiGoldSK schema.
+    """
+    if isinstance(label, int):
+        try:
+            return NER_LABELS[label]
+        except IndexError as error:
+            raise ValueError(f"Unexpected WikiGoldSK label: {label}") from error
+    if label not in NER_LABELS:
+        raise ValueError(f"Unexpected WikiGoldSK label: {label}")
+    return label
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/dataset_creation/dataset_utils.py
+++ b/src/scripts/dataset_creation/dataset_utils.py
@@ -1,4 +1,4 @@
-"""Shared helpers for creating the SKLEP-derived mini datasets."""
+"""Shared helpers for capping dataset splits and uploading them to the Hub."""
 
 from datasets import Dataset, DatasetDict
 from huggingface_hub import HfApi

--- a/src/scripts/dataset_creation/sklep_utils.py
+++ b/src/scripts/dataset_creation/sklep_utils.py
@@ -1,0 +1,52 @@
+"""Shared helpers for creating the SKLEP-derived mini datasets."""
+
+from datasets import Dataset, DatasetDict
+from huggingface_hub import HfApi
+
+SEED = 4242
+MAX_TRAIN = 1024
+MAX_VAL = 256
+MAX_TEST = 2048
+
+
+def make_dataset_dict(
+    train: Dataset, validation: Dataset, test: Dataset
+) -> DatasetDict:
+    """Cap source splits and expose validation under EuroEval's ``val`` name.
+
+    Returns:
+        A dataset dictionary with independently capped splits.
+    """
+    return DatasetDict(
+        {
+            "train": cap_split(dataset=train, maximum=MAX_TRAIN),
+            "val": cap_split(dataset=validation, maximum=MAX_VAL),
+            "test": cap_split(dataset=test, maximum=MAX_TEST),
+        }
+    )
+
+
+def cap_split(dataset: Dataset, maximum: int) -> Dataset:
+    """Sample at most ``maximum`` rows without crossing source split boundaries.
+
+    Returns:
+        The capped dataset.
+    """
+    if dataset.num_rows <= maximum:
+        return dataset
+    return dataset.shuffle(seed=SEED).select(range(maximum))
+
+
+def upload_private(dataset: DatasetDict, repository_id: str) -> None:
+    """Replace a Hub dataset and fail unless the resulting repository is private.
+
+    Raises:
+        RuntimeError:
+            If the resulting repository is public.
+    """
+    api = HfApi()
+    api.delete_repo(repository_id, repo_type="dataset", missing_ok=True)
+    dataset.push_to_hub(repository_id, private=True)
+    repository = api.repo_info(repository_id, repo_type="dataset")
+    if not repository.private:
+        raise RuntimeError(f"Dataset repository {repository_id} is not private")

--- a/src/scripts/dataset_creation/sklep_utils.py
+++ b/src/scripts/dataset_creation/sklep_utils.py
@@ -45,8 +45,8 @@ def upload_private(dataset: DatasetDict, repository_id: str) -> None:
             If the resulting repository is public.
     """
     api = HfApi()
-    api.delete_repo(repository_id, repo_type="dataset", missing_ok=True)
-    dataset.push_to_hub(repository_id, private=True)
-    repository = api.repo_info(repository_id, repo_type="dataset")
+    api.delete_repo(repo_id=repository_id, repo_type="dataset", missing_ok=True)
+    dataset.push_to_hub(repo_id=repository_id, private=True)
+    repository = api.repo_info(repo_id=repository_id, repo_type="dataset")
     if not repository.private:
         raise RuntimeError(f"Dataset repository {repository_id} is not private")

--- a/tests/test_scripts/test_create_sklep_datasets.py
+++ b/tests/test_scripts/test_create_sklep_datasets.py
@@ -2,8 +2,8 @@
 
 from datasets import Dataset, DatasetDict
 
-from src.euroeval.dataset_configs.slovak import SKLEP_RTE_CONFIG
-from src.euroeval.tasks import NLI
+from euroeval.dataset_configs.slovak import SKLEP_RTE_CONFIG
+from euroeval.tasks import NLI
 from src.scripts.dataset_creation.create_reviews3 import (
     process_dataset as process_reviews3,
 )
@@ -42,19 +42,14 @@ def test_each_split_is_capped_independently() -> None:
     )
 
     result = process_nli(raw_dataset=source)
+    repeated_result = process_nli(raw_dataset=source)
 
     assert {split: dataset.num_rows for split, dataset in result.items()} == {
         "train": 1024,
         "val": 256,
         "test": 2048,
     }
-    assert result["train"]["text"][:5] == [
-        "Premise: p73\nHypothesis: h73",
-        "Premise: p963\nHypothesis: h963",
-        "Premise: p836\nHypothesis: h836",
-        "Premise: p683\nHypothesis: h683",
-        "Premise: p494\nHypothesis: h494",
-    ]
+    assert result["train"].to_list() == repeated_result["train"].to_list()
 
 
 def test_nli_formats_pairs_and_maps_all_labels() -> None:

--- a/tests/test_scripts/test_create_sklep_datasets.py
+++ b/tests/test_scripts/test_create_sklep_datasets.py
@@ -1,0 +1,166 @@
+"""Tests for the SKLEP-derived dataset creation scripts."""
+
+from datasets import Dataset, DatasetDict
+
+from src.scripts.dataset_creation.create_reviews3 import (
+    process_dataset as process_reviews3,
+)
+from src.scripts.dataset_creation.create_sk_quad import (
+    process_dataset as process_sk_quad,
+)
+from src.scripts.dataset_creation.create_sklep_nli import process_dataset as process_nli
+from src.scripts.dataset_creation.create_sklep_rte import process_dataset as process_rte
+from src.scripts.dataset_creation.create_wikigoldsk import (
+    process_dataset as process_wikigoldsk,
+)
+
+
+def test_each_split_is_capped_independently() -> None:
+    """The cap is applied to each source split, not after combining them."""
+    source = DatasetDict(
+        {
+            "train": Dataset.from_dict(
+                {
+                    "premise": ["p"] * 1025,
+                    "hypothesis": ["h"] * 1025,
+                    "label": [0] * 1025,
+                }
+            ),
+            "validation": Dataset.from_dict(
+                {"premise": ["p"] * 257, "hypothesis": ["h"] * 257, "label": [0] * 257}
+            ),
+            "test": Dataset.from_dict(
+                {
+                    "premise": ["p"] * 2049,
+                    "hypothesis": ["h"] * 2049,
+                    "label": [0] * 2049,
+                }
+            ),
+        }
+    )
+
+    result = process_nli(raw_dataset=source)
+
+    assert {split: dataset.num_rows for split, dataset in result.items()} == {
+        "train": 1024,
+        "val": 256,
+        "test": 2048,
+    }
+
+
+def test_nli_formats_pairs_and_maps_all_labels() -> None:
+    """NLI pairs use EuroEval's standard three-way labels."""
+    source = DatasetDict(
+        {
+            split: Dataset.from_dict(
+                {
+                    "premise": ["p0", "p1", "p2"],
+                    "hypothesis": ["h0", "h1", "h2"],
+                    "label": [0, 1, 2],
+                }
+            )
+            for split in ("train", "validation", "test")
+        }
+    )
+
+    result = process_nli(raw_dataset=source)
+
+    assert result["train"].to_list() == [
+        {"text": "Premise: p0\nHypothesis: h0", "label": "entailment"},
+        {"text": "Premise: p1\nHypothesis: h1", "label": "neutral"},
+        {"text": "Premise: p2\nHypothesis: h2", "label": "contradiction"},
+    ]
+
+
+def test_reviews3_maps_binary_sentiment_labels() -> None:
+    """Reviews3 labels are exposed as negative and positive strings."""
+    source = DatasetDict(
+        {
+            split: Dataset.from_dict({"text": ["zlé", "dobré"], "label": [0, 1]})
+            for split in ("train", "validation", "test")
+        }
+    )
+
+    result = process_reviews3(raw_dataset=source)
+
+    assert result["train"]["label"] == ["negative", "positive"]
+
+
+def test_rte_uses_binary_labels() -> None:
+    """RTE remains binary while using the NLI dataset schema."""
+    source = DatasetDict(
+        {
+            split: Dataset.from_dict(
+                {"text1": ["p0", "p1"], "text2": ["h0", "h1"], "label": [0, 1]}
+            )
+            for split in ("train", "validation", "test")
+        }
+    )
+
+    result = process_rte(raw_dataset=source)
+
+    assert result["train"]["label"] == ["entailment", "not entailment"]
+
+
+def test_sk_quad_drops_empty_and_invalid_answers() -> None:
+    """Only answerable rows with offsets matching their context are retained."""
+    source = DatasetDict(
+        {
+            split: Dataset.from_list(
+                [
+                    {
+                        "context": "Odpoveď je tu.",
+                        "question": "Čo je tu?",
+                        "answers": {"text": ["Odpoveď"], "answer_start": [0]},
+                    },
+                    {
+                        "context": "Bez odpovede.",
+                        "question": "Čo?",
+                        "answers": {"text": [], "answer_start": []},
+                    },
+                    {
+                        "context": "Odpoveď je tu.",
+                        "question": "Čo?",
+                        "answers": {"text": ["odpoveď"], "answer_start": [0]},
+                    },
+                ]
+            )
+            for split in ("train", "validation", "test")
+        }
+    )
+
+    result = process_sk_quad(raw_dataset=source)
+
+    assert result["train"].num_rows == 1
+    assert result["train"][0] == {
+        "id": "0",
+        "context": "Odpoveď je tu.",
+        "question": "Čo je tu?",
+        "answers": {"text": ["Odpoveď"], "answer_start": [0]},
+    }
+
+
+def test_wikigoldsk_uses_sentence_tokens_and_text_labels() -> None:
+    """WikiGoldSK exposes aligned tokens and canonical BIO labels."""
+    source = DatasetDict(
+        {
+            split: Dataset.from_list(
+                [
+                    {
+                        "sentence": "Bratislava je mesto.",
+                        "tokens": ["Bratislava", "je", "mesto", "."],
+                        "ner_tags_text": ["B-LOC", "O", "O", "O"],
+                    }
+                ]
+            )
+            for split in ("train", "validation", "test")
+        }
+    )
+
+    result = process_wikigoldsk(raw_dataset=source)
+
+    assert result["train"][0] == {
+        "text": "Bratislava je mesto.",
+        "tokens": ["Bratislava", "je", "mesto", "."],
+        "labels": ["B-LOC", "O", "O", "O"],
+    }

--- a/tests/test_scripts/test_create_sklep_datasets.py
+++ b/tests/test_scripts/test_create_sklep_datasets.py
@@ -2,6 +2,8 @@
 
 from datasets import Dataset, DatasetDict
 
+from src.euroeval.dataset_configs.slovak import SKLEP_RTE_CONFIG
+from src.euroeval.tasks import NLI
 from src.scripts.dataset_creation.create_reviews3 import (
     process_dataset as process_reviews3,
 )
@@ -21,8 +23,8 @@ def test_each_split_is_capped_independently() -> None:
         {
             "train": Dataset.from_dict(
                 {
-                    "premise": ["p"] * 1025,
-                    "hypothesis": ["h"] * 1025,
+                    "premise": [f"p{idx}" for idx in range(1025)],
+                    "hypothesis": [f"h{idx}" for idx in range(1025)],
                     "label": [0] * 1025,
                 }
             ),
@@ -46,6 +48,13 @@ def test_each_split_is_capped_independently() -> None:
         "val": 256,
         "test": 2048,
     }
+    assert result["train"]["text"][:5] == [
+        "Premise: p73\nHypothesis: h73",
+        "Premise: p963\nHypothesis: h963",
+        "Premise: p836\nHypothesis: h836",
+        "Premise: p683\nHypothesis: h683",
+        "Premise: p494\nHypothesis: h494",
+    ]
 
 
 def test_nli_formats_pairs_and_maps_all_labels() -> None:
@@ -84,6 +93,22 @@ def test_reviews3_maps_binary_sentiment_labels() -> None:
     result = process_reviews3(raw_dataset=source)
 
     assert result["train"]["label"] == ["negative", "positive"]
+
+
+def test_rte_config_supports_binary_encoder_and_generative_evaluation() -> None:
+    """The unofficial RTE config exposes one consistent binary label contract."""
+    assert SKLEP_RTE_CONFIG.task == NLI
+    assert SKLEP_RTE_CONFIG.labels == ["entailment", "not entailment"]
+    assert SKLEP_RTE_CONFIG.prompt_label_mapping == {
+        "entailment": "pravda",
+        "not entailment": "nepravda",
+    }
+    assert SKLEP_RTE_CONFIG.unofficial is True
+    assert SKLEP_RTE_CONFIG.prompt_prefix is not None
+    assert SKLEP_RTE_CONFIG.prompt_template is not None
+    assert SKLEP_RTE_CONFIG.instruction_prompt is not None
+    assert "neutral" not in SKLEP_RTE_CONFIG.prompt_prefix
+    assert "contradiction" not in SKLEP_RTE_CONFIG.instruction_prompt
 
 
 def test_rte_uses_binary_labels() -> None:

--- a/tests/test_scripts/test_create_sklep_datasets.py
+++ b/tests/test_scripts/test_create_sklep_datasets.py
@@ -70,9 +70,9 @@ def test_nli_formats_pairs_and_maps_all_labels() -> None:
     result = process_nli(raw_dataset=source)
 
     assert result["train"].to_list() == [
-        {"text": "Premise: p0\nHypothesis: h0", "label": "entailment"},
-        {"text": "Premise: p1\nHypothesis: h1", "label": "neutral"},
-        {"text": "Premise: p2\nHypothesis: h2", "label": "contradiction"},
+        {"text": "Prvé tvrdenie: p0\nDruhé tvrdenie: h0", "label": "entailment"},
+        {"text": "Prvé tvrdenie: p1\nDruhé tvrdenie: h1", "label": "neutral"},
+        {"text": "Prvé tvrdenie: p2\nDruhé tvrdenie: h2", "label": "contradiction"},
     ]
 
 


### PR DESCRIPTION
## What

Adds five SKLEP-derived Slovak datasets as unofficial EuroEval benchmarks: NLI,
binary RTE, answerable-only SK-QuAD, WikiGoldSK NER, and binary Reviews3
sentiment.

## Key features

- preserves the original train, validation, and test boundaries
- samples each split deterministically with seed 4242
- caps splits at 1,024 train, 256 validation, and 2,048 test examples
- filters SK-QuAD to answerable examples with valid extractive-answer offsets
- provides a dedicated binary RTE prompt and label mapping
- adds five reproducible dataset-creation scripts, tests, documentation, cached
  split sizes, and an unreleased changelog entry
- marks every new dataset configuration as unofficial

## Datasets

The processed datasets are currently private in the EuroEval Hugging Face
organisation:

- `EuroEval/sklep-nli-mini`
- `EuroEval/sklep-rte-mini`
- `EuroEval/sk-quad-mini`
- `EuroEval/wikigoldsk-mini`
- `EuroEval/reviews3-mini`

SKLEP declares mixed upstream licences, so the documentation retains component
provenance rather than assigning one umbrella licence.

## Usage

```bash
euroeval --model <model-id> --dataset sklep-nli
euroeval --model <model-id> --dataset sklep-rte
euroeval --model <model-id> --dataset sk-quad
euroeval --model <model-id> --dataset wikigoldsk
euroeval --model <model-id> --dataset reviews3
```

## Validation

- targeted SKLEP creation/configuration tests pass
- all five data-loading checks pass
- all five Hub repositories were verified private
- regenerated datasets exactly match uploaded schemas, rows, and split sizes
- Ruff, formatting, ty, Markdown lint, JSON validation, and diff checks pass
- independent review passed with no remaining issues
