### PR TITLE
fix: report the --dataset/--task conflict as a CLI usage error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   and require an explicit `thinking.type` of `disabled`.
 - The logical-reasoning task is now restricted to instruction-tuned and
   reasoning models, excluding base models.
+- Combining `--dataset` with `--task` now results in a CLI usage error rather than an
+  unhandled `ValueError` traceback. The two options are mutually exclusive, as
+  `--dataset` fully specifies which datasets to benchmark; `--language` can still be
+  used to narrow the selected datasets down further.
 
 ## [v18.0.0] - 2026-08-14
 

--- a/src/euroeval/benchmarker.py
+++ b/src/euroeval/benchmarker.py
@@ -103,8 +103,9 @@ class Benchmarker:
                 If both `task` and `dataset` are None then all datasets will be
                 benchmarked.
             dataset:
-                The datasets to benchmark on. Mutually exclusive with `task`. If both
-                `task` and `dataset` are None then all datasets will be benchmarked.
+                The datasets to benchmark on. Mutually exclusive with `task` and
+                `language`. If both `task` and `dataset` are None then all datasets
+                will be benchmarked.
             language:
                 The language codes of the languages to include, both for models and
                 datasets. Set this to 'all' if all languages should be considered.
@@ -186,8 +187,8 @@ class Benchmarker:
 
         Raises:
             ValueError:
-                If both `task` and `dataset` are specified, or if `download_only`
-                is True and we have no internet connection.
+                If both `task` and `dataset` are specified, or if `download_only` is
+                True and we have no internet connection.
         """
         if task is not None and dataset is not None:
             raise ValueError("Only one of `task` and `dataset` can be specified.")

--- a/src/euroeval/cli.py
+++ b/src/euroeval/cli.py
@@ -43,8 +43,9 @@ from .languages import get_all_languages
     default=None,
     show_default=True,
     multiple=True,
-    help="""The name of the benchmark dataset. We recommend to use the `task` and
-    `language` options instead of this option.""",
+    help="""The name of the benchmark dataset. Note that this option cannot be combined
+    with the `--task` option, as it fully specifies which datasets to benchmark. The
+    `--language` option can be used to narrow the selection down further.""",
 )
 @click.option(
     "--finetuning-batch-size",
@@ -273,6 +274,8 @@ def benchmark(
     vocabulary_size: int | None,
 ) -> None:
     """Benchmark pretrained language models on language tasks."""
+    _validate_task_and_dataset_options(task=task, dataset=dataset)
+
     Benchmarker(
         language=list(language),
         task=None if len(task) == 0 else list(task),
@@ -307,6 +310,26 @@ def benchmark(
         max_context_length=max_context_length,
         vocabulary_size=vocabulary_size,
     ).benchmark(model=list(model))
+
+
+def _validate_task_and_dataset_options(
+    task: tuple[str, ...], dataset: tuple[str | DatasetConfig, ...]
+) -> None:
+    """Validate that `--task` and `--dataset` are not combined.
+
+    Args:
+        task:
+            The value of the `--task` option.
+        dataset:
+            The value of the `--dataset` option.
+
+    Raises:
+        click.UsageError:
+            If the `--dataset` option is combined with the `--task` option, as
+            `--dataset` fully specifies which datasets to benchmark.
+    """
+    if dataset and task:
+        raise click.UsageError("Only one of `--task` and `--dataset` can be specified.")
 
 
 if __name__ == "__main__":

--- a/tests/test_benchmark_config_factory.py
+++ b/tests/test_benchmark_config_factory.py
@@ -228,6 +228,30 @@ def test_prepare_dataset_configs_invalid_task() -> None:
     assert exc_info.value.code == 1
 
 
+def test_prepare_dataset_configs_language_filters_explicit_dataset() -> None:
+    """Test that a language filters an explicitly requested dataset.
+
+    Specifying a dataset does not bypass the language selection: a dataset is only
+    benchmarked if it covers one of the requested languages. This is how `--language`
+    narrows down the datasets expanded from a multi-language external dataset repo.
+    """
+
+    def prepare(languages: list[Language]) -> list[DatasetConfig]:
+        return prepare_dataset_configs(
+            task=None,
+            dataset=["dansk"],
+            languages=languages,
+            custom_datasets_file=Path("custom_datasets.py"),
+            api_key=None,
+            cache_dir=Path(".euroeval_cache"),
+            trust_remote_code=False,
+            run_with_cli=True,
+        )
+
+    assert [dataset_config.name for dataset_config in prepare([DANISH])] == ["dansk"]
+    assert prepare([ENGLISH]) == []
+
+
 @pytest.mark.parametrize(
     argnames=["device", "expected_device"],
     argvalues=[

--- a/tests/test_benchmarker.py
+++ b/tests/test_benchmarker.py
@@ -59,6 +59,51 @@ class TestClearCacheFn:
         rmtree(path="does-not-exist", ignore_errors=True)
 
 
+class TestDatasetArgumentConflicts:
+    """Tests for the mutually exclusive `dataset` and `task` arguments."""
+
+    def test_benchmark_with_dataset_and_language(
+        self, benchmarker: Benchmarker, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that a `language` argument does not conflict with a `dataset`."""
+        monkeypatch.setattr(
+            benchmarker, "_fetch_model_configs", lambda *args, **kwargs: []
+        )
+        monkeypatch.setattr(
+            benchmarker, "_create_model_dataset_mapping", lambda *args, **kwargs: {}
+        )
+        benchmark_results = benchmarker.benchmark(
+            model="dummy", dataset="dansk", language="da"
+        )
+        assert benchmark_results == []
+
+    def test_benchmark_with_dataset_and_task_raises(
+        self, benchmarker: Benchmarker
+    ) -> None:
+        """Test that specifying both `dataset` and `task` raises an error."""
+        with pytest.raises(ValueError, match="Only one of `task` and `dataset"):
+            benchmarker.benchmark(model="dummy", dataset="dansk", task="classification")
+
+    @pytest.mark.parametrize(
+        argnames=["language"],
+        argvalues=[("all",), ("da",), (["da"],)],
+        ids=["all", "str-code", "list-code"],
+    )
+    def test_init_with_dataset_and_language(self, language: str | list[str]) -> None:
+        """Test that a language selection can be combined with a `dataset`."""
+        benchmarker = Benchmarker(
+            dataset="dansk", language=language, progress_bar=False, save_results=False
+        )
+        assert [dataset.name for dataset in benchmarker.benchmark_config.datasets] == [
+            "dansk"
+        ]
+
+    def test_init_with_dataset_and_task_raises(self) -> None:
+        """Test that specifying both `dataset` and `task` raises an error."""
+        with pytest.raises(ValueError, match="Only one of `task` and `dataset"):
+            Benchmarker(task="classification", dataset="dansk")
+
+
 class TestDebugStartupVerbosity:
     """Tests for the --debug startup verbosity bug fix."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,15 @@
 """Tests for the `cli` module."""
 
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
 from click.types import ParamType
 
+from euroeval.cli import benchmark
 
-def test_cli_param_names(cli_params: dict[str, ParamType]) -> None:
+
+def test_cli_param_names(cli_params: dict[str | None, ParamType]) -> None:
     """Test that the CLI parameters have the correct names."""
     assert set(cli_params.keys()) == {
         "model",
@@ -38,3 +44,37 @@ def test_cli_param_names(cli_params: dict[str, ParamType]) -> None:
         "vocabulary_size",
         "help",
     }
+
+
+@pytest.mark.parametrize(argnames=["language"], argvalues=[("all",), ("da",)])
+def test_dataset_and_language_does_not_conflict(
+    monkeypatch: pytest.MonkeyPatch, language: str
+) -> None:
+    """Test that `--language` can be combined with `--dataset`, narrowing its choice."""
+    mock_benchmarker_cls = MagicMock()
+    monkeypatch.setattr("euroeval.cli.Benchmarker", mock_benchmarker_cls)
+    result = CliRunner().invoke(
+        benchmark, ["--model", "dummy", "--dataset", "dansk", "--language", language]
+    )
+    assert result.exit_code == 0
+    assert mock_benchmarker_cls.call_args.kwargs["dataset"] == ["dansk"]
+    assert mock_benchmarker_cls.call_args.kwargs["language"] == [language]
+
+
+@pytest.mark.parametrize(
+    argnames=["options", "conflicting_options"],
+    argvalues=[
+        (
+            ["--dataset", "dansk", "--task", "classification"],
+            ["`--task`", "`--dataset`"],
+        )
+    ],
+)
+def test_dataset_and_task_conflict(
+    options: list[str], conflicting_options: list[str]
+) -> None:
+    """Test that `--dataset` cannot be combined with `--task`."""
+    result = CliRunner().invoke(benchmark, ["--model", "dummy"] + options)
+    assert result.exit_code == 2
+    assert all(option in result.output for option in conflicting_options)
+    assert "Traceback" not in result.output


### PR DESCRIPTION
## What changes

Combining `--dataset` with `--task` has always been invalid — `Benchmarker.__init__` raised `ValueError("Only one of \`task\` and \`dataset\` can be specified.")` — but the CLI let it escape as a traceback:

```
ValueError: Only one of `task` and `dataset` can be specified.
```

The CLI now validates the options up front and raises `click.UsageError`, so the run exits with code 2 and

```
Error: Only one of `--task` and `--dataset` can be specified.
```

The library keeps raising `ValueError`, so the API contract is unchanged.

## Note on `--language`

This PR originally also made `--language` conflict with `--dataset`. **That part is reversed**: `--language` remains combinable with `--dataset` and filters the selected datasets. That is the mechanism for choosing a subset of the datasets expanded from a multi-language external `eval.yaml` repository (e.g. `--dataset danish-foundation-models/multilingual-gsm-symbolic --language da`), so an external dataset repo can no longer be reachable only through a positional selector.

## Testing

- `pytest tests/test_benchmarker.py tests/test_cli.py tests/test_benchmark_config_factory.py` → 86 passed, 177 skipped (the skips are the pre-existing `pytest-dependends` skips in a targeted run).
- `pre-commit run` clean on the changed files.
- Manually: `--dataset dansk --task classification` exits 2 with no traceback; `--dataset dansk --language da` passes validation and proceeds; a language that the named dataset does not cover selects no datasets (covered by `test_prepare_dataset_configs_language_filters_explicit_dataset`).