### PR TITLE
fix: retry without unsupported max_tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- LiteLLM now retries custom OpenAI-compatible APIs that reject `max_tokens` without
+  sending the unsupported parameter.
+
 ## [v18.1.0] - 2026-09-11
 
 ### Added

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -949,6 +949,9 @@ class LiteLLMModel(BenchmarkModule):
         max_completion_tokens_pattern = re.compile(
             r"does not support parameters: \[.*'max_completion_tokens'.*\]"
         )
+        max_tokens_pattern = re.compile(
+            r"does not support parameters: \[.*'max_tokens'.*\]"
+        )
         temperature_pattern = re.compile(
             r"does not support parameters: \[.*'temperature'.*\]"
         )
@@ -1034,6 +1037,15 @@ class LiteLLMModel(BenchmarkModule):
             generation_kwargs["max_tokens"] = generation_kwargs.pop(
                 "max_completion_tokens", None
             )
+            return generation_kwargs, 0
+
+        # Max tokens
+        if max_tokens_pattern.search(string=error_msg):
+            log_once(
+                f"The model {model_id!r} does not support max_tokens, so disabling it.",
+                level=logging.DEBUG,
+            )
+            generation_kwargs.pop("max_tokens", None)
             return generation_kwargs, 0
 
         # Temperature not supported

--- a/tests/test_benchmark_modules/test_litellm.py
+++ b/tests/test_benchmark_modules/test_litellm.py
@@ -39,42 +39,6 @@ class TestBPCGating:
             )
 
 
-class TestParameterErrorHandling:
-    """Tests for unsupported generation parameter handling."""
-
-    def test_max_completion_tokens_falls_back_to_max_tokens(self) -> None:
-        """Unsupported max_completion_tokens is replaced by max_tokens."""
-        error = UnsupportedParamsError(
-            message="openai does not support parameters: ['max_completion_tokens']"
-        )
-        model = object.__new__(LiteLLMModel)
-
-        result = model._handle_parameter_error(
-            error=error,
-            error_msg=str(error).lower(),
-            model_id="test-model",
-            generation_kwargs={"max_completion_tokens": 128},
-        )
-
-        assert result == ({"max_tokens": 128}, 0)
-
-    def test_max_tokens_is_removed_when_unsupported(self) -> None:
-        """Unsupported max_tokens is removed before retrying the request."""
-        error = UnsupportedParamsError(
-            message="openai does not support parameters: ['max_tokens']"
-        )
-        model = object.__new__(LiteLLMModel)
-
-        result = model._handle_parameter_error(
-            error=error,
-            error_msg=str(error).lower(),
-            model_id="test-model",
-            generation_kwargs={"max_tokens": 128},
-        )
-
-        assert result == ({}, 0)
-
-
 class TestCreateModelOutput:
     """Tests for the _create_model_output method in LiteLLMModel."""
 
@@ -149,6 +113,42 @@ class TestCreateModelOutput:
         assert output.scores[0] is not None
         assert len(output.scores[0]) == 1
         assert output.scores[1] == []
+
+
+class TestParameterErrorHandling:
+    """Tests for unsupported generation parameter handling."""
+
+    def test_max_completion_tokens_falls_back_to_max_tokens(self) -> None:
+        """Unsupported max_completion_tokens is replaced by max_tokens."""
+        error = UnsupportedParamsError(
+            message="openai does not support parameters: ['max_completion_tokens']"
+        )
+        model = object.__new__(LiteLLMModel)
+
+        result = model._handle_parameter_error(
+            error=error,
+            error_msg=str(error).lower(),
+            model_id="test-model",
+            generation_kwargs={"max_completion_tokens": 128},
+        )
+
+        assert result == ({"max_tokens": 128}, 0)
+
+    def test_max_tokens_is_removed_when_unsupported(self) -> None:
+        """Unsupported max_tokens is removed before retrying the request."""
+        error = UnsupportedParamsError(
+            message="openai does not support parameters: ['max_tokens']"
+        )
+        model = object.__new__(LiteLLMModel)
+
+        result = model._handle_parameter_error(
+            error=error,
+            error_msg=str(error).lower(),
+            model_id="test-model",
+            generation_kwargs={"max_tokens": 128},
+        )
+
+        assert result == ({}, 0)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_benchmark_modules/test_litellm.py
+++ b/tests/test_benchmark_modules/test_litellm.py
@@ -4,6 +4,7 @@ import dataclasses
 from unittest.mock import MagicMock, patch
 
 import pytest
+from litellm.exceptions import UnsupportedParamsError
 from litellm.types.utils import Choices
 
 from euroeval.benchmark_modules.litellm import (
@@ -36,6 +37,42 @@ class TestBPCGating:
                 dataset_config=dataset_config,
                 benchmark_config=bpc_config,
             )
+
+
+class TestParameterErrorHandling:
+    """Tests for unsupported generation parameter handling."""
+
+    def test_max_completion_tokens_falls_back_to_max_tokens(self) -> None:
+        """Unsupported max_completion_tokens is replaced by max_tokens."""
+        error = UnsupportedParamsError(
+            message="openai does not support parameters: ['max_completion_tokens']"
+        )
+        model = object.__new__(LiteLLMModel)
+
+        result = model._handle_parameter_error(
+            error=error,
+            error_msg=str(error).lower(),
+            model_id="test-model",
+            generation_kwargs={"max_completion_tokens": 128},
+        )
+
+        assert result == ({"max_tokens": 128}, 0)
+
+    def test_max_tokens_is_removed_when_unsupported(self) -> None:
+        """Unsupported max_tokens is removed before retrying the request."""
+        error = UnsupportedParamsError(
+            message="openai does not support parameters: ['max_tokens']"
+        )
+        model = object.__new__(LiteLLMModel)
+
+        result = model._handle_parameter_error(
+            error=error,
+            error_msg=str(error).lower(),
+            model_id="test-model",
+            generation_kwargs={"max_tokens": 128},
+        )
+
+        assert result == ({}, 0)
 
 
 class TestCreateModelOutput:


### PR DESCRIPTION
## What

Allow EuroEval to retry custom OpenAI-compatible APIs that reject `max_tokens`, completing the existing fallback from `max_completion_tokens`.

## Why

Some OpenAI-compatible backends reject both token-limit parameter names. EuroEval already adapts to `max_completion_tokens`; it should also remove an explicitly unsupported `max_tokens` value rather than failing the benchmark.

## Verification

- Targeted LiteLLM parameter-error tests pass
- Ruff lint and format checks pass
- funcsort hook passes
- End-to-end AngryTweets zero-shot benchmark completed successfully against the local Pi-backed OpenAI-compatible endpoint