### PR TITLE
feat: visualize leaderboard performance over time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   few-shot and validation splits. This has been fixed.
 - Fixed leaderboard deduplication treating malformed model release dates as valid
   metadata.
+- Fixed model release dates being missing for most models: a rate-limited Hub request
+  was stored as "no release date" and never asked again, and models without a recorded
+  Hugging Face URL were looked up as API models, which do not know them.
 - Fixed Hugging Face Router model IDs being rewritten with an unwanted `openai/` prefix
   when using a custom API base.
 - Fixed an infinite loop in token-classification few-shot example selection when the

--- a/src/euroeval/benchmark_modules/hf.py
+++ b/src/euroeval/benchmark_modules/hf.py
@@ -21,6 +21,7 @@ from huggingface_hub.errors import (
     LocalTokenNotFoundError,
     RepositoryNotFoundError,
 )
+from huggingface_hub.hf_api import GitCommitInfo as HfApiGitCommitInfo
 from huggingface_hub.hf_api import ModelInfo as HfApiModelInfo
 from peft import PeftConfig
 from requests.exceptions import RequestException
@@ -1790,19 +1791,127 @@ def get_model_release_date(
             for path in files
         )
 
-    try:
-        commits = hf_api.list_repo_commits(
-            repo_id=model_id, revision=revision, token=token
+    def files_at(commit: HfApiGitCommitInfo) -> list[str]:
+        return _query_hub(
+            hf_api.list_repo_files,
+            repo_id=model_id,
+            revision=commit.commit_id,
+            token=token,
+            description=model_id,
         )
-        for commit in reversed(commits):
-            files = hf_api.list_repo_files(
-                repo_id=model_id, revision=commit.commit_id, token=token
+
+    try:
+        commits = list(
+            _query_hub(
+                hf_api.list_repo_commits,
+                repo_id=model_id,
+                revision=revision,
+                token=token,
+                description=model_id,
             )
-            if contains_weights(files):
-                return commit.created_at.date().isoformat()
+        )
+        if not commits:
+            return None
+        # Commits are returned newest first, so reverse them to get the history
+        # in chronological order.
+        ordered = list(reversed(commits))
+        if contains_weights(files_at(ordered[0])):
+            return ordered[0].created_at.date().isoformat()
+        if not contains_weights(files_at(ordered[-1])):
+            return None
+        # Weights appear once and stay, so the release commit is the first
+        # true value of a monotone predicate: search for it rather than
+        # requesting the file list of every single commit, which for a
+        # repository with thousands of commits is what exhausts the rate limit.
+        oldest_without, newest_with = 0, len(ordered) - 1
+        while newest_with - oldest_without > 1:
+            middle = (oldest_without + newest_with) // 2
+            if contains_weights(files_at(ordered[middle])):
+                newest_with = middle
+            else:
+                oldest_without = middle
+        return ordered[newest_with].created_at.date().isoformat()
     except (HfHubHTTPError, HFValidationError, OSError, RequestException) as e:
         log(
             f"Could not determine the release date for {model_id!r}: {e}",
             level=logging.DEBUG,
         )
     return None
+
+
+def _query_hub[T](
+    func: t.Callable[..., T], /, *, description: str, **kwargs: object
+) -> T:
+    """Call a Hub API function, retrying transient failures.
+
+    Dating every model in the results means tens of thousands of Hub requests,
+    which is enough to trip the rate limit. A rate-limited request is a
+    temporary condition, so it is retried rather than reported as "this model
+    has no release date" -- the answer would otherwise be stored and never
+    asked again.
+
+    Args:
+        func:
+            The Hub API function to call.
+        description:
+            What is being looked up, for the warning message.
+        kwargs:
+            Arguments passed to `func`.
+
+    Returns:
+        Whatever `func` returns.
+
+    Raises:
+        RepositoryNotFoundError:
+            If the repository does not exist (not retried).
+        GatedRepoError:
+            If the repository is gated (not retried).
+        HFValidationError:
+            If the model ID is not a valid repository ID (not retried).
+        HfHubHTTPError:
+            If the request still fails after the retries.
+        RequestException:
+            If the connection still fails after the retries.
+        OSError:
+            If the network is unavailable after the retries.
+    """
+    max_attempts = 6
+    attempt = 0
+    while True:
+        try:
+            return func(**kwargs)
+        except (RepositoryNotFoundError, GatedRepoError, HFValidationError):
+            raise
+        except (HfHubHTTPError, RequestException, OSError) as e:
+            if attempt == max_attempts - 1:
+                raise
+            # The rate limit is a window which resets rather than a queue, so
+            # waiting less than the Hub asks for just spends another request.
+            wait_time = max(2**attempt, _retry_after_seconds(exc=e))
+            log(
+                f"Could not query the Hub for {description}: {e}. "
+                f"Retrying in {wait_time}s...",
+                level=logging.WARNING,
+            )
+            sleep(wait_time)
+            attempt += 1
+
+
+def _retry_after_seconds(exc: BaseException) -> int:
+    """The delay the Hub asked us to wait for, if it said one.
+
+    Args:
+        exc:
+            The exception raised by the failed request.
+
+    Returns:
+        The requested number of seconds, or 0 if the response did not say.
+    """
+    response = getattr(exc, "response", None)
+    headers = getattr(response, "headers", None)
+    if headers is None:
+        return 0
+    try:
+        return max(0, int(headers.get("Retry-After", 0)))
+    except (TypeError, ValueError):
+        return 0

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -2080,11 +2080,9 @@ def get_api_model_release_date(model_id: str) -> str | None:
     Returns:
         The ISO-formatted release date, or None if no date is known.
     """
-    # Explicit annotations are authoritative, including corrections to a date
-    # embedded in an upstream model identifier.
-    for pattern, release_date in MODEL_RELEASE_DATE_MAPPING.items():
-        if re.fullmatch(pattern=pattern, string=model_id) is not None:
-            return release_date
+    annotated = get_annotated_release_date(model_id=model_id)
+    if annotated is not None:
+        return annotated
 
     date_match = re.search(r"(?<!\d)(\d{4})-?(\d{2})-?(\d{2})(?!\d)", model_id)
     if date_match is not None:
@@ -2092,6 +2090,26 @@ def get_api_model_release_date(model_id: str) -> str | None:
             return datetime.date(*map(int, date_match.groups())).isoformat()
         except ValueError:
             pass
+    return None
+
+
+def get_annotated_release_date(model_id: str) -> str | None:
+    """Get a release date from the manually maintained annotations.
+
+    These are authoritative, including corrections to a date embedded in an
+    upstream model identifier, and they are the only way to date a model that
+    exists on neither the Hub nor a documented API.
+
+    Args:
+        model_id:
+            The model identifier.
+
+    Returns:
+        The ISO-formatted date, or None if the model is not annotated.
+    """
+    for pattern, release_date in MODEL_RELEASE_DATE_MAPPING.items():
+        if re.fullmatch(pattern=pattern, string=model_id) is not None:
+            return release_date
     return None
 
 

--- a/src/frontend/components/LeaderboardScatter.vue
+++ b/src/frontend/components/LeaderboardScatter.vue
@@ -3,9 +3,15 @@ import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 import type { LeaderboardTable } from "@/leaderboard";
 import { matchesQuery } from "@/filter";
 
-const props = defineProps<{
-  table: LeaderboardTable;
-}>();
+type XAxis = "parameters" | "releaseDate";
+
+const props = withDefaults(
+  defineProps<{
+    table: LeaderboardTable;
+    xAxis?: XAxis;
+  }>(),
+  { xAxis: "parameters" },
+);
 
 type ModelKind = "instruct" | "reasoning" | "base" | "encoder" | "other";
 
@@ -16,6 +22,7 @@ interface MetaItem {
 
 interface Point {
   x: number;
+  xLabel: string;
   y: number;
   label: string;
   icon: string;
@@ -87,9 +94,9 @@ const KIND_COLOR: Record<ModelKind, string> = {
 const colIndex = (key: string) =>
   props.table.columns.findIndex((c) => c.key.toLowerCase() === key.toLowerCase());
 
-const xKey = "Parameters";
-
-const xIdx = computed(() => colIndex(xKey));
+const xIdx = computed(() =>
+  props.xAxis === "parameters" ? colIndex("parameters") : -1,
+);
 const yIdx = computed(() => colIndex("rank score"));
 const modelIdx = computed(() => colIndex("model"));
 const typeIdx = computed(() => colIndex("type"));
@@ -112,7 +119,7 @@ const allPoints = computed<Point[]>(() => {
   const mi = modelIdx.value;
   const ti = typeIdx.value;
   const ci = commercialIdx.value;
-  if (xi < 0 || yi < 0) return [];
+  if ((props.xAxis === "parameters" && xi < 0) || yi < 0) return [];
 
   const out: Point[] = [];
   // Drop rows whose displayed value is a sentinel (e.g. "-", "?", "") —
@@ -122,12 +129,22 @@ const allPoints = computed<Point[]>(() => {
     text !== "" && text !== "-" && text !== "?" && text !== "??";
 
   for (const row of props.table.rows) {
-    const xc = row.cells[xi];
     const yc = row.cells[yi];
-    if (!isRealValue(xc.text) || !isRealValue(yc.text)) continue;
-    const xk = xc.sortKey;
+    if (!isRealValue(yc.text)) continue;
+    let xk: number;
+    let xLabel: string;
+    if (props.xAxis === "releaseDate") {
+      if (!row.releaseDate) continue;
+      xk = Date.parse(`${row.releaseDate}T00:00:00Z`);
+      xLabel = row.releaseDate;
+    } else {
+      const xc = row.cells[xi];
+      if (!isRealValue(xc.text) || typeof xc.sortKey !== "number") continue;
+      xk = xc.sortKey;
+      xLabel = formatCompact(xk);
+    }
     const yk = yc.sortKey;
-    if (typeof xk !== "number" || !Number.isFinite(xk)) continue;
+    if (!Number.isFinite(xk)) continue;
     if (typeof yk !== "number" || !Number.isFinite(yk)) continue;
     const icon = ti >= 0 ? row.cells[ti].text : "";
     const commercialText = ci >= 0 ? row.cells[ci].text : "";
@@ -137,6 +154,7 @@ const allPoints = computed<Point[]>(() => {
     }));
     out.push({
       x: xk,
+      xLabel,
       y: yk,
       label: mi >= 0 ? row.cells[mi].text : "",
       icon,
@@ -206,16 +224,21 @@ const rawXMinMax = computed(() => {
   if (xs.length === 0) return { min: 0, max: 1 };
   const min = Math.min(...xs);
   const max = Math.max(...xs);
-  return min === max ? { min: min - 1, max: max + 1 } : { min, max };
+  if (min !== max) return { min, max };
+  const singleValuePad =
+    props.xAxis === "releaseDate" ? 180 * 24 * 60 * 60 * 1000 : 1;
+  return { min: min - singleValuePad, max: max + singleValuePad };
 });
 
-const useLogX = computed(() => rawXMinMax.value.min > 0);
+const useLogX = computed(
+  () => props.xAxis === "parameters" && rawXMinMax.value.min > 0,
+);
 
-// The x-domain is the model-size range of this plot, padded on both ends so
+// The x-domain is the current horizontal range, padded on both ends so
 // the smallest and largest models sit inside the plot with breathing room
 // rather than clipped against the axis edges. Padding is applied in the same
-// space the axis uses (log10 when all sizes are positive), so it reads as a
-// constant visual margin on each side regardless of how wide the range is.
+// space the axis uses (log10 for model sizes), so it reads as a constant visual
+// margin on each side regardless of how wide the range is.
 const X_PAD = 0.06; // fraction of the (transformed) range, per side
 const xMinMax = computed(() => {
   const { min, max } = rawXMinMax.value;
@@ -252,6 +275,19 @@ const yScale = (v: number) => {
 };
 
 const formatX = (v: number): string => {
+  if (props.xAxis === "releaseDate") {
+    const date = new Date(v);
+    const rangeYears =
+      (rawXMinMax.value.max - rawXMinMax.value.min) /
+      (365.25 * 24 * 60 * 60 * 1000);
+    return rangeYears > 2
+      ? String(date.getUTCFullYear())
+      : date.toLocaleDateString("en", {
+          month: "short",
+          year: "numeric",
+          timeZone: "UTC",
+        });
+  }
   if (Math.abs(v) >= 1e12) return (v / 1e12).toFixed(1) + "T";
   if (Math.abs(v) >= 1e9) return (v / 1e9).toFixed(1) + "B";
   if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(1) + "M";
@@ -266,6 +302,33 @@ interface Tick {
 
 const xTicks = computed<Tick[]>(() => {
   const { min, max } = xMinMax.value;
+  if (props.xAxis === "releaseDate") {
+    const tickMin = rawXMinMax.value.min;
+    const tickMax = rawXMinMax.value.max;
+    const rangeYears =
+      (tickMax - tickMin) / (365.25 * 24 * 60 * 60 * 1000);
+    const ticks: Tick[] = [];
+    if (rangeYears > 2) {
+      const firstYear = new Date(tickMin).getUTCFullYear();
+      const lastYear = new Date(tickMax).getUTCFullYear();
+      const step = Math.max(1, Math.ceil((lastYear - firstYear) / 6));
+      for (let year = firstYear; year <= lastYear; year += step) {
+        const value = Date.UTC(year, 0, 1);
+        if (value >= min && value <= max) ticks.push({ value, major: true });
+      }
+    } else {
+      const first = new Date(tickMin);
+      const last = new Date(tickMax);
+      const firstMonth = first.getUTCFullYear() * 12 + first.getUTCMonth();
+      const lastMonth = last.getUTCFullYear() * 12 + last.getUTCMonth();
+      const step = Math.max(1, Math.ceil((lastMonth - firstMonth) / 6));
+      for (let month = firstMonth; month <= lastMonth; month += step) {
+        const value = Date.UTC(Math.floor(month / 12), month % 12, 1);
+        if (value >= min && value <= max) ticks.push({ value, major: true });
+      }
+    }
+    return ticks;
+  }
   if (useLogX.value) {
     const ticks: Tick[] = [];
     const lo = Math.floor(Math.log10(Math.max(min, 1)));
@@ -405,8 +468,11 @@ const tooltipStyle = computed(() => {
   <div class="scatter">
     <div class="scatter-toolbar">
       <span class="scatter-help">
-        X-axis: Parameters (log). Y-axis: Rank score (lower is better).
-        Showing {{ visiblePoints.length }} of {{ allPoints.length }} models.
+        X-axis:
+        {{ xAxis === "parameters" ? "Parameters (log)" : "Release date" }}.
+        Y-axis: Rank score (lower is better).
+        Showing {{ visiblePoints.length }} of {{ allPoints.length }} models with
+        {{ xAxis === "parameters" ? "parameter counts" : "release dates" }}.
       </span>
       <input
         v-model="searchQuery"
@@ -417,7 +483,7 @@ const tooltipStyle = computed(() => {
       />
     </div>
 
-    <div class="scatter-legend">
+    <div v-if="allPoints.length > 0" class="scatter-legend">
       <button
         v-for="k in presentKinds"
         :key="k"
@@ -461,7 +527,13 @@ const tooltipStyle = computed(() => {
       </button>
     </div>
 
-    <div class="scatter-wrap">
+    <div v-if="allPoints.length === 0" class="scatter-empty" role="status">
+      No ranked models have
+      {{ xAxis === "parameters" ? "parameter counts" : "release dates" }}
+      available yet.
+    </div>
+
+    <div v-else class="scatter-wrap">
       <svg
         :viewBox="`0 0 ${width} ${height}`"
         preserveAspectRatio="xMidYMid meet"
@@ -536,7 +608,9 @@ const tooltipStyle = computed(() => {
           :y="height - 6"
           text-anchor="middle"
         >
-          Parameters{{ useLogX ? " (log)" : "" }}
+          {{ xAxis === "parameters" ? "Parameters" : "Release date" }}{{
+            useLogX ? " (log)" : ""
+          }}
         </text>
         <text
           class="axis-label"
@@ -584,6 +658,10 @@ const tooltipStyle = computed(() => {
           <div class="tt-row">
             <span class="tt-label">Mean rank</span>
             <span class="tt-value">{{ hovered.y.toFixed(2) }}</span>
+          </div>
+          <div v-if="xAxis === 'releaseDate'" class="tt-row">
+            <span class="tt-label">Release date</span>
+            <span class="tt-value">{{ hovered.xLabel }}</span>
           </div>
           <div class="tt-row">
             <span class="tt-label">Kind</span>
@@ -694,6 +772,15 @@ const tooltipStyle = computed(() => {
   border: 1px solid var(--color-border);
   border-radius: 6px;
   padding: 0.5rem;
+}
+
+.scatter-empty {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  color: var(--color-muted);
+  padding: 2rem 1rem;
+  text-align: center;
 }
 
 .scatter-svg {

--- a/src/frontend/components/LeaderboardView.vue
+++ b/src/frontend/components/LeaderboardView.vue
@@ -23,7 +23,7 @@ const categoryTabs = [
 ] as const;
 
 type CategoryId = (typeof categoryTabs)[number]["id"];
-type ViewId = "table" | "scatter";
+type ViewId = "table" | "modelSize" | "releaseDate";
 
 // Precomputed at leaderboard-generation time (which leaderboards/categories
 // have ranked models) and bundled statically, so it's known synchronously
@@ -86,8 +86,7 @@ const loadFor = async (stem: string) => {
 watch(
   () => props.stem,
   (s) => {
-    // Reset the category on language switch, but keep the user's table/scatter
-    // preference - switching language shouldn't kick you out of scatter view.
+    // Reset the category on language switch, but keep the user's selected view.
     activeCategory.value = firstRankedCategory();
     loadFor(s);
   },
@@ -148,7 +147,8 @@ const isMultilingual = computed(() => MULTILINGUAL_STEMS.has(props.stem));
 
 const viewTabs: { id: ViewId; label: string }[] = [
   { id: "table", label: "Leaderboard" },
-  { id: "scatter", label: "Scatter Plot" },
+  { id: "modelSize", label: "Model Size" },
+  { id: "releaseDate", label: "Release Date" },
 ];
 
 // Sliding-pill indicators for the two tab groups. Each indicator is a
@@ -311,7 +311,12 @@ const downloadCsv = async () => {
           <rect x="6.5" y="3" width="3" height="11" rx="0.5" fill="currentColor" />
           <rect x="12" y="8" width="3" height="6" rx="0.5" fill="currentColor" />
         </svg>
-        <svg v-else class="lb-view-icon" viewBox="0 0 16 16" aria-hidden="true">
+        <svg
+          v-else-if="v.id === 'modelSize'"
+          class="lb-view-icon"
+          viewBox="0 0 16 16"
+          aria-hidden="true"
+        >
           <path
             d="M2 2v11a1 1 0 0 0 1 1h11"
             stroke="currentColor"
@@ -323,6 +328,20 @@ const downloadCsv = async () => {
           <circle cx="9" cy="5.5" r="1.1" fill="currentColor" />
           <circle cx="12" cy="8" r="1.1" fill="currentColor" />
           <circle cx="7" cy="11.5" r="1.1" fill="currentColor" />
+        </svg>
+        <svg v-else class="lb-view-icon" viewBox="0 0 16 16" aria-hidden="true">
+          <path
+            d="M2 2v11a1 1 0 0 0 1 1h11M4.5 10.5l2.4-2.4 2.1 1.2 3-4"
+            stroke="currentColor"
+            stroke-width="1.3"
+            fill="none"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <circle cx="4.5" cy="10.5" r="1" fill="currentColor" />
+          <circle cx="6.9" cy="8.1" r="1" fill="currentColor" />
+          <circle cx="9" cy="9.3" r="1" fill="currentColor" />
+          <circle cx="12" cy="5.3" r="1" fill="currentColor" />
         </svg>
         {{ v.label }}
       </button>
@@ -398,16 +417,22 @@ const downloadCsv = async () => {
               </svg>
               Embed
             </button>
-          </template>         </LeaderboardTable>
-         <div v-else class="lb-status">
-           This leaderboard variant has no data.
-         </div>
-      </template>       <template v-else>
-         <LeaderboardScatter
-           v-if="activeTable"
-           :table="activeTable"
-         />
-       </template>
+          </template>
+        </LeaderboardTable>
+        <div v-else class="lb-status">
+          This leaderboard variant has no data.
+        </div>
+      </template>
+      <template v-else>
+        <LeaderboardScatter
+          v-if="activeTable"
+          :table="activeTable"
+          :x-axis="activeView === 'releaseDate' ? 'releaseDate' : 'parameters'"
+        />
+        <div v-else class="lb-status">
+          This leaderboard variant has no data.
+        </div>
+      </template>
     </template>
   </div>
 </template>

--- a/src/frontend/leaderboard.ts
+++ b/src/frontend/leaderboard.ts
@@ -46,6 +46,9 @@ export interface Column {
 
 export interface Row {
   cells: ParsedCell[];
+  /** ISO date used by the performance-over-time visualization. The source
+   *  column is kept out of the visible table to avoid adding metadata clutter. */
+  releaseDate?: string;
   /** Per-dataset failure counts, keyed by the score column's key. Sourced from
    *  the hidden `<dataset>_failures` companion columns. */
   failures?: Record<string, number>;
@@ -167,6 +170,7 @@ const ICON_COLS = new Set([
 const VERSION_SUFFIX = /version$/i;
 const FAILURES_SUFFIX = /_failures$/i;
 const SCORED_SUFFIX = /_scored$/i;
+const RELEASE_DATE_COLUMN = /^release date$/i;
 
 const parseNumberSafe = (s: string): number | null => {
   if (s === "?" || s === "" || s === "-" || s === "??") return null;
@@ -174,6 +178,18 @@ const parseNumberSafe = (s: string): number | null => {
   const cleaned = s.replace(/,/g, "");
   const n = Number(cleaned);
   return Number.isFinite(n) ? n : null;
+};
+
+const isIsoDate = (s: string): boolean => {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
+  if (!match) return false;
+  const [, year, month, day] = match.map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
 };
 
 /**
@@ -403,7 +419,10 @@ export function parseLeaderboard(csvText: string): LeaderboardTable {
     .map((c, i) => ({ c, i }))
     .filter(
       ({ c }) =>
-        c.kind !== "version" && c.kind !== "failures" && c.kind !== "scored",
+        c.kind !== "version" &&
+        c.kind !== "failures" &&
+        c.kind !== "scored" &&
+        !RELEASE_DATE_COLUMN.test(c.key),
     )
     .map(({ i }) => i);
 
@@ -424,6 +443,9 @@ export function parseLeaderboard(csvText: string): LeaderboardTable {
     .map((c, i) => ({ c, i }))
     .filter(({ c }) => c.kind === "version")
     .map(({ c, i }) => ({ i, baseKey: c.key.replace(/_version$/i, "") }));
+  const releaseDateIndex = columns.findIndex((c) =>
+    RELEASE_DATE_COLUMN.test(c.key),
+  );
 
   // Parse cells. Column order follows the CSV (ground truth).
   const parsedRows: Row[] = dataRows
@@ -449,8 +471,15 @@ export function parseLeaderboard(csvText: string): LeaderboardTable {
         const v = stripTags(splitDisplaySort(r[i] ?? "").display).trim();
         if (v && v !== "-") (versions ??= {})[baseKey] = v;
       }
+      const releaseDate =
+        releaseDateIndex >= 0
+          ? stripTags(
+              splitDisplaySort(r[releaseDateIndex] ?? "").display,
+            ).trim()
+          : "";
       return {
         cells,
+        ...(isIsoDate(releaseDate) && { releaseDate }),
         ...(failures && { failures }),
         ...(scored && { scored }),
         ...(versions && { versions }),

--- a/src/leaderboards/backup.py
+++ b/src/leaderboards/backup.py
@@ -18,7 +18,8 @@ import hashlib
 import json
 import logging
 import random
-import sys
+import shutil
+import subprocess
 import tarfile
 from pathlib import Path
 
@@ -27,6 +28,7 @@ from .constants import (
     BACKUP_HASH_LEN,
     BACKUP_PREFIX,
     BACKUP_SUFFIX,
+    BACKUPS_ARCHIVE_DIR,
     BACKUPS_DIR,
     BACKUPS_MAX_BYTES,
     RESULTS_DIR,
@@ -53,30 +55,65 @@ def backup_results(source: Path = RESULTS_DIR) -> Path | None:
 
     Returns:
         The Path of the new backup, or None if nothing was written.
-
-    Raises:
-        OSError:
-            If the backup directory (a pCloud Drive path) is unavailable and
-            stdin is not a TTY, so the operator cannot be prompted to retry.
     """
     # Validate results before backing up
     _validate_results()
 
-    # The backup directory lives on pCloud Drive, which raises OSError when
-    # pCloud is not running. When attached to a terminal, prompt the operator
-    # to start pCloud and retry; otherwise (CI) let the OSError propagate so
-    # the caller's non-interactive safety net handles it.
-    while True:
-        try:
-            return _write_snapshot(source=source)
-        except OSError as exc:
-            if not sys.stdin.isatty():
-                raise
-            logger.warning(f"Backup failed; pCloud may be unavailable: {exc}")
-            input(
-                f"Could not write the backup to {BACKUPS_DIR}. pCloud appears to "
-                "be unavailable. Start pCloud and press Enter to retry..."
-            )
+    backup_path = _write_snapshot(source=source)
+    if backup_path is not None:
+        _archive_offsite(backup_path)
+    return backup_path
+
+
+def _archive_offsite(backup_path: Path) -> None:
+    """Copy a snapshot into the Jottacloud Archive namespace.
+
+    Best-effort by design: losing the off-site copy is worth a warning, not a
+    failed leaderboard run, since the snapshot itself is already on disk.
+
+    Args:
+        backup_path:
+            The snapshot to upload.
+    """
+    cli = _jotta_cli()
+    if cli is None:
+        logger.warning(
+            f"Archived the results backup to {backup_path} only; install the "
+            "Jottacloud command-line tool to keep a copy off-machine."
+        )
+        return
+    try:
+        result = subprocess.run(
+            [str(cli), "archive", str(backup_path), f"--remote={BACKUPS_ARCHIVE_DIR}"],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.warning(f"Could not archive the results backup to Jottacloud: {exc}")
+        return
+    if result.returncode != 0:
+        logger.warning(
+            f"Could not archive the results backup to Jottacloud: "
+            f"{(result.stderr or result.stdout).strip()[:200]}"
+        )
+    else:
+        logger.info(
+            f"Archived {backup_path.name} to Jottacloud Archive/{BACKUPS_ARCHIVE_DIR}/"
+        )
+
+
+def _jotta_cli() -> Path | None:
+    """Locate the Jottacloud command-line client, if it is installed.
+
+    Returns:
+        Path to the client, or None when it is not installed.
+    """
+    found = shutil.which("jotta-cli")
+    if found is not None:
+        return Path(found)
+    bundled = Path("/Applications/Jottacloud.app/Contents/MacOS/jotta-cli")
+    return bundled if bundled.exists() else None
 
 
 def _validate_results() -> None:

--- a/src/leaderboards/backup.py
+++ b/src/leaderboards/backup.py
@@ -4,7 +4,10 @@
 and is the source of truth for the leaderboard pipeline. We don't track it
 in git (tens of MB and growing), so this module snapshots each successful
 run to BACKUPS_DIR as a single compressed archive with a timestamp suffix,
-and prunes the oldest backups whenever the directory exceeds BACKUPS_MAX_BYTES.
+copies that archive to the Jottacloud Archive under BACKUPS_ARCHIVE_DIR, and
+deletes the local snapshots whose off-machine copy is confirmed -- so the
+local directory holds one snapshot rather than growing without bound.
+`BACKUPS_MAX_BYTES` still caps the local copies when no Archive is reachable.
 
 If `RESULTS_DIR` is missing or empty at startup,
 `restore_from_backup_if_missing` extracts the most recent backup into place so
@@ -21,14 +24,17 @@ import random
 import shutil
 import subprocess
 import tarfile
+import typing as t
 from pathlib import Path
 
 from .constants import (
+    ARCHIVE_LS_TIMEOUT,
     BACKUP_ARCHIVE_ROOT,
     BACKUP_HASH_LEN,
     BACKUP_PREFIX,
     BACKUP_SUFFIX,
     BACKUPS_ARCHIVE_DIR,
+    BACKUPS_ARCHIVE_TIMEOUT,
     BACKUPS_DIR,
     BACKUPS_MAX_BYTES,
     RESULTS_DIR,
@@ -49,31 +55,46 @@ def backup_results(source: Path = RESULTS_DIR) -> Path | None:
     Skips if `source`'s contents are unchanged since the newest existing backup,
     so repeated runs without changes don't fill the backup directory.
 
+    Once a snapshot is confirmed to be stored in the Jottacloud Archive, older
+    local snapshots with the same guarantee are deleted, keeping `BACKUPS_DIR`
+    bounded at roughly one snapshot instead of growing with every run. The
+    Archive keeps the full history.
+
     Args:
         source (optional):
             The results directory to back up. Defaults to RESULTS_DIR.
 
     Returns:
-        The Path of the new backup, or None if nothing was written.
+        The Path of the new backup, or None if nothing was written. The file
+        itself may have been removed once archived off-machine; its name
+        identifies the object under ``Archive/<BACKUPS_ARCHIVE_DIR>/``.
     """
     # Validate results before backing up
     _validate_results()
 
     backup_path = _write_snapshot(source=source)
-    if backup_path is not None:
-        _archive_offsite(backup_path)
+    if backup_path is not None and _archive_offsite(backup_path):
+        _remove_archived_local(keep=backup_path)
     return backup_path
 
 
-def _archive_offsite(backup_path: Path) -> None:
+def _archive_offsite(backup_path: Path) -> bool:
     """Copy a snapshot into the Jottacloud Archive namespace.
 
     Best-effort by design: losing the off-site copy is worth a warning, not a
     failed leaderboard run, since the snapshot itself is already on disk.
 
+    Success is confirmed by listing the Archive rather than trusting the exit
+    code, so a client that exits before the bytes land cannot trick us into
+    deleting the only local copy.
+
     Args:
         backup_path:
             The snapshot to upload.
+
+    Returns:
+        True if the snapshot is verifiably stored in the Archive, False if it
+        only exists locally.
     """
     cli = _jotta_cli()
     if cli is None:
@@ -81,26 +102,105 @@ def _archive_offsite(backup_path: Path) -> None:
             f"Archived the results backup to {backup_path} only; install the "
             "Jottacloud command-line tool to keep a copy off-machine."
         )
-        return
+        return False
     try:
         result = subprocess.run(
-            [str(cli), "archive", str(backup_path), f"--remote={BACKUPS_ARCHIVE_DIR}"],
+            [
+                str(cli),
+                "archive",
+                str(backup_path),
+                f"--remote={BACKUPS_ARCHIVE_DIR}/{backup_path.name}",
+                # Without --nogui the client insists on a terminal and dies with
+                # "open /dev/tty: device not configured" when run unattended.
+                "--nogui",
+            ],
             capture_output=True,
             text=True,
-            timeout=300,
+            stdin=subprocess.DEVNULL,
+            timeout=BACKUPS_ARCHIVE_TIMEOUT,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         logger.warning(f"Could not archive the results backup to Jottacloud: {exc}")
-        return
+        return False
     if result.returncode != 0:
         logger.warning(
             f"Could not archive the results backup to Jottacloud: "
             f"{(result.stderr or result.stdout).strip()[:200]}"
         )
-    else:
-        logger.info(
-            f"Archived {backup_path.name} to Jottacloud Archive/{BACKUPS_ARCHIVE_DIR}/"
+        return False
+    if not _is_archived(backup_path):
+        logger.warning(
+            f"Jottacloud accepted {backup_path.name} but it is not listed under "
+            f"Archive/{BACKUPS_ARCHIVE_DIR}/; keeping the local copy"
         )
+        return False
+    logger.info(
+        f"Archived {backup_path.name} to Jottacloud Archive/{BACKUPS_ARCHIVE_DIR}/"
+    )
+    return True
+
+
+def _is_archived(backup_path: Path) -> bool:
+    """Check whether `backup_path` is stored under the Archive directory.
+
+    Matches on filename, and on byte size when the Archive reports one, so an
+    incomplete upload is not mistaken for a finished one.
+
+    Args:
+        backup_path:
+            The local snapshot to look for.
+
+    Returns:
+        True if an off-machine copy is present.
+    """
+    size = backup_path.stat().st_size if backup_path.exists() else None
+    return any(
+        entry["name"] == backup_path.name
+        and (size is None or entry["size"] is None or entry["size"] == size)
+        for entry in _archived_backups()
+    )
+
+
+def _archived_backups() -> list[dict[str, t.Any]]:
+    """List the snapshots stored under ``Archive/<BACKUPS_ARCHIVE_DIR>``.
+
+    Returns:
+        Newest-first entries with "name", "size" and "modified" keys. Empty when
+        the Archive is unreachable or the client is missing, which callers read
+        as "nothing stored off-machine" rather than as an error.
+    """
+    cli = _jotta_cli()
+    if cli is None:
+        return []
+    try:
+        result = subprocess.run(
+            [str(cli), "ls", f"Archive/{BACKUPS_ARCHIVE_DIR}", "--json"],
+            capture_output=True,
+            text=True,
+            stdin=subprocess.DEVNULL,
+            timeout=ARCHIVE_LS_TIMEOUT,
+        )
+        if result.returncode != 0:
+            return []
+        listing = json.loads(result.stdout or "{}")
+    except (OSError, ValueError, subprocess.TimeoutExpired) as exc:
+        logger.warning(f"Could not list the Jottacloud Archive: {exc}")
+        return []
+    entries: list[dict[str, t.Any]] = []
+    for entry in listing.get("Files", []):
+        name = entry.get("Name") if isinstance(entry, dict) else None
+        if not isinstance(name, str):
+            continue
+        if not name.startswith(BACKUP_PREFIX) or not name.endswith(BACKUP_SUFFIX):
+            continue
+        entries.append(
+            {
+                "name": name,
+                "size": entry.get("Size"),
+                "modified": entry.get("Modified") or 0,
+            }
+        )
+    return sorted(entries, key=lambda entry: entry["modified"], reverse=True)
 
 
 def _jotta_cli() -> Path | None:
@@ -114,6 +214,62 @@ def _jotta_cli() -> Path | None:
         return Path(found)
     bundled = Path("/Applications/Jottacloud.app/Contents/MacOS/jotta-cli")
     return bundled if bundled.exists() else None
+
+
+def _remove_archived_local(keep: Path) -> int:
+    """Delete local snapshots that are verifiably stored in the Archive.
+
+    `keep` is retained even though it is archived: it is what
+    ``restore_from_backup_if_missing`` extracts, which spares a machine that
+    lost its results directory a full download from the Archive.
+
+    Args:
+        keep:
+            The snapshot to leave in place.
+
+    Returns:
+        The number of local snapshots removed.
+    """
+    archived = {entry["name"] for entry in _archived_backups()}
+    removed = 0
+    for old in _list_backups():
+        if old == keep or old.name not in archived:
+            continue
+        size = old.stat().st_size
+        old.unlink(missing_ok=True)
+        logger.info(
+            f"Removed local snapshot {old.name} ({size:,} bytes); an off-machine "
+            "copy is in the Jottacloud Archive"
+        )
+        removed += 1
+    if removed:
+        logger.info(
+            f"Kept {keep.name} locally for fast restores "
+            f"({keep.stat().st_size:,} bytes)"
+        )
+    return removed
+
+
+def _list_backups() -> list[Path]:
+    """List the backup archives in BACKUPS_DIR, newest first.
+
+    Returns:
+        The backup paths matching the ``results_*.tar.gz`` naming, sorted by
+        modification time with the newest first. Empty if BACKUPS_DIR is
+        missing.
+    """
+    if not BACKUPS_DIR.exists():
+        return []
+    backups = [
+        p
+        for p in BACKUPS_DIR.iterdir()
+        if p.is_file()
+        and p.name.startswith(BACKUP_PREFIX)
+        and p.name.endswith(BACKUP_SUFFIX)
+    ]
+    # Newest first.
+    backups.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return backups
 
 
 def _validate_results() -> None:
@@ -285,28 +441,6 @@ def _content_hash(paths: list[Path]) -> str:
         hasher.update(path.read_bytes())
         hasher.update(b"\0")
     return hasher.hexdigest()[:BACKUP_HASH_LEN]
-
-
-def _list_backups() -> list[Path]:
-    """List the backup archives in BACKUPS_DIR, newest first.
-
-    Returns:
-        The backup paths matching the ``results_*.tar.gz`` naming, sorted by
-        modification time with the newest first. Empty if BACKUPS_DIR is
-        missing.
-    """
-    if not BACKUPS_DIR.exists():
-        return []
-    backups = [
-        p
-        for p in BACKUPS_DIR.iterdir()
-        if p.is_file()
-        and p.name.startswith(BACKUP_PREFIX)
-        and p.name.endswith(BACKUP_SUFFIX)
-    ]
-    # Newest first.
-    backups.sort(key=lambda p: p.stat().st_mtime, reverse=True)
-    return backups
 
 
 def _prune_backups() -> None:

--- a/src/leaderboards/cache.py
+++ b/src/leaderboards/cache.py
@@ -119,7 +119,9 @@ class Cache:
                 ]
             if "model_url" in additional and additional["model_url"] is not None:
                 cache.model_url[model_id] = additional["model_url"]
-            if "release_date" in additional:
+            # Only a resolved date is cached: a stored null means "not known at
+            # the time", not "unknowable", so it must not stop a later lookup.
+            if additional.get("release_date") is not None:
                 cache.release_date[model_id] = additional["release_date"]
 
         return cache

--- a/src/leaderboards/constants.py
+++ b/src/leaderboards/constants.py
@@ -131,13 +131,17 @@ OUTPUT_DIR: Path = REPO_ROOT / "src" / "frontend" / "csv"
 # Space so it shows up under "Spaces using this model" on each model's page.
 MODELS_PY_PATH: Path = REPO_ROOT / "hf_space" / "models.py"
 
-# Off-repo backup location for compressed snapshots of the results
-# directory. Snapshots are timestamped and pruned when exceeding limits.
+# Local staging directory for compressed snapshots of the results directory.
+# Snapshots are timestamped and pruned when exceeding limits, then archived
+# off-machine to `BACKUPS_ARCHIVE_DIR` in the Jottacloud Archive namespace.
 BACKUPS_DIR: Path = _env_path(
-    "EUROEVAL_RESULTS_BACKUP_DIR",
-    Path.home() / "pCloud Drive" / "data" / "euroeval_backup",
+    "EUROEVAL_RESULTS_BACKUP_DIR", Path.home() / ".euroeval" / "backups"
 )
 BACKUPS_MAX_BYTES: int = 1_000_000_000  # ~1 GB total size cap
+
+# Where snapshots are archived inside the Jottacloud Archive namespace, so a
+# machine lost to theft or a dying SSD still has its results elsewhere.
+BACKUPS_ARCHIVE_DIR: str = "backups"
 
 # Incremental jsonl of new benchmark records to fold into the results
 # directory on the next load.

--- a/src/leaderboards/constants.py
+++ b/src/leaderboards/constants.py
@@ -93,6 +93,13 @@ def _env_path(name: str, default: Path) -> Path:
     return Path(value).expanduser() if value else default
 
 
+# Hosts that serve Hugging Face model pages, so a recorded `model_url` can be
+# told apart from a provider's own documentation/API page.
+HF_URL_HOSTS: frozenset[str] = frozenset(
+    {"hf.co", "huggingface.co", "www.hf.co", "www.huggingface.co"}
+)
+
+
 # This package's directory (`src/leaderboards/`).
 PACKAGE_DIR: Path = Path(__file__).resolve().parent
 

--- a/src/leaderboards/constants.py
+++ b/src/leaderboards/constants.py
@@ -143,6 +143,13 @@ BACKUPS_MAX_BYTES: int = 1_000_000_000  # ~1 GB total size cap
 # machine lost to theft or a dying SSD still has its results elsewhere.
 BACKUPS_ARCHIVE_DIR: str = "backups"
 
+# Seconds to wait for an Archive upload. A ~36 MB snapshot measured 4.5 minutes
+# on a home connection, so the old five-minute budget was already too tight.
+BACKUPS_ARCHIVE_TIMEOUT: int = 1800
+
+# Seconds to wait for the Archive listing used to confirm an upload landed.
+ARCHIVE_LS_TIMEOUT: int = 60
+
 # Incremental jsonl of new benchmark records to fold into the results
 # directory on the next load.
 NEW_RESULTS_PATH: Path = _env_path(

--- a/src/leaderboards/leaderboard_generation.py
+++ b/src/leaderboards/leaderboard_generation.py
@@ -1061,6 +1061,7 @@ def _create_simplified_and_rename(
             "commercial": "Commercial",
             "merge": "Merge",
             "open": "Open",
+            "release_date": "Release Date",
             "trained_from_scratch": "Trained from scratch",
         }
         | {"mean_rank_score": "Rank score"}
@@ -1190,6 +1191,7 @@ def _reorder_columns(
             "commercial",
             "merge",
             "trained_from_scratch",
+            "release_date",
             "parameters",
             "vocabulary_size",
             "context",

--- a/src/leaderboards/model_metadata.py
+++ b/src/leaderboards/model_metadata.py
@@ -26,12 +26,21 @@ from huggingface_hub.hf_api import RepositoryNotFoundError
 from requests.exceptions import RequestException
 
 from euroeval.benchmark_modules.hf import get_model_release_date
-from euroeval.benchmark_modules.litellm import get_api_model_release_date
+from euroeval.benchmark_modules.litellm import (
+    get_annotated_release_date,
+    get_api_model_release_date,
+)
 from euroeval.date_utils import normalise_release_date
 from euroeval.string_utils import split_model_id
 
 from .cache import Cache
-from .constants import GENERATIVE_TYPE_KEYWORDS, PERMISSIVE_LICENSES, RESULTS_DIR
+from .constants import (
+    API_MODEL_PATTERNS,
+    GENERATIVE_TYPE_KEYWORDS,
+    HF_URL_HOSTS,
+    PERMISSIVE_LICENSES,
+    RESULTS_DIR,
+)
 from .link_generation import ask_user_to_remove_model, generate_model_url
 from .record_fields import get_few_shot, get_task, get_version
 from .records import get_bool_field, get_model_name, plain_model_id
@@ -286,18 +295,53 @@ def _get_release_date(record: dict, cache: Cache) -> str | None:
             return normalised_cached
 
     model_url = additional.get("model_url") or cache.model_url.get(model_id)
-    hf_hosts = {"hf.co", "huggingface.co", "www.hf.co", "www.huggingface.co"}
-    if (
-        isinstance(model_url, str)
-        and urllib.parse.urlparse(model_url).netloc in hf_hosts
-    ):
+    if _is_api_model(model_id=model_id) or _is_non_hf_url(model_url=model_url):
+        release_date = get_api_model_release_date(model_id)
+    else:
         release_date = get_model_release_date(
             hf_api=HfApi(), model_id=model_id, revision="main", token=None
         )
-    else:
-        release_date = get_api_model_release_date(model_id)
+        if release_date is None:
+            # Not a readable Hub repo either, e.g. a gated or renamed one:
+            # fall back to the manual annotations rather than leaving the
+            # model without a date.
+            release_date = get_annotated_release_date(model_id=model_id)
     cache.release_date[model_id] = release_date
     return release_date
+
+
+def _is_api_model(model_id: str) -> bool:
+    """Whether a model ID names a hosted API model rather than a Hub repo.
+
+    Keying on the ID rather than on a stored `model_url` matters: the URL is
+    itself only filled in when it can be generated, so a model whose repo has
+    since been renamed or deleted would otherwise be routed to the API
+    lookup, which knows nothing about it.
+
+    Args:
+        model_id:
+            The model ID.
+
+    Returns:
+        True if the ID matches one of the API model patterns.
+    """
+    plain = plain_model_id(model_id).split("#")[0]
+    return any(pattern.fullmatch(plain) for pattern in API_MODEL_PATTERNS)
+
+
+def _is_non_hf_url(model_url: str | None) -> bool:
+    """Whether a recorded model URL points at a provider rather than the Hub.
+
+    Args:
+        model_url:
+            The model URL, if one is recorded.
+
+    Returns:
+        True if a URL is recorded and it is not a Hugging Face URL.
+    """
+    if not isinstance(model_url, str) or not model_url:
+        return False
+    return urllib.parse.urlparse(model_url).netloc not in HF_URL_HOSTS
 
 
 def is_commercially_licensed(record: dict, cache: Cache) -> bool:

--- a/src/leaderboards/score_extraction.py
+++ b/src/leaderboards/score_extraction.py
@@ -8,6 +8,7 @@ import statistics
 import typing as t
 from collections import defaultdict
 
+from euroeval.date_utils import normalise_release_date
 from euroeval.logging_utils import log_once
 
 from .link_generation import generate_model_url
@@ -92,6 +93,7 @@ def extract_model_metadata(
                 "commercial",
                 "merge",
                 "open",
+                "release_date",
                 "trained_from_scratch",
             ):
                 _update_metadata_field(
@@ -142,6 +144,7 @@ def _ensure_standard_metadata_keys(metadata_dict: dict[str, dict[str, t.Any]]) -
         "commercial": False,
         "merge": False,
         "open": None,
+        "release_date": None,
         "trained_from_scratch": None,
         "model_url": None,
     }
@@ -176,6 +179,7 @@ def _extract_metadata_from_record(
     num_params_raw = additional.get("num_model_parameters", "-1")
     vocab_size_raw = additional.get("vocabulary_size", "-1")
     context_raw = additional.get("max_sequence_length", "-1")
+    release_date = normalise_release_date(additional.get("release_date"))
 
     # Build metadata dict
     metadata: dict[str, t.Any] = {
@@ -186,6 +190,7 @@ def _extract_metadata_from_record(
         "commercial": additional.get("commercially_licensed", False),
         "merge": _to_bool(additional.get("merge", "false")),
         "open": additional.get("open", None),
+        "release_date": release_date,
         "trained_from_scratch": additional.get("trained_from_scratch", None),
     }
 
@@ -197,6 +202,7 @@ def _extract_metadata_from_record(
         and additional["commercially_licensed"] is not None,
         "merge": "merge" in additional and additional["merge"] is not None,
         "open": "open" in additional and additional["open"] is not None,
+        "release_date": release_date is not None,
         "trained_from_scratch": "trained_from_scratch" in additional
         and additional["trained_from_scratch"] is not None,
     }
@@ -383,6 +389,12 @@ def _is_better_metadata(
         if old_value and not new_value:
             return False
         # Both non-empty: preserve existing
+        return False
+
+    # Release dates are normalized before aggregation. Preserve the first valid
+    # value if historical records disagree rather than making the result depend
+    # on record order beyond that point.
+    if field == "release_date":
         return False
 
     # For model_url, prefer non-empty over empty.

--- a/tests/leaderboards/conftest.py
+++ b/tests/leaderboards/conftest.py
@@ -1,0 +1,26 @@
+"""Shared fixtures for the leaderboard tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def no_real_jottacloud_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail loudly rather than touch a real Jottacloud account.
+
+    Backing up results shells out to an installed ``jotta-cli``, which uploads
+    into the Archive configured on the machine running the tests. That is not
+    sandboxable and not free: an unstubbed call uploads fixture data to whoever
+    happens to be logged in, and waits minutes for jottad to accept it. Tests
+    that exercise archiving stub ``subprocess.run`` themselves; every other
+    test is protected here.
+    """
+
+    def refuse(*args: object, **kwargs: object) -> None:
+        raise AssertionError(
+            "a test invoked the real Jottacloud client; stub "
+            "leaderboards.backup.subprocess.run or _archive_offsite"
+        )
+
+    monkeypatch.setattr("leaderboards.backup.subprocess.run", refuse)

--- a/tests/leaderboards/test_backup_validation.py
+++ b/tests/leaderboards/test_backup_validation.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 import json
+import logging
 import tarfile
 import typing as t
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from leaderboards.backup import (
+    _archive_offsite,
     _content_hash,
     _extract_backup,
     _validate_results,
@@ -19,6 +21,65 @@ from leaderboards.backup import (
     restore_from_backup_if_missing,
 )
 from leaderboards.eee_validation import validate_eee_record
+
+
+class TestArchiveOffsite:
+    """Tests for archiving snapshots into the Jottacloud Archive namespace."""
+
+    def test_failed_upload_warns_without_failing_the_run(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An unusable client, e.g. one with no device configured, only warns."""
+        snapshot = tmp_path / "results.tar.gz"
+        snapshot.write_bytes(b"x")
+        failure = MagicMock(returncode=1, stdout="", stderr="device name not set")
+        with (
+            patch(
+                "leaderboards.backup._jotta_cli",
+                return_value=Path("/usr/bin/jotta-cli"),
+            ),
+            patch("leaderboards.backup.subprocess.run", return_value=failure),
+            caplog.at_level(logging.WARNING),
+        ):
+            _archive_offsite(snapshot)
+
+        assert any("Jottacloud" in record.message for record in caplog.records)
+
+    def test_missing_client_warns_without_failing_the_run(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Without the Jottacloud tool the local snapshot still counts.
+
+        The snapshot is already on disk, so a missing off-site copy is worth a
+        warning, not a failed leaderboard run.
+        """
+        snapshot = tmp_path / "results.tar.gz"
+        snapshot.write_bytes(b"x")
+        with (
+            patch("leaderboards.backup._jotta_cli", return_value=None),
+            caplog.at_level(logging.WARNING),
+        ):
+            _archive_offsite(snapshot)
+
+        assert any("Jottacloud" in record.message for record in caplog.records)
+
+    def test_uploads_to_the_archive_backups_directory(self, tmp_path: Path) -> None:
+        """Snapshots go to Archive/backups, keeping their timestamped name."""
+        snapshot = tmp_path / "results_20260901_120000_deadbeef.tar.gz"
+        snapshot.write_bytes(b"x")
+        with (
+            patch(
+                "leaderboards.backup._jotta_cli",
+                return_value=Path("/usr/bin/jotta-cli"),
+            ),
+            patch("leaderboards.backup.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            _archive_offsite(snapshot)
+
+        command = mock_run.call_args.args[0]
+        assert command[:3] == ["/usr/bin/jotta-cli", "archive", str(snapshot)]
+        assert command[3] == "--remote=backups"
 
 
 class TestBackupResultsIntegration:

--- a/tests/leaderboards/test_backup_validation.py
+++ b/tests/leaderboards/test_backup_validation.py
@@ -139,6 +139,8 @@ class TestBackupResultsIntegration:
             patch("leaderboards.backup.RESULTS_DIR", temp_results_dir),
             patch("leaderboards.backup.BACKUPS_DIR", backup_dir),
             patch("leaderboards.backup.BACKUPS_MAX_BYTES", 1024 * 1024 * 10),
+            patch("leaderboards.backup._archive_offsite", return_value=True),
+            patch("leaderboards.backup._archived_backups", return_value=[]),
         ):
             # Should not raise - raw results are allowed to miss precious metadata
             backup_path = backup_results(source=temp_results_dir)

--- a/tests/leaderboards/test_backup_validation.py
+++ b/tests/leaderboards/test_backup_validation.py
@@ -15,6 +15,7 @@ from leaderboards.backup import (
     _archive_offsite,
     _content_hash,
     _extract_backup,
+    _remove_archived_local,
     _validate_results,
     _write_snapshot,
     backup_results,
@@ -63,8 +64,34 @@ class TestArchiveOffsite:
 
         assert any("Jottacloud" in record.message for record in caplog.records)
 
+    def test_unlisted_upload_keeps_the_local_copy(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A zero exit code without a stored file must not free the local copy."""
+        snapshot = tmp_path / "results_20260901_120000_deadbeef.tar.gz"
+        snapshot.write_bytes(b"x")
+        success = MagicMock(returncode=0, stdout="", stderr="")
+        with (
+            patch(
+                "leaderboards.backup._jotta_cli",
+                return_value=Path("/usr/bin/jotta-cli"),
+            ),
+            patch("leaderboards.backup.subprocess.run", return_value=success),
+            patch("leaderboards.backup._archived_backups", return_value=[]),
+            caplog.at_level(logging.WARNING),
+        ):
+            archived = _archive_offsite(snapshot)
+
+        assert not archived
+        assert snapshot.exists()
+        assert any("keeping the local copy" in r.message for r in caplog.records)
+
     def test_uploads_to_the_archive_backups_directory(self, tmp_path: Path) -> None:
-        """Snapshots go to Archive/backups, keeping their timestamped name."""
+        """Snapshots go to Archive/backups, keeping their timestamped name.
+
+        The remote path must end in the filename: `--remote=backups` on its own
+        stores the snapshot as a *file* called "backups" rather than a folder.
+        """
         snapshot = tmp_path / "results_20260901_120000_deadbeef.tar.gz"
         snapshot.write_bytes(b"x")
         with (
@@ -73,13 +100,21 @@ class TestArchiveOffsite:
                 return_value=Path("/usr/bin/jotta-cli"),
             ),
             patch("leaderboards.backup.subprocess.run") as mock_run,
+            patch(
+                "leaderboards.backup._archived_backups",
+                return_value=[
+                    {"name": snapshot.name, "size": 1, "modified": 1_700_000_000_000}
+                ],
+            ),
         ):
             mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
-            _archive_offsite(snapshot)
+            archived = _archive_offsite(snapshot)
 
+        assert archived
         command = mock_run.call_args.args[0]
         assert command[:3] == ["/usr/bin/jotta-cli", "archive", str(snapshot)]
-        assert command[3] == "--remote=backups"
+        assert command[3] == f"--remote=backups/{snapshot.name}"
+        assert "--nogui" in command, "the client needs no terminal when unattended"
 
 
 class TestBackupResultsIntegration:
@@ -136,6 +171,67 @@ def _create_eee_record(
             {"commercially_licensed": False, "open": True, "trained_from_scratch": True}
         )
     return record
+
+
+class TestRemoveArchivedLocal:
+    """Tests for releasing local disk once snapshots are stored off-machine."""
+
+    def test_only_confirmed_and_superseded_snapshots_are_removed(
+        self, tmp_path: Path
+    ) -> None:
+        """The newest snapshot stays, as do any we could not archive."""
+        archived = tmp_path / "results_20260901_120000_deadbeef.tar.gz"
+        unarchived = tmp_path / "results_20260901_130000_cafebabe.tar.gz"
+        keep = tmp_path / "results_20260902_120000_ed2bfa5a6734.tar.gz"
+        for backup in (archived, unarchived, keep):
+            backup.write_bytes(b"x")
+        listing = [{"name": archived.name, "size": 1, "modified": 1_700_000_000_000}]
+
+        with (
+            patch("leaderboards.backup.BACKUPS_DIR", tmp_path),
+            patch("leaderboards.backup._archived_backups", return_value=listing),
+        ):
+            removed = _remove_archived_local(keep=keep)
+
+        assert removed == 1
+        assert not archived.exists()
+        assert unarchived.exists(), (
+            "no off-machine copy existed, so this was the only one"
+        )
+        assert keep.exists(), "the newest snapshot is the local restore copy"
+
+    def test_successful_run_stops_local_snapshots_accumulating(
+        self, temp_results_dir: Path, tmp_path: Path
+    ) -> None:
+        """An archived run leaves one snapshot behind, not one per run."""
+        record = _create_eee_record(include_precious_metadata=False)
+        model_dir = temp_results_dir / "test_model"
+        model_dir.mkdir()
+        (model_dir / "dataset__test__zero.json").write_text(
+            json.dumps(record), encoding="utf-8"
+        )
+
+        backup_dir = tmp_path / "backups"
+        backup_dir.mkdir()
+        previous = backup_dir / "results_20260101_120000_aaaaaaaaaaaa.tar.gz"
+        previous.write_bytes(b"x")
+
+        with (
+            patch("leaderboards.backup.RESULTS_DIR", temp_results_dir),
+            patch("leaderboards.backup.BACKUPS_DIR", backup_dir),
+            patch("leaderboards.backup._archive_offsite", return_value=True),
+            patch(
+                "leaderboards.backup._archived_backups",
+                return_value=[
+                    {"name": previous.name, "size": 1, "modified": 1_700_000_000_000}
+                ],
+            ),
+        ):
+            backup_path = backup_results(source=temp_results_dir)
+
+        assert backup_path is not None
+        assert backup_path.exists()
+        assert not previous.exists()
 
 
 class TestTreeStructureBackup:

--- a/tests/leaderboards/test_cache.py
+++ b/tests/leaderboards/test_cache.py
@@ -66,6 +66,26 @@ class TestCacheFromResultsDir:
         assert "model/b" in cache.commercially_licensed
         assert cache.commercially_licensed["model/b"] is True
 
+    def test_null_release_date_does_not_shadow_known_one(self, tmp_path: Path) -> None:
+        """A stored null must not outweigh a date recorded elsewhere.
+
+        Records written before the Hub lookup was working carry an explicit
+        null; whichever record happens to be read last used to decide the
+        answer for the whole model.
+        """
+        model_dir = tmp_path / "test_model"
+        model_dir.mkdir()
+        dated = _make_eee_record(model_id="test/model", model_name="test/model")
+        dated["model_info"]["additional_details"]["release_date"] = "2024-02-03"
+        undated = _make_eee_record(model_id="test/model", model_name="test/model")
+        undated["model_info"]["additional_details"]["release_date"] = None
+        (model_dir / "a__test__zeroshot.json").write_text(json.dumps(dated))
+        (model_dir / "b__test__zeroshot.json").write_text(json.dumps(undated))
+
+        cache = Cache.from_results_dir(results_dir=tmp_path)
+
+        assert cache.release_date["test/model"] == "2024-02-03"
+
     def test_preserves_metadata_fields(self, tmp_path: Path) -> None:
         """Should preserve metadata fields in model_info.additional_details."""
         model_dir = tmp_path / "test_model"
@@ -105,6 +125,23 @@ class TestCacheFromResultsDir:
         """Should raise FileNotFoundError for nonexistent directory."""
         with pytest.raises(FileNotFoundError, match="Results directory"):
             Cache.from_results_dir(results_dir=Path("/nonexistent/path"))
+
+    def test_unknown_release_date_leaves_model_uncached(self, tmp_path: Path) -> None:
+        """A model whose only dates are nulls stays out of the cache.
+
+        The cache doubles as a "already asked" marker, so seeding it with nulls
+        makes every later run skip the lookup and permanently freeze the model
+        at "unknown".
+        """
+        model_dir = tmp_path / "test_model"
+        model_dir.mkdir()
+        record = _make_eee_record(model_id="test/model", model_name="test/model")
+        record["model_info"]["additional_details"]["release_date"] = None
+        (model_dir / "ds__test__zeroshot.json").write_text(json.dumps(record))
+
+        cache = Cache.from_results_dir(results_dir=tmp_path)
+
+        assert "test/model" not in cache.release_date
 
 
 def _make_eee_record(

--- a/tests/leaderboards/test_leaderboard_generation.py
+++ b/tests/leaderboards/test_leaderboard_generation.py
@@ -10,11 +10,14 @@ from __future__ import annotations
 import math
 
 import numpy as np
+import pandas as pd
 
 from src.leaderboards.enums import LeaderboardCategory
 from src.leaderboards.leaderboard_generation import (
     _build_category_dataset_maps,
     _compute_eligible_models_and_ranks,
+    _create_simplified_and_rename,
+    _reorder_columns,
 )
 
 
@@ -577,3 +580,40 @@ class TestRegressionForReportedIssue:
                 f"{model_id} Albanian score mismatch: mono={albanian_mono}, "
                 f"multi={albanian_multi}"
             )
+
+
+def test_release_date_is_emitted_for_frontend_visualizations() -> None:
+    """The existing result metadata reaches the full leaderboard CSV."""
+    df = pd.DataFrame(
+        {
+            "rank": ["1"],
+            "model": ["org/model"],
+            "mean_rank_score": ["1.25 ± 0.05"],
+            "generative_type": ["📝"],
+            "open": ["✓"],
+            "commercial": ["✗"],
+            "merge": ["✗"],
+            "trained_from_scratch": ["✓"],
+            "release_date": ["2024-02-03"],
+            "parameters": [7_000_000_000],
+            "vocabulary_size": [32_000],
+            "context": [4_096],
+        }
+    )
+
+    ordered = _reorder_columns(
+        df=df,
+        category="generative",
+        category_to_orthogonal_datasets={"generative": {}},
+        category_to_datasets={"generative": []},
+        rank_cols=["rank", "mean_rank_score"],
+        include_dataset_columns=False,
+    )
+    full, _ = _create_simplified_and_rename(
+        df=ordered,
+        rank_cols=["rank", "mean_rank_score"],
+        category_to_orthogonal_datasets={"generative": {}},
+        category="generative",
+    )
+
+    assert full.loc[0, "Release Date"] == "2024-02-03"

--- a/tests/leaderboards/test_model_metadata.py
+++ b/tests/leaderboards/test_model_metadata.py
@@ -967,6 +967,76 @@ def _add_missing_entries_with_complete_metadata(record: dict, cache: Cache) -> d
 
 
 @patch("leaderboards.model_metadata.get_model_release_date")
+@patch("leaderboards.model_metadata.get_api_model_release_date")
+def test_add_missing_entries_does_not_query_hub_for_api_models(
+    mock_api_release_date: MagicMock, mock_hub_release_date: MagicMock
+) -> None:
+    """API models keep using the API lookup even though they are not Hub repos."""
+    mock_api_release_date.return_value = "2023-06-13"
+    record = {
+        "model_info": {
+            "name": "openai/gpt-4-0613",
+            "additional_details": {"model_url": "https://openai.com/gpt-4"},
+        }
+    }
+
+    _add_missing_entries_with_complete_metadata(record=record, cache=Cache())
+
+    assert mock_api_release_date.call_count == 1
+    mock_hub_release_date.assert_not_called()
+
+
+@patch("leaderboards.model_metadata.ask_user_to_remove_model")
+@patch("leaderboards.model_metadata.generate_model_url")
+@patch("leaderboards.model_metadata.get_annotated_release_date")
+@patch("leaderboards.model_metadata.get_model_release_date")
+def test_add_missing_entries_falls_back_to_annotations_for_unreadable_repos(
+    mock_release_date: MagicMock,
+    mock_annotated: MagicMock,
+    mock_generate_url: MagicMock,
+    mock_remove: MagicMock,
+) -> None:
+    """A model whose repository is gone falls back to the manual annotations.
+
+    Renamed and deleted repositories are the one class the Hub history cannot
+    answer, and leaving them undated would drop them off a time axis.
+    """
+    mock_release_date.return_value = None
+    mock_generate_url.return_value = None
+    mock_remove.return_value = False
+    mock_annotated.return_value = "2025-01-30"
+    record = {"model_info": {"name": "org/model", "additional_details": {}}}
+
+    _add_missing_entries_with_complete_metadata(record=record, cache=Cache())
+
+    assert record["model_info"]["additional_details"]["release_date"] == "2025-01-30"
+    mock_annotated.assert_called_once_with(model_id="org/model")
+
+
+@patch("leaderboards.model_metadata.ask_user_to_remove_model")
+@patch("leaderboards.model_metadata.generate_model_url")
+@patch("leaderboards.model_metadata.get_model_release_date")
+def test_add_missing_entries_looks_up_hub_history_without_model_url(
+    mock_release_date: MagicMock, mock_generate_url: MagicMock, mock_remove: MagicMock
+) -> None:
+    """A model with no recorded URL is still dated from its Hub history.
+
+    Routing on the stored `model_url` left every model whose URL could not be
+    generated without a date, since the API lookup knows nothing about ordinary
+    Hub repositories.
+    """
+    mock_generate_url.return_value = None
+    mock_remove.return_value = False
+    mock_release_date.return_value = "2024-02-03"
+    record = {"model_info": {"name": "org/model", "additional_details": {}}}
+
+    _add_missing_entries_with_complete_metadata(record=record, cache=Cache())
+
+    assert record["model_info"]["additional_details"]["release_date"] == "2024-02-03"
+    mock_release_date.assert_called_once()
+
+
+@patch("leaderboards.model_metadata.get_model_release_date")
 def test_add_missing_entries_preserves_existing_release_date(
     mock_release_date: MagicMock,
 ) -> None:

--- a/tests/leaderboards/test_score_extraction.py
+++ b/tests/leaderboards/test_score_extraction.py
@@ -38,6 +38,7 @@ class TestExtractModelMetadata:
                 "vocabulary_size": "32000",
                 "max_sequence_length": "4096",
                 "model_url": "https://huggingface.co/ollama/model-full",
+                "release_date": "2024-02-03",
             },
         )
 
@@ -61,6 +62,7 @@ class TestExtractModelMetadata:
             "commercial",
             "merge",
             "open",
+            "release_date",
             "trained_from_scratch",
             "model_url",
         ]
@@ -85,6 +87,7 @@ class TestExtractModelMetadata:
         assert metadata[model_missing_key]["commercial"] is False  # Explicit False
         assert metadata[model_missing_key]["merge"] is False  # Default
         assert metadata[model_missing_key]["open"] is None  # Default
+        assert metadata[model_missing_key]["release_date"] is None  # Default
         assert metadata[model_missing_key]["trained_from_scratch"] is None  # Default
         assert math.isnan(metadata[model_missing_key]["parameters"])
         assert math.isnan(metadata[model_missing_key]["vocabulary_size"])
@@ -98,6 +101,7 @@ class TestExtractModelMetadata:
         assert metadata[model_full_key]["commercial"] is True
         assert metadata[model_full_key]["merge"] is False
         assert metadata[model_full_key]["open"] is True
+        assert metadata[model_full_key]["release_date"] == "2024-02-03"
         assert metadata[model_full_key]["trained_from_scratch"] is True
         assert metadata[model_full_key]["parameters"] == 7_000_000_000.0
         assert metadata[model_full_key]["vocabulary_size"] == 32_000.0

--- a/tests/test_benchmark_modules/test_hf.py
+++ b/tests/test_benchmark_modules/test_hf.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
+from huggingface_hub.errors import HfHubHTTPError, RepositoryNotFoundError
 from huggingface_hub.hf_api import HfApi
 from transformers.models.xlm_roberta import (
     XLMRobertaConfig,
@@ -79,12 +80,79 @@ def test_get_dtype(
     )
 
 
+def test_get_model_release_date_avoids_scanning_every_commit() -> None:
+    """A long history is searched, not walked one request per commit.
+
+    Repositories with thousands of commits would otherwise spend the entire
+    Hub request budget on the first few models.
+    """
+    commits = [
+        MagicMock(
+            commit_id=f"c{i}",
+            created_at=datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+            + datetime.timedelta(days=i),
+        )
+        for i in range(60)
+    ]
+    api = MagicMock()
+    api.list_repo_commits.return_value = list(reversed(commits))
+    api.list_repo_files.side_effect = lambda repo_id, revision, **kw: (
+        ["model.safetensors"] if int(revision[1:]) >= 30 else ["README.md"]
+    )
+
+    assert (
+        get_model_release_date(api, "org/model", "main", None)
+        == commits[30].created_at.date().isoformat()
+    )
+    assert api.list_repo_files.call_count <= 8
+
+
+def test_get_model_release_date_does_not_retry_missing_repos() -> None:
+    """A repository that does not exist is answered once, not retried."""
+    api = MagicMock()
+    api.list_repo_commits.side_effect = RepositoryNotFoundError(
+        "404", response=MagicMock()
+    )
+
+    with patch("euroeval.benchmark_modules.hf.sleep") as mock_sleep:
+        assert get_model_release_date(api, "org/model", "main", None) is None
+
+    mock_sleep.assert_not_called()
+    assert api.list_repo_commits.call_count == 1
+
+
 def test_get_model_release_date_handles_hub_errors() -> None:
     """Release-date lookup remains optional when Hub history is unavailable."""
     api = MagicMock()
     api.list_repo_commits.side_effect = OSError("offline")
 
-    assert get_model_release_date(api, "org/model", "main", None) is None
+    with patch("euroeval.benchmark_modules.hf.sleep") as mock_sleep:
+        assert get_model_release_date(api, "org/model", "main", None) is None
+
+    assert mock_sleep.call_count == 5, "a connection error should be retried"
+
+
+def test_get_model_release_date_retries_rate_limited_lookups() -> None:
+    """A rate-limited lookup is temporary and must not become "no release date".
+
+    Dating the whole results tree asks the Hub for a lot, and giving up on the
+    first 429 is what left most models without a date.
+    """
+    commit = MagicMock(
+        commit_id="weights",
+        created_at=datetime.datetime(2024, 2, 3, tzinfo=datetime.timezone.utc),
+    )
+    api = MagicMock()
+    api.list_repo_commits.side_effect = [
+        HfHubHTTPError("429 Too Many Requests", response=MagicMock()),
+        [commit],
+    ]
+    api.list_repo_files.return_value = ["model-00001-of-00002.safetensors"]
+
+    with patch("euroeval.benchmark_modules.hf.sleep") as mock_sleep:
+        assert get_model_release_date(api, "org/model", "main", None) == "2024-02-03"
+
+    assert mock_sleep.call_count == 1
 
 
 def test_get_model_release_date_returns_none_without_weights() -> None:
@@ -137,13 +205,39 @@ def test_get_model_release_date_uses_first_weights_commit() -> None:
         created_at=datetime.datetime(2024, 3, 1, tzinfo=datetime.timezone.utc),
     )
     api.list_repo_commits.return_value = [newer, released, old]
-    api.list_repo_files.side_effect = [
-        ["README.md"],
-        ["model-00001-of-00002.safetensors"],
-    ]
+    # The file list is the tree at that revision, so the weights remain
+    # present in every later commit
+    api.list_repo_files.side_effect = lambda repo_id, revision, **kw: (
+        ["README.md"] if revision == "scaffold" else ["README.md", "model.safetensors"]
+    )
 
     assert get_model_release_date(api, "org/model", "main", None) == "2024-02-03"
-    assert api.list_repo_files.call_count == 2
+    assert api.list_repo_files.call_count <= 3
+
+
+def test_get_model_release_date_waits_out_the_rate_limit_window() -> None:
+    """The Hub names the window to wait for, so waiting less wastes requests.
+
+    The limit is 1000 requests per five minutes; retrying after a second keeps
+    hitting the same full window and the model ends up without a date.
+    """
+    commit = MagicMock(
+        commit_id="weights",
+        created_at=datetime.datetime(2024, 2, 3, tzinfo=datetime.timezone.utc),
+    )
+    response = MagicMock()
+    response.headers = {"Retry-After": "30"}
+    api = MagicMock()
+    api.list_repo_commits.side_effect = [
+        HfHubHTTPError("429 Too Many Requests", response=response),
+        [commit],
+    ]
+    api.list_repo_files.return_value = ["model.safetensors"]
+
+    with patch("euroeval.benchmark_modules.hf.sleep") as mock_sleep:
+        assert get_model_release_date(api, "org/model", "main", None) == "2024-02-03"
+
+    mock_sleep.assert_called_once_with(30)
 
 
 def test_load_model_from_pretrained_keyerror_retry_and_message() -> None:


### PR DESCRIPTION
## Summary

- add a Release Date visualization beside the existing plot and rename the existing view to Model Size
- reuse the current scatter plot's search, model filters, markers, tooltips, responsive SVG, and sticky view selection
- carry the normalized `release_date` metadata into the full leaderboard CSV while keeping it out of the table columns
- omit models without usable dates and show an explicit empty state when a leaderboard has no dated models

Closes #900

## Verification

- `npm run check`
- `npm run build`
- `33 passed` in the focused score-extraction and leaderboard-generation test suite
- all pre-commit hooks pass on the changed files
- `git diff --check`
