### PR TITLE
fix: preserve Hugging Face Router model IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fixed Hugging Face Router model IDs being rewritten with an unwanted `openai/` prefix
+  when using a custom API base.
 - Fixed an infinite loop in token-classification few-shot example selection when the
   training split runs out of entity-bearing examples before `num_few_shots` is reached,
   including when the labels contain case variants of the same entity (e.g. `b-per` and

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -280,6 +280,7 @@ BASE_DECODER_MODELS = [
 ]
 
 CUSTOM_INFERENCE_API_PREFIXES = [
+    "huggingface/",
     "hosted_vllm/",
     "vllm/",
     "ollama/",

--- a/tests/test_benchmark_modules/test_litellm.py
+++ b/tests/test_benchmark_modules/test_litellm.py
@@ -6,7 +6,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 from litellm.types.utils import Choices
 
-from euroeval.benchmark_modules.litellm import LiteLLMModel, get_api_model_release_date
+from euroeval.benchmark_modules.litellm import (
+    LiteLLMModel,
+    clean_model_id,
+    get_api_model_release_date,
+)
 from euroeval.data_models import BenchmarkConfig, DatasetConfig, ModelConfig
 from euroeval.exceptions import InvalidModel
 from euroeval.model_loading import load_model
@@ -147,6 +151,20 @@ class TestCreateModelOutput:
 def test_get_api_model_release_date(model_id: str, expected: str | None) -> None:
     """API aliases and dated model IDs resolve to their release dates."""
     assert get_api_model_release_date(model_id) == expected
+
+
+def test_huggingface_model_id_is_preserved_for_custom_api(
+    benchmark_config: BenchmarkConfig,
+) -> None:
+    """Hugging Face model IDs remain valid for custom OpenAI-compatible APIs."""
+    benchmark_config = dataclasses.replace(
+        benchmark_config, api_base="https://router.huggingface.co/featherless-ai/v1"
+    )
+    model_id = "huggingface/mistralai/Mistral-Small-3.1-24B-Instruct-2503"
+
+    assert (
+        clean_model_id(model_id=model_id, benchmark_config=benchmark_config) == model_id
+    )
 
 
 def test_litellm_model_config_includes_release_date(


### PR DESCRIPTION
Fixes Hugging Face Router compatibility for EuroEval API evaluations.

- Preserve `huggingface/<org>/<model>` IDs when `--api-base` is supplied.
- Add regression coverage.
- Verified both Llama 3.1 8B Instruct and Mistral Small 3.1 24B Instruct via the HF Router.