### PR TITLE
Update API model release dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   `--task` does.
 - Added model release dates to benchmark result metadata for Hugging Face Hub and API
   models.
+- Added release-date metadata for GPT-6 Astra, Claude Fable 5.1, Claude Mythos 5.1,
+  and Gemini 3.8 Flash.
 - Added the unofficial Belarusian Word-in-Context dataset `bewic`, based on the BeWiC
   dataset from BelarusianGLUE.
 - Added the unofficial Belarusian linguistic acceptability dataset `belacola`, based on

--- a/src/euroeval/benchmark_modules/litellm.py
+++ b/src/euroeval/benchmark_modules/litellm.py
@@ -212,6 +212,7 @@ MODEL_RELEASE_DATE_MAPPING = {
     r"(openai/)?gpt-5\.5": "2026-04-23",
     r"(openai/)?gpt-5\.5-pro": "2026-04-23",
     r"(openai/)?gpt-5\.6(?:-(?:sol|terra|luna))?": "2026-07-09",
+    r"(openai/)?gpt-6-astra": "2026-09-03",
     # Anthropic
     r"(anthropic/)?claude-3-opus": "2024-03-04",
     r"(anthropic/)?claude-3-sonnet": "2024-03-04",
@@ -232,6 +233,7 @@ MODEL_RELEASE_DATE_MAPPING = {
     r"(anthropic/)?claude-(?:fable|mythos)-5": "2026-06-09",
     r"(anthropic/)?claude-sonnet-5": "2026-06-30",
     r"(anthropic/)?claude-opus-5": "2026-07-24",
+    r"(anthropic/)?claude-(?:fable|mythos)-5-1": "2026-09-01",
     # Google
     r"(gemini/)?gemini-1\.5-pro.*": "2024-02-15",
     r"(gemini/)?gemini-1\.5-flash.*": "2024-05-14",
@@ -246,6 +248,7 @@ MODEL_RELEASE_DATE_MAPPING = {
     r"(gemini/)?gemini-3\.5-flash-lite$": "2026-07-21",
     r"(gemini/)?gemini-3\.6-flash$": "2026-07-21",
     r"(gemini/)?gemini-3\.7-flash$": "2026-08-13",
+    r"(gemini/)?gemini-3\.8-flash$": "2026-09-02",
     # xAI
     r"(xai/)?grok-1": "2023-11-04",
     r"(xai/)?grok-1\.5": "2024-03-28",


### PR DESCRIPTION
## What

Update API model release dates for the latest documented text models from OpenAI, Anthropic, and Google:

- GPT-6 Astra — 3 September 2026
- Claude Fable 5.1 and Claude Mythos 5.1 — 1 September 2026
- Gemini 3.8 Flash — 2 September 2026

xAI's current latest text model, Grok 4.6, is already present.

## Sources

- https://developers.openai.com/api/docs/changelog
- https://platform.claude.com/docs/en/release-notes/overview
- https://ai.google.dev/gemini-api/docs/changelog

## Verification

- `uv run ruff check src/euroeval/benchmark_modules/litellm.py`
- `uv run ruff format --check src/euroeval/benchmark_modules/litellm.py`
- `uv run pytest tests/test_benchmark_modules/test_litellm.py -q` (36 passed)
