### PR TITLE
fix: restore leading letters dropped by RobBERT QA offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fixed RobBERT-family question-answering predictions losing the first character of
+  word-initial answers because of their tokeniser offset mappings.
 - Restored backwards-compatible `Language(code, name)` construction while retaining
   ISO 639-3 and optional ISO 639-1 language codes.
 - Fixed expanded `eval.yaml` task identities so entries without declared splits,

--- a/src/euroeval/task_group_utils/question_answering.py
+++ b/src/euroeval/task_group_utils/question_answering.py
@@ -418,9 +418,12 @@ def find_valid_answers(
             # If we got to this point then the answer is valid, so we store the
             # corresponding start- and end character indices in the original context,
             # and from these extract the answer
-            start_char = offset_mapping[start_index][0]
-            end_char = offset_mapping[end_index][1]
-            text = context[start_char:end_char]
+            text = _answer_text_from_offsets(
+                offset_mapping=offset_mapping,
+                start_index=start_index,
+                end_index=end_index,
+                context=context,
+            )
 
             # Compute the score of the answer, being the sum of the start and end
             # logits. Intuitively, this indicates how likely the answer is to be
@@ -433,6 +436,48 @@ def find_valid_answers(
                 valid_answers.append(dict(score=score, text=text))
 
     return valid_answers
+
+
+def _answer_text_from_offsets(
+    offset_mapping: c.Sequence[tuple[int, int]],
+    start_index: int,
+    end_index: int,
+    context: str,
+) -> str:
+    """Slice the context for a predicted token span, repairing word-initial offsets.
+
+    Some tokenisers (notably RobBERT-family models whose pre-tokeniser is
+    ``Sequence[Whitespace, ByteLevel, Punctuation]`` rather than plain ByteLevel)
+    report the start offset of a word-initial token one character into the word.
+    Slicing the context with those offsets drops the first letter and collapses
+    SQuAD Exact Match; see https://github.com/EuroEval/EuroEval/issues/2171.
+
+    Only a hole that is not already covered by the previous in-context token is
+    filled, and only across non-whitespace, so standard BERT/RoBERTa offsets and
+    mid-word overflowing features are left alone.
+
+    Returns:
+        The context slice for the predicted token span.
+    """
+    start_char = offset_mapping[start_index][0]
+    end_char = offset_mapping[end_index][1]
+    if (
+        start_char > 0
+        and start_char <= len(context)
+        and not context[start_char - 1].isspace()
+    ):
+        prev = tuple(offset_mapping[start_index - 1]) if start_index > 0 else (-1, -1)
+        if prev != (-1, -1):
+            if prev[1] < start_char:
+                while (
+                    start_char > prev[1]
+                    and start_char > 0
+                    and not context[start_char - 1].isspace()
+                ):
+                    start_char -= 1
+        elif start_char == 1 or context[start_char - 2].isspace():
+            start_char -= 1
+    return context[start_char:end_char]
 
 
 def extract_labels_from_generation(

--- a/src/euroeval/task_group_utils/question_answering.py
+++ b/src/euroeval/task_group_utils/question_answering.py
@@ -456,6 +456,16 @@ def _answer_text_from_offsets(
     filled, and only across non-whitespace, so standard BERT/RoBERTa offsets and
     mid-word overflowing features are left alone.
 
+    Args:
+        offset_mapping:
+            Character offsets for every token in the encoded feature.
+        start_index:
+            Index of the first token in the predicted answer span.
+        end_index:
+            Index of the final token in the predicted answer span.
+        context:
+            Original context from which to extract the answer text.
+
     Returns:
         The context slice for the predicted token span.
     """

--- a/tests/test_task_group_utils/test_question_answering.py
+++ b/tests/test_task_group_utils/test_question_answering.py
@@ -11,12 +11,13 @@ from euroeval.task_group_utils.question_answering import (
 class TestAnswerTextFromOffsets:
     """Tests for reconstructing answer text from token offset mappings."""
 
-    def test_standard_offsets_are_unchanged(self) -> None:
-        """Contiguous BERT-style offsets slice the context as reported."""
-        context = "The capital of France is Paris."
-        #                    0123456789012345678901234567890
-        offsets = [(0, 3), (4, 11), (12, 14), (15, 21), (22, 24), (25, 30), (30, 31)]
-        assert _answer_text_from_offsets(offsets, 5, 5, context) == "Paris"
+    def test_overflow_feature_starting_mid_word_is_not_expanded(self) -> None:
+        """A stride that starts mid-word must not pull in the missing prefix."""
+        context = "xxAmsterdam"
+        # Feature starts at 'm' (index 3) inside "Amsterdam"; previous token is
+        # not in this context, and the character before is not whitespace.
+        offsets = [(-1, -1), (3, 11)]
+        assert _answer_text_from_offsets(offsets, 1, 1, context) == "msterdam"
 
     def test_robbert_word_initial_offset_is_repaired(self) -> None:
         """A word-initial start offset of +1 still yields the full word.
@@ -30,12 +31,12 @@ class TestAnswerTextFromOffsets:
         offsets = [(-1, -1), (1, 9), (10, 12), (13, 16), (17, 24)]
         assert _answer_text_from_offsets(offsets, 1, 1, context) == "Amsterdam"
 
-    def test_word_initial_offset_after_space_is_repaired(self) -> None:
-        """The same +1 hole after a previous word is filled."""
-        context = "in Amsterdam today"
-        # "Amsterdam" is [3:12]; the token reports (4, 12).
-        offsets = [(-1, -1), (0, 2), (4, 12), (13, 18)]
-        assert _answer_text_from_offsets(offsets, 2, 2, context) == "Amsterdam"
+    def test_standard_offsets_are_unchanged(self) -> None:
+        """Contiguous BERT-style offsets slice the context as reported."""
+        context = "The capital of France is Paris."
+        #                    0123456789012345678901234567890
+        offsets = [(0, 3), (4, 11), (12, 14), (15, 21), (22, 24), (25, 30), (30, 31)]
+        assert _answer_text_from_offsets(offsets, 5, 5, context) == "Paris"
 
     def test_subword_continuation_is_not_expanded(self) -> None:
         """A continuation subword whose previous token is in-context is left as-is."""
@@ -43,13 +44,12 @@ class TestAnswerTextFromOffsets:
         offsets = [(0, 4), (4, 7)]
         assert _answer_text_from_offsets(offsets, 1, 1, context) == "ing"
 
-    def test_overflow_feature_starting_mid_word_is_not_expanded(self) -> None:
-        """A stride that starts mid-word must not pull in the missing prefix."""
-        context = "xxAmsterdam"
-        # Feature starts at 'm' (index 3) inside "Amsterdam"; previous token is
-        # not in this context, and the character before is not whitespace.
-        offsets = [(-1, -1), (3, 11)]
-        assert _answer_text_from_offsets(offsets, 1, 1, context) == "msterdam"
+    def test_word_initial_offset_after_space_is_repaired(self) -> None:
+        """The same +1 hole after a previous word is filled."""
+        context = "in Amsterdam today"
+        # "Amsterdam" is [3:12]; the token reports (4, 12).
+        offsets = [(-1, -1), (0, 2), (4, 12), (13, 18)]
+        assert _answer_text_from_offsets(offsets, 2, 2, context) == "Amsterdam"
 
 
 class TestFindValidAnswersRobbertOffsets:

--- a/tests/test_task_group_utils/test_question_answering.py
+++ b/tests/test_task_group_utils/test_question_answering.py
@@ -1,0 +1,75 @@
+"""Tests for the `task_group_utils.question_answering` module."""
+
+import numpy as np
+
+from euroeval.task_group_utils.question_answering import (
+    _answer_text_from_offsets,
+    find_valid_answers,
+)
+
+
+class TestAnswerTextFromOffsets:
+    """Tests for reconstructing answer text from token offset mappings."""
+
+    def test_standard_offsets_are_unchanged(self) -> None:
+        """Contiguous BERT-style offsets slice the context as reported."""
+        context = "The capital of France is Paris."
+        #                    0123456789012345678901234567890
+        offsets = [(0, 3), (4, 11), (12, 14), (15, 21), (22, 24), (25, 30), (30, 31)]
+        assert _answer_text_from_offsets(offsets, 5, 5, context) == "Paris"
+
+    def test_robbert_word_initial_offset_is_repaired(self) -> None:
+        """A word-initial start offset of +1 still yields the full word.
+
+        This is the RobBERT-family ByteLevel hole from
+        https://github.com/EuroEval/EuroEval/issues/2171.
+        """
+        context = "Amsterdam is the capital"
+        # First context token claims (1, 9) instead of (0, 9); previous token is
+        # a question/special token marked as not in the context.
+        offsets = [(-1, -1), (1, 9), (10, 12), (13, 16), (17, 24)]
+        assert _answer_text_from_offsets(offsets, 1, 1, context) == "Amsterdam"
+
+    def test_word_initial_offset_after_space_is_repaired(self) -> None:
+        """The same +1 hole after a previous word is filled."""
+        context = "in Amsterdam today"
+        # "Amsterdam" is [3:12]; the token reports (4, 12).
+        offsets = [(-1, -1), (0, 2), (4, 12), (13, 18)]
+        assert _answer_text_from_offsets(offsets, 2, 2, context) == "Amsterdam"
+
+    def test_subword_continuation_is_not_expanded(self) -> None:
+        """A continuation subword whose previous token is in-context is left as-is."""
+        context = "playing"
+        offsets = [(0, 4), (4, 7)]
+        assert _answer_text_from_offsets(offsets, 1, 1, context) == "ing"
+
+    def test_overflow_feature_starting_mid_word_is_not_expanded(self) -> None:
+        """A stride that starts mid-word must not pull in the missing prefix."""
+        context = "xxAmsterdam"
+        # Feature starts at 'm' (index 3) inside "Amsterdam"; previous token is
+        # not in this context, and the character before is not whitespace.
+        offsets = [(-1, -1), (3, 11)]
+        assert _answer_text_from_offsets(offsets, 1, 1, context) == "msterdam"
+
+
+class TestFindValidAnswersRobbertOffsets:
+    """`find_valid_answers` must emit the repaired span, not the truncated one."""
+
+    def test_best_answer_keeps_the_leading_letter(self) -> None:
+        """The predicted span is the full gold word despite a +1 start offset."""
+        context = "Amsterdam is the capital"
+        offset_mapping = [(-1, -1), (1, 9), (10, 12), (13, 16), (17, 24)]
+        start_logits = np.array([-10.0, 5.0, 0.0, 0.0, 0.0])
+        end_logits = np.array([-10.0, 5.0, 0.0, 0.0, 0.0])
+        answers = find_valid_answers(
+            start_logits=start_logits,
+            end_logits=end_logits,
+            offset_mapping=offset_mapping,
+            context=context,
+            max_answer_length=30,
+            num_best_logits=5,
+            min_null_score=-100.0,
+        )
+        texts = {answer["text"] for answer in answers}
+        assert "Amsterdam" in texts
+        assert "msterdam" not in texts


### PR DESCRIPTION
Fixes #2171.

`find_valid_answers` rebuilt the predicted answer by slicing the context with the tokenizer `offset_mapping`. RobBERT-family models use `Sequence[Whitespace, ByteLevel, Punctuation]` rather than plain ByteLevel, so a word-initial token's start offset is one character into the word. The slice then drops the first letter (`Amsterdam` → `msterdam`) and SQuAD Exact Match on `squad-nl` collapses (RobBERT-2023-base: EM 8 vs 46.7 on DUMB).

The reconstruction now fills only a non-whitespace hole that is not already covered by the previous in-context token. Standard BERT/RoBERTa spans and overflowing features that start mid-word are unchanged.

Local: `pytest tests/test_task_group_utils/test_question_answering.py -o addopts=` → 6 passed. `ruff check` on the two changed files is clean.

An LLM agent was used to draft this change. I reviewed the offset cases, wrote the tests, and am accountable for the result.